### PR TITLE
timestamp should be span start timestamp

### DIFF
--- a/api/Trace/Span.php
+++ b/api/Trace/Span.php
@@ -9,9 +9,25 @@ interface Span extends SpanStatus, SpanKind
     public function getSpanName(): string;
     public function getContext(): SpanContext;
     public function getParent(): ?SpanContext;
+
+    /**
+     * Returns Epoch timestamp value (RealtimeClock) when the Span was created
+     * @return int
+     */
     public function getStartEpochTimestamp(): int;
+
+    /**
+     * Returns system time clock value (MonotonicClock) when the Span was created
+     * @return int
+     */
     public function getStart(): int;
+
+    /**
+     * Returns system time clock value (MonotonicClock) when the Span was stopped
+     * @return int
+     */
     public function getEnd(): ?int;
+
     public function getAttributes(): Attributes;
     public function getLinks(): Links;
     public function getEvents(): Events;

--- a/api/Trace/Span.php
+++ b/api/Trace/Span.php
@@ -9,8 +9,9 @@ interface Span extends SpanStatus, SpanKind
     public function getSpanName(): string;
     public function getContext(): SpanContext;
     public function getParent(): ?SpanContext;
-    public function getStartTimestamp(): int;
-    public function getEndTimestamp(): ?int;
+    public function getStartEpochTimestamp(): int;
+    public function getStart(): int;
+    public function getEnd(): ?int;
     public function getAttributes(): Attributes;
     public function getLinks(): Links;
     public function getEvents(): Events;

--- a/api/Trace/SpanOptions.php
+++ b/api/Trace/SpanOptions.php
@@ -21,10 +21,17 @@ interface SpanOptions
 
     /**
      * This should only be used if the creation time has already passed; will set timestamp to current time by default
-     * @param $timestamp
-     * @return mixed
+     * @param int $timestamp
+     * @return SpanOptions
      */
-    public function addStartTimestamp($timestamp): SpanOptions;
+    public function addStartTimestamp(int $timestamp): SpanOptions;
+    /**
+     * This should only be used if the creation time has already passed; will set to current monotonic clock
+     * value by default
+     * @param int $now
+     * @return SpanOptions
+     */
+    public function addStart(int $now): SpanOptions;
 
     public function toSpan(): Span;
     // todo: how do we want to optionally let people make these spans active? bool arg, setActive, or toActiveSpan?

--- a/contrib/Zipkin/SpanConverter.php
+++ b/contrib/Zipkin/SpanConverter.php
@@ -69,8 +69,9 @@ class SpanConverter
             if (!array_key_exists('annotations', $row)) {
                 $row['annotations'] = [];
             }
+            // Maybe $event->getTimestamp() (if not null)?
             $row['annotations'][] = [
-                'timestamp' => (int) ($timestamp / 1e3), // RealtimeClock in microseconds
+                'timestamp' => (int) ($start_realtime / 1e3), // RealtimeClock in microseconds
                 'value' => $event->getName(),
             ];
         }

--- a/contrib/Zipkin/SpanConverter.php
+++ b/contrib/Zipkin/SpanConverter.php
@@ -42,10 +42,6 @@ class SpanConverter
 
     public function convert(Span $span)
     {
-        $start_realtime = $span->getStartTimestamp();
-        $end_realtime = $span->getEndTimestamp();
-        $elapsed_realtime = (int) (($end_realtime - $start_realtime) / 1e3); // diff in microseconds
-
         $row = [
             'id' => $span->getContext()->getSpanId(),
             'traceId' => $span->getContext()->getTraceId(),
@@ -54,8 +50,8 @@ class SpanConverter
                 'serviceName' => $this->serviceName,
             ],
             'name' => $span->getSpanName(),
-            'timestamp' => (int) ($start_realtime / 1e3), // RealtimeClock in microseconds
-            'duration' => $elapsed_realtime,
+            'timestamp' => (int) ($span->getStartEpochTimestamp() / 1e3), // RealtimeClock in microseconds
+            'duration' => (int) (($span->getEnd() - $span->getStart()) / 1e3), // Diff in microseconds
         ];
 
         foreach ($span->getAttributes() as $k => $v) {
@@ -69,9 +65,8 @@ class SpanConverter
             if (!array_key_exists('annotations', $row)) {
                 $row['annotations'] = [];
             }
-            // Maybe $event->getTimestamp() (if not null)?
             $row['annotations'][] = [
-                'timestamp' => (int) ($start_realtime / 1e3), // RealtimeClock in microseconds
+                'timestamp' => (int) ($event->getTimestamp() / 1e3), // RealtimeClock in microseconds
                 'value' => $event->getName(),
             ];
         }

--- a/contrib/Zipkin/SpanConverter.php
+++ b/contrib/Zipkin/SpanConverter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\Zipkin;
 
-use OpenTelemetry\Sdk\Trace\Clock;
 use OpenTelemetry\Trace\Span;
 
 class SpanConverter
@@ -43,7 +42,6 @@ class SpanConverter
 
     public function convert(Span $span)
     {
-        $timestamp = Clock::get()->timestamp();
         $start_realtime = $span->getStartTimestamp();
         $end_realtime = $span->getEndTimestamp();
         $elapsed_realtime = (int) (($end_realtime - $start_realtime) / 1e3); // diff in microseconds
@@ -56,7 +54,7 @@ class SpanConverter
                 'serviceName' => $this->serviceName,
             ],
             'name' => $span->getSpanName(),
-            'timestamp' => (int) ($timestamp / 1e3), // RealtimeClock in microseconds
+            'timestamp' => (int) ($start_realtime / 1e3), // RealtimeClock in microseconds
             'duration' => $elapsed_realtime,
         ];
 

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -13,6 +13,7 @@ class Span implements API\Span
     private $parentSpanContext;
     private $spanKind;
 
+    private $startEpochTimestamp;
     private $start;
     private $end;
     private $statusCode = API\SpanStatus::OK;
@@ -47,7 +48,9 @@ class Span implements API\Span
         $this->spanContext = $spanContext;
         $this->parentSpanContext = $parentSpanContext;
         $this->spanKind = $spanKind;
-        $this->start = Clock::get()->timestamp();
+        $moment = Clock::get()->moment();
+        $this->startEpochTimestamp = $moment[0];
+        $this->start = $moment[1];
         $this->statusCode = API\SpanStatus::OK;
         $this->statusDescription = API\SpanStatus::DESCRIPTION[$this->statusCode];
 
@@ -77,28 +80,40 @@ class Span implements API\Span
         return $this;
     }
 
-    public function end(int $timestamp = null): API\Span
+    public function getStart(): int
+    {
+        return $this->start;
+    }
+
+    public function setStart(int $start): Span
+    {
+        $this->start = $start;
+
+        return $this;
+    }
+
+    public function end(?int $now = null): API\Span
     {
         if (!isset($this->end)) {
-            $this->end = $timestamp ?? Clock::get()->timestamp();
+            $this->end = $now ?? Clock::get()->now();
         }
 
         return $this;
     }
 
-    public function setStartTimestamp(int $timestamp): Span
+    public function setStartEpochTimestamp(int $timestamp): Span
     {
-        $this->start = $timestamp;
+        $this->startEpochTimestamp = $timestamp;
 
         return $this;
     }
 
-    public function getStartTimestamp(): int
+    public function getStartEpochTimestamp(): int
     {
-        return $this->start;
+        return $this->startEpochTimestamp;
     }
 
-    public function getEndTimestamp(): ?int
+    public function getEnd(): ?int
     {
         return $this->end;
     }

--- a/sdk/Trace/SpanOptions.php
+++ b/sdk/Trace/SpanOptions.php
@@ -19,6 +19,8 @@ final class SpanOptions implements API\SpanOptions
     private $kind = API\SpanKind::KIND_INTERNAL;
 
     /** @var int|null */
+    private $startEpochTimestamp = null;
+    /** @var int|null */
     private $start = null;
 
     public function __construct(Tracer $tracer, string $name)
@@ -73,9 +75,16 @@ final class SpanOptions implements API\SpanOptions
         return $this;
     }
 
-    public function addStartTimestamp($timestamp): API\SpanOptions
+    public function addStartTimestamp(int $timestamp): API\SpanOptions
     {
-        $this->start = $timestamp;
+        $this->startEpochTimestamp = $timestamp;
+
+        return $this;
+    }
+
+    public function addStart(int $now): API\SpanOptions
+    {
+        $this->start = $now;
 
         return $this;
     }
@@ -89,8 +98,12 @@ final class SpanOptions implements API\SpanOptions
 
         $span = new Span($this->name, $context, $this->parent, $this->kind);
 
-        if (isset($this->start)) {
-            $span->setStartTimestamp($this->start);
+        if ($this->startEpochTimestamp !== null) {
+            $span->setStartEpochTimestamp($this->startEpochTimestamp);
+        }
+
+        if ($this->start !== null) {
+            $span->setStart($this->start);
         }
 
         if (isset($this->attributes)) {

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -41,7 +41,7 @@ class Tracer implements API\Tracer
      */
     public function getActiveSpan(): API\Span
     {
-        while (count($this->tail) && $this->active->getEndTimestamp()) {
+        while (count($this->tail) && $this->active->getEnd()) {
             $this->active = array_pop($this->tail);
         }
 

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -68,7 +68,7 @@ class ZipkinSpanConverterTest extends TestCase
         $row = (new SpanConverter('duration.test'))->convert($span);
 
         $this->assertEquals(
-            (int) (($span->getEndTimestamp() - $span->getStartTimestamp()) / 1000),
+            (int) (($span->getEnd() - $span->getStart()) / 1000),
             $row['duration']
         );
     }

--- a/tests/Sdk/Unit/Trace/SpanOptionsTest.php
+++ b/tests/Sdk/Unit/Trace/SpanOptionsTest.php
@@ -29,7 +29,8 @@ class SpanOptionsTest extends TestCase
 
         $this->assertSame($global->getContext()->getTraceId(), $web->getContext()->getTraceId());
         $this->assertEquals($web->getParent(), $global->getContext());
-        $this->assertNotNull($web->getStartTimestamp());
+        $this->assertNotNull($web->getStartEpochTimestamp());
+        $this->assertNotNull($web->getStart());
         $this->assertTrue($web->isRecording());
         $this->assertNull($web->getDuration());
     }
@@ -38,7 +39,7 @@ class SpanOptionsTest extends TestCase
     {
         $tracer = $this->getTracer();
         $spanOptions = new SpanOptions($tracer, 'web');
-        $global = $tracer->getActiveSpan();
+        $tracer->getActiveSpan();
         $this->assertSame($spanOptions, $spanOptions->setSpanName('web2'));
         $this->assertSame($spanOptions, $spanOptions->addStartTimestamp(1234));
 
@@ -49,14 +50,14 @@ class SpanOptionsTest extends TestCase
 
         // Assert previously set vars
         $this->assertEquals('web2', $web->getSpanName());
-        $this->assertEquals(1234, $web->getStartTimestamp());
+        $this->assertEquals(1234, $web->getStartEpochTimestamp());
     }
 
     public function testShouldCreateCorrectSpanAttributes()
     {
         $tracer = $this->getTracer();
         $spanOptions = new SpanOptions($tracer, 'web');
-        $global = $tracer->getActiveSpan();
+        $tracer->getActiveSpan();
 
         $attribRaw = [
             'attr_1' => 'value_1',

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
+use function iterator_to_array;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Sdk\Trace as SDK;
 use OpenTelemetry\Sdk\Trace\Attribute;
@@ -83,7 +84,7 @@ class TracingTest extends TestCase
         $this->assertSame($tracer->getActiveSpan(), $mysql);
         $this->assertSame($global->getContext()->getTraceId(), $mysql->getContext()->getTraceId());
         $this->assertEquals($mysql->getParent(), $global->getContext());
-        $this->assertNotNull($mysql->getStartTimestamp());
+        $this->assertNotNull($mysql->getStartEpochTimestamp());
         $this->assertTrue($mysql->isRecording());
         $this->assertNull($mysql->getDuration());
 
@@ -180,7 +181,7 @@ class TracingTest extends TestCase
         ];
         $span->replaceAttributes(new Attributes(['a' => 1, 'b' => 2]));
 
-        $actual = \iterator_to_array($span->getAttributes());
+        $actual = iterator_to_array($span->getAttributes());
         self::assertEquals($expected, $actual);
 
         // attribute update don't change the order
@@ -191,7 +192,7 @@ class TracingTest extends TestCase
             'a' => new Attribute('a', 3),
             'b' => new Attribute('b', 4),
         ];
-        $actual = \iterator_to_array($span->getAttributes());
+        $actual = iterator_to_array($span->getAttributes());
         self::assertEquals($expected, $actual);
     }
 
@@ -204,17 +205,17 @@ class TracingTest extends TestCase
 
         $this->assertFalse($span->isRecording());
         $this->assertCount(1, $span->getAttributes());
-        $this->assertArrayHasKey('key1', \iterator_to_array($span->getAttributes()));
+        $this->assertArrayHasKey('key1', iterator_to_array($span->getAttributes()));
 
         $span->setAttribute('key2', 'value2');
         $this->assertCount(1, $span->getAttributes());
-        $this->assertArrayHasKey('key1', \iterator_to_array($span->getAttributes()));
-        $this->assertArrayNotHasKey('key2', \iterator_to_array($span->getAttributes()));
+        $this->assertArrayHasKey('key1', iterator_to_array($span->getAttributes()));
+        $this->assertArrayNotHasKey('key2', iterator_to_array($span->getAttributes()));
 
         $span->replaceAttributes(new Attributes(['foo' => 'bar']));
         $this->assertCount(1, $span->getAttributes());
-        $this->assertArrayHasKey('key1', \iterator_to_array($span->getAttributes()));
-        $this->assertArrayNotHasKey('foo', \iterator_to_array($span->getAttributes()));
+        $this->assertArrayHasKey('key1', iterator_to_array($span->getAttributes()));
+        $this->assertArrayNotHasKey('foo', iterator_to_array($span->getAttributes()));
     }
 
     public function testEventRegistration()
@@ -232,7 +233,7 @@ class TracingTest extends TestCase
         $events = $span->getEvents();
         self::assertCount(1, $events);
 
-        [$event] = \iterator_to_array($events);
+        [$event] = iterator_to_array($events);
         $this->assertSame($event->getName(), 'select');
         $attributes = new Attributes([
             'space' => 'guard.session',
@@ -258,14 +259,14 @@ class TracingTest extends TestCase
         $events = $span->getEvents();
         self::assertCount(1, $events);
 
-        [$event] = \iterator_to_array($events);
+        [$event] = iterator_to_array($events);
         $this->assertSame($event->getName(), 'recorded_event');
 
         $span->end();
         $span->addEvent('not_recorded_event', 1);
 
         $this->assertCount(1, $span->getEvents());
-        [$event] = \iterator_to_array($events);
+        [$event] = iterator_to_array($events);
         $this->assertSame($event->getName(), 'recorded_event');
     }
 


### PR DESCRIPTION
As reported here https://zipkin.io/zipkin-api/#/default/post_spans: 'Epoch microseconds of the start of this span, possibly absent if incomplete.'