### PR TITLE
Disable XDebug on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,5 @@ script:
     - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
     - vendor/bin/phan
 
-after_script:
-    - |
-        if [[ "$TRAVIS_PHP_VERSION" != 'hhvm' ]]; then
-          wget https://scrutinizer-ci.com/ocular.phar
-          php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-        fi
-
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ cache:
         - $HOME/.composer/cache
 
 before_script:
+    - source .travis/xdebug.sh
+    - xdebug-disable
     - pecl install ast-1.0.4
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
@@ -23,8 +25,9 @@ script:
         CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
         if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); else EXTRA_ARGS=''; fi
         vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}
-    - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
     - vendor/bin/phan
+    - xdebug-enable
+    - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis/xdebug.sh
+++ b/.travis/xdebug.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# The problem is that we do not want to remove the configuration file, just disable it for a few tasks, then enable it
+#
+# For reference, see
+#
+# - https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions
+# - https://docs.travis-ci.com/user/languages/php#Custom-PHP-configuration
+
+config="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
+
+function xdebug-disable() {
+    if [[ -f $config ]]; then
+        mv $config "$config.bak"
+    fi
+}
+
+function xdebug-enable() {
+    if [[ -f "$config.bak" ]]; then
+        mv "$config.bak" $config
+    fi
+}


### PR DESCRIPTION
Only enables XDebug when running PHPUnit. This should speed up PHP tasks like Phan and in some cases Composer if Travis doesn't optimize for that.