### PR TITLE
Initial Correlation Context API Definition

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -357,6 +357,7 @@ return [
     // your application should be included in this list.
     'directory_list' => [
         'api',
+        'Context',
         'sdk',
         'vendor/composer/xdebug-handler/src',
         'vendor/guzzlehttp',

--- a/Context/Context.php
+++ b/Context/Context.php
@@ -9,7 +9,7 @@ class Context
     /**
      * @var ContextKey|null
      */
-    private $key;
+    protected $key;
 
     /**
      * @var mixed|null

--- a/Context/Context.php
+++ b/Context/Context.php
@@ -34,6 +34,7 @@ class Context
      * @param ContextKey $key
      * @param mixed $value
      *
+     * @param Context|null $parent
      * @return Context
      */
     public static function setValue(ContextKey $key, $value, ?Context $parent=null): Context
@@ -87,6 +88,7 @@ class Context
     }
 
     /**
+     * @param Context $ctx
      * @return callable
      */
     public static function attach(Context $ctx): callable
@@ -100,19 +102,11 @@ class Context
     }
 
     /**
+     * @param callable $token
+     * @return Context
      */
     public static function detach(callable $token): Context
     {
         return self::$current_context = call_user_func($token);
-    }
-
-    /**
-     * @param Context $parent
-     *
-     * @return null
-     */
-    protected function setParent(Context $parent)
-    {
-        $this->parent = $parent;
     }
 }

--- a/Context/Context.php
+++ b/Context/Context.php
@@ -105,4 +105,14 @@ class Context
     {
         return self::$current_context = call_user_func($token);
     }
+
+    /**
+     * @param Context $parent
+     *
+     * @return null
+     */
+    protected function setParent(Context $parent)
+    {
+        $this->parent = $parent;
+    }
 }

--- a/api/CorrelationContext/CorrelationContext.php
+++ b/api/CorrelationContext/CorrelationContext.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\CorrelationContext;
+
+use OpenTelemetry\Context\Context;
+
+interface CorrelationContext
+{
+    public function getCorrelations(); // TODO
+    public function get(ContextKey $key);
+    public static function getValue(ContextKey $key, ?Context $ctx);
+    public function set(ContextKey $key, $value): Context;
+    public static function setValue(ContextKey $key, $value, ?Context $parent=null): Context;
+    public function removeCorrelation(): Context;
+    public function clearCorrelations(); // TODO
+}

--- a/api/CorrelationContext/CorrelationContext.php
+++ b/api/CorrelationContext/CorrelationContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\CorrelationContext;
 
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKey;
 
 interface CorrelationContext
 {

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     "autoload": {
         "psr-4": {
             "OpenTelemetry\\Context\\": "Context",
-            "OpenTelemetry\\api\\CorrelationContext\\": "api/CorrelationContext",
-            "OpenTelemetry\\sdk\\CorrelationContext\\": "sdk/CorrelationContext",
+            "OpenTelemetry\\Sdk\\CorrelationContext\\": "sdk/CorrelationContext",
             "OpenTelemetry\\Trace\\": "api/Trace",
             "OpenTelemetry\\Sdk\\Trace\\": "sdk/Trace",
             "OpenTelemetry\\Sdk\\Resource\\": "sdk/Resource"

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,9 @@
     "autoload": {
         "psr-4": {
             "OpenTelemetry\\Context\\": "Context",
+            "OpenTelemetry\\api\\CorrelationContext\\": "api/CorrelationContext",
+            "OpenTelemetry\\sdk\\CorrelationContext\\": "sdk/CorrelationContext",
             "OpenTelemetry\\Trace\\": "api/Trace",
-            "OpenTelemetry\\Sdk\\Internal\\": "sdk/Internal",
             "OpenTelemetry\\Sdk\\Trace\\": "sdk/Trace",
             "OpenTelemetry\\Sdk\\Resource\\": "sdk/Resource"
         }

--- a/sdk/CorrelationContext/CorrelationContext.php
+++ b/sdk/CorrelationContext/CorrelationContext.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\CorrelationContext;
+
+use OpenTelemetry\Context\Context;
+
+class CorrelationContext implements Context
+{
+    /**
+     * @param Context $context
+     *
+     * @return Generator|mixed[]
+     */
+    public function getCorrelations($context = null)
+    {
+        // TODO: Write me
+    }
+
+    /**
+     * @param ContextKey $key
+     *
+     * @return Context
+     */
+    public function removeCorrelation(ContextKey $key): Context
+    {
+        if ($this->key === $key) {
+            return $this->parent;
+        }
+
+        $this->removeCorrelationHelper($key, null);
+        return $this;
+    }
+
+    private function removeCorrelationHelper(ContextKey $key, Context $child)
+    {
+        if ($this->key != $key) {
+            if (is_null($this->parent)) {
+                return;
+            }
+
+            $this->parent->removeCorrelationHelper($key, $this);
+        }
+
+        $child->setParent($this->parent);
+    }
+
+    public function clearCorrelations()
+    {
+        // TODO: Write me
+    }
+}

--- a/sdk/CorrelationContext/CorrelationContext.php
+++ b/sdk/CorrelationContext/CorrelationContext.php
@@ -6,7 +6,6 @@ namespace OpenTelemetry\Sdk\CorrelationContext;
 
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextKey;
-
 class CorrelationContext extends Context
 {
     /**

--- a/sdk/CorrelationContext/CorrelationContext.php
+++ b/sdk/CorrelationContext/CorrelationContext.php
@@ -30,13 +30,14 @@ class CorrelationContext implements Context
         }
 
         $this->removeCorrelationHelper($key, null);
+
         return $this;
     }
 
     private function removeCorrelationHelper(ContextKey $key, Context $child)
     {
         if ($this->key != $key) {
-            if (is_null($this->parent)) {
+            if (null === $this->parent) {
                 return;
             }
 

--- a/sdk/CorrelationContext/CorrelationContext.php
+++ b/sdk/CorrelationContext/CorrelationContext.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\CorrelationContext;
 
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKey;
 
-class CorrelationContext implements Context
+class CorrelationContext extends Context
 {
     /**
+     * @var CorrelationContext|null
+     */
+    private $parent;
+
+    /**
      * @param Context $context
-     *
-     * @return Generator|mixed[]
      */
     public function getCorrelations($context = null)
     {
@@ -34,7 +38,7 @@ class CorrelationContext implements Context
         return $this;
     }
 
-    private function removeCorrelationHelper(ContextKey $key, Context $child)
+    private function removeCorrelationHelper(ContextKey $key, ?Context $child)
     {
         if ($this->key != $key) {
             if (null === $this->parent) {

--- a/tests/unit/CorrelationContext/CorrelationContextTest.php
+++ b/tests/unit/CorrelationContext/CorrelationContextTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\CorrelationContext;
 
-
-use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextKey;
-use OpenTelemetry\sdk\CorrelationContext\CorrelationContext;
+use OpenTelemetry\Sdk\CorrelationContext\CorrelationContext;
 use PHPUnit\Framework\TestCase;
 
 class CorrelationContextTest extends TestCase
@@ -41,8 +39,13 @@ class CorrelationContextTest extends TestCase
         $key2 = new ContextKey('key2');
         $key3 = new ContextKey('key3');
         $key4 = new ContextKey('key4');
-        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2')->set($key3, 'val3')->set($key4, 'val4');
+        $ctx = (new CorrelationContext())->
+            set($key1, 'val1')->
+            set($key2, 'val2')->
+            set($key3, 'val3')->
+            set($key4, 'val4');
         $result = $ctx->removeCorrelation($key3);
-        print_r($result);
+        //print_r($result);
+        //4 keys, 2keys, 1key, 0keys
     }
 }

--- a/tests/unit/CorrelationContext/CorrelationContextTest.php
+++ b/tests/unit/CorrelationContext/CorrelationContextTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\CorrelationContext;
+
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Sdk\CorrelationContext\CorrelationContext;
+use PHPUnit\Framework\TestCase;
+
+class CorrelationContextTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getCorrelationsTest()
+    {
+        //todo
+    }
+
+    /**
+     * @test
+     */
+    public function getTest()
+    {
+
+        $key1 = new ContextKey('key1');
+        $key2 = new ContextKey('key2');
+        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
+        $this->assertSame($ctx->get($key1), 'val1');
+        $this->assertSame($ctx->get($key2), 'val2');
+    }
+
+    /**
+     * @test
+     */
+    public function correlationRemovalTest()
+    {
+        $key1 = new ContextKey('key1');
+        $key2 = new ContextKey('key2');
+        $key3 = new ContextKey('key3');
+        $key4 = new ContextKey('key4');
+        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2')->set($key3, 'val3')->set($key4, 'val4');
+        $result = $this->removeCorrelation($key3);
+        print_r($result);
+    }
+}

--- a/tests/unit/CorrelationContext/CorrelationContextTest.php
+++ b/tests/unit/CorrelationContext/CorrelationContextTest.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\Tests\Unit\CorrelationContext;
 
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextKey;
-use OpenTelemetry\Sdk\CorrelationContext\CorrelationContext;
+use OpenTelemetry\sdk\CorrelationContext\CorrelationContext;
 use PHPUnit\Framework\TestCase;
 
 class CorrelationContextTest extends TestCase
@@ -27,7 +27,7 @@ class CorrelationContextTest extends TestCase
     {
         $key1 = new ContextKey('key1');
         $key2 = new ContextKey('key2');
-        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
+        $ctx = (new CorrelationContext())->set($key1, 'val1')->set($key2, 'val2');
         $this->assertSame($ctx->get($key1), 'val1');
         $this->assertSame($ctx->get($key2), 'val2');
     }

--- a/tests/unit/CorrelationContext/CorrelationContextTest.php
+++ b/tests/unit/CorrelationContext/CorrelationContextTest.php
@@ -25,7 +25,6 @@ class CorrelationContextTest extends TestCase
      */
     public function getTest()
     {
-
         $key1 = new ContextKey('key1');
         $key2 = new ContextKey('key2');
         $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
@@ -43,7 +42,7 @@ class CorrelationContextTest extends TestCase
         $key3 = new ContextKey('key3');
         $key4 = new ContextKey('key4');
         $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2')->set($key3, 'val3')->set($key4, 'val4');
-        $result = $this->removeCorrelation($key3);
+        $result = $ctx->removeCorrelation($key3);
         print_r($result);
     }
 }


### PR DESCRIPTION
This is my initial stab at the Correlation Context API Definition.  I have a couple questions for the other contributors:

1.  How are we planning on passing the `$Context` variable around?  I have it earmarked here as an array, as that feels like the right data type to me.  The spec for Context is delivered [here](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/context.md) - I'm planning on stubbing it out in a subsequent PR.

2.  Where should we implement this?  It looks like other sigs have implemented it in different places within their repositories.  As an example, [Python](https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-api/src/opentelemetry) implemented `Context` right next to `CorrelationContext` - this doesn't feel natural for our repo setup.  I'm open to options here.  Context is defined [here](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/context.md)

3.  We'll need to discuss how and where we want to implement [Serialization](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/correlationcontext/api.md#serialization).
