### PR TITLE
Add Duration, Time and Timestamp SDK classes for the time values

### DIFF
--- a/api/Trace/Event.php
+++ b/api/Trace/Event.php
@@ -8,5 +8,5 @@ interface Event
 {
     public function getName(): string;
     public function getAttributes(): Attributes;
-    public function getTimestamp(): ?string;
+    public function getTimestamp(): ?Timestamp;
 }

--- a/api/Trace/Events.php
+++ b/api/Trace/Events.php
@@ -10,10 +10,10 @@ interface Events extends \IteratorAggregate, \Countable
      * Adding an event should not invalidate nor change any existing iterators.
      * @param string $name
      * @param Attributes|null $attributes
-     * @param string|null $timestamp
+     * @param Timestamp|null $timestamp
      * @return Events Must return $this to allow setting multiple attributes at once in a chain.
      */
-    public function addEvent(string $name, ?Attributes $attributes = null, ?string $timestamp = null): Events;
+    public function addEvent(string $name, ?Attributes $attributes = null, ?Timestamp $timestamp = null): Events;
 
     public function count(): int;
     public function getIterator(): EventsIterator;

--- a/api/Trace/Span.php
+++ b/api/Trace/Span.php
@@ -9,8 +9,8 @@ interface Span extends SpanStatus, SpanKind
     public function getSpanName(): string;
     public function getContext(): SpanContext;
     public function getParent(): ?SpanContext;
-    public function getStartTimestamp(): string;
-    public function getEndTimestamp(): ?string;
+    public function getStartTimestamp(): Timestamp;
+    public function getEndTimestamp(): ?Timestamp;
     public function getAttributes(): Attributes;
     public function getLinks(): Links;
     public function getEvents(): Events;
@@ -29,10 +29,10 @@ interface Span extends SpanStatus, SpanKind
     /**
      * @param string $name
      * @param Attributes|null $attributes
-     * @param string|null $timestamp
+     * @param Timestamp|null $timestamp
      * @return Span Must return $this to allow setting multiple attributes at once in a chain.
      */
-    public function addEvent(string $name, ?Attributes $attributes = null, ?string $timestamp = null): Span;
+    public function addEvent(string $name, ?Attributes $attributes = null, ?Timestamp $timestamp = null): Span;
 
     /**
      * @param SpanContext $context
@@ -58,10 +58,10 @@ interface Span extends SpanStatus, SpanKind
     public function setSpanStatus(int $code, ?string $description = null): Span;
 
     /**
-     * @param string|null $timestamp
+     * @param Timestamp|null $timestamp
      * @return Span Must return $this
      */
-    public function end(?string $timestamp = null): Span;
+    public function end(?Timestamp $timestamp = null): Span;
 
     // TODO: addLazyEvent
 }

--- a/api/Trace/SpanOptions.php
+++ b/api/Trace/SpanOptions.php
@@ -21,10 +21,10 @@ interface SpanOptions
 
     /**
      * This should only be used if the creation time has already passed; will set timestamp to current time by default
-     * @param $timestamp
+     * @param Timestamp $timestamp
      * @return mixed
      */
-    public function addStartTimestamp($timestamp): SpanOptions;
+    public function addStartTimestamp(Timestamp $timestamp): SpanOptions;
 
     public function toSpan(): Span;
     // todo: how do we want to optionally let people make these spans active? bool arg, setActive, or toActiveSpan?

--- a/api/Trace/Timestamp.php
+++ b/api/Trace/Timestamp.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Trace;
+
+interface Timestamp
+{
+}

--- a/api/Trace/Tracer.php
+++ b/api/Trace/Tracer.php
@@ -14,6 +14,6 @@ interface Tracer
     public function setActiveSpan(Span $span): void;
 
     // "finished vs "active" is a bit murky to me
-    public function finishSpan(Span $span, ?string $timestamp = null): void;
+    public function finishSpan(Span $span, ?Timestamp $timestamp = null): void;
     public function deactivateActiveSpan(): void;
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.2",
+        "php-64bit": "*",
         "ext-json": "*"
     },
     "authors": [

--- a/examples/TimeExample.php
+++ b/examples/TimeExample.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\Sdk\Internal\Duration;
+use OpenTelemetry\Sdk\Internal\Time;
+use OpenTelemetry\Sdk\Internal\Timestamp;
+
+/**
+ * Example of \OpenTelemetry\Sdk\Internal\Timestamp and \OpenTelemetry\Sdk\Internal\Duration usage
+ */
+
+// current timestamp
+$timestampNow = Timestamp::now();
+
+// timestamp ar current `time()` in seconds
+$timestampAt = Timestamp::at(time() * Time::SECOND);
+
+// Duration of 5 ms
+$duration5Ms = Duration::of(5 * Time::MILLISECOND);
+
+// Duration between two timestamps
+$duration24h = Duration::between(
+    Timestamp::at(strtotime('-24 hours') * Time::SECOND),
+    Timestamp::at(strtotime('now') * Time::SECOND)
+);
+
+// Duration time in seconds
+$seconds = $duration24h->to(Time::SECOND);

--- a/sdk/Internal/Clock.php
+++ b/sdk/Internal/Clock.php
@@ -4,18 +4,14 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Internal;
 
-use function microtime;
-
 class Clock
 {
     public function __construct()
     {
     }
 
-    public function millitime(): string
+    public function now(): Timestamp
     {
-        $millitime = microtime(true) * 1000;
-
-        return (string) $millitime;
+        return Timestamp::now();
     }
 }

--- a/sdk/Internal/Duration.php
+++ b/sdk/Internal/Duration.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Internal;
+
+use OpenTelemetry\Trace as API;
+
+final class Duration extends Time
+{
+    /**
+     * @param int $period Duration period in nanoseconds
+     * @return Duration
+     */
+    public static function of(int $period): Duration
+    {
+        return new Duration($period);
+    }
+
+    /**
+     * @param Timestamp|API\Timestamp $start
+     * @param Timestamp|API\Timestamp $end
+     * @return Duration
+     */
+    public static function between(API\Timestamp $start, API\Timestamp $end): Duration
+    {
+        // todo: check the duration is the positive number, if it's necessary
+        return $end->sub($start);
+    }
+}

--- a/sdk/Internal/Time.php
+++ b/sdk/Internal/Time.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Internal;
+
+/**
+ * Class Time
+ * Base class for Duration and Timestamp.
+ * @package OpenTelemetry\Sdk\Internal
+ */
+abstract class Time
+{
+    public const NANOSECOND = 1;
+    public const MICROSECOND = Time::NANOSECOND * 1000;
+    public const MILLISECOND = Time::MICROSECOND * 1000;
+    public const SECOND = Time::MILLISECOND * 1000;
+
+    /**
+     * @var int Time value in nanoseconds
+     */
+    protected $time;
+
+    protected function __construct(int $time)
+    {
+        $this->time = $time;
+    }
+
+    /**
+     * @param int $resolution Resolution type constant.
+     * @return int Integer value of time in appropriate resolution.
+     */
+    public function to(int $resolution): int
+    {
+        switch ($resolution) {
+            case Time::NANOSECOND:
+                return $this->time;
+            case Time::MICROSECOND:
+            case Time::MILLISECOND:
+            case Time::SECOND:
+                return (int) (round($this->time / $resolution));
+            default:
+                throw new \InvalidArgumentException('Invalid resolution');
+        }
+    }
+}

--- a/sdk/Internal/Timestamp.php
+++ b/sdk/Internal/Timestamp.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Internal;
+
+use OpenTelemetry\Trace as API;
+
+final class Timestamp extends Time implements API\Timestamp
+{
+
+    /**
+     * @var int|float Monotonic clock timestamp
+     * @see https://www.php.net/manual/en/function.hrtime
+     */
+    private $monotonic;
+
+    /**
+     * @return Timestamp Returns OpenTelemetry\Sdk\Internal\Timestamp corresponding to the current local time.
+     */
+    public static function now(): Timestamp
+    {
+        $timestamp = new Timestamp((int) (microtime(true) * Time::SECOND));
+
+        // `hrtime` is available in PHP>=7.3
+        if (function_exists('hrtime')) {
+            // save monotonic timestamp for more precise Duration calculations
+            $timestamp->monotonic = \hrtime(true);
+        }
+
+        return $timestamp;
+    }
+
+    /**
+     * @param int $nsec Number of nanoseconds elapsed since January 1, 1970 UTC.
+     * @return Timestamp Returns OpenTelemetry\Sdk\Internal\Timestamp corresponding to the given Unix time in nanoseconds.
+     */
+    public static function at(int $nsec): Timestamp
+    {
+        return new Timestamp($nsec);
+    }
+
+    /**
+     * @param Timestamp $t
+     * @return Duration Returns the OpenTelemetry\Sdk\Internal\Duration time elapsed since Timestamp `t`
+     */
+    public function sub(Timestamp $t): Duration
+    {
+        // both timestamps have monotonic values
+        if (null !== $this->monotonic && null !== $t->monotonic) {
+            if (is_float($this->monotonic)) {
+                // monotonic timestamp is a float number on 32-bit platforms
+                return Duration::of((int) (($this->monotonic - $t->monotonic) * Time::SECOND));
+            }
+
+            return Duration::of($this->monotonic - $t->monotonic);
+        }
+
+        return Duration::of($this->time - $t->time);
+    }
+}

--- a/sdk/Tests/InternalClockTest.php
+++ b/sdk/Tests/InternalClockTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\Tests;
 
 use OpenTelemetry\Sdk\Internal\Clock;
+use OpenTelemetry\Sdk\Internal\Time;
 use PHPUnit\Framework\TestCase;
 
 class InternalClockTest extends TestCase
@@ -12,11 +13,11 @@ class InternalClockTest extends TestCase
     /**
      * @test
      */
-    public function testReturnetStringRepresentMilliseconds()
+    public function testReturnedRepresentMilliseconds()
     {
         $clock = new Clock();
-        $milliseconds = $clock->millitime();
+        $milliseconds = $clock->now()->to(Time::MILLISECOND);
 
-        $this->assertGreaterThan(1e12, (float) $milliseconds);
+        $this->assertGreaterThan(1e12, $milliseconds);
     }
 }

--- a/sdk/Tests/InternalDurationTest.php
+++ b/sdk/Tests/InternalDurationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Tests;
+
+use OpenTelemetry\Sdk\Internal\Duration;
+use OpenTelemetry\Sdk\Internal\Time;
+use OpenTelemetry\Sdk\Internal\Timestamp;
+use PHPUnit\Framework\TestCase;
+
+class InternalDurationTest extends TestCase
+{
+    public function testOf()
+    {
+        $duration = Duration::of(137);
+        $this->assertEquals(137, $duration->to(Time::NANOSECOND));
+    }
+
+    public function testBetween()
+    {
+        $start = Timestamp::at(30);
+        $end = Timestamp::at(45);
+        $duration = Duration::between($start, $end);
+
+        $this->assertEquals(15, $duration->to(Time::NANOSECOND));
+    }
+}

--- a/sdk/Tests/InternalTimeTest.php
+++ b/sdk/Tests/InternalTimeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Tests;
+
+use OpenTelemetry\Sdk\Internal\Time;
+use PHPUnit\Framework\TestCase;
+
+class InternalTimeTest extends TestCase
+{
+    public function testTo()
+    {
+        $time = $this->createTime(1234567890987654321);
+        // seconds a milliseconds are rounded up
+        $this->assertEquals(1234567891, $time->to(Time::SECOND));
+        $this->assertEquals(1234567890988, $time->to(Time::MILLISECOND));
+        $this->assertEquals(1234567890987654, $time->to(Time::MICROSECOND));
+        $this->assertEquals(1234567890987654321, $time->to(Time::NANOSECOND));
+    }
+
+    private function createTime(int $time)
+    {
+        return new class($time) extends Time {
+            public function __construct(int $time)
+            {
+                parent::__construct($time);
+            }
+        };
+    }
+}

--- a/sdk/Tests/InternalTimestampTest.php
+++ b/sdk/Tests/InternalTimestampTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Tests;
+
+use OpenTelemetry\Sdk\Internal\Time;
+use OpenTelemetry\Sdk\Internal\Timestamp;
+use PHPUnit\Framework\TestCase;
+
+class InternalTimestampTest extends TestCase
+{
+    public function testNow()
+    {
+        $timestamp = Timestamp::now();
+
+        $this->assertGreaterThan(1e15, $timestamp->to(Time::NANOSECOND), 'Timestamp for current Unix time has at least 15 digits');
+    }
+
+    public function testAt()
+    {
+        $timetamp = Timestamp::at(7);
+
+        $this->assertEquals(7, $timetamp->to(Time::NANOSECOND));
+    }
+}

--- a/sdk/Tests/InternalTimestampTest.php
+++ b/sdk/Tests/InternalTimestampTest.php
@@ -14,13 +14,17 @@ class InternalTimestampTest extends TestCase
     {
         $timestamp = Timestamp::now();
 
-        $this->assertGreaterThan(1e15, $timestamp->to(Time::NANOSECOND), 'Timestamp for current Unix time has at least 15 digits');
+        $this->assertGreaterThanOrEqual(
+            19,
+            strlen(sprintf('%d', $timestamp->to(Time::NANOSECOND))),
+            'Timestamp for current Unix time has at least 19 digits'
+        );
     }
 
     public function testAt()
     {
-        $timetamp = Timestamp::at(7);
+        $timestamp = Timestamp::at(7);
 
-        $this->assertEquals(7, $timetamp->to(Time::NANOSECOND));
+        $this->assertEquals(7, $timestamp->to(Time::NANOSECOND));
     }
 }

--- a/sdk/Tests/TracingTest.php
+++ b/sdk/Tests/TracingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Tests;
 
+use OpenTelemetry\Sdk\Internal\Time;
 use OpenTelemetry\Sdk\Trace as SDK;
 use OpenTelemetry\Sdk\Trace\Attribute;
 use OpenTelemetry\Sdk\Trace\Attributes;
@@ -88,7 +89,7 @@ class TracingTest extends TestCase
 
         // subsequent calls to end should be ignored
         $mysql->end();
-        self::assertSame($duration, $mysql->getDuration());
+        self::assertEquals($duration->to(Time::NANOSECOND), $mysql->getDuration()->to(Time::NANOSECOND));
 
         self::assertTrue($mysql->isStatusOK());
         

--- a/sdk/Trace/Event.php
+++ b/sdk/Trace/Event.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace;
 
-use OpenTelemetry\Sdk\Internal\Clock;
+use OpenTelemetry\Sdk\Internal\Timestamp;
 use OpenTelemetry\Trace as API;
 
 class Event implements API\Event
@@ -13,11 +13,10 @@ class Event implements API\Event
     private $timestamp;
     private $attributes;
 
-    // todo: pick datatype for timestamp
-    public function __construct(string $name, ?API\Attributes $attributes = null, string $timestamp = null)
+    public function __construct(string $name, ?API\Attributes $attributes = null, API\Timestamp $timestamp = null)
     {
         if (null === $timestamp) {
-            $timestamp = (new Clock())->millitime();
+            $timestamp = Timestamp::now();
         }
         $this->name = $name;
         $this->timestamp = $timestamp;
@@ -41,7 +40,7 @@ class Event implements API\Event
         return $this->name;
     }
 
-    public function getTimestamp(): string
+    public function getTimestamp(): API\Timestamp
     {
         return $this->timestamp;
     }

--- a/sdk/Trace/Events.php
+++ b/sdk/Trace/Events.php
@@ -13,7 +13,7 @@ class Events implements API\Events
     public function addEvent(
         string $name,
         ?API\Attributes $attributes = null,
-        ?string $timestamp = null
+        ?API\Timestamp $timestamp = null
     ): API\Events {
         $this->events[] = new Event($name, $attributes, $timestamp);
 

--- a/sdk/Trace/SpanOptions.php
+++ b/sdk/Trace/SpanOptions.php
@@ -17,7 +17,7 @@ final class SpanOptions implements API\SpanOptions
     private $attributes = null;
     private $links = null;
 
-    /** @var string|null */
+    /** @var API\Timestamp|null */
     private $start = null;
 
     public function __construct(Tracer $tracer, string $name)
@@ -67,7 +67,7 @@ final class SpanOptions implements API\SpanOptions
         return $this;
     }
 
-    public function addStartTimestamp($timestamp): API\SpanOptions
+    public function addStartTimestamp(API\Timestamp $timestamp): API\SpanOptions
     {
         $this->start = $timestamp;
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -98,14 +98,14 @@ class Tracer implements API\Tracer
         return $this->spans;
     }
 
-    public function endActiveSpan(?string $timestamp = null)
+    public function endActiveSpan(?API\Timestamp $timestamp = null)
     {
         /**
          * a span should be ended before is sent to exporters, because the exporters need's span duration.
          */
         $span = $this->getActiveSpan();
         $wasRecording = $span->isRecording();
-        $span->end();
+        $span->end($timestamp);
 
         if ($wasRecording) {
             foreach ($this->spanProcessors as $spanProcessor) {
@@ -131,7 +131,7 @@ class Tracer implements API\Tracer
         return new SpanOptions($this, $name);
     }
 
-    public function finishSpan(API\Span $span, ?string $timestamp = null): void
+    public function finishSpan(API\Span $span, ?API\Timestamp $timestamp = null): void
     {
         // TODO: Implement finishSpan() method.
     }

--- a/tests/unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\Trace\SpanProcessor;
 
 use OpenTelemetry\Sdk\Internal\Clock;
+use OpenTelemetry\Sdk\Internal\Time;
+use OpenTelemetry\Sdk\Internal\Timestamp;
 use OpenTelemetry\Sdk\Trace\BatchSpanProcessor;
 use OpenTelemetry\Sdk\Trace\Exporter;
 use OpenTelemetry\Sdk\Trace\Span;
@@ -29,7 +31,7 @@ class BatchSpanProcessorTest extends TestCase
         $exporter->expects($this->at(0))->method('export')->with($spans);
 
         $clock = self::createMock(Clock::class);
-        $clock->method('millitime')->will($this->returnValue((string) ($exportDelay + 1)));
+        $clock->method('now')->will($this->returnValue(Timestamp::at(($exportDelay + 1) * Time::MILLISECOND)));
 
         $exporter->expects($this->atLeastOnce())->method('export');
 
@@ -50,7 +52,7 @@ class BatchSpanProcessorTest extends TestCase
         $exporter = self::createMock(Exporter::class);
         $exporter->expects($this->exactly(0))->method('export');
         $clock = self::createMock(Clock::class);
-        $clock->method('millitime')->will($this->returnValue((string) ($exportDelay + 1)));
+        $clock->method('now')->will($this->returnValue(Timestamp::at(($exportDelay + 1) * Time::MILLISECOND)));
 
         $processor = new BatchSpanProcessor($exporter, $clock, $batchSize, $exportDelay, 3000, $batchSize);
 
@@ -70,7 +72,7 @@ class BatchSpanProcessorTest extends TestCase
 
         $exportDelay = 2;
         $clock = self::createMock(Clock::class);
-        $clock->method('millitime')->will($this->returnValue((string) ($exportDelay - 1)));
+        $clock->method('now')->will($this->returnValue(Timestamp::at(($exportDelay - 1) * Time::MILLISECOND)));
 
         $processor = new BatchSpanProcessor($exporter, $clock, $batchSize, $exportDelay, 3000, $batchSize);
 


### PR DESCRIPTION
Added an `API\Timestamp` interface to reference it in other API interfaces and SDK classes.

Added an abstract class `OpenTelemetry\Sdk\Internal\Time` to represent "a time" value (a timestamp as a elapsed time since UNIX epoch or a duration as an absolute time period).

Internally time is stored in nanoseconds as an `int` value (64-bit is required in `composer.json`).

`OpenTelemetry\Sdk\Internal\Timestamp` is used to store a number of nanoseconds since UNIX epoch time. It also saves a current monotonic timestamp using `\hrtime()` (available in PHP>=7.3, not required).

See `examples/TimeExample.php` for usage example.