### PR TITLE
Adding Explicit Reference for Attribute Iterables

### DIFF
--- a/api/Trace/Attribute.php
+++ b/api/Trace/Attribute.php
@@ -9,8 +9,8 @@ interface Attribute
     public function getKey(): string;
 
     /**
-     * 
-     * @return bool|int|float|string|list<int>|list<float> 
+     *
+     * @return bool|int|float|string|list<int>|list<float>
      *
      */
     public function getValue();

--- a/api/Trace/Attribute.php
+++ b/api/Trace/Attribute.php
@@ -10,7 +10,7 @@ interface Attribute
 
     /**
      *
-     * @return bool|int|float|string|list<int>|list<float>
+     * @return bool|int|float|string|list<int>|list<float>|list<string>
      *
      */
     public function getValue();

--- a/api/Trace/Attribute.php
+++ b/api/Trace/Attribute.php
@@ -10,7 +10,7 @@ interface Attribute
 
     /**
      *
-     * @return bool|int|float|string|list<int>|list<float>|list<string>
+     * @return bool|int|float|string|list<bool>|list<int>|list<float>|list<string>
      *
      */
     public function getValue();

--- a/api/Trace/Attribute.php
+++ b/api/Trace/Attribute.php
@@ -9,8 +9,9 @@ interface Attribute
     public function getKey(): string;
 
     /**
-     * @return bool|int|float|string|iterable Note: the iterable MUST be homogeneous, i.e. it MUST NOT contain values
-     *                                        of different types.
+     * 
+     * @return bool|int|float|string|list<int>|list<float> 
+     *
      */
     public function getValue();
 }

--- a/sdk/Trace/Attribute.php
+++ b/sdk/Trace/Attribute.php
@@ -25,6 +25,11 @@ class Attribute implements API\Attribute
 
     public function getValue()
     {
+        /**
+        * 
+        * @return bool|int|float|string|list<int>|list<float> 
+        *
+        */
         return $this->value;
     }
 }

--- a/sdk/Trace/Attribute.php
+++ b/sdk/Trace/Attribute.php
@@ -26,8 +26,8 @@ class Attribute implements API\Attribute
     public function getValue()
     {
         /**
-        * 
-        * @return bool|int|float|string|list<int>|list<float> 
+        *
+        * @return bool|int|float|string|list<int>|list<float>
         *
         */
         return $this->value;


### PR DESCRIPTION
@beniamin mentioned that we should add explicit references for attribute iterables.  I performed this action for the api and sdk trace attribute `getValue` functions; we should discuss whether or not there are other places where we would like to do this.