### PR TITLE
Remove PHP 7.1, add PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: php
 os: linux
 
 php:
-    - 7.1
     - 7.2
     - 7.3
-
+    - 7.4
 ## Cache composer
 cache:
     directories:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-buster
+FROM php:7.2-buster
 
 RUN apt-get -y update && apt-get -y install git zip && \
 curl -sS https://getcomposer.org/installer | php && \

--- a/src/Trace/TracerFactory.php
+++ b/src/Trace/TracerFactory.php
@@ -65,7 +65,8 @@ class TracerFactory
 
     public function getTracer(string $name, string $version = ''): Tracer
     {
-        if ($this->tracers != null && $this->tracers[$name] instanceof Tracer) {
+
+        if (isset($this->tracers[$name]) && $this->tracers[$name] instanceof Tracer) {
             return $this->tracers[$name];
         }
 

--- a/src/Trace/TracerFactory.php
+++ b/src/Trace/TracerFactory.php
@@ -65,7 +65,6 @@ class TracerFactory
 
     public function getTracer(string $name, string $version = ''): Tracer
     {
-
         if (isset($this->tracers[$name]) && $this->tracers[$name] instanceof Tracer) {
             return $this->tracers[$name];
         }

--- a/src/Trace/TracerFactory.php
+++ b/src/Trace/TracerFactory.php
@@ -65,7 +65,7 @@ class TracerFactory
 
     public function getTracer(string $name, string $version = ''): Tracer
     {
-        if ($this->tracers[$name] instanceof Tracer) {
+        if ($this->tracers != null && $this->tracers[$name] instanceof Tracer) {
             return $this->tracers[$name];
         }
 


### PR DESCRIPTION
PHP 7.1 has been EoL'ed, and doesn't have security support anymore.  I've removed it from CI and moved our default Dockerfile to use PHP7.2.  

I've also added in testing for PHP7.4, as php 7.4.2 is the current stable PHP version.