### PR TITLE
Run PHP 7.1 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: trusty
 language: php
 
 php:
+    - 7.1
     - 7.2
     - 7.3
 


### PR DESCRIPTION
At least so far we've officially been supporting PHP 7.1+, so it makes sense to run tests for PHP 7.1.