### PR TITLE
Correct relative link to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To make sure the tests in this repo work as you expect, you can use the included
 Execute `make test` from your bash compatible shell.  This will output the test output as well as a test coverage analysis.  Code that doesn't pass our currently defined tests will emit a failure in CI
 
 ## Examples
-You can use the [examples/AlwaysSampleTraceExample.php](/open-telemetry/opentelemetry-php/blob/master/examples/AlwaysOnTraceExample.php) file to test out the reference implementation we have.  This example perfoms a sample trace with a grouping of 5 spans and POSTs the result to a local zipkin instance.
+You can use the [examples/AlwaysSampleTraceExample.php](/examples/AlwaysOnTraceExample.php) file to test out the reference implementation we have.  This example perfoms a sample trace with a grouping of 5 spans and POSTs the result to a local zipkin instance.
 
 The PHP should execute by itself (if you have a zipkin instance running on localhost), but if you'd like a no-fuss way to test this out with docker and docker-compose, you can perform the following simple steps:
 


### PR DESCRIPTION
Hi all,

While the title is pretty self explanatory, the link to `examples/AlwaysOnTraceExample.php` is broken in the README. This commit corrects the relative path to always be correct for a given fork/branch.

Thanks!