### PR TITLE
Adding HTTP Tracing to Jaeger

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -360,6 +360,7 @@ return [
         'sdk',
         'vendor/composer/xdebug-handler/src',
         'vendor/phan/phan/src/Phan',
+        'vendor/guzzlehttp',
         'vendor/phpunit/phpunit/src',
     ],
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.2",
-        "ext-json": "*"
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^6.5"
     },
     "authors": [
         {

--- a/examples/JaegerExporterExample.php
+++ b/examples/JaegerExporterExample.php
@@ -9,7 +9,12 @@ use OpenTelemetry\Sdk\Trace\JaegerExporter;
 use OpenTelemetry\Sdk\Trace\SimpleSpanProcessor;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
 
-$sampler = (new AlwaysOnSampler())->shouldSample();
+$sampler = (new AlwaysOnSampler())->shouldSample(
+    null,
+    md5((string) microtime(true)),
+    substr(md5((string) microtime(true)), 16),
+    'io.opentelemetry.jagerexporterexample'
+);
 
 $exporter = new JaegerExporter(
     'jaegerExporterExample',


### PR DESCRIPTION
Same change as https://github.com/open-telemetry/opentelemetry-php/pull/72, only for Jaeger.  I think we could eventually DRY these two out as they are the same, but figured I would leave them for now in case we need to diverge them.