### PR TITLE
Exporter refactor to Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 composer.lock
 vendor
+.idea/

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -7,22 +7,30 @@ namespace OpenTelemetry;
 use OpenTelemetry\Tracing\Span;
 use OpenTelemetry\Tracing\Tracer;
 
-abstract class Exporter
+/**
+ * A simple Exporter interface
+ *
+ * @package OpenTelemetry
+ */
+interface Exporter
 {
-    abstract public function convertSpan(Span $span) : array;
+    /**
+     * Possible return values as outlined in the OpenTelemetry spec
+     */
+    const SUCCESS = 0;
+    const FAILED_NOT_RETRYABLE = 1;
+    const FAILED_RETRYABLE = 2;
 
-    public function flush(Tracer $tracer, Transport $transport) : int
-    {
-        $data = [];
+    /**
+     * Export trace data (spans)
+     * @param Span[] $spans List of spans to export
+     * @return int
+     */
+    public function export(Span ...$spans) : int;
 
-        foreach ($tracer->getSpans() as $span) {
-            $data[] = $this->convertSpan($span);
-        }
-
-        if (count($data)) {
-            $transport->write($data);
-        }
-
-        return count($data);
-    }
+    /**
+     * Shutdown the exporter, provide cleanup
+     * @return int
+     */
+    public function shutdown() : int;
 }

--- a/src/Exporter/ZipkinExporter.php
+++ b/src/Exporter/ZipkinExporter.php
@@ -8,11 +8,52 @@ use OpenTelemetry\Exporter;
 use OpenTelemetry\Tracing\Span;
 use OpenTelemetry\Tracing\Tracer;
 
-class ZipkinExporter extends Exporter
+/**
+ * Class ZipkinExporter - implements the export interface for data transfer via Zipkin protocol
+ * @package OpenTelemetry\Exporter
+ */
+class ZipkinExporter implements Exporter
 {
+
+    /**
+     * @var endpoint to send Spans to
+     */
     private $endpoint;
 
-    public function convertSpan(Span $span) : array
+    /**
+     * Exports the provided Span data via the Zipkin protocol
+     *
+     * @param Span ...$spans Array of Spans
+     * @return int return code, defined on the Exporter interface
+     */
+    public function export(Span ...$spans) : int
+    {
+        $convertedSpans = [];
+        foreach ($spans as &$span) {
+            array_push($convertedSpans, converSpan($span));
+        }
+
+        #todo: format into JSON paylod for zipkin: (see https://github.com/census-ecosystem/opencensus-php-exporter-zipkin/blob/master/src/ZipkinExporter.php#L143)
+    }
+
+    #todo: this method is required via the spec, but not sure if needed
+    /**
+     * Shutdown the export
+     *
+     * @return int
+     */
+    public function shutdown() : int
+    {
+
+    }
+
+    /**
+     * Converts spans to Zipkin format for export
+     *
+     * @param Span $span
+     * @return array
+     */
+    private function convertSpan(Span $span) : array
     {
         $row = [
             'id' => $span->getContext()->getSpanId(),
@@ -49,11 +90,22 @@ class ZipkinExporter extends Exporter
         return $row;
     }
 
+    /**
+     * Gets the configured endpoint for the Zipkin exporter
+     *
+     * @return endpoint
+     */
     public function getEndpoint()
     {
         return $this->endpoint;
     }
 
+    /**
+     * Sets the configured endpoint for the zipkin exportedr
+     *
+     * @param array $endpoint
+     * @return $this
+     */
     public function setEndpoint(array $endpoint) : self
     {
         $this->endpoint = $endpoint;


### PR DESCRIPTION
The covers issue https://github.com/open-telemetry/opentelemetry-php/issues/22

The opentelemetry spec requires the exporter to be implemented as an interface with two methods: export & shutdown. This is a simple change to refactor what was the Exporter class to an Exporter interface, and update what we have of the zipkin exporter class. 

There's more work that needs to be done to consider this finalized, but it may need to be done in parallel with a functioning export class that implements it. 