### PR TITLE
Phpcs fix in shell script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: php
 os: linux
 
@@ -17,12 +17,7 @@ before_script:
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
 script:
-    - |
-        IFS='
-        '
-        CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
-        if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); else EXTRA_ARGS=''; fi
-        vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}
+    - .travis/phpcs.sh
     - vendor/bin/phan
     - xdebug-enable
     - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.travis/phpcs.sh
+++ b/.travis/phpcs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")
+GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
+
+if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then
+  EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}");
+else
+  EXTRA_ARGS='';
+fi
+
+echo php-cs-fixer binary     :  ${GIT_ROOT_DIR}/vendor/bin/php-cs-fixer
+echo php-cs-fixer config file:  ${GIT_ROOT_DIR}/.php_cs
+${GIT_ROOT_DIR}/vendor/bin/php-cs-fixer fix --config=${GIT_ROOT_DIR}/.php_cs -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}


### PR DESCRIPTION
This PR accomplishes 2 things:

* Updates the version we test with from Trusty (16.04) to Bionic (18.04).  Trusty is out of standard support, so I figured it was best to move to the next version.

* Moves the travis phpcs test from within the `.travis.yml` file to its own separate script in `.travis/phpcs.sh`.  This makes the [output from CI](https://travis-ci.org/github/open-telemetry/opentelemetry-php/jobs/694432862#L504-L509) a little easier to read and grok.
