### PR TITLE
internal clock milliseconds fix

### DIFF
--- a/sdk/Internal/Clock.php
+++ b/sdk/Internal/Clock.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Internal;
 
+use function microtime;
+
 class Clock
 {
     public function __construct()
@@ -12,16 +14,8 @@ class Clock
 
     public function millitime(): string
     {
-        return self::format_microtime_to_millitime(\microtime());
-    }
+        $millitime = microtime(true) * 1000;
 
-    public static function format_microtime_to_millitime(string $microtime): string
-    {
-        $space_at = \strpos($microtime, ' ');
-        $decimal = (float) \substr($microtime, 0, $space_at);
-        $seconds = \substr($microtime, $space_at + 1);
-        $milliseconds = (string) ($decimal * 1000);
-
-        return "{$seconds}${milliseconds}";
+        return (string) $millitime;
     }
 }

--- a/sdk/Tests/InternalClockTest.php
+++ b/sdk/Tests/InternalClockTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Tests;
+
+use OpenTelemetry\Sdk\Internal\Clock;
+use PHPUnit\Framework\TestCase;
+
+class InternalClockTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testReturnetStringRepresentMilliseconds()
+    {
+        $clock = new Clock();
+        $milliseconds = $clock->millitime();
+
+        $this->assertGreaterThan(1e12, (float) $milliseconds);
+    }
+}


### PR DESCRIPTION
This PR fixes a bug when some digits for milliseconds were missing due to transformation between floats and strings.

ex.
microtime: 0.00116800 1586110291
expected: 1586110291001.168
actual result:  1586110291168