### PR TITLE
Clean up Exporter and ZipkinExporter

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -23,14 +23,12 @@ interface Exporter
 
     /**
      * Export trace data (spans)
-     * @param Span[] $spans List of spans to export
+     * @param iterable<Span> $spans Batch of spans to export
      * @return int
      */
-    public function export(Span ...$spans) : int;
+    public function export(iterable $spans) : int;
 
-    /**
-     * Shutdown the exporter, provide cleanup
-     * @return int
+    /* The spec mentions a shutdown() function. We don't see this as necessary;
+     * if an Exporter needs to clean up, it can use a destructor.
      */
-    public function shutdown() : int;
 }

--- a/src/Exporter/ZipkinExporter.php
+++ b/src/Exporter/ZipkinExporter.php
@@ -6,7 +6,6 @@ namespace OpenTelemetry\Exporter;
 
 use OpenTelemetry\Exporter;
 use OpenTelemetry\Tracing\Span;
-use OpenTelemetry\Tracing\Tracer;
 
 /**
  * Class ZipkinExporter - implements the export interface for data transfer via Zipkin protocol
@@ -23,28 +22,19 @@ class ZipkinExporter implements Exporter
     /**
      * Exports the provided Span data via the Zipkin protocol
      *
-     * @param Span ...$spans Array of Spans
+     * @param iterable<Span> $spans Array of Spans
      * @return int return code, defined on the Exporter interface
      */
-    public function export(Span ...$spans) : int
+    public function export(iterable $spans) : int
     {
         $convertedSpans = [];
         foreach ($spans as &$span) {
-            array_push($convertedSpans, converSpan($span));
+            array_push($convertedSpans, $this->convertSpan($span));
         }
 
-        #todo: format into JSON paylod for zipkin: (see https://github.com/census-ecosystem/opencensus-php-exporter-zipkin/blob/master/src/ZipkinExporter.php#L143)
-    }
-
-    #todo: this method is required via the spec, but not sure if needed
-    /**
-     * Shutdown the export
-     *
-     * @return int
-     */
-    public function shutdown() : int
-    {
-
+        /* todo: format into JSON paylod for zipkin:
+         * @see https://github.com/census-ecosystem/opencensus-php-exporter-zipkin/blob/master/src/ZipkinExporter.php#L143
+         */
     }
 
     /**


### PR DESCRIPTION
This uses an `iterable` of `Span` instead of a variadic. This allows for implementers to use `SplFixedArray` or some other custom type instead of forcing them to use PHP's arrays.

Removes `shutdown`. The semantics of `shutdown()` are equivalent to a destructor, aside from this bit:

> After the call to Shutdown subsequent calls to Export are not allowed and should return FailedNotRetryable error.

I see no point. If it's done, it's done, don't try to call it.