### PR TITLE
Require the pcntl extension for development

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,8 @@ curl -sS https://getcomposer.org/installer | php && \
 mv composer.phar /usr/local/bin/composer && \
 chmod +x /usr/local/bin/composer && \
 pecl install ast-1.0.4 xdebug && \
-docker-php-ext-enable ast xdebug
+docker-php-ext-enable ast xdebug && \
+# The pcntl extension is used for speeding up `make phan`
+docker-php-ext-install pcntl
 
 WORKDIR /usr/src/myapp


### PR DESCRIPTION
This extension speeds up the `make phan` step on multi-processor systems

Before:

```
-> % time make phan
make phan  0.49s user 0.09s system 4% cpu 13.460 total
```

After:

```
-> % time make phan
make phan  0.53s user 0.11s system 13% cpu 4.733 total
```