### PR TITLE
Add exporter Status class

### DIFF
--- a/src/Exporter/BasisExporter.php
+++ b/src/Exporter/BasisExporter.php
@@ -22,6 +22,6 @@ class BasisExporter implements ExporterInterface
 
     public function export(iterable $spans): int
     {
-        return ExporterInterface::SUCCESS;
+        return Status::SUCCESS;
     }
 }

--- a/src/Exporter/ExporterInterface.php
+++ b/src/Exporter/ExporterInterface.php
@@ -23,7 +23,8 @@ interface ExporterInterface
     /**
      * Export trace data (spans)
      * @param iterable<Span> $spans Batch of spans to export
-     * @return int
+     * @return int Result of operation
+     * @see \OpenTelemetry\Exporter\Status
      */
     public function export(iterable $spans) : int;
 

--- a/src/Exporter/ExporterInterface.php
+++ b/src/Exporter/ExporterInterface.php
@@ -14,13 +14,6 @@ use OpenTelemetry\Trace\Span;
 interface ExporterInterface
 {
     /**
-     * Possible return values as outlined in the OpenTelemetry spec
-     */
-    const SUCCESS = 0;
-    const FAILED_NOT_RETRYABLE = 1;
-    const FAILED_RETRYABLE = 2;
-
-    /**
      * Export trace data (spans)
      * @param iterable<Span> $spans Batch of spans to export
      * @return int Result of operation

--- a/src/Exporter/Status.php
+++ b/src/Exporter/Status.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace OpenTelemetry\Exporter;
+
+final class Status
+{
+    /**
+     * Possible return values as outlined in the OpenTelemetry spec
+     */
+    const SUCCESS = 0;
+    const FAILED_NOT_RETRYABLE = 1;
+    const FAILED_RETRYABLE = 2;
+}

--- a/src/Exporter/ZipkinExporter.php
+++ b/src/Exporter/ZipkinExporter.php
@@ -42,7 +42,7 @@ class ZipkinExporter implements ExporterInterface
     public function export(iterable $spans) : int
     {
         if (empty($spans)) {
-            return ExporterInterface::SUCCESS;
+            return Status::SUCCESS;
         }
 
         $convertedSpans = [];
@@ -64,10 +64,10 @@ class ZipkinExporter implements ExporterInterface
 
 
         } catch (Exception $e) {
-            return ExporterInterface::FAILED_RETRYABLE;
+            return Status::FAILED_RETRYABLE;
         }
 
-        return ExporterInterface::SUCCESS;
+        return Status::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
Creates a `Exporter\Status` class that holds the constants for possible responses from the exporter and replaces usages of the constants to this class.

This is similarly done for the `Trace` package.