### PR TITLE
Suppresses warnings from Phan about Xdebug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ update:
 test:
 	$(DC_RUN_PHP) php ./vendor/bin/phpunit --colors=always
 phan:
-	$(DC_RUN_PHP) php ./vendor/bin/phan
+	$(DC_RUN_PHP) env PHAN_DISABLE_XDEBUG_WARN=1 php ./vendor/bin/phan
 examples: FORCE
 	$(DC_RUN_PHP) php ./examples/AlwaysOnTraceExample.php
 bash:


### PR DESCRIPTION
This doesn't remove the lines originating from XdebugHandler, e.g.

```
[debug] Checking PHAN_ALLOW_XDEBUG
[debug] Because xdebug was installed, Phan will restart.
[debug] The Xdebug extension is loaded (2.9.1)
[debug] Process restarting (PHAN_ALLOW_XDEBUG=internal|2.9.1|1|*|*)
[debug] Running '/usr/local/bin/php' '-n' '-c' '/tmp/LPtCmV' './vendor/bin/phan'
```