### PR TITLE
Fix - Remove debug code from Zipkin exporter

### DIFF
--- a/contrib/Zipkin/Exporter.php
+++ b/contrib/Zipkin/Exporter.php
@@ -87,11 +87,6 @@ class Exporter implements Trace\Exporter
             $headers = ['content-type' => 'application/json'];
             $request = new Request('POST', $this->endpointUrl, $headers, $json);
             $response = $client->send($request, ['timeout' => 30]);
-
-            // Used for debugging output for exporters
-            foreach ((array) $container as $transaction) {
-                echo (string) $transaction['request']->getBody();
-            }
         } catch (Exception $e) {
             return Trace\Exporter::FAILED_RETRYABLE;
         }


### PR DESCRIPTION
 - This change prevents output from being sent to the client during the request.