### PR TITLE
replaceAttributes should only accept Attributes()

### DIFF
--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -153,13 +153,10 @@ class Span implements API\Span
         return $this->attributes;
     }
 
-    public function replaceAttributes(iterable $attributes): self
+    public function replaceAttributes(API\Attributes $attributes): self
     {
         if ($this->isRecording()) {
-            $this->attributes = new Attributes();
-            foreach ($attributes as $k => $v) {
-                $this->setAttribute($k, $v);
-            }
+            $this->attributes = $attributes;
         }
 
         return $this;

--- a/tests/Sdk/Unit/Trace/SpanOptionsTest.php
+++ b/tests/Sdk/Unit/Trace/SpanOptionsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
+
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\SpanOptions;
+use OpenTelemetry\Sdk\Trace\Tracer;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use PHPUnit\Framework\TestCase;
+
+class SpanOptionsTest extends TestCase
+{
+    public function testShouldCreateSpanFromOptions()
+    {
+        $tracer = $this->getTracer();
+        $spanOptions = new SpanOptions($tracer, 'web');
+
+        $global = $tracer->getActiveSpan();
+        $spanOptions->setParentSpan($global);
+
+        // Create span from options
+        $web = $spanOptions->toSpan();
+
+        // Make sure created span is not activated
+        $this->assertSame($tracer->getActiveSpan(), $global);
+
+        $this->assertSame($global->getContext()->getTraceId(), $web->getContext()->getTraceId());
+        $this->assertEquals($web->getParent(), $global->getContext());
+        $this->assertNotNull($web->getStartTimestamp());
+        $this->assertTrue($web->isRecording());
+        $this->assertNull($web->getDuration());
+    }
+
+    public function testShouldCreateAndSetActiveSpanFromOptions()
+    {
+        $tracer = $this->getTracer();
+        $spanOptions = new SpanOptions($tracer, 'web');
+        $global = $tracer->getActiveSpan();
+        $this->assertSame($spanOptions, $spanOptions->setSpanName('web2'));
+        $this->assertSame($spanOptions, $spanOptions->addStartTimestamp(1234));
+
+        $web = $spanOptions->toActiveSpan();
+
+        // Make sure created span is not activated
+        $this->assertSame($tracer->getActiveSpan(), $web);
+
+        // Assert previously set vars
+        $this->assertEquals('web2', $web->getSpanName());
+        $this->assertEquals(1234, $web->getStartTimestamp());
+    }
+
+    public function testShouldCreateCorrectSpanAttributes()
+    {
+        $tracer = $this->getTracer();
+        $spanOptions = new SpanOptions($tracer, 'web');
+        $global = $tracer->getActiveSpan();
+
+        $attribRaw = [
+            'attr_1' => 'value_1',
+            'attr_2' => 2,
+            'attr_3' => true,
+            'attr_4' => 3.14159,
+            'attr_5' => [1,2,3,4,5],
+            'attr_6' => [1.1,2.2,3.3,4.4,5.5],
+        ];
+
+        $attributes = new Attributes($attribRaw);
+
+        $spanOptions->addAttributes($attributes);
+
+        $web = $spanOptions->toActiveSpan();
+
+        // Check that span attributes are the ones passed in to spanOptions
+        $this->assertSame($attributes, $web->getAttributes());
+    }
+
+    protected function getTracer(): Tracer
+    {
+        $tracerProvider = new TracerProvider();
+
+        return $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+    }
+}

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -149,13 +149,13 @@ class TracingTest extends TestCase
         self::assertInstanceOf(SDK\Span::class, $span);
 
         // set attributes
-        $span->replaceAttributes(['username' => 'nekufa']);
+        $span->replaceAttributes(new Attributes(['username' => 'nekufa']));
 
         // get attribute
         $this->assertEquals(new Attribute('username', 'nekufa'), $span->getAttribute('username'));
 
         // otherwrite
-        $span->replaceAttributes(['email' => 'nekufa@gmail.com']);
+        $span->replaceAttributes(new Attributes(['email' => 'nekufa@gmail.com']));
 
         // null attributes
         self::assertNull($span->getAttribute('username'));
@@ -169,12 +169,16 @@ class TracingTest extends TestCase
         self::assertEquals(new Attribute('email', 'nekufa@gmail.com'), $span->getAttribute('email'));
         self::assertEquals(new Attribute('username', 'nekufa'), $span->getAttribute('username'));
 
+        // attribute key - code coverage
+        self::assertEquals('email', $span->getAttribute('email')->getKey());
+        self::assertEquals('username', $span->getAttribute('username')->getKey());
+
         // keep order
         $expected = [
             'a' => new Attribute('a', 1),
             'b' => new Attribute('b', 2),
         ];
-        $span->replaceAttributes(['a' => 1, 'b' => 2]);
+        $span->replaceAttributes(new Attributes(['a' => 1, 'b' => 2]));
 
         $actual = \iterator_to_array($span->getAttributes());
         self::assertEquals($expected, $actual);
@@ -207,7 +211,7 @@ class TracingTest extends TestCase
         $this->assertArrayHasKey('key1', \iterator_to_array($span->getAttributes()));
         $this->assertArrayNotHasKey('key2', \iterator_to_array($span->getAttributes()));
 
-        $span->replaceAttributes(['foo' => 'bar']);
+        $span->replaceAttributes(new Attributes(['foo' => 'bar']));
         $this->assertCount(1, $span->getAttributes());
         $this->assertArrayHasKey('key1', \iterator_to_array($span->getAttributes()));
         $this->assertArrayNotHasKey('foo', \iterator_to_array($span->getAttributes()));


### PR DESCRIPTION
Post discussion in gitter about an issue with creating spans from options (outlined [in this gist](https://gist.github.com/benagricola/4b86214497244b178ba85d97c2d17e34)).
 - Refactor implementation of `$span->replaceAttributes()` to copy input to attributes property rather than iterating.
  - Add relevant tests for `SpanOptions`.
  - Refactor existing tests passing array to `$span->replaceAttributes()`.

Potentially conflicts with #146 as both add `SpanOptionsTest.php` 