### PR TITLE
Removes Dockerfile warning for continuation line

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get -y update && apt-get -y install git zip && \
 curl -sS https://getcomposer.org/installer | php && \
 mv composer.phar /usr/local/bin/composer && \
 chmod +x /usr/local/bin/composer && \
-
 pecl install ast-1.0.4 xdebug && \
 docker-php-ext-enable ast xdebug
 


### PR DESCRIPTION
This warning will become an error in a future release

```bash
[WARNING]: Empty continuation line found in:
    RUN apt-get -y update && apt-get -y install git zip && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer && chmod +x /usr/local/bin/composer && pecl install ast-1.0.4 xdebug && docker-php-ext-enable ast xdebug
[WARNING]: Empty continuation lines will become errors in a future release.
```