### PR TITLE
Added SamplingResult getters for attributes and links

### DIFF
--- a/sdk/Trace/Sampler/AlwaysOnSampler.php
+++ b/sdk/Trace/Sampler/AlwaysOnSampler.php
@@ -32,7 +32,7 @@ class AlwaysOnSampler implements Sampler
         ?API\Links $links = null
     ): SamplingResult {
         // todo: hook up $attributes and $links
-        return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED);
+        return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED, $attributes, $links);
     }
 
     public function getDescription(): string

--- a/sdk/Trace/Sampler/AlwaysOnSampler.php
+++ b/sdk/Trace/Sampler/AlwaysOnSampler.php
@@ -31,7 +31,6 @@ class AlwaysOnSampler implements Sampler
         ?API\Attributes $attributes = null,
         ?API\Links $links = null
     ): SamplingResult {
-        // todo: hook up $attributes and $links
         return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED, $attributes, $links);
     }
 

--- a/sdk/Trace/Sampler/AlwaysParentSampler.php
+++ b/sdk/Trace/Sampler/AlwaysParentSampler.php
@@ -31,12 +31,11 @@ class AlwaysParentSampler implements Sampler
         ?API\Attributes $attributes = null,
         ?API\Links $links = null
     ): SamplingResult {
-        // todo: hook up $attributes and $links
         if (null !== $parentContext && ($parentContext->getTraceFlags() & API\SpanContext::TRACE_FLAG_SAMPLED)) {
-            return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED);
+            return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED, $attributes, $links);
         }
 
-        return new SamplingResult(SamplingResult::NOT_RECORD);
+        return new SamplingResult(SamplingResult::NOT_RECORD, $attributes, $links);
     }
 
     public function getDescription(): string

--- a/sdk/Trace/Sampler/ProbabilitySampler.php
+++ b/sdk/Trace/Sampler/ProbabilitySampler.php
@@ -46,7 +46,7 @@ class ProbabilitySampler implements Sampler
         ?API\Links $links = null
     ): SamplingResult {
         if (null !== $parentContext && ($parentContext->getTraceFlags() & API\SpanContext::TRACE_FLAG_SAMPLED)) {
-            return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED);
+            return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED, $attributes, $links);
         }
 
         // TODO: implement as a function of TraceID when specification is ready
@@ -54,7 +54,7 @@ class ProbabilitySampler implements Sampler
             ? SamplingResult::RECORD_AND_SAMPLED
             : SamplingResult::NOT_RECORD;
 
-        return new SamplingResult($decision);
+        return new SamplingResult($decision, $attributes, $links);
     }
 
     public function getDescription(): string

--- a/sdk/Trace/SamplingResult.php
+++ b/sdk/Trace/SamplingResult.php
@@ -33,10 +33,16 @@ final class SamplingResult
      */
     private $attributes;
 
-    public function __construct(int $decision, ?API\Attributes $attributes = null)
+    /**
+     * @var ?API\Links Collection of links that will be associated with the Span to be created.
+     */
+    private $links;
+
+    public function __construct(int $decision, ?API\Attributes $attributes = null, ?API\Links $links = null)
     {
         $this->decision = $decision;
         $this->attributes = $attributes;
+        $this->links = $links;
     }
 
     /**
@@ -53,5 +59,13 @@ final class SamplingResult
     public function getAttributes(): ?API\Attributes
     {
         return $this->attributes;
+    }
+
+    /**
+     * Return a collection of links that will be associated with the Span to be created.
+     */
+    public function getLinks(): ?API\Links
+    {
+        return $this->links;
     }
 }

--- a/tests/Sdk/Unit/Trace/SpanResultTest.php
+++ b/tests/Sdk/Unit/Trace/SpanResultTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
-use OpenTelemetry\Sdk\Trace\SamplingResult;
 use OpenTelemetry\Sdk\Trace\Attributes;
-use PHPUnit\Framework\TestCase;
+use OpenTelemetry\Sdk\Trace\SamplingResult;
 use OpenTelemetry\Trace\Links;
+use PHPUnit\Framework\TestCase;
 
 class SpanResultTest extends TestCase
 {

--- a/tests/Sdk/Unit/Trace/SpanResultTest.php
+++ b/tests/Sdk/Unit/Trace/SpanResultTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
+
+use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use PHPUnit\Framework\TestCase;
+use OpenTelemetry\Trace\Links;
+
+class SpanResultTest extends TestCase
+{
+    /**
+     * @dataProvider provideAttributesAndLinks
+     */
+    public function testAttributesAndLinksGetters($attributes, $links)
+    {
+        $result = new SamplingResult(SamplingResult::NOT_RECORD, $attributes, $links);
+
+        $this->assertSame($attributes, $result->getAttributes());
+        $this->assertSame($links, $result->getLinks());
+    }
+
+    /**
+     * Provide different sets of data to test SamplingResult constructor and getters
+     */
+    public function provideAttributesAndLinks(): array
+    {
+        return [
+            [
+                new Attributes(['foo' => 'bar']),
+                $this->createMock(Links::class),
+            ],
+            [
+                null,
+                null,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Closes #139 

- Attributes and Links are passed to `SamplingResult` constructor
- Added getter for Links.
- Added test for getters
- Examples are fixed accordingly