### PR TITLE
Implement a ValueRecorder Instrument for the Metrics API

### DIFF
--- a/api/Metrics/ValueRecorder.php
+++ b/api/Metrics/ValueRecorder.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\Metrics;
 interface ValueRecorder
 {
     /**
-     * record.
+     * records the given value to this ValueRecorder.
      *
      * @access	public
      * @param int|float $value

--- a/api/Metrics/ValueRecorder.php
+++ b/api/Metrics/ValueRecorder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Metrics;
 
-interface ValueRecorder
+interface ValueRecorder extends Metric
 {
     /**
      * records the given value to this ValueRecorder.
@@ -14,4 +14,36 @@ interface ValueRecorder
      * @return void
      */
     public function record($value) : void;
+
+    /**
+     * Returns the sum of the values
+     *
+     * @access	public
+     * @return	float
+     */
+    public function getSum(): float;
+
+    /**
+     * Returns the min of the values
+     *
+     * @access	public
+     * @return	float
+     */
+    public function getMin(): float;
+
+    /**
+     * Returns the max of the values
+     *
+     * @access	public
+     * @return	float
+     */
+    public function getMax(): float;
+
+    /**
+     * Returns the count of the values
+     *
+     * @access	public
+     * @return	int
+     */
+    public function getCount(): int;
 }

--- a/sdk/Metrics/ValueRecorder.php
+++ b/sdk/Metrics/ValueRecorder.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Metrics;
+
+use InvalidArgumentException;
+use OpenTelemetry\Metrics as API;
+
+/*
+ * Name	: ValueRecorder
+ * Instrument kind : Synchronous
+ * Function(argument) : Record(value)
+ * Default aggregation : MinMaxSumCount
+ * Notes : Per-request, any non-additive measurement
+ *
+ * ValueRecorder is a non-additive synchronous instrument useful for
+ * recording any non-additive number, positive or negative. Values
+ * captured by a Record(value) are treated as individual events
+ * belonging to a distribution that is being summarized. ValueRecorder
+ * should be chosen either when capturing measurements that do not
+ * contribute meaningfully to a sum, or when capturing numbers that
+ * are additive in nature, but where the distribution of individual
+ * increments is considered interesting.
+ *
+ * Example: One of the most common uses for ValueRecorder is to capture latency
+ * measurements. Latency measurements are not additive in the sense that
+ * there is little need to know the latency-sum of all processed requests.
+ * We use a ValueRecorder instrument to capture latency measurements
+ * typically because we are interested in knowing mean, median, and other
+ * summary statistics about individual events.
+ *
+ * The default aggregation for ValueRecorder computes the minimum and maximum
+ * values, the sum of event values, and the count of events, allowing the rate,
+ * the mean, and range of input values to be monitored.
+ */
+class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\LabelableMetric
+{
+    use HasLabels;
+
+    /**
+     * @var float $valueSum
+     * @var float $valueMin
+     * @var float $valueMax
+     * @var int $valueCount
+     */
+    protected $valueSum = 0;
+    protected $valueMin = INF;
+    protected $valueMax = -INF;
+    protected $valueCount = 0;
+
+    /*
+     * Testing floating point values for equality is problematic, due to
+     * the way that they are represented internally.  Therefore, force all
+     * precision to a predetermined number, and equality can be determined.
+     */
+    private $decimalPointPrecision = 10;
+
+
+    /**
+     * GetType: get the type of metric instrument
+     *
+     * @return  int
+     */
+    public function getType(): int
+    {
+        return API\MetricKind::VALUE_RECORDER;
+    }
+
+    /**
+     * Returns the sum of the values
+     *
+     * @access	public
+     * @return	float
+     */
+    public function getValueSum(): float
+    {
+        return $this->valueSum;
+    }
+
+    /**
+     * Returns the min of the values
+     *
+     * @access	public
+     * @return	float
+     */
+    public function getValueMin(): float
+    {
+        return $this->valueMin;
+    }
+
+    /**
+     * Returns the max of the values
+     *
+     * @access	public
+     * @return	float
+     */
+    public function getValueMax(): float
+    {
+        return $this->valueMax;
+    }
+
+    /**
+     * Returns the mean of the values
+     *
+     * @access	public
+     * @return	float
+     */
+    public function getValueMean(): float
+    {
+        if ($this->valueCount) {
+            return ($this->valueSum/$this->valueCount);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Returns the count of the values
+     *
+     * @access	public
+     * @return	int
+     */
+    public function getValueCount(): int
+    {
+        return $this->valueCount;
+    }
+
+    /**
+     * Updates the ValueRecorder's value with the specified value then returns
+     * the current value count.
+     *
+     * @access	public
+     *
+     * @param float $value, accepts INTs or FLOATs. If value is an int, it it cast as a float.
+     *
+     * @return int $valueCount, returns the current count of values recorded.
+     */
+
+    public function Record($value): int
+    {
+        if (is_int($value)) {
+            /*
+             *
+             * todo: send the following message to the log when logger is implemented:
+             *       Integer detected, casting as a float.
+             */
+            $value = (float) $value;
+        }
+        if (!is_float($value)) {
+            throw new InvalidArgumentException('Only numerical values can be used 
+                                                to update the ValueRecorder.');
+        }
+
+        $value = round($value, $this->decimalPointPrecision);
+
+        $this->valueSum += $value;
+        $this->valueMin = min($this->valueMin, $value);
+        $this->valueMax = max($this->valueMax, $value);
+        $this->valueCount++;
+
+        return $this->valueCount;
+    }
+}

--- a/sdk/Metrics/ValueRecorder.php
+++ b/sdk/Metrics/ValueRecorder.php
@@ -72,7 +72,7 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      * @access	public
      * @return	float
      */
-    public function getValueSum(): float
+    public function getSum(): float
     {
         return $this->valueSum;
     }
@@ -83,7 +83,7 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      * @access	public
      * @return	float
      */
-    public function getValueMin(): float
+    public function getMin(): float
     {
         return $this->valueMin;
     }
@@ -94,7 +94,7 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      * @access	public
      * @return	float
      */
-    public function getValueMax(): float
+    public function getMax(): float
     {
         return $this->valueMax;
     }
@@ -105,7 +105,7 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      * @access	public
      * @return	float
      */
-    public function getValueMean(): float
+    public function getMean(): float
     {
         if (0 == $this->valueCount) {
             return 0;
@@ -120,7 +120,7 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      * @access	public
      * @return	int
      */
-    public function getValueCount(): int
+    public function getCount(): int
     {
         return $this->valueCount;
     }
@@ -130,12 +130,9 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      * the current value count.
      *
      * @access	public
-     *
-     * @param float $value, accepts INTs or FLOATs. If value is an int, it it cast as a float.
-     *
-     * @return int $valueCount, returns the current count of values recorded.
+     * @param int|float $value, accepts INTs or FLOATs. If value is an int, it it cast as a float.
+     * @return void
      */
-
     public function record($value): void
     {
         if (is_int($value)) {

--- a/sdk/Metrics/ValueRecorder.php
+++ b/sdk/Metrics/ValueRecorder.php
@@ -10,7 +10,7 @@ use OpenTelemetry\Metrics as API;
 /*
  * Name	: ValueRecorder
  * Instrument kind : Synchronous
- * Function(argument) : Record(value)
+ * Function(argument) : record(value)
  * Default aggregation : MinMaxSumCount
  * Notes : Per-request, any non-additive measurement
  *
@@ -56,9 +56,8 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      */
     private $decimalPointPrecision = 10;
 
-
     /**
-     * GetType: get the type of metric instrument
+     * getType: get the type of metric instrument
      *
      * @return  int
      */
@@ -108,11 +107,11 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      */
     public function getValueMean(): float
     {
-        if ($this->valueCount) {
-            return ($this->valueSum/$this->valueCount);
+        if (0 == $this->valueCount) {
+            return 0;
         }
 
-        return 0;
+        return ($this->valueSum/$this->valueCount);
     }
 
     /**
@@ -137,7 +136,7 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
      * @return int $valueCount, returns the current count of values recorded.
      */
 
-    public function Record($value): int
+    public function record($value): void
     {
         if (is_int($value)) {
             /*
@@ -158,7 +157,5 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorder, API\Lab
         $this->valueMin = min($this->valueMin, $value);
         $this->valueMax = max($this->valueMax, $value);
         $this->valueCount++;
-
-        return $this->valueCount;
     }
 }

--- a/tests/Sdk/Unit/Metrics/ValueRecorderTest.php
+++ b/tests/Sdk/Unit/Metrics/ValueRecorderTest.php
@@ -17,117 +17,132 @@ class ValueRecorderTest extends TestCase
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5);
-        $this->assertEquals(1, $metric->getValueCount());
-        $this->assertEquals(5, $metric->getValueMax());
-        $this->assertEquals(5, $metric->getValueMin());
-        $this->assertEquals(5, $metric->getValueSum());
+        $this->assertEquals(1, $metric->getCount());
+        $this->assertEquals(5, $metric->getMax());
+        $this->assertEquals(5, $metric->getMin());
+        $this->assertEquals(5, $metric->getSum());
         $metric->record(2);
-        $this->assertEquals(2, $metric->getValueCount());
-        $this->assertEquals(5, $metric->getValueMax());
-        $this->assertEquals(2, $metric->getValueMin());
-        $this->assertEquals(7, $metric->getValueSum());
+        $this->assertEquals(2, $metric->getCount());
+        $this->assertEquals(5, $metric->getMax());
+        $this->assertEquals(2, $metric->getMin());
+        $this->assertEquals(7, $metric->getSum());
     }
+
     public function testValidNegativeIntRecord()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5);
-        $this->assertEquals(1, $metric->getValueCount());
-        $this->assertEquals(-5, $metric->getValueMax());
-        $this->assertEquals(-5, $metric->getValueMin());
-        $this->assertEquals(-5, $metric->getValueSum());
+        $this->assertEquals(1, $metric->getCount());
+        $this->assertEquals(-5, $metric->getMax());
+        $this->assertEquals(-5, $metric->getMin());
+        $this->assertEquals(-5, $metric->getSum());
         $metric->record(-2);
-        $this->assertEquals(2, $metric->getValueCount());
-        $this->assertEquals(-2, $metric->getValueMax());
-        $this->assertEquals(-5, $metric->getValueMin());
-        $this->assertEquals(-7, $metric->getValueSum());
+        $this->assertEquals(2, $metric->getCount());
+        $this->assertEquals(-2, $metric->getMax());
+        $this->assertEquals(-5, $metric->getMin());
+        $this->assertEquals(-7, $metric->getSum());
     }
 
     public function testValidPositiveAndNegativeIntRecord()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5);
-        $this->assertEquals(1, $metric->getValueCount());
-        $this->assertEquals(5, $metric->getValueMax());
-        $this->assertEquals(5, $metric->getValueMin());
-        $this->assertEquals(5, $metric->getValueSum());
+        $this->assertEquals(1, $metric->getCount());
+        $this->assertEquals(5, $metric->getMax());
+        $this->assertEquals(5, $metric->getMin());
+        $this->assertEquals(5, $metric->getSum());
         $metric->record(-2);
-        $this->assertEquals(2, $metric->getValueCount());
-        $this->assertEquals(5, $metric->getValueMax());
-        $this->assertEquals(-2, $metric->getValueMin());
-        $this->assertEquals(3, $metric->getValueSum());
+        $this->assertEquals(2, $metric->getCount());
+        $this->assertEquals(5, $metric->getMax());
+        $this->assertEquals(-2, $metric->getMin());
+        $this->assertEquals(3, $metric->getSum());
     }
+
     public function testValidNegativeAndPositiveRecord()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5);
-        $this->assertEquals(1, $metric->getValueCount());
-        $this->assertEquals(-5, $metric->getValueMax());
-        $this->assertEquals(-5, $metric->getValueMin());
-        $this->assertEquals(-5, $metric->getValueSum());
+        $this->assertEquals(1, $metric->getCount());
+        $this->assertEquals(-5, $metric->getMax());
+        $this->assertEquals(-5, $metric->getMin());
+        $this->assertEquals(-5, $metric->getSum());
         $metric->record(2);
-        $this->assertEquals(2, $metric->getValueCount());
-        $this->assertEquals(2, $metric->getValueMax());
-        $this->assertEquals(-5, $metric->getValueMin());
-        $this->assertEquals(-3, $metric->getValueSum());
+        $this->assertEquals(2, $metric->getCount());
+        $this->assertEquals(2, $metric->getMax());
+        $this->assertEquals(-5, $metric->getMin());
+        $this->assertEquals(-3, $metric->getSum());
     }
 
     public function testValidPositiveFloastRecord()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5.2222);
-        $this->assertEquals(1, $metric->getValueCount());
-        $this->assertEquals(5.2222, $metric->getValueMax());
-        $this->assertEquals(5.2222, $metric->getValueMin());
-        $this->assertEquals(5.2222, $metric->getValueSum());
+        $this->assertEquals(1, $metric->getCount());
+        $this->assertEquals(5.2222, $metric->getMax());
+        $this->assertEquals(5.2222, $metric->getMin());
+        $this->assertEquals(5.2222, $metric->getSum());
         $metric->record(2.6666);
-        $this->assertEquals(2, $metric->getValueCount());
-        $this->assertEquals(5.2222, $metric->getValueMax());
-        $this->assertEquals(2.6666, $metric->getValueMin());
-        $this->assertEquals(7.8888, $metric->getValueSum());
+        $this->assertEquals(2, $metric->getCount());
+        $this->assertEquals(5.2222, $metric->getMax());
+        $this->assertEquals(2.6666, $metric->getMin());
+        $this->assertEquals(7.8888, $metric->getSum());
     }
+
     public function testValidNegativeFloatRecord()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5.2222);
-        $this->assertEquals(1, $metric->getValueCount());
-        $this->assertEquals(-5.2222, $metric->getValueMax());
-        $this->assertEquals(-5.2222, $metric->getValueMin());
-        $this->assertEquals(-5.2222, $metric->getValueSum());
+        $this->assertEquals(1, $metric->getCount());
+        $this->assertEquals(-5.2222, $metric->getMax());
+        $this->assertEquals(-5.2222, $metric->getMin());
+        $this->assertEquals(-5.2222, $metric->getSum());
         $metric->record(-2.6666);
-        $this->assertEquals(2, $metric->getValueCount());
-        $this->assertEquals(-2.6666, $metric->getValueMax());
-        $this->assertEquals(-5.2222, $metric->getValueMin());
-        $this->assertEquals(-7.8888, $metric->getValueSum());
+        $this->assertEquals(2, $metric->getCount());
+        $this->assertEquals(-2.6666, $metric->getMax());
+        $this->assertEquals(-5.2222, $metric->getMin());
+        $this->assertEquals(-7.8888, $metric->getSum());
     }
 
     public function testValidPositiveAndNegativeFloatRecord()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5.2222);
-        $this->assertEquals(1, $metric->getValueCount());
-        $this->assertEquals(5.2222, $metric->getValueMax());
-        $this->assertEquals(5.2222, $metric->getValueMin());
-        $this->assertEquals(5.2222, $metric->getValueSum());
-        $metric->record(-2.6666, $metric->getValueCount());
-        $this->assertEquals(2, $metric->getValueCount());
-        $this->assertEquals(5.2222, $metric->getValueMax());
-        $this->assertEquals(-2.6666, $metric->getValueMin());
-        $this->assertEquals(2.5556, $metric->getValueSum());
+        $this->assertEquals(1, $metric->getCount());
+        $this->assertEquals(5.2222, $metric->getMax());
+        $this->assertEquals(5.2222, $metric->getMin());
+        $this->assertEquals(5.2222, $metric->getSum());
+        $metric->record(-2.6666, $metric->getCount());
+        $this->assertEquals(2, $metric->getCount());
+        $this->assertEquals(5.2222, $metric->getMax());
+        $this->assertEquals(-2.6666, $metric->getMin());
+        $this->assertEquals(2.5556, $metric->getSum());
     }
+
     public function testValidNegativeAndPositiveFloatRecord()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5.2222);
-        $this->assertEquals(1, $metric->getValueCount());
-        $this->assertEquals(-5.2222, $metric->getValueMax());
-        $this->assertEquals(-5.2222, $metric->getValueMin());
-        $this->assertEquals(-5.2222, $metric->getValueSum());
+        $this->assertEquals(1, $metric->getCount());
+        $this->assertEquals(-5.2222, $metric->getMax());
+        $this->assertEquals(-5.2222, $metric->getMin());
+        $this->assertEquals(-5.2222, $metric->getSum());
         $metric->record(2.6666);
-        $this->assertEquals(2, $metric->getValueCount());
-        $this->assertEquals(2.6666, $metric->getValueMax());
-        $this->assertEquals(-5.2222, $metric->getValueMin());
-        $this->assertEquals(-2.5556, $metric->getValueSum());
+        $this->assertEquals(2, $metric->getCount());
+        $this->assertEquals(2.6666, $metric->getMax());
+        $this->assertEquals(-5.2222, $metric->getMin());
+        $this->assertEquals(-2.5556, $metric->getSum());
     }
+
+    public function testValueRecorderInitialization()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $this->assertEquals(0, $metric->getCount());
+        $this->assertEquals(INF, $metric->getMax());
+        $this->assertEquals(-INF, $metric->getMin());
+        $this->assertEquals(0, $metric->getSum());
+        $this->assertEquals(0, $metric->getMean());
+    }
+
     public function testInvalidValueRecorderRecordThrowsException()
     {
         $metric = new ValueRecorder('name', 'description');

--- a/tests/Sdk/Unit/Metrics/ValueRecorderTest.php
+++ b/tests/Sdk/Unit/Metrics/ValueRecorderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\Metrics;
+
+use InvalidArgumentException;
+use OpenTelemetry\Sdk\Metrics\ValueRecorder;
+use PHPUnit\Framework\TestCase;
+
+class ValueRecorderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testValidPositiveIntRecord()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $retVal = $metric->Record(5);
+        $this->assertEquals(1, $retVal);
+        $retVal = $metric->Record(2);
+        $this->assertEquals(2, $retVal);
+        $this->assertEquals(5, $metric->getValueMax());
+        $this->assertEquals(2, $metric->getValueMin());
+        $this->assertEquals(7, $metric->getValueSum());
+    }
+    public function testValidNegativeIntRecord()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $retVal = $metric->Record(-5);
+        $this->assertEquals(1, $retVal);
+        $retVal = $metric->Record(-2);
+        $this->assertEquals(2, $retVal);
+        $this->assertEquals(-2, $metric->getValueMax());
+        $this->assertEquals(-5, $metric->getValueMin());
+        $this->assertEquals(-7, $metric->getValueSum());
+    }
+
+    public function testValidPositiveAndNegativeIntRecord()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $retVal = $metric->Record(5);
+        $this->assertEquals(1, $retVal);
+        $retVal = $metric->Record(-2);
+        $this->assertEquals(2, $retVal);
+        $this->assertEquals(5, $metric->getValueMax());
+        $this->assertEquals(-2, $metric->getValueMin());
+        $this->assertEquals(3, $metric->getValueSum());
+    }
+    public function testValidNegativeAndPositiveRecord()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $retVal = $metric->Record(-5);
+        $this->assertEquals(1, $retVal);
+        $retVal = $metric->Record(2);
+        $this->assertEquals(2, $retVal);
+        $this->assertEquals(2, $metric->getValueMax());
+        $this->assertEquals(-5, $metric->getValueMin());
+        $this->assertEquals(-3, $metric->getValueSum());
+    }
+
+    public function testValidPositiveFloastRecord()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $retVal = $metric->Record(5.2222);
+        $this->assertEquals(1, $retVal);
+        $retVal = $metric->Record(2.6666);
+        $this->assertEquals(2, $retVal);
+        $this->assertEquals(5.2222, $metric->getValueMax());
+        $this->assertEquals(2.6666, $metric->getValueMin());
+        $this->assertEquals(7.8888, $metric->getValueSum());
+    }
+    public function testValidNegativeFloatRecord()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $retVal = $metric->Record(-5.2222);
+        $this->assertEquals(1, $retVal);
+        $retVal = $metric->Record(-2.6666);
+        $this->assertEquals(2, $retVal);
+        $this->assertEquals(-2.6666, $metric->getValueMax());
+        $this->assertEquals(-5.2222, $metric->getValueMin());
+        $this->assertEquals(-7.8888, $metric->getValueSum());
+    }
+
+    public function testValidPositiveAndNegativeFloatRecord()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $retVal = $metric->Record(5.2222);
+        $this->assertEquals(1, $retVal);
+        $retVal = $metric->Record(-2.6666);
+        $this->assertEquals(2, $retVal);
+        $this->assertEquals(5.2222, $metric->getValueMax());
+        $this->assertEquals(-2.6666, $metric->getValueMin());
+        $this->assertEquals(2.5556, $metric->getValueSum());
+    }
+    public function testValidNegativeAndPositiveFloatRecord()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $retVal = $metric->Record(-5.2222);
+        $this->assertEquals(1, $retVal);
+        $retVal = $metric->Record(2.6666);
+        $this->assertEquals(2, $retVal);
+        $this->assertEquals(2.6666, $metric->getValueMax());
+        $this->assertEquals(-5.2222, $metric->getValueMin());
+        $this->assertEquals(-2.5556, $metric->getValueSum());
+    }
+    public function testInvalidValueRecorderRecordThrowsException()
+    {
+        $metric = new ValueRecorder('name', 'description');
+        $this->expectException(InvalidArgumentException::class);
+        $retVal = $metric->Record('a');
+    }
+}

--- a/tests/Sdk/Unit/Metrics/ValueRecorderTest.php
+++ b/tests/Sdk/Unit/Metrics/ValueRecorderTest.php
@@ -16,10 +16,13 @@ class ValueRecorderTest extends TestCase
     public function testValidPositiveIntRecord()
     {
         $metric = new ValueRecorder('name', 'description');
-        $retVal = $metric->Record(5);
-        $this->assertEquals(1, $retVal);
-        $retVal = $metric->Record(2);
-        $this->assertEquals(2, $retVal);
+        $metric->record(5);
+        $this->assertEquals(1, $metric->getValueCount());
+        $this->assertEquals(5, $metric->getValueMax());
+        $this->assertEquals(5, $metric->getValueMin());
+        $this->assertEquals(5, $metric->getValueSum());
+        $metric->record(2);
+        $this->assertEquals(2, $metric->getValueCount());
         $this->assertEquals(5, $metric->getValueMax());
         $this->assertEquals(2, $metric->getValueMin());
         $this->assertEquals(7, $metric->getValueSum());
@@ -27,10 +30,13 @@ class ValueRecorderTest extends TestCase
     public function testValidNegativeIntRecord()
     {
         $metric = new ValueRecorder('name', 'description');
-        $retVal = $metric->Record(-5);
-        $this->assertEquals(1, $retVal);
-        $retVal = $metric->Record(-2);
-        $this->assertEquals(2, $retVal);
+        $metric->record(-5);
+        $this->assertEquals(1, $metric->getValueCount());
+        $this->assertEquals(-5, $metric->getValueMax());
+        $this->assertEquals(-5, $metric->getValueMin());
+        $this->assertEquals(-5, $metric->getValueSum());
+        $metric->record(-2);
+        $this->assertEquals(2, $metric->getValueCount());
         $this->assertEquals(-2, $metric->getValueMax());
         $this->assertEquals(-5, $metric->getValueMin());
         $this->assertEquals(-7, $metric->getValueSum());
@@ -39,10 +45,13 @@ class ValueRecorderTest extends TestCase
     public function testValidPositiveAndNegativeIntRecord()
     {
         $metric = new ValueRecorder('name', 'description');
-        $retVal = $metric->Record(5);
-        $this->assertEquals(1, $retVal);
-        $retVal = $metric->Record(-2);
-        $this->assertEquals(2, $retVal);
+        $metric->record(5);
+        $this->assertEquals(1, $metric->getValueCount());
+        $this->assertEquals(5, $metric->getValueMax());
+        $this->assertEquals(5, $metric->getValueMin());
+        $this->assertEquals(5, $metric->getValueSum());
+        $metric->record(-2);
+        $this->assertEquals(2, $metric->getValueCount());
         $this->assertEquals(5, $metric->getValueMax());
         $this->assertEquals(-2, $metric->getValueMin());
         $this->assertEquals(3, $metric->getValueSum());
@@ -50,10 +59,13 @@ class ValueRecorderTest extends TestCase
     public function testValidNegativeAndPositiveRecord()
     {
         $metric = new ValueRecorder('name', 'description');
-        $retVal = $metric->Record(-5);
-        $this->assertEquals(1, $retVal);
-        $retVal = $metric->Record(2);
-        $this->assertEquals(2, $retVal);
+        $metric->record(-5);
+        $this->assertEquals(1, $metric->getValueCount());
+        $this->assertEquals(-5, $metric->getValueMax());
+        $this->assertEquals(-5, $metric->getValueMin());
+        $this->assertEquals(-5, $metric->getValueSum());
+        $metric->record(2);
+        $this->assertEquals(2, $metric->getValueCount());
         $this->assertEquals(2, $metric->getValueMax());
         $this->assertEquals(-5, $metric->getValueMin());
         $this->assertEquals(-3, $metric->getValueSum());
@@ -62,10 +74,13 @@ class ValueRecorderTest extends TestCase
     public function testValidPositiveFloastRecord()
     {
         $metric = new ValueRecorder('name', 'description');
-        $retVal = $metric->Record(5.2222);
-        $this->assertEquals(1, $retVal);
-        $retVal = $metric->Record(2.6666);
-        $this->assertEquals(2, $retVal);
+        $metric->record(5.2222);
+        $this->assertEquals(1, $metric->getValueCount());
+        $this->assertEquals(5.2222, $metric->getValueMax());
+        $this->assertEquals(5.2222, $metric->getValueMin());
+        $this->assertEquals(5.2222, $metric->getValueSum());
+        $metric->record(2.6666);
+        $this->assertEquals(2, $metric->getValueCount());
         $this->assertEquals(5.2222, $metric->getValueMax());
         $this->assertEquals(2.6666, $metric->getValueMin());
         $this->assertEquals(7.8888, $metric->getValueSum());
@@ -73,10 +88,13 @@ class ValueRecorderTest extends TestCase
     public function testValidNegativeFloatRecord()
     {
         $metric = new ValueRecorder('name', 'description');
-        $retVal = $metric->Record(-5.2222);
-        $this->assertEquals(1, $retVal);
-        $retVal = $metric->Record(-2.6666);
-        $this->assertEquals(2, $retVal);
+        $metric->record(-5.2222);
+        $this->assertEquals(1, $metric->getValueCount());
+        $this->assertEquals(-5.2222, $metric->getValueMax());
+        $this->assertEquals(-5.2222, $metric->getValueMin());
+        $this->assertEquals(-5.2222, $metric->getValueSum());
+        $metric->record(-2.6666);
+        $this->assertEquals(2, $metric->getValueCount());
         $this->assertEquals(-2.6666, $metric->getValueMax());
         $this->assertEquals(-5.2222, $metric->getValueMin());
         $this->assertEquals(-7.8888, $metric->getValueSum());
@@ -85,10 +103,13 @@ class ValueRecorderTest extends TestCase
     public function testValidPositiveAndNegativeFloatRecord()
     {
         $metric = new ValueRecorder('name', 'description');
-        $retVal = $metric->Record(5.2222);
-        $this->assertEquals(1, $retVal);
-        $retVal = $metric->Record(-2.6666);
-        $this->assertEquals(2, $retVal);
+        $metric->record(5.2222);
+        $this->assertEquals(1, $metric->getValueCount());
+        $this->assertEquals(5.2222, $metric->getValueMax());
+        $this->assertEquals(5.2222, $metric->getValueMin());
+        $this->assertEquals(5.2222, $metric->getValueSum());
+        $metric->record(-2.6666, $metric->getValueCount());
+        $this->assertEquals(2, $metric->getValueCount());
         $this->assertEquals(5.2222, $metric->getValueMax());
         $this->assertEquals(-2.6666, $metric->getValueMin());
         $this->assertEquals(2.5556, $metric->getValueSum());
@@ -96,10 +117,13 @@ class ValueRecorderTest extends TestCase
     public function testValidNegativeAndPositiveFloatRecord()
     {
         $metric = new ValueRecorder('name', 'description');
-        $retVal = $metric->Record(-5.2222);
-        $this->assertEquals(1, $retVal);
-        $retVal = $metric->Record(2.6666);
-        $this->assertEquals(2, $retVal);
+        $metric->record(-5.2222);
+        $this->assertEquals(1, $metric->getValueCount());
+        $this->assertEquals(-5.2222, $metric->getValueMax());
+        $this->assertEquals(-5.2222, $metric->getValueMin());
+        $this->assertEquals(-5.2222, $metric->getValueSum());
+        $metric->record(2.6666);
+        $this->assertEquals(2, $metric->getValueCount());
         $this->assertEquals(2.6666, $metric->getValueMax());
         $this->assertEquals(-5.2222, $metric->getValueMin());
         $this->assertEquals(-2.5556, $metric->getValueSum());
@@ -108,6 +132,6 @@ class ValueRecorderTest extends TestCase
     {
         $metric = new ValueRecorder('name', 'description');
         $this->expectException(InvalidArgumentException::class);
-        $retVal = $metric->Record('a');
+        $retVal = $metric->record('a');
     }
 }


### PR DESCRIPTION
* Unit tests included.
* Initial ValueRecorder commit.

`ValueRecorder` depends on and extends `AbstractMetric` from the `Metrics api` [pull request](https://github.com/open-telemetry/opentelemetry-php/pull/155/files).