### PR TITLE
Fixes Broken Example Code and Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ composer require open-telemetry/opentelemetry
 
 ### Examples
 
-You can use the [examples/AlwaysSampleTraceExample.php](https://github.com/open-telemetry/opentelemetry-php/tree/master/examples/AlwaysSampleTraceExample.php) file to test out the reference implementation we have.  
+You can use the [examples/AlwaysSampleTraceExample.php](/open-telemetry/opentelemetry-php/blob/master/examples/AlwaysOnTraceExample.php) file to test out the reference implementation we have.
 First you should start zipkin server by running `docker-compose up -d` and then you can you can easily execute examples using `make example`.
 Exported spans can be seen in zipkin at [http://127.0.0.1:9411](http://127.0.0.1:9411)
 

--- a/examples/AlwaysOffTraceExample.php
+++ b/examples/AlwaysOffTraceExample.php
@@ -6,7 +6,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use OpenTelemetry\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\Trace\TracerFactory;
 
-$sampler = (new AlwaysOffSampler)->shouldSample();
+$sampler = (new AlwaysOffSampler())->shouldSample();
 if ($sampler) {
     $tracer = TracerFactory::getInstance()
         ->getTracer('io.opentelemetry.contrib.php');

--- a/examples/AlwaysOffTraceExample.php
+++ b/examples/AlwaysOffTraceExample.php
@@ -6,7 +6,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use OpenTelemetry\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\Trace\TracerFactory;
 
-$sampler = AlwaysOffSampler::shouldSample();
+$sampler = (new AlwaysOffSampler)->shouldSample();
 if ($sampler) {
     $tracer = TracerFactory::getInstance()
         ->getTracer('io.opentelemetry.contrib.php');

--- a/examples/AlwaysOnTraceExample.php
+++ b/examples/AlwaysOnTraceExample.php
@@ -8,7 +8,7 @@ use OpenTelemetry\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\Trace\TracerFactory;
 
-$sampler = (new AlwaysOnSampler)->shouldSample();
+$sampler = (new AlwaysOnSampler())->shouldSample();
 
 $zipkinExporter = new ZipkinExporter(
     'alwaysOnExporter',
@@ -33,7 +33,7 @@ if ($sampler) {
         'username' => 'otuser' . $i,
     ]);
         $span->addEvent('generated_session', [
-        'id' => md5((string)microtime(true)),
+        'id' => md5((string) microtime(true)),
     ]);
 
         $tracer->endActiveSpan();

--- a/examples/AlwaysOnTraceExample.php
+++ b/examples/AlwaysOnTraceExample.php
@@ -8,7 +8,7 @@ use OpenTelemetry\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\Trace\TracerFactory;
 
-$sampler = AlwaysOnSampler::shouldSample();
+$sampler = (new AlwaysOnSampler)->shouldSample();
 
 $zipkinExporter = new ZipkinExporter(
     'alwaysOnExporter',
@@ -33,7 +33,7 @@ if ($sampler) {
         'username' => 'otuser' . $i,
     ]);
         $span->addEvent('generated_session', [
-        'id' => md5(microtime(true)),
+        'id' => md5((string)microtime(true)),
     ]);
 
         $tracer->endActiveSpan();


### PR DESCRIPTION
I tried giving the sample code a try and ran into a "non-static method called statically" error and a type error trying to pass a non-string to the `md5` function.  This PR fixes these PHP errors, and also fixes the link to the sample program from the README.md