### PR TITLE
Adding Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,2 @@
+#Code Of Conduct
+opentelemetry-php follows the code of conduct that the rest of the OpenTelemetry [community](https://github.com/open-telemetry/community/blob/master/code-of-conduct.md) follows, the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)


### PR DESCRIPTION
Adding a code of conduct for reference, which mirrors OpenTelemetry's Code of Conduct, which mirrors the CNCF code of conduct.