### PR TITLE
Implement an UpDownCounter Instrument for the Metrics API

### DIFF
--- a/api/Metrics/UpDownCounter.php
+++ b/api/Metrics/UpDownCounter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Metrics;
 
-
 /*
  * Name: UpDownCounter
  * Instrument kind : Synchronous additive
@@ -21,5 +20,12 @@ namespace OpenTelemetry\Metrics;
  */
 interface UpDownCounter
 {
+    /**
+     * Updates counter value with the positive or negative int that is passed in.
+     *
+     * @access	public
+     * @param	int	$value
+     * @return	int returns the non-monotonic sum
+     */
     public function add($increment) : int;
 }

--- a/api/Metrics/UpDownCounter.php
+++ b/api/Metrics/UpDownCounter.php
@@ -4,22 +4,22 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Metrics;
 
-interface UpDownCounter extends Counter
-{
-    /**
-     * Subtracts counter value
-     *
-     * @access	public
-     * @param	int	$value
-     * @return	UpDownCounter
-     */
-    public function subtract(int $value) : UpDownCounter;
 
-    /**
-     * Decrements counter value
-     *
-     * @access	public
-     * @return	UpDownCounter
-     */
-    public function decrement() : UpDownCounter;
+/*
+ * Name: UpDownCounter
+ * Instrument kind : Synchronous additive
+ * Function(argument) : Add(increment) where increment is a numeric value
+ * Default aggregation : Sum
+ * Notes : Per-request, part of a non-monotonic sum
+ *
+ * UpDownCounter supports negative increments. This makes UpDownCounter
+ * not useful for computing a rate aggregation. It aggregates a Sum,
+ * only the sum is non-monotonic. It is generally useful for capturing changes
+ * in an amount of resources used, or any quantity that rises and falls during
+ * a request.
+ *
+ */
+interface UpDownCounter
+{
+    public function add($increment) : int;
 }

--- a/api/Metrics/UpDownCounter.php
+++ b/api/Metrics/UpDownCounter.php
@@ -24,7 +24,7 @@ interface UpDownCounter
      * Updates counter value with the positive or negative int that is passed in.
      *
      * @access	public
-     * @param	int	$value
+     * @param	$increment
      * @return	int returns the non-monotonic sum
      */
     public function add($increment) : int;

--- a/sdk/Metrics/UpDownCounter.php
+++ b/sdk/Metrics/UpDownCounter.php
@@ -32,6 +32,7 @@ class UpDownCounter extends AbstractMetric implements API\UpDownCounter, API\Lab
     /**
      * Get $type
      *
+     * @access	public
      * @return  int
      */
     public function getType(): int

--- a/sdk/Metrics/UpDownCounter.php
+++ b/sdk/Metrics/UpDownCounter.php
@@ -30,10 +30,10 @@ class UpDownCounter extends AbstractMetric implements API\UpDownCounter, API\Lab
     protected $value = 0;
 
     /**
-     * Get $type
+     * getType
      *
      * @access	public
-     * @return  int
+     * @return	int
      */
     public function getType(): int
     {

--- a/tests/Sdk/Unit/Metrics/CounterTest.php
+++ b/tests/Sdk/Unit/Metrics/CounterTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Sdk\Unit\Metrics;
 
 use OpenTelemetry\Sdk\Metrics\Counter;
-use OpenTelemetry\Sdk\Metrics\UpDownCounter;
 use PHPUnit\Framework\TestCase;
 
 class CounterTest extends TestCase
@@ -28,35 +27,5 @@ class CounterTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $counter->add(-1);
-    }
-
-    public function testUpDownCounterIncrementsAndDecrements()
-    {
-        $counter = new UpDownCounter('some_counter');
-
-        $this->assertSame(0, $counter->getValue());
-
-        $counter->increment();
-
-        $this->assertSame(1, $counter->getValue());
-
-        $counter->decrement();
-
-        $this->assertSame(0, $counter->getValue());
-    }
-
-    public function testUpDownCounterAcceptNegativeNumbers()
-    {
-        $counter = new UpDownCounter('some_up_down_counter');
-
-        $this->assertSame(0, $counter->getValue());
-
-        $counter->add(-1);
-
-        $this->assertSame(-1, $counter->getValue());
-
-        $counter->subtract(3);
-
-        $this->assertSame(-4, $counter->getValue());
     }
 }

--- a/tests/Sdk/Unit/Metrics/UpDownCounterTest.php
+++ b/tests/Sdk/Unit/Metrics/UpDownCounterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\Metrics;
+
+use InvalidArgumentException;
+use OpenTelemetry\Sdk\Metrics\UpDownCounter;
+use PHPUnit\Framework\TestCase;
+
+class UpDownCounterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testValidPositiveIntAdd()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $retVal = $counter->Add(5);
+        $this->assertEquals(5, $retVal);
+        $retVal = $counter->Add(2);
+        $this->assertEquals(7, $retVal);
+    }
+    public function testValidNegativeIntAdd()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $retVal = $counter->Add(-5);
+        $this->assertEquals(-5, $retVal);
+        $retVal = $counter->Add(-2);
+        $this->assertEquals(-7, $retVal);
+    }
+
+    public function testValidPositiveAndNegativeIntAdd()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $retVal = $counter->Add(5);
+        $this->assertEquals(5, $retVal);
+        $retVal = $counter->Add(-2);
+        $this->assertEquals(3, $retVal);
+    }
+    public function testValidNegativeAndPositiveAdd()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $retVal = $counter->Add(-5);
+        $this->assertEquals(-5, $retVal);
+        $retVal = $counter->Add(2);
+        $this->assertEquals(-3, $retVal);
+    }
+
+    public function testValidPositiveFloastAdd()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $retVal = $counter->Add(5.2222);
+        $this->assertEquals(5, $retVal);
+        $retVal = $counter->Add(2.6666);
+        $this->assertEquals(7, $retVal);
+    }
+    public function testValidNegativeFloatAdd()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $retVal = $counter->Add(-5.2222);
+        $this->assertEquals(-5, $retVal);
+        $retVal = $counter->Add(-2.6666);
+        $this->assertEquals(-7, $retVal);
+    }
+
+    public function testValidPositiveAndNegativeFloatAdd()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $retVal = $counter->Add(5.2222);
+        $this->assertEquals(5, $retVal);
+        $retVal = $counter->Add(-2.6666);
+        $this->assertEquals(3, $retVal);
+    }
+    public function testValidNegativeAndPositiveFloatAdd()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $retVal = $counter->Add(-5.2222);
+        $this->assertEquals(-5, $retVal);
+        $retVal = $counter->Add(2.6666);
+        $this->assertEquals(-3, $retVal);
+    }
+    public function testInvalidUpDownCounterAddThrowsException()
+    {
+        $counter = new UpDownCounter('name', 'description');
+        $this->expectException(InvalidArgumentException::class);
+        $retVal = $counter->Add('a');
+    }
+}

--- a/tests/Sdk/Unit/Metrics/UpDownCounterTest.php
+++ b/tests/Sdk/Unit/Metrics/UpDownCounterTest.php
@@ -16,74 +16,74 @@ class UpDownCounterTest extends TestCase
     public function testValidPositiveIntAdd()
     {
         $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->Add(5);
+        $retVal = $counter->add(5);
         $this->assertEquals(5, $retVal);
-        $retVal = $counter->Add(2);
+        $retVal = $counter->add(2);
         $this->assertEquals(7, $retVal);
     }
     public function testValidNegativeIntAdd()
     {
         $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->Add(-5);
+        $retVal = $counter->add(-5);
         $this->assertEquals(-5, $retVal);
-        $retVal = $counter->Add(-2);
+        $retVal = $counter->add(-2);
         $this->assertEquals(-7, $retVal);
     }
 
     public function testValidPositiveAndNegativeIntAdd()
     {
         $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->Add(5);
+        $retVal = $counter->add(5);
         $this->assertEquals(5, $retVal);
-        $retVal = $counter->Add(-2);
+        $retVal = $counter->add(-2);
         $this->assertEquals(3, $retVal);
     }
     public function testValidNegativeAndPositiveAdd()
     {
         $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->Add(-5);
+        $retVal = $counter->add(-5);
         $this->assertEquals(-5, $retVal);
-        $retVal = $counter->Add(2);
+        $retVal = $counter->add(2);
         $this->assertEquals(-3, $retVal);
     }
 
     public function testValidPositiveFloastAdd()
     {
         $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->Add(5.2222);
+        $retVal = $counter->add(5.2222);
         $this->assertEquals(5, $retVal);
-        $retVal = $counter->Add(2.6666);
+        $retVal = $counter->add(2.6666);
         $this->assertEquals(7, $retVal);
     }
     public function testValidNegativeFloatAdd()
     {
         $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->Add(-5.2222);
+        $retVal = $counter->add(-5.2222);
         $this->assertEquals(-5, $retVal);
-        $retVal = $counter->Add(-2.6666);
+        $retVal = $counter->add(-2.6666);
         $this->assertEquals(-7, $retVal);
     }
 
     public function testValidPositiveAndNegativeFloatAdd()
     {
         $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->Add(5.2222);
+        $retVal = $counter->add(5.2222);
         $this->assertEquals(5, $retVal);
-        $retVal = $counter->Add(-2.6666);
+        $retVal = $counter->add(-2.6666);
         $this->assertEquals(3, $retVal);
     }
     public function testValidNegativeAndPositiveFloatAdd()
     {
         $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->Add(-5.2222);
+        $retVal = $counter->add(-5.2222);
         $this->assertEquals(-5, $retVal);
-        $retVal = $counter->Add(2.6666);
+        $retVal = $counter->add(2.6666);
         $this->assertEquals(-3, $retVal);
     }
     public function testInvalidUpDownCounterAddThrowsException()
     {
         $counter = new UpDownCounter('name', 'description');
         $this->expectException(InvalidArgumentException::class);
-        $retVal = $counter->Add('a');
+        $retVal = $counter->add('a');
     }
 }


### PR DESCRIPTION
* Initial UpDownCounter commit.
* Unit tests included.

`UpDownCounter` extends `AbstractMetric` from the `Metrics api` [pull request](https://github.com/open-telemetry/opentelemetry-php/pull/155/files).

