### PR TITLE
Add clocks to the API/SDK

### DIFF
--- a/api/Trace/MonotonicClock.php
+++ b/api/Trace/MonotonicClock.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Trace;
+
+/**
+ * The API Specification says:
+ * OpenTelemetry can operate on time values up to nanosecond (ns) precision.
+ * The representation of those values is language specific.
+ * A duration is the elapsed time between two events.
+ *   - The minimal precision is milliseconds.
+ *   - The maximal precision is nanoseconds.
+ *
+ * In the PHP standard library, the best suited function for measuring elapsed
+ * time is `hrtime`, available since PHP 7.3. In other words, callers can
+ * reasonably expect to have nanosecond resolution (nsec) on PHP 7.3 and newer.
+ */
+interface MonotonicClock
+{
+    /**
+     * Represents the amount of time in nanoseconds since an unspecified point
+     * in the past (for example, system start-up time, or the Epoch). This point
+     * does not change after system start-up time.
+     * @return int
+     */
+    public function now(): int;
+}

--- a/api/Trace/RealtimeClock.php
+++ b/api/Trace/RealtimeClock.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Trace;
+
+/**
+ * The API specification says:
+ * OpenTelemetry can operate on time values up to nanosecond (ns) precision.
+ * The representation of those values is language specific.
+ * A timestamp is the time elapsed since the Unix epoch.
+ *   - The minimal precision is milliseconds.
+ *   - The maximal precision is nanoseconds.
+ *
+ * In the PHP standard library, the best suited function for time since the
+ * Unix epoch is `microtime`, which uses microseconds or usecs. This interface
+ * uses nanosecond resolution so it can represent nanoseconds as per
+ * OpenTelemetry specification, but keep this mind as most implementations will
+ * probably use `microtime` so don't expect nanosecond accuracy for a
+ * RealtimeClock.
+ */
+interface RealtimeClock
+{
+    /**
+     * @return int Number of nanoseconds since the Unix epoch
+     */
+    public function now(): int;
+}

--- a/sdk/Trace/MonotonicClock.php
+++ b/sdk/Trace/MonotonicClock.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+//Please read the documentation on the MonotonicClock interface.
+class MonotonicClock implements \OpenTelemetry\Trace\MonotonicClock
+{
+    public function now(): int
+    {
+        return \hrtime(true);
+    }
+}

--- a/sdk/Trace/RealtimeClock.php
+++ b/sdk/Trace/RealtimeClock.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+// Please read the documentation on the RealtimeClock interface.
+class RealtimeClock implements \OpenTelemetry\Trace\RealtimeClock
+{
+    private const NSEC_PER_SEC = 1000000000;
+    private const NSEC_PER_USEC = 1000;
+    public function now(): int
+    {
+        \sscanf(\microtime(), '%d %d', $usec, $seconds);
+
+        return $seconds * self::NSEC_PER_SEC + $usec * self::NSEC_PER_USEC;
+    }
+}


### PR DESCRIPTION
I think this is the direction we want to go towards in our tracing package. We need two clocks: a monotonic and realtime.

A monotonic clock is used for calculating durations _only_. This should be used on Spans to calculate the duration of the span.

A realtime clock is used for getting timestamps _only_. This is should be used on Events to note the time of the event.

However, the spec currently says that a Span has a begin and end _timestamp_, so I suppose we have to use both a realtime clock and a monotonic clock on each span begin/end.

-----

I would like feedback on this direction before changing APIs and fixing tests. Notably, how do we want to represent the pair of clock values? We can pass them individually to every function, or we could store them in a `[$timestamp, $monotonic]` pair, or maybe something else?