### PR TITLE
Implement SpanProcessor::shutdown()

### DIFF
--- a/sdk/Trace/JaegerExporter.php
+++ b/sdk/Trace/JaegerExporter.php
@@ -26,6 +26,11 @@ class JaegerExporter implements Exporter
      */
     private $spanConverter;
 
+    /**
+     * @var bool
+     */
+    private $running = true;
+
     public function __construct($name, string $endpointUrl, SpanConverter $spanConverter = null)
     {
         $url = parse_url($endpointUrl);
@@ -61,6 +66,10 @@ class JaegerExporter implements Exporter
      */
     public function export(iterable $spans) : int
     {
+        if (!$this->running) {
+            return Exporter::FAILED_NOT_RETRYABLE;
+        }
+
         if (empty($spans)) {
             return Exporter::SUCCESS;
         }
@@ -90,6 +99,6 @@ class JaegerExporter implements Exporter
 
     public function shutdown(): void
     {
-        // TODO: Implement shutdown() method.
+        $this->running = false;
     }
 }

--- a/sdk/Trace/SimpleSpanProcessor.php
+++ b/sdk/Trace/SimpleSpanProcessor.php
@@ -9,11 +9,16 @@ use OpenTelemetry\Trace as API;
 class SimpleSpanProcessor implements SpanProcessor
 {
     /**
-     * @var Exporter
+     * @var Exporter|null
      */
     private $exporter;
 
-    public function __construct(Exporter $exporter)
+    /**
+     * @var bool
+     */
+    private $running = true;
+
+    public function __construct(?Exporter $exporter)
     {
         $this->exporter = $exporter;
     }
@@ -23,7 +28,6 @@ class SimpleSpanProcessor implements SpanProcessor
      */
     public function onStart(API\Span $span): void
     {
-        // nothing to do here
     }
 
     /**
@@ -31,9 +35,20 @@ class SimpleSpanProcessor implements SpanProcessor
      */
     public function onEnd(API\Span $span): void
     {
-        // @todo only spans with SampleFlag === true should be exported according to
-        // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-tracing.md#sampling
-        $this->exporter->export([$span]);
+        if ($this->running) {
+            // @todo only spans with SampleFlag === true should be exported according to
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-tracing.md#sampling
+            if (null !== $this->exporter) {
+                $this->exporter->export([$span]);
+            }
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function forceFlush(): void
+    {
     }
 
     /**
@@ -41,6 +56,10 @@ class SimpleSpanProcessor implements SpanProcessor
      */
     public function shutdown(): void
     {
-        // TODO: Implement shutdown() method.
+        $this->running = false;
+
+        if (null !== $this->exporter) {
+            $this->exporter->shutdown();
+        }
     }
 }

--- a/sdk/Trace/SpanMultiProcessor.php
+++ b/sdk/Trace/SpanMultiProcessor.php
@@ -50,4 +50,11 @@ final class SpanMultiProcessor implements SpanProcessor
             $processor->shutdown();
         }
     }
+
+    public function forceFlush(): void
+    {
+        foreach ($this->processors as $processor) {
+            $processor->forceFlush();
+        }
+    }
 }

--- a/sdk/Trace/SpanProcessor.php
+++ b/sdk/Trace/SpanProcessor.php
@@ -23,7 +23,12 @@ interface SpanProcessor
     public function onEnd(API\Span $span): void;
 
     /**
-     * Cleanup; after shutdown, calling onStart or onEnd is invalid
+     * Export all ended spans to the configured Exporter that have not yet been exported.
+     */
+    public function forceFlush(): void;
+
+    /**
+     * Cleanup; after shutdown, calling onStart, onEnd, or forceFlush is invalid
      */
     public function shutdown(): void;
 }

--- a/sdk/Trace/TracerProvider.php
+++ b/sdk/Trace/TracerProvider.php
@@ -29,6 +29,12 @@ final class TracerProvider implements API\TracerProvider
     {
         $this->spanProcessors = new SpanMultiProcessor();
         $this->resource = $resource ?? ResourceInfo::emptyResource();
+        register_shutdown_function([$this, 'shutdown']);
+    }
+
+    public function shutdown(): void
+    {
+        $this->spanProcessors->shutdown();
     }
 
     public function getTracer(string $name, ?string $version = ''): API\Tracer

--- a/sdk/Trace/ZipkinExporter.php
+++ b/sdk/Trace/ZipkinExporter.php
@@ -28,6 +28,11 @@ class ZipkinExporter implements Exporter
      */
     private $spanConverter;
 
+    /**
+     * @var bool
+     */
+    private $running = true;
+
     public function __construct($name, string $endpointUrl, SpanConverter $spanConverter = null)
     {
         $parsedDsn = parse_url($endpointUrl);
@@ -58,6 +63,10 @@ class ZipkinExporter implements Exporter
      */
     public function export(iterable $spans): int
     {
+        if (!$this->running) {
+            return Exporter::FAILED_NOT_RETRYABLE;
+        }
+
         if (empty($spans)) {
             return Exporter::SUCCESS;
         }
@@ -92,6 +101,6 @@ class ZipkinExporter implements Exporter
 
     public function shutdown(): void
     {
-        // TODO: Implement shutdown() method.
+        $this->running = false;
     }
 }

--- a/tests/unit/Exporter/JaegerExporterTest.php
+++ b/tests/unit/Exporter/JaegerExporterTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\Exporter;
 
 use InvalidArgumentException;
 use OpenTelemetry\Sdk\Trace\JaegerExporter;
+use OpenTelemetry\Sdk\Trace\Span;
 use PHPUnit\Framework\TestCase;
 
 class JaegerExporterTest extends TestCase
@@ -18,7 +19,7 @@ class JaegerExporterTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new JaegerExporter('test.zipkin', $invalidDsn);
+        new JaegerExporter('test.jaeger', $invalidDsn);
     }
 
     public function invalidDsnDataProvider()
@@ -33,5 +34,17 @@ class JaegerExporterTest extends TestCase
             'invalid host' => ['scheme:///end:1234/path'],
             'unimplemented path' => ['scheme:///host:1234/api/v1/spans'],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function failsIfNotRunning()
+    {
+        $exporter = new JaegerExporter('test.jaeger', 'scheme://host:123/api/v1/spans');
+        $span = $this->createMock(Span::class);
+        $exporter->shutdown();
+
+        $this->assertEquals($exporter->export([$span]), \OpenTelemetry\Sdk\Trace\Exporter::FAILED_NOT_RETRYABLE);
     }
 }

--- a/tests/unit/Exporter/ZipkinExporterTest.php
+++ b/tests/unit/Exporter/ZipkinExporterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\Exporter;
 
 use InvalidArgumentException;
+use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\ZipkinExporter;
 use PHPUnit\Framework\TestCase;
 
@@ -32,5 +33,17 @@ class ZipkinExporterTest extends TestCase
             'invalid scheme' => ['1234://host:port/path'],
             'invalid host' => ['scheme:///end:1234/path'],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function failsIfNotRunning()
+    {
+        $exporter = new ZipkinExporter('test.jaeger', 'scheme://host:123/path');
+        $span = $this->createMock(Span::class);
+        $exporter->shutdown();
+
+        $this->assertEquals($exporter->export([$span]), \OpenTelemetry\Sdk\Trace\Exporter::FAILED_NOT_RETRYABLE);
     }
 }

--- a/tests/unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -15,11 +15,13 @@ class BatchSpanProcessorTest extends TestCase
     /**
      * @test
      */
-    public function shouldExportIfBatchLimitIsReached()
+    public function shouldExportIfBatchLimitIsReachedButDelayNotReached()
     {
         $batchSize = 3;
-        $exportDelay = 1;
+        $queueSize = 5; // queue is larger than batch
+        $exportDelay = 3;
         $spans = [];
+        $timeout = 3000;
 
         for ($i = 0; $i < $batchSize; $i++) {
             $spans[] = self::createMock(Span::class);
@@ -27,15 +29,15 @@ class BatchSpanProcessorTest extends TestCase
 
         $exporter = self::createMock(Exporter::class);
         $exporter->expects($this->at(0))->method('export')->with($spans);
-
-        $clock = self::createMock(Clock::class);
-        $clock->method('timestamp')->will($this->returnValue(($exportDelay + 1)));
-
         $exporter->expects($this->atLeastOnce())->method('export');
+
+        // Export will still happen even if clock will never trigger the batch
+        $clock = self::createMock(Clock::class);
+        $clock->method('timestamp')->will($this->returnValue(($exportDelay - 1)));
 
         /** @var \OpenTelemetry\Sdk\Trace\Exporter $exporter */
         /** @var \OpenTelemetry\Sdk\Trace\Clock $clock */
-        $processor = new BatchSpanProcessor($exporter, $clock, $batchSize, $exportDelay, 3000, $batchSize);
+        $processor = new BatchSpanProcessor($exporter, $clock, $queueSize, $exportDelay, $timeout, $batchSize);
 
         foreach ($spans as $span) {
             $processor->onEnd($span);
@@ -45,19 +47,57 @@ class BatchSpanProcessorTest extends TestCase
     /**
      * @test
      */
-    public function shouldNotExportIfSpanBatchDidntReachedLimit()
+    public function shouldExportIfDelayLimitReachedButBatchSizeNotReached()
     {
-        $batchSize = 3;
+        $batchSize = 4;
+        $queueSize = 5;
         $exportDelay = 1;
+        $timeout = 3000;
+
+        for ($i = 0; $i < $batchSize - 1; $i++) {
+            $spans[] = self::createMock(Span::class);
+        }
+
         $exporter = self::createMock(Exporter::class);
-        $exporter->expects($this->exactly(0))->method('export');
+        $exporter->expects($this->exactly(1))->method('export')->with($spans);
+
+        // The clock will be "before" the delay until the final call, then the timeout will trigger
         $clock = self::createMock(Clock::class);
-        $clock->method('timestamp')->will($this->returnValue(($exportDelay + 1)));
+        for ($i = 0; $i < count($spans) - 1; $i++) {
+            $clock->expects($this->at($i))->method('timestamp')->will($this->returnValue(($exportDelay - 1)));
+        }
+        $clock->expects($this->at(count($spans) - 1))->method('timestamp')->will($this->returnValue(($exportDelay + 1)));
 
         /** @var \OpenTelemetry\Sdk\Trace\Exporter $exporter */
         /** @var \OpenTelemetry\Sdk\Trace\Clock $clock */
         /** @var \OpenTelemetry\Sdk\Trace\BatchSpanProcessor $processor */
-        $processor = new BatchSpanProcessor($exporter, $clock, $batchSize, $exportDelay, 3000, $batchSize);
+        $processor = new BatchSpanProcessor($exporter, $clock, $queueSize, $exportDelay, $timeout, $batchSize);
+
+        foreach ($spans as $span) {
+            /** @var \OpenTelemetry\Sdk\Trace\Span $mock_span */
+            $processor->onEnd($span);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotExportIfNotEnoughTimePassedAndBatchNotFull()
+    {
+        $batchSize = 3;
+        $queueSize = 5;
+        $exportDelay = 2;
+        $timeout = 3000;
+
+        $clock = self::createMock(Clock::class);
+        $clock->method('timestamp')->will($this->returnValue(($exportDelay - 1)));
+
+        $exporter = self::createMock(Exporter::class);
+        $exporter->expects($this->exactly(0))->method('export');
+
+        /** @var \OpenTelemetry\Sdk\Trace\Exporter $exporter */
+        /** @var \OpenTelemetry\Sdk\Trace\Clock $clock */
+        $processor = new BatchSpanProcessor($exporter, $clock, $queueSize, $exportDelay, $timeout, $batchSize);
 
         for ($i = 0; $i < $batchSize - 1; $i++) {
             $mock_span = self::createMock(Span::class);
@@ -69,24 +109,80 @@ class BatchSpanProcessorTest extends TestCase
     /**
      * @test
      */
-    public function shouldNotExportIfNotEnoughTimePassedSinceLastExport()
+    public function shouldAllowNullExporter()
+    {
+        $proc = new BatchSpanProcessor(null, self::createMock(Clock::class));
+        $span = self::createMock(Span::class);
+        $proc->onStart($span);
+        $proc->onEnd($span);
+        $proc->forceFlush();
+        $proc->shutdown();
+        $this->assertTrue(true); // phpunit requires an assertion
+    }
+
+    /**
+     * @test
+     */
+    public function forceFlushExportsAllEndedSpans()
     {
         $batchSize = 3;
-        $exporter = self::createMock(Exporter::class);
-        $exporter->expects($this->exactly(0))->method('export');
-
+        $queueSize = 3;
         $exportDelay = 2;
+        $timeout = 3000;
+
         $clock = self::createMock(Clock::class);
         $clock->method('timestamp')->will($this->returnValue(($exportDelay - 1)));
 
+        $exporter = self::createMock(Exporter::class);
         /** @var \OpenTelemetry\Sdk\Trace\Exporter $exporter */
         /** @var \OpenTelemetry\Sdk\Trace\Clock $clock */
-        $processor = new BatchSpanProcessor($exporter, $clock, $batchSize, $exportDelay, 3000, $batchSize);
+        $processor = new BatchSpanProcessor($exporter, $clock, $queueSize, $exportDelay, $timeout, $batchSize);
 
-        for ($i = 0; $i < $batchSize; $i++) {
-            $mock_span = self::createMock(Span::class);
+        $spans = [];
+        for ($i = 0; $i < $batchSize - 1; $i++) {
+            $span = self::createMock(Span::class);
+            $spans[] = $span;
             /** @var \OpenTelemetry\Sdk\Trace\Span $mock_span */
-            $processor->onEnd($mock_span);
+            $processor->onEnd($span);
         }
+
+        $exporter->expects($this->exactly(1))->method('export')->with($spans);
+        $processor->forceFlush();
+    }
+
+    /**
+     * @test
+     */
+    public function shutdownCallsExporterShutdown()
+    {
+        $exporter = self::createMock(Exporter::class);
+        $proc = new BatchSpanProcessor($exporter, self::createMock(Clock::class));
+
+        $exporter->expects($this->exactly(1))->method('shutdown');
+        $proc->shutdown();
+    }
+
+    /**
+     * @test
+     */
+    public function noExportAfterShutdown()
+    {
+        $exporter = self::createMock(Exporter::class);
+        // grap a reference to the InvocationOrder object so we can inspect/assert *when* the call happens
+        $exporter->expects($spy = $this->exactly(1))->method('shutdown');
+
+        $this->assertEquals(0, $spy->getInvocationCount());
+
+        $proc = new BatchSpanProcessor($exporter, self::createMock(Clock::class));
+        $proc->shutdown();
+        // calling SpanProcessor's shutdown() calls Exporter's shutdown()
+        $this->assertEquals(1, $spy->getInvocationCount());
+
+        $span = self::createMock(Span::class);
+        $proc->onStart($span);
+        $proc->onEnd($span);
+
+        // calling onEnd here does NOT result in another call to shutdown
+        $this->assertEquals(1, $spy->getInvocationCount());
     }
 }

--- a/tests/unit/Trace/SpanProcessor/SimpleSpanProcessorTest.php
+++ b/tests/unit/Trace/SpanProcessor/SimpleSpanProcessorTest.php
@@ -23,4 +23,54 @@ class SimpleSpanProcessorTest extends TestCase
             self::createMock(Span::class)
         );
     }
+
+    /**
+     * @test
+     */
+    public function shouldAllowNullExporter()
+    {
+        $proc = new SimpleSpanProcessor(null);
+        $span = self::createMock(Span::class);
+        $proc->onStart($span);
+        $proc->onEnd($span);
+        $proc->forceFlush();
+        $proc->shutdown();
+        $this->assertTrue(true); // phpunit requires an assertion
+    }
+
+    /**
+     * @test
+     */
+    public function shutdownCallsExporterShutdown()
+    {
+        $exporter = self::createMock(Exporter::class);
+        $proc = new SimpleSpanProcessor($exporter);
+
+        $exporter->expects($this->exactly(1))->method('shutdown');
+        $proc->shutdown();
+    }
+
+    /**
+     * @test
+     */
+    public function noExportAfterShutdown()
+    {
+        $exporter = self::createMock(Exporter::class);
+        // grap a reference to the InvocationOrder object so we can inspect/assert *when* the call happens
+        $exporter->expects($spy = $this->exactly(1))->method('shutdown');
+
+        $this->assertEquals(0, $spy->getInvocationCount());
+
+        $proc = new SimpleSpanProcessor($exporter);
+        $proc->shutdown();
+        // calling SpanProcessor's shutdown() calls Exporter's shutdown()
+        $this->assertEquals(1, $spy->getInvocationCount());
+
+        $span = self::createMock(Span::class);
+        $proc->onStart($span);
+        $proc->onEnd($span);
+
+        // calling onEnd here does NOT result in another call to shutdown
+        $this->assertEquals(1, $spy->getInvocationCount());
+    }
 }

--- a/tests/unit/Trace/TracingTest.php
+++ b/tests/unit/Trace/TracingTest.php
@@ -99,10 +99,10 @@ class TracingTest extends TestCase
         self::assertSame($duration, $mysql->getDuration());
 
         self::assertTrue($mysql->isStatusOK());
-        
+
         // active span rolled back
         $this->assertSame($tracer->getActiveSpan(), $global);
-        
+
         // active span should be kept for global span
         $global->end();
         $this->assertSame($tracer->getActiveSpan(), $global);


### PR DESCRIPTION
The diff isn't crazy big here, but unfortunately there are several logical changes combined. None of the individual moving parts would make sense without the bigger picture of what they enabled, so it may actually be hard to review in chunks without seeing the end state but I'm happy to break the PR up into logical chunks if desired.

This change also:
- Implements `shutdown()` for `SimpleSpanProcessor` and `BatchSpanProcessor`
- Implements `shutdown()` for the Jaeger and Zipkin Exporter implementations
- Makes Exporters optional for `SpanProcessors` (per spec)
- Changes the `BatchSpanProcessor` such that if *either* the configured batch size OR
the configured delay is reached, then a batch is sent, both are no longer required
- Adds `SpanProcessor::forceFlush()` (per spec)

I didn't see any logging in our existing code. Some of the other language libraries do some logging amount of logging (for example when `SpanProcessor`'s `$maxQueueSize` is reached. I've never authored a php library so I wasn't sure if good solutions exist to enable us to log that don't stomp on the app developers integration.

This would close: https://github.com/open-telemetry/opentelemetry-php/issues/85