### PR TITLE
Fixes for trace examples

### DIFF
--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -94,7 +94,7 @@ final class SpanContext implements API\SpanContext
      */
     public static function generateSampled(): SpanContext
     {
-        return self::generate($sampled);
+        return self::generate(true);
     }
 
     /**

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -89,7 +89,6 @@ final class SpanContext implements API\SpanContext
     /**
      * Creates a new sampled context with random trace
      *
-     * @param boolean $sampled Default: false
      * @return SpanContext
      */
     public static function generateSampled(): SpanContext

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -87,6 +87,17 @@ final class SpanContext implements API\SpanContext
     }
 
     /**
+     * Creates a new sampled context with random trace
+     *
+     * @param boolean $sampled Default: false
+     * @return SpanContext
+     */
+    public static function generateSampled(): SpanContext
+    {
+        return self::generate($sampled);
+    }
+
+    /**
      * Creates a new context with random span on the same trace
      *
      * @param string $traceId Existing trace

--- a/sdk/Trace/TracerProvider.php
+++ b/sdk/Trace/TracerProvider.php
@@ -45,7 +45,7 @@ final class TracerProvider implements API\TracerProvider
             return $this->tracers[$name];
         }
 
-        $spanContext = SpanContext::generate();
+        $spanContext = SpanContext::generateSampled();
 
         $resource = ResourceInfo::create(
             new Attributes(

--- a/tests/Sdk/Unit/Trace/SpanContextTest.php
+++ b/tests/Sdk/Unit/Trace/SpanContextTest.php
@@ -31,18 +31,22 @@ class SpanContextTest extends TestCase
         $span = SpanContext::generate(true);
 
         $this->assertTrue($span->isSampled());
+
+        $span = SpanContext::generateSampled();
+
+        $this->assertTrue($span->isSampled());
     }
 
     /**
      * @test
      */
-    public function testDefaultSpansFromTracerAreNotSampled()
+    public function testDefaultSpansFromTracerAreSampled()
     {
         $tracer = $this->getTracer();
 
         $span = $tracer->startAndActivateSpan('test');
 
-        $this->assertFalse($span->isSampled());
+        $this->assertTrue($span->isSampled());
     }
 
     /**


### PR DESCRIPTION
Closes #156 

The idea is to change default span context behavior so that the first context is sampled by default