### PR TITLE
fix ZipkinSpanConverterTest style

### DIFF
--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -71,13 +71,12 @@ class ZipkinSpanConverterTest extends TestCase
      */
     public function durationShouldBeInMicroseconds()
     {
-        $span = new Span("duration.test", SpanContext::generate());
+        $span = new Span('duration.test', SpanContext::generate());
 
         $row = (new SpanConverter('duration.test'))->convert($span);
 
-
         $this->assertEquals(
-            (int)(($span->getEndTimestamp() - $span->getStartTimestamp()) / 1000),
+            (int) (($span->getEndTimestamp() - $span->getStartTimestamp()) / 1000),
             $row['duration']
         );
     }


### PR DESCRIPTION
After https://github.com/open-telemetry/opentelemetry-php/pull/97 was merged, some styling gone wrong.