### PR TITLE
Using Guzzle for Zipkin HTTP Requests

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -359,6 +359,7 @@ return [
         'api',
         'sdk',
         'vendor/composer/xdebug-handler/src',
+        'vendor/guzzlehttp',
         'vendor/phan/phan/src/Phan',
         'vendor/phpunit/phpunit/src',
     ],

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.2",
-        "ext-json": "*"
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^6.5"
     },
     "authors": [
         {

--- a/sdk/Trace/ZipkinExporter.php
+++ b/sdk/Trace/ZipkinExporter.php
@@ -54,9 +54,10 @@ class ZipkinExporter implements Exporter
 
         try {
             $json = json_encode($convertedSpans);
+            $url = $this->getEndpointUrl();
             $client = new \GuzzleHttp\Client();
             $headers = ['content-type' => 'application/json'];
-            $request = new Request('POST', $this->endpointUrl, $headers, $json);
+            $request = new Request('POST', $url, $headers, $json);
             $response = $client->send($request, ['timeout' => 2]);
         } catch (Exception $e) {
             return Exporter::FAILED_RETRYABLE;

--- a/sdk/Trace/ZipkinExporter.php
+++ b/sdk/Trace/ZipkinExporter.php
@@ -58,7 +58,7 @@ class ZipkinExporter implements Exporter
             $client = new \GuzzleHttp\Client();
             $headers = ['content-type' => 'application/json'];
             $request = new Request('POST', $url, $headers, $json);
-            $response = $client->send($request, ['timeout' => 2]);
+            $response = $client->send($request, ['timeout' => 30]);
         } catch (Exception $e) {
             return Exporter::FAILED_RETRYABLE;
         }

--- a/sdk/Trace/ZipkinExporter.php
+++ b/sdk/Trace/ZipkinExporter.php
@@ -72,7 +72,6 @@ class ZipkinExporter implements Exporter
             $headers = ['content-type' => 'application/json'];
             $request = new Request('POST', $url, $headers, $json);
             $response = $client->send($request, ['timeout' => 30]);
-
         } catch (Exception $e) {
             return Exporter::FAILED_RETRYABLE;
         }

--- a/sdk/Trace/ZipkinExporter.php
+++ b/sdk/Trace/ZipkinExporter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\Trace;
 
 use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;
 
 use OpenTelemetry\Trace as API;
@@ -53,15 +55,11 @@ class ZipkinExporter implements Exporter
 
         try {
             $json = json_encode($convertedSpans);
-            $contextOptions = [
-                'http' => [
-                    'method' => 'POST',
-                    'header' => 'Content-Type: application/json',
-                    'content' => $json,
-                ],
-            ];
-            $context = stream_context_create($contextOptions);
-            file_get_contents($this->getEndpointUrl(), false, $context);
+            $client = new \GuzzleHttp\Client();
+            $headers = ['content-type' => 'application/json'];
+            $request = new Request('POST', $this->endpointUrl, $headers, $json);
+            $response = $client->send($request, ['timeout' => 2]);
+
         } catch (Exception $e) {
             return Exporter::FAILED_RETRYABLE;
         }

--- a/sdk/Trace/ZipkinExporter.php
+++ b/sdk/Trace/ZipkinExporter.php
@@ -67,10 +67,9 @@ class ZipkinExporter implements Exporter
 
         try {
             $json = json_encode($convertedSpans);
-            $url = $this->getEndpointUrl();
             $client = new \GuzzleHttp\Client();
             $headers = ['content-type' => 'application/json'];
-            $request = new Request('POST', $url, $headers, $json);
+            $request = new Request('POST', $this->endpointUrl, $headers, $json);
             $response = $client->send($request, ['timeout' => 30]);
         } catch (Exception $e) {
             return Exporter::FAILED_RETRYABLE;

--- a/sdk/Trace/ZipkinExporter.php
+++ b/sdk/Trace/ZipkinExporter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\Trace;
 
 use Exception;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;
 
@@ -59,7 +58,6 @@ class ZipkinExporter implements Exporter
             $headers = ['content-type' => 'application/json'];
             $request = new Request('POST', $this->endpointUrl, $headers, $json);
             $response = $client->send($request, ['timeout' => 2]);
-
         } catch (Exception $e) {
             return Exporter::FAILED_RETRYABLE;
         }


### PR DESCRIPTION
In our gitter channel, we discussed using Guzzle as our HTTP request client rather than file_get_contents.  

Using [Guzzle](http://docs.guzzlephp.org/en/stable/) seemed like a sane choice here.  This is an initial thought about how to implement this for the zipkinExporter.  I also have changed this for @beniamin 's open PR in [this branch](https://github.com/open-telemetry/opentelemetry-php/compare/jaegertest?expand=1) should we choose to go this route.

I'll be happy to write tests for this, but I wanted to make sure we were all on board with this implementation before I wrote them.