### PR TITLE
external http client on exporters

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -361,6 +361,8 @@ return [
         'contrib',
         'vendor/composer/xdebug-handler/src',
         'vendor/guzzlehttp',
+        'vendor/psr',
+        'vendor/php-http',
         'vendor/phan/phan/src/Phan',
         'vendor/phpunit/phpunit/src',
     ],

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "require": {
         "php": "^7.3",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.5"
+        "guzzlehttp/guzzle": "^6.5",
+        "psr/http-client": "^1.0",
+        "php-http/guzzle6-adapter": "^2.0"
     },
     "authors": [
         {

--- a/tests/Contrib/Unit/ZipkinExporterTest.php
+++ b/tests/Contrib/Unit/ZipkinExporterTest.php
@@ -4,16 +4,104 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Contrib\Unit;
 
+use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
 use OpenTelemetry\Contrib\Zipkin\Exporter;
 use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
 
 class ZipkinExporterTest extends TestCase
 {
+
+    /**
+     * @test
+     * @dataProvider exporterResponseStatusesDataProvider
+     */
+    public function exporterResponseStatuses($responseStatus, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willReturn(
+            new Response($responseStatus)
+        );
+
+        $exporter = new Exporter('test.zipkin', 'scheme://host:123/path', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.zipkin.span', SpanContext::generate())])
+        );
+    }
+
+    public function exporterResponseStatusesDataProvider()
+    {
+        return [
+            'ok'                => [200, Exporter::SUCCESS],
+            'not found'         => [404, Exporter::FAILED_NOT_RETRYABLE],
+            'not authorized'    => [401, Exporter::FAILED_NOT_RETRYABLE],
+            'bad request'       => [402, Exporter::FAILED_NOT_RETRYABLE],
+            'too many requests' => [429, Exporter::FAILED_NOT_RETRYABLE],
+            'server error'      => [500, Exporter::FAILED_RETRYABLE],
+            'timeout'           => [503, Exporter::FAILED_RETRYABLE],
+            'bad gateway'       => [502, Exporter::FAILED_RETRYABLE],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider clientExceptionsShouldDecideReturnCodeDataProvider
+     */
+    public function clientExceptionsShouldDecideReturnCode($exception, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willThrowException($exception);
+
+        $exporter = new Exporter('test.zipkin', 'scheme://host:123/path', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.zipkin.span', SpanContext::generate())])
+        );
+    }
+
+    public function clientExceptionsShouldDecideReturnCodeDataProvider()
+    {
+        return [
+            'client'    => [
+                self::createMock(ClientExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'network'   => [
+                self::createMock(NetworkExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'request'   => [
+                self::createMock(RequestExceptionInterface::class),
+                Exporter::FAILED_NOT_RETRYABLE,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBeOkToExporterEmptySpansCollection()
+    {
+        $this->assertEquals(
+            Exporter::SUCCESS,
+            (new Exporter('test.zipkin', 'scheme://host:123/path'))->export([])
+        );
+    }
+
     /**
      * @test
      * @dataProvider invalidDsnDataProvider
+     *
+     * @param $invalidDsn
      */
     public function shouldThrowExceptionIfInvalidDsnIsPassed($invalidDsn)
     {

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -25,6 +25,7 @@ class ZipkinSpanConverterTest extends TestCase
 
         $span = $tracer->startAndActivateSpan('guard.validate');
         $span->setAttribute('service', 'guard');
+        $span->setAttribute('boolean', true);
         $span->addEvent('validators.list', $timestamp, new Attributes(['job' => 'stage.updateTime']));
         $span->end();
 
@@ -44,8 +45,9 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertIsInt($row['duration']);
         $this->assertGreaterThan(0, $row['duration']);
 
-        $this->assertCount(1, $row['tags']);
+        $this->assertCount(2, $row['tags']);
         $this->assertEquals($span->getAttribute('service')->getValue(), $row['tags']['service']);
+        $this->assertEquals($span->getAttribute('boolean')->getValue(), $row['tags']['boolean']);
 
         $this->assertCount(1, $row['annotations']);
         [$annotation] = $row['annotations'];


### PR DESCRIPTION
I added the possibility to inject external HTTP client to the exporters, in order to ease the configuration of it. I thought this will be the simplest way, to have a configured HTTP client.

Also, I improved the tests coverage and implement the exporter return based on zipkin/jaeger server response code.