### PR TITLE
Context and correlationcontext inheritance

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -357,6 +357,7 @@ return [
     // your application should be included in this list.
     'directory_list' => [
         'api',
+        'Context',
         'sdk',
         'vendor/composer/xdebug-handler/src',
         'vendor/guzzlehttp',

--- a/Context/Context.php
+++ b/Context/Context.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Context;
 
-class Context
+trait Context
 {
     /**
      * @var ContextKey|null
@@ -23,7 +23,24 @@ class Context
 
     private static $current_context = null;
 
-    public function __construct(ContextKey $key=null, $value=null, ?Context $parent=null)
+    /**
+     * The constructor for a Context object. Because this is a trait, a `Context` cannot be instantiated directly,
+     * this constructor is intended for use by the classes that use this trait. Throughout the docsblocks and comments
+     * in this class, we will refer to "Context instance" which really refers to an instance of the class
+     * that uses this trait.
+     *
+     * This is a general purpose read-only key-value store. Read-only in the sense that adding a new value does not
+     * mutate the existing context, but returns a new Context which has the new value added.
+     *
+     * In practical terms, this is implemented as a linked list of Context instances, with each one holding a reference
+     * to the key object, the value that corresponds to the key, and an optional reference to the parent Context
+     * (i.e. the next link in the linked list chain)
+     *
+     * @param ContextKey|null $key The key object. Should only be null when creating an "empty" context
+     * @param mixed|null $value
+     * @param Context|null $parent Reference to the parent object
+     */
+    public function __construct(?ContextKey $key=null, $value=null, $parent=null)
     {
         $this->key = $key;
         $this->value = $value;
@@ -31,28 +48,62 @@ class Context
     }
 
     /**
+     * This adds a k/v pair to this Context. We do this by instantiating a new Context instance with the k/v and pass
+     * a reference to $this as the "parent" creating the linked list chain.
+     *
+     * The object instantiated will be of the same type as the concrete class using this trait as referenced by __CLASS__
+     *
      * @param ContextKey $key
      * @param mixed $value
      *
-     * @return Context
+     * @suppress PhanTypeInstantiateTrait
+     *
+     * @return Context a new Context containing the k/v
      */
-    public static function setValue(ContextKey $key, $value, ?Context $parent=null): Context
+    public function set(ContextKey $key, $value)
     {
-        if (null === $parent) {
-            return self::$current_context = new Context($key, $value, Context::getCurrent());
-        }
+        $cls = __CLASS__;
 
-        return new Context($key, $value, $parent);
-    }
-
-    public function set(ContextKey $key, $value): Context
-    {
-        return new Context($key, $value, $this);
+        return new $cls($key, $value, $this);
     }
 
     /**
+     * This is a static version of set().
+     * This is primarily useful when the caller doesn't already have a reference to a Context that they want to mutate.
+     *
+     * There are two ways to call this function.
+     * 1) With a $parent parameter:
+     *    This should be an instance of __CLASS__ which is a concrete class that uses this Trait.
+     *    Context::setValue($key, $value, $ctx) is functionally equivalent to $ctx->set($key, $value)
+     * 2) Without a $parent parameter:
+     *    In this scenario, setValue() will use the `$current_context` reference as supplied by `getCurrent()`
+     *    `getCurrent()` will always return a valid Context/__CLASS__. If one does not exist at the global scope,
+     *    an "empty" context will be created.
+     *
+     * @param ContextKey $key
+     * @param mixed $value
+     * @param Context|null $parent
+     *
+     * @suppress PhanTypeInstantiateTrait
+     *
+     * @return Context a new Context containing the k/v
+     */
+    public static function setValue(ContextKey $key, $value, $parent=null)
+    {
+        $cls = __CLASS__;
+        if (null === $parent) {
+            return static::$current_context = new $cls($key, $value, $cls::getCurrent());
+        }
+
+        return new $cls($key, $value, $parent);
+    }
+
+    /**
+     * Fetch a value from the Context given a key value.
+     *
      * @param ContextKey $key
      *
+     * @throws ContextValueNotFoundException
      * @return mixed
      */
     public function get(ContextKey $key)
@@ -67,32 +118,59 @@ class Context
         return $this->parent->get($key);
     }
 
-    public static function getValue(ContextKey $key, ?Context $ctx=null)
+    /**
+     * Static version of get()
+     * This is primarily useful when the caller doesn't already have a reference to the Context that they want to mutate.
+     * This will operate on the "current" global context in that scenario.
+     *
+     * There are two ways to call this function:
+     * 1) With a $ctx value:
+     *    This should be an instance of __CLASS__ which is a concrete class that uses this trait.
+     *    Context::getValue($key, $ctx) is functionally equivalent to $ctx->get($key)
+     * 2) Without a $ctx value:
+     *    This will fetch the "current" Context if one exists or create one if not, then attempt to get the value from it.
+     *
+     * @param ContextKey $key
+     * @param Context|null $ctx
+     *
+     * @throws ContextValueNotFoundException
+     * @return mixed
+     */
+    public static function getValue(ContextKey $key, $ctx=null)
     {
-        $ctx = $ctx ?? Context::getCurrent();
+        $cls = __CLASS__;
+        $ctx = $ctx ?? $cls::getCurrent();
 
         return $ctx->get($key);
     }
 
     /**
+     * @suppress PhanTypeInstantiateTrait
+     *
      * @return Context
      */
-    public static function getCurrent(): Context
+    public static function getCurrent()
     {
-        if (null === self::$current_context) {
-            self::$current_context = new Context();
+        if (null === static::$current_context) {
+            $cls = __CLASS__;
+            static::$current_context = new $cls();
         }
 
-        return self::$current_context;
+        return static::$current_context;
     }
 
     /**
-     * @return callable
+     * This will set the given Context to be the "current" one. We return a token which can be passed to `detach()` to
+     * reset the Current Context back to the previous one.
+     *
+     * @param Context $ctx
+     *
+     * @return callable token for resetting the $current_context back
      */
-    public static function attach(Context $ctx): callable
+    public static function attach($ctx): callable
     {
-        $former_ctx = self::$current_context;
-        self::$current_context = $ctx;
+        $former_ctx = static::$current_context;
+        static::$current_context = $ctx;
 
         return function () use ($former_ctx) {
             return $former_ctx;
@@ -100,9 +178,14 @@ class Context
     }
 
     /**
+     * Given a token, the current context will be set back to the one prior to the token being generated.
+     *
+     * @param callable $token
+     *
+     * @return Context
      */
-    public static function detach(callable $token): Context
+    public static function detach(callable $token)
     {
-        return self::$current_context = call_user_func($token);
+        return static::$current_context = call_user_func($token);
     }
 }

--- a/api/CorrelationContext.php
+++ b/api/CorrelationContext.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\CorrelationContext;
+
+use OpenTelemetry\Context\ContextKey;
+
+interface CorrelationContext
+{
+    public function getCorrelations(); // TODO
+
+    public function get(ContextKey $key);
+
+    public static function getValue(ContextKey $key, ?CorrelationContext $ctx);
+
+    public function set(ContextKey $key, $value): CorrelationContext;
+
+    public static function setValue(ContextKey $key, $value, ?CorrelationContext $parent = null): CorrelationContext;
+
+    public function removeCorrelation(): CorrelationContext;
+
+    public function clearCorrelations(); // TODO
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,9 @@
         <testsuite name="Contrib Unit Tests">
             <directory>./tests/Contrib/Unit</directory>
         </testsuite>
+        <testsuite name="Context Unit Tests">
+            <directory>./tests/Context/Unit</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>

--- a/sdk/CorrelationContext.php
+++ b/sdk/CorrelationContext.php
@@ -7,14 +7,12 @@ namespace OpenTelemetry\Sdk;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextKey;
 
-class CorrelationContext
+class CorrelationContext extends Context
 {
-    use Context;
-
     /**
      * @var CorrelationContext|null
      */
-    private $parent;
+    protected $parent;
 
     /**
      * Return the k/v Correlation pairs from the CorrelationContext
@@ -69,7 +67,7 @@ class CorrelationContext
      *
      * @return null
      */
-    public function setParent(CorrelationContext $parent)
+    protected function setParent(CorrelationContext $parent)
     {
         $this->parent = $parent;
     }

--- a/sdk/CorrelationContext.php
+++ b/sdk/CorrelationContext.php
@@ -12,11 +12,22 @@ class CorrelationContext
     use Context;
 
     /**
-     * @param CorrelationContext $context
+     * @var CorrelationContext|null
      */
-    public function getCorrelations($context = null)
+    private $parent;
+
+    /**
+     * Return the k/v Correlation pairs from the CorrelationContext
+     * The yielded values are of the form `ContextKey => mixed`
+     *
+     * @return \Generator
+     */
+    public function getCorrelations()
     {
-        // TODO: Write me
+        if (null !== $this->parent) {
+            yield from $this->parent->getCorrelations();
+        }
+        yield $this->key => $this->value;
     }
 
     /**
@@ -38,8 +49,6 @@ class CorrelationContext
     /**
      * @param ContextKey $key
      * @param CorrelationContext|null $child
-     * @suppress PhanUndeclaredMethod
-     * @suppress PhanTypeMismatchArgument
      */
     private function removeCorrelationHelper(ContextKey $key, ?CorrelationContext $child)
     {
@@ -65,8 +74,18 @@ class CorrelationContext
         $this->parent = $parent;
     }
 
+    /**
+     * When called on a CorrelationContext, this function will destroy all Correlation data
+     *
+     * @return null
+     */
     public function clearCorrelations()
     {
-        // TODO: Write me
+        if (null !== $this->parent) {
+            $this->parent->clearCorrelations();
+        }
+        $this->key = null;
+        $this->value = null;
+        $this->parent = null;
     }
 }

--- a/sdk/CorrelationContext.php
+++ b/sdk/CorrelationContext.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKey;
+
+class CorrelationContext
+{
+    use Context;
+
+    /**
+     * @param CorrelationContext $context
+     */
+    public function getCorrelations($context = null)
+    {
+        // TODO: Write me
+    }
+
+    /**
+     * @param ContextKey $key
+     *
+     * @return CorrelationContext
+     */
+    public function removeCorrelation(ContextKey $key): CorrelationContext
+    {
+        if ($this->key === $key) {
+            return $this->parent;
+        }
+
+        $this->removeCorrelationHelper($key, null);
+
+        return $this;
+    }
+
+    /**
+     * @param ContextKey $key
+     * @param CorrelationContext|null $child
+     * @suppress PhanUndeclaredMethod
+     * @suppress PhanTypeMismatchArgument
+     */
+    private function removeCorrelationHelper(ContextKey $key, ?CorrelationContext $child)
+    {
+        if ($this->key !== $key) {
+            if (null === $this->parent) {
+                return;
+            }
+            $this->parent->removeCorrelationHelper($key, $this);
+
+            return;
+        }
+
+        $child->setParent($this->parent);
+    }
+
+    /**
+     * @param CorrelationContext $parent
+     *
+     * @return null
+     */
+    public function setParent(CorrelationContext $parent)
+    {
+        $this->parent = $parent;
+    }
+
+    public function clearCorrelations()
+    {
+        // TODO: Write me
+    }
+}

--- a/tests/Context/Unit/ContextTest.php
+++ b/tests/Context/Unit/ContextTest.php
@@ -19,7 +19,7 @@ class ContextTest extends TestCase
         $key1 = new ContextKey('key1');
         $key2 = new ContextKey('key2');
 
-        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
+        $ctx = (new MyClassUsesContextTrait())->set($key1, 'val1')->set($key2, 'val2');
 
         $this->assertSame($ctx->get($key1), 'val1');
         $this->assertSame($ctx->get($key2), 'val2');
@@ -33,7 +33,7 @@ class ContextTest extends TestCase
         $key1 = new ContextKey();
         $key2 = new ContextKey();
 
-        $parent = (new Context())->set($key1, 'foo');
+        $parent = (new MyClassUsesContextTrait())->set($key1, 'foo');
         $child = $parent->set($key2, 'bar');
 
         $this->assertSame($child->get($key1), 'foo');
@@ -54,7 +54,7 @@ class ContextTest extends TestCase
         $key1 = new ContextKey($key_name);
         $key2 = new ContextKey($key_name);
 
-        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
+        $ctx = (new MyClassUsesContextTrait())->set($key1, 'val1')->set($key2, 'val2');
 
         $this->assertSame($ctx->get($key1), 'val1');
         $this->assertSame($ctx->get($key2), 'val2');
@@ -68,7 +68,7 @@ class ContextTest extends TestCase
         $key1 = new ContextKey();
         $key2 = new ContextKey();
 
-        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
+        $ctx = (new MyClassUsesContextTrait())->set($key1, 'val1')->set($key2, 'val2');
 
         $this->assertSame($ctx->get($key1), 'val1');
         $this->assertSame($ctx->get($key2), 'val2');
@@ -89,7 +89,7 @@ class ContextTest extends TestCase
         $null_key = new ContextKey();
         $obj_key = new ContextKey();
 
-        $ctx = (new Context())
+        $ctx = (new MyClassUsesContextTrait())
             ->set($scalar_key, $scalar_val)
             ->set($array_key, $array_val)
             ->set($null_key, $null_val)
@@ -110,14 +110,14 @@ class ContextTest extends TestCase
         foreach (range(0, 9) as $i) {
             $r = rand(0, 100);
             $key = new ContextKey((string) $r);
-            Context::setValue($key, $r);
+            MyClassUsesContextTrait::setValue($key, $r);
             $arr[$r] = $key;
         }
 
         ksort($arr);
 
         foreach ($arr as $v => $k) {
-            $this->assertSame(Context::getValue($k), $v);
+            $this->assertSame(MyClassUsesContextTrait::getValue($k), $v);
         }
     }
 
@@ -130,20 +130,20 @@ class ContextTest extends TestCase
         $key2 = new ContextKey();
         $key3 = new ContextKey();
 
-        Context::setValue($key1, '111');
-        Context::setValue($key2, '222');
+        MyClassUsesContextTrait::setValue($key1, '111');
+        MyClassUsesContextTrait::setValue($key2, '222');
 
-        $ctx = Context::setValue($key3, '333', new Context());
+        $ctx = MyClassUsesContextTrait::setValue($key3, '333', new MyClassUsesContextTrait());
 
-        $this->assertSame(Context::getValue($key1), '111');
-        $this->assertSame(Context::getValue($key2), '222');
+        $this->assertSame(MyClassUsesContextTrait::getValue($key1), '111');
+        $this->assertSame(MyClassUsesContextTrait::getValue($key2), '222');
 
-        $this->assertSame(Context::getValue($key3, $ctx), '333');
+        $this->assertSame(MyClassUsesContextTrait::getValue($key3, $ctx), '333');
 
         $e = null;
 
         try {
-            Context::getValue($key1, $ctx);
+            MyClassUsesContextTrait::getValue($key1, $ctx);
         } catch (\Exception $e) {
         }
         $this->assertInstanceOf(ContextValueNotFoundException::class, $e);
@@ -151,7 +151,7 @@ class ContextTest extends TestCase
         $e = null;
 
         try {
-            Context::getValue($key2, $ctx);
+            MyClassUsesContextTrait::getValue($key2, $ctx);
         } catch (\Exception $e) {
         }
         $this->assertInstanceOf(ContextValueNotFoundException::class, $e);
@@ -159,7 +159,7 @@ class ContextTest extends TestCase
         $e = null;
 
         try {
-            Context::getValue($key3);
+            MyClassUsesContextTrait::getValue($key3);
         } catch (\Exception $e) {
         }
         $this->assertInstanceOf(ContextValueNotFoundException::class, $e);
@@ -171,7 +171,7 @@ class ContextTest extends TestCase
     public function reusingKeyOverwritesValue()
     {
         $key = new ContextKey();
-        $ctx = (new Context())->set($key, 'val1');
+        $ctx = (new MyClassUsesContextTrait())->set($key, 'val1');
         $this->assertSame($ctx->get($key), 'val1');
 
         $ctx = $ctx->set($key, 'val2');
@@ -184,7 +184,7 @@ class ContextTest extends TestCase
     public function ctxValueNotFoundThrows()
     {
         $this->expectException(ContextValueNotFoundException::class);
-        $ctx = (new Context())->set(new ContextKey('foo'), 'bar');
+        $ctx = (new MyClassUsesContextTrait())->set(new ContextKey('foo'), 'bar');
         $ctx->get(new ContextKey('baz'));
     }
 
@@ -194,9 +194,9 @@ class ContextTest extends TestCase
     public function attachAndDetachSetCurrentCtx()
     {
         $key = new ContextKey();
-        Context::attach((new Context())->set($key, '111'));
+        Context::attach((new MyClassUsesContextTrait())->set($key, '111'));
 
-        $token = Context::attach((new Context())->set($key, '222'));
+        $token = Context::attach((new MyClassUsesContextTrait())->set($key, '222'));
         $this->assertSame(Context::getValue($key), '222');
 
         Context::detach($token);
@@ -208,14 +208,14 @@ class ContextTest extends TestCase
      */
     public function instanceSetAndStaticGetUseSameCtx()
     {
-        $key = new ContextKey();
+        $key = new ContextKey('ofoba');
         $val = 'foobar';
 
-        $ctx = (new Context())->set($key, $val);
-        Context::attach($ctx);
+        $ctx = (new MyClassUsesContextTrait())->set($key, $val);
+        MyClassUsesContextTrait::attach($ctx);
 
-        $this->assertSame(Context::getValue($key, $ctx), $val);
-        $this->assertSame(Context::getValue($key), $val);
+        $this->assertSame(MyClassUsesContextTrait::getValue($key, $ctx), $val);
+        $this->assertSame(MyClassUsesContextTrait::getValue($key, null, true), $val);
     }
 
     /**
@@ -228,8 +228,8 @@ class ContextTest extends TestCase
         $val1 = '111';
         $val2 = '222';
 
-        $ctx = Context::setValue($key1, $val1);
-        $ctx = Context::setValue($key2, $val2, $ctx);
+        $ctx = MyClassUsesContextTrait::setValue($key1, $val1);
+        $ctx = MyClassUsesContextTrait::setValue($key2, $val2, $ctx);
 
         $this->assertSame($ctx->get($key1), $val1);
         $this->assertSame($ctx->get($key2), $val2);
@@ -240,12 +240,12 @@ class ContextTest extends TestCase
      */
     public function staticWithoutPassedCtxUsesCurrent()
     {
-        $ctx = Context::setValue(new ContextKey(), '111');
-        $first = Context::getCurrent();
+        $ctx = MyClassUsesContextTrait::setValue(new ContextKey(), '111');
+        $first = MyClassUsesContextTrait::getCurrent();
         $this->assertSame($first, $ctx);
 
-        $ctx = Context::setValue(new ContextKey(), '222');
-        $second = Context::getCurrent();
+        $ctx = MyClassUsesContextTrait::setValue(new ContextKey(), '222');
+        $second = MyClassUsesContextTrait::getCurrent();
         $this->assertSame($second, $ctx);
 
         $this->assertNotSame($first, $second);
@@ -257,10 +257,15 @@ class ContextTest extends TestCase
     public function staticWithPassedCtxDoesNotUseCurrent()
     {
         $key1 = new ContextKey();
-        $currentCtx = Context::setValue($key1, '111');
+        $currentCtx = MyClassUsesContextTrait::setValue($key1, '111');
 
         $key2 = new ContextKey();
-        $otherCtx = Context::setValue($key2, '222', new Context());
-        $this->assertSame($currentCtx, Context::getCurrent());
+        $otherCtx = MyClassUsesContextTrait::setValue($key2, '222', new MyClassUsesContextTrait());
+        $this->assertSame($currentCtx, MyClassUsesContextTrait::getCurrent());
     }
+}
+
+class MyClassUsesContextTrait
+{
+    use Context;
 }

--- a/tests/Context/Unit/ContextTest.php
+++ b/tests/Context/Unit/ContextTest.php
@@ -19,7 +19,7 @@ class ContextTest extends TestCase
         $key1 = new ContextKey('key1');
         $key2 = new ContextKey('key2');
 
-        $ctx = (new MyClassUsesContextTrait())->set($key1, 'val1')->set($key2, 'val2');
+        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
 
         $this->assertSame($ctx->get($key1), 'val1');
         $this->assertSame($ctx->get($key2), 'val2');
@@ -33,7 +33,7 @@ class ContextTest extends TestCase
         $key1 = new ContextKey();
         $key2 = new ContextKey();
 
-        $parent = (new MyClassUsesContextTrait())->set($key1, 'foo');
+        $parent = (new Context())->set($key1, 'foo');
         $child = $parent->set($key2, 'bar');
 
         $this->assertSame($child->get($key1), 'foo');
@@ -54,7 +54,7 @@ class ContextTest extends TestCase
         $key1 = new ContextKey($key_name);
         $key2 = new ContextKey($key_name);
 
-        $ctx = (new MyClassUsesContextTrait())->set($key1, 'val1')->set($key2, 'val2');
+        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
 
         $this->assertSame($ctx->get($key1), 'val1');
         $this->assertSame($ctx->get($key2), 'val2');
@@ -68,7 +68,7 @@ class ContextTest extends TestCase
         $key1 = new ContextKey();
         $key2 = new ContextKey();
 
-        $ctx = (new MyClassUsesContextTrait())->set($key1, 'val1')->set($key2, 'val2');
+        $ctx = (new Context())->set($key1, 'val1')->set($key2, 'val2');
 
         $this->assertSame($ctx->get($key1), 'val1');
         $this->assertSame($ctx->get($key2), 'val2');
@@ -89,7 +89,7 @@ class ContextTest extends TestCase
         $null_key = new ContextKey();
         $obj_key = new ContextKey();
 
-        $ctx = (new MyClassUsesContextTrait())
+        $ctx = (new Context())
             ->set($scalar_key, $scalar_val)
             ->set($array_key, $array_val)
             ->set($null_key, $null_val)
@@ -110,14 +110,14 @@ class ContextTest extends TestCase
         foreach (range(0, 9) as $i) {
             $r = rand(0, 100);
             $key = new ContextKey((string) $r);
-            MyClassUsesContextTrait::setValue($key, $r);
+            Context::setValue($key, $r);
             $arr[$r] = $key;
         }
 
         ksort($arr);
 
         foreach ($arr as $v => $k) {
-            $this->assertSame(MyClassUsesContextTrait::getValue($k), $v);
+            $this->assertSame(Context::getValue($k), $v);
         }
     }
 
@@ -130,20 +130,20 @@ class ContextTest extends TestCase
         $key2 = new ContextKey();
         $key3 = new ContextKey();
 
-        MyClassUsesContextTrait::setValue($key1, '111');
-        MyClassUsesContextTrait::setValue($key2, '222');
+        Context::setValue($key1, '111');
+        Context::setValue($key2, '222');
 
-        $ctx = MyClassUsesContextTrait::setValue($key3, '333', new MyClassUsesContextTrait());
+        $ctx = Context::setValue($key3, '333', new Context());
 
-        $this->assertSame(MyClassUsesContextTrait::getValue($key1), '111');
-        $this->assertSame(MyClassUsesContextTrait::getValue($key2), '222');
+        $this->assertSame(Context::getValue($key1), '111');
+        $this->assertSame(Context::getValue($key2), '222');
 
-        $this->assertSame(MyClassUsesContextTrait::getValue($key3, $ctx), '333');
+        $this->assertSame(Context::getValue($key3, $ctx), '333');
 
         $e = null;
 
         try {
-            MyClassUsesContextTrait::getValue($key1, $ctx);
+            Context::getValue($key1, $ctx);
         } catch (\Exception $e) {
         }
         $this->assertInstanceOf(ContextValueNotFoundException::class, $e);
@@ -151,7 +151,7 @@ class ContextTest extends TestCase
         $e = null;
 
         try {
-            MyClassUsesContextTrait::getValue($key2, $ctx);
+            Context::getValue($key2, $ctx);
         } catch (\Exception $e) {
         }
         $this->assertInstanceOf(ContextValueNotFoundException::class, $e);
@@ -159,7 +159,7 @@ class ContextTest extends TestCase
         $e = null;
 
         try {
-            MyClassUsesContextTrait::getValue($key3);
+            Context::getValue($key3);
         } catch (\Exception $e) {
         }
         $this->assertInstanceOf(ContextValueNotFoundException::class, $e);
@@ -171,7 +171,7 @@ class ContextTest extends TestCase
     public function reusingKeyOverwritesValue()
     {
         $key = new ContextKey();
-        $ctx = (new MyClassUsesContextTrait())->set($key, 'val1');
+        $ctx = (new Context())->set($key, 'val1');
         $this->assertSame($ctx->get($key), 'val1');
 
         $ctx = $ctx->set($key, 'val2');
@@ -184,7 +184,7 @@ class ContextTest extends TestCase
     public function ctxValueNotFoundThrows()
     {
         $this->expectException(ContextValueNotFoundException::class);
-        $ctx = (new MyClassUsesContextTrait())->set(new ContextKey('foo'), 'bar');
+        $ctx = (new Context())->set(new ContextKey('foo'), 'bar');
         $ctx->get(new ContextKey('baz'));
     }
 
@@ -194,9 +194,9 @@ class ContextTest extends TestCase
     public function attachAndDetachSetCurrentCtx()
     {
         $key = new ContextKey();
-        Context::attach((new MyClassUsesContextTrait())->set($key, '111'));
+        Context::attach((new Context())->set($key, '111'));
 
-        $token = Context::attach((new MyClassUsesContextTrait())->set($key, '222'));
+        $token = Context::attach((new Context())->set($key, '222'));
         $this->assertSame(Context::getValue($key), '222');
 
         Context::detach($token);
@@ -211,11 +211,11 @@ class ContextTest extends TestCase
         $key = new ContextKey('ofoba');
         $val = 'foobar';
 
-        $ctx = (new MyClassUsesContextTrait())->set($key, $val);
-        MyClassUsesContextTrait::attach($ctx);
+        $ctx = (new Context())->set($key, $val);
+        Context::attach($ctx);
 
-        $this->assertSame(MyClassUsesContextTrait::getValue($key, $ctx), $val);
-        $this->assertSame(MyClassUsesContextTrait::getValue($key, null, true), $val);
+        $this->assertSame(Context::getValue($key, $ctx), $val);
+        $this->assertSame(Context::getValue($key, null, true), $val);
     }
 
     /**
@@ -228,8 +228,8 @@ class ContextTest extends TestCase
         $val1 = '111';
         $val2 = '222';
 
-        $ctx = MyClassUsesContextTrait::setValue($key1, $val1);
-        $ctx = MyClassUsesContextTrait::setValue($key2, $val2, $ctx);
+        $ctx = Context::setValue($key1, $val1);
+        $ctx = Context::setValue($key2, $val2, $ctx);
 
         $this->assertSame($ctx->get($key1), $val1);
         $this->assertSame($ctx->get($key2), $val2);
@@ -240,12 +240,12 @@ class ContextTest extends TestCase
      */
     public function staticWithoutPassedCtxUsesCurrent()
     {
-        $ctx = MyClassUsesContextTrait::setValue(new ContextKey(), '111');
-        $first = MyClassUsesContextTrait::getCurrent();
+        $ctx = Context::setValue(new ContextKey(), '111');
+        $first = Context::getCurrent();
         $this->assertSame($first, $ctx);
 
-        $ctx = MyClassUsesContextTrait::setValue(new ContextKey(), '222');
-        $second = MyClassUsesContextTrait::getCurrent();
+        $ctx = Context::setValue(new ContextKey(), '222');
+        $second = Context::getCurrent();
         $this->assertSame($second, $ctx);
 
         $this->assertNotSame($first, $second);
@@ -257,15 +257,10 @@ class ContextTest extends TestCase
     public function staticWithPassedCtxDoesNotUseCurrent()
     {
         $key1 = new ContextKey();
-        $currentCtx = MyClassUsesContextTrait::setValue($key1, '111');
+        $currentCtx = Context::setValue($key1, '111');
 
         $key2 = new ContextKey();
-        $otherCtx = MyClassUsesContextTrait::setValue($key2, '222', new MyClassUsesContextTrait());
-        $this->assertSame($currentCtx, MyClassUsesContextTrait::getCurrent());
+        $otherCtx = Context::setValue($key2, '222', new Context());
+        $this->assertSame($currentCtx, Context::getCurrent());
     }
-}
-
-class MyClassUsesContextTrait
-{
-    use Context;
 }

--- a/tests/Sdk/Unit/CorrelationContext/CorrelationContextTest.php
+++ b/tests/Sdk/Unit/CorrelationContext/CorrelationContextTest.php
@@ -76,4 +76,42 @@ class CorrelationContextTest extends TestCase
         $this->assertNotEquals('bar', $cctx->get($key1));
         $this->assertNotEquals('foo', $cctx->get($key2));
     }
+
+    /**
+     * @test
+     */
+    public function testClearCorrelations()
+    {
+        $key1 = new ContextKey();
+        $key2 = new ContextKey();
+
+        $cctx = (new CorrelationContext())->set($key1, 'foo')->set($key2, 'bar');
+
+        $this->assertEquals('foo', $cctx->get($key1));
+        $this->assertEquals('bar', $cctx->get($key2));
+
+        $cctx->clearCorrelations();
+        $this->expectException(ContextValueNotFoundException::class);
+        $cctx->get($key1);
+    }
+
+    /**
+     * @test
+     */
+    public function testGetCorrelations()
+    {
+        $key1 = new ContextKey();
+        $key2 = new ContextKey();
+
+        $cctx = (new CorrelationContext())->set($key1, 'foo')->set($key2, 'bar');
+
+        $res = [];
+        foreach ($cctx->getCorrelations() as $k => $v) {
+            // I am inverting the k/v pairs in an array here because php does not allow for object keys
+            $res[$v] = $k;
+        }
+
+        $this->assertSame($key1, $res['foo']);
+        $this->assertSame($key2, $res['bar']);
+    }
 }

--- a/tests/Sdk/Unit/CorrelationContext/CorrelationContextTest.php
+++ b/tests/Sdk/Unit/CorrelationContext/CorrelationContextTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\CorrelationContext;
+
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Context\ContextValueNotFoundException;
+use OpenTelemetry\Sdk\CorrelationContext;
+use PHPUnit\Framework\TestCase;
+
+class CorrelationContextTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testRemoveCorrelationFromBeginning()
+    {
+        $key1 = new ContextKey();
+        $key2 = new ContextKey();
+        $cctx = (new CorrelationContext())->set($key1, 'foo')->set($key2, 'bar');
+        $cctx_res = $cctx->removeCorrelation($key2);
+        $this->assertEquals('foo', $cctx_res->get($key1));
+        $this->expectException(ContextValueNotFoundException::class);
+        $cctx_res->get($key2);
+    }
+
+    /**
+     * @test
+     */
+    public function testRemoveCorrelationFromMiddle()
+    {
+        $key1 = new ContextKey('key1');
+        $key2 = new ContextKey('key2');
+        $key3 = new ContextKey('key3');
+        $cctx = (new CorrelationContext())->set($key1, 'foo')->set($key2, 'bar')->set($key3, 'baz');
+        $cctx_res = $cctx->removeCorrelation($key2);
+        $this->assertEquals('foo', $cctx_res->get($key1));
+        $this->assertEquals('baz', $cctx_res->get($key3));
+        $this->expectException(ContextValueNotFoundException::class);
+        $cctx_res->get($key2);
+    }
+
+    /**
+     * @test
+     */
+    public function testRemoveCorrelationFromEnd()
+    {
+        $key1 = new ContextKey();
+        $key2 = new ContextKey();
+        $cctx = (new CorrelationContext())->set($key2, 'bar')->set($key1, 'foo');
+        $cctx_res = $cctx->removeCorrelation($key2);
+        $this->assertEquals('foo', $cctx_res->get($key1));
+        $this->expectException(ContextValueNotFoundException::class);
+        $cctx_res->get($key2);
+    }
+
+    /**
+     * @test
+     */
+    public function testOnlyItemInTheContext()
+    {
+        $key1 = new ContextKey();
+        $cctx = (new CorrelationContext())->set($key1, 'foo');
+        $this->assertEquals('foo', $cctx->get($key1));
+    }
+
+    /**
+     * @test
+     */
+    public function testWrongKeyValue()
+    {
+        $key1 = new ContextKey();
+        $key2 = new ContextKey();
+        $cctx = (new CorrelationContext())->set($key2, 'bar')->set($key1, 'foo');
+        $this->assertNotEquals('bar', $cctx->get($key1));
+        $this->assertNotEquals('foo', $cctx->get($key2));
+    }
+}


### PR DESCRIPTION
Add `Context` and `CorrelationContext` via standard inheritance.

When subclassing `Context` it is necessary to shadow the `$parent` attr to ensure that all operations on a `CorrelationContext` also return a `CorrelationContext` instead of a `Context`