### PR TITLE
Meter interface

### DIFF
--- a/api/Metrics/Meter.php
+++ b/api/Metrics/Meter.php
@@ -16,15 +16,15 @@ interface Meter
     /**
      * Returns the meter version.
      *
-     * @return string
+     * @return string (optional) - Metric version
      */
     public function getVersion(): ?string;
 
     /**
      * Creates a Counter metric instrument.
      *
-     * @param string $name        - (required) - Counter name
-     * @param string $description - (optional) - Counter description
+     * @param string $name        (required) - Counter name
+     * @param string $description (optional) - Counter description
      *
      * @return Counter
      */
@@ -33,8 +33,8 @@ interface Meter
     /**
      * Creates an UpDownCounter metric instrument.
      *
-     * @param string $name        - (required) - UpDownCounter name
-     * @param string $description - (optional) - UpDownCounter description
+     * @param string $name        (required) - UpDownCounter name
+     * @param string $description (optional) - UpDownCounter description
      *
      * @return UpDownCounter
      */
@@ -43,8 +43,8 @@ interface Meter
     /**
      * Creates a ValueRecorder metric instrument.
      *
-     * @param string $name        - (required) - ValueRecorder name
-     * @param string $description - (optional) - ValueRecorder description
+     * @param string $name        (required) - ValueRecorder name
+     * @param string $description (optional) - ValueRecorder description
      *
      * @return ValueRecorder
      */

--- a/api/Metrics/Meter.php
+++ b/api/Metrics/Meter.php
@@ -6,4 +6,47 @@ namespace OpenTelemetry\Metrics;
 
 interface Meter
 {
+    /**
+     * Returns the meter name.
+     *
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * Returns the meter version.
+     *
+     * @return string
+     */
+    public function getVersion(): ?string;
+
+    /**
+     * Creates a Counter metric instrument.
+     *
+     * @param string $name        - (required) - Counter name
+     * @param string $description - (optional) - Counter description
+     *
+     * @return Counter
+     */
+    public function newCounter(string $name, string $description): Counter;
+
+    /**
+     * Creates an UpDownCounter metric instrument.
+     *
+     * @param string $name        - (required) - UpDownCounter name
+     * @param string $description - (optional) - UpDownCounter description
+     *
+     * @return UpDownCounter
+     */
+    public function newUpDownCounter(string $name, string $description): UpDownCounter;
+
+    /**
+     * Creates a ValueRecorder metric instrument.
+     *
+     * @param string $name        - (required) - ValueRecorder name
+     * @param string $description - (optional) - ValueRecorder description
+     *
+     * @return ValueRecorder
+     */
+    public function newValueRecorder(string $name, string $description): ValueRecorder;
 }

--- a/api/Metrics/Meter.php
+++ b/api/Metrics/Meter.php
@@ -16,9 +16,9 @@ interface Meter
     /**
      * Returns the meter version.
      *
-     * @return string (optional) - Metric version
+     * @return string Metric version
      */
-    public function getVersion(): ?string;
+    public function getVersion(): string;
 
     /**
      * Creates a Counter metric instrument.

--- a/sdk/Metrics/Meter.php
+++ b/sdk/Metrics/Meter.php
@@ -8,5 +8,68 @@ use OpenTelemetry\Metrics as API;
 
 class Meter implements API\Meter
 {
-    // Temp stub
+    /**
+     * @var string            $name
+     * @var string            $version
+     * @var API\Counter       $counter
+     * @var API\UpDownCounter $upDownCounter
+     * @var API\ValueRecorder $valueRecorder
+     */
+    private $name;
+    private $version;
+    private $counter;
+    private $upDownCounter;
+    private $valueRecorder;
+
+    public function __construct(string $name, ?string $version = null)
+    {
+        $this->name = $name;
+        $this->version = $version !== null ? $version : '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion(): ?string
+    {
+        return $this->version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function newCounter(string $name, string $description = null): API\Counter
+    {
+        $this->counter = new Counter($name, $description);
+
+        return $this->counter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function newUpDownCounter(string $name, string $description = null): API\UpDownCounter
+    {
+        $this->upDownCounter = new UpDownCounter($name, $description);
+
+        return $this->upDownCounter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function newValueRecorder(string $name, string $description = null): API\ValueRecorder
+    {
+        $this->valueRecorder = new ValueRecorder($name, $description);
+
+        return $this->valueRecorder;
+    }
 }

--- a/sdk/Metrics/Meter.php
+++ b/sdk/Metrics/Meter.php
@@ -12,8 +12,8 @@ class Meter implements API\Meter
      * @var string $name
      * @var string $version
      */
-    private $name;
-    private $version;
+    protected $name;
+    protected $version;
 
     public function __construct(string $name, string $version = null)
     {

--- a/sdk/Metrics/Meter.php
+++ b/sdk/Metrics/Meter.php
@@ -9,22 +9,16 @@ use OpenTelemetry\Metrics as API;
 class Meter implements API\Meter
 {
     /**
-     * @var string            $name
-     * @var string            $version
-     * @var API\Counter       $counter
-     * @var API\UpDownCounter $upDownCounter
-     * @var API\ValueRecorder $valueRecorder
+     * @var string $name
+     * @var string $version
      */
     private $name;
     private $version;
-    private $counter;
-    private $upDownCounter;
-    private $valueRecorder;
 
-    public function __construct(string $name, ?string $version = null)
+    public function __construct(string $name, string $version = null)
     {
         $this->name = $name;
-        $this->version = $version !== null ? $version : '';
+        $this->version = (string) $version;
     }
 
     /**
@@ -38,7 +32,7 @@ class Meter implements API\Meter
     /**
      * {@inheritdoc}
      */
-    public function getVersion(): ?string
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -48,9 +42,7 @@ class Meter implements API\Meter
      */
     public function newCounter(string $name, string $description = null): API\Counter
     {
-        $this->counter = new Counter($name, $description);
-
-        return $this->counter;
+        return new Counter($name, $description);
     }
 
     /**
@@ -58,9 +50,7 @@ class Meter implements API\Meter
      */
     public function newUpDownCounter(string $name, string $description = null): API\UpDownCounter
     {
-        $this->upDownCounter = new UpDownCounter($name, $description);
-
-        return $this->upDownCounter;
+        return new UpDownCounter($name, $description);
     }
 
     /**
@@ -68,8 +58,6 @@ class Meter implements API\Meter
      */
     public function newValueRecorder(string $name, string $description = null): API\ValueRecorder
     {
-        $this->valueRecorder = new ValueRecorder($name, $description);
-
-        return $this->valueRecorder;
+        return new ValueRecorder($name, $description);
     }
 }

--- a/sdk/Metrics/Providers/MeterProvider.php
+++ b/sdk/Metrics/Providers/MeterProvider.php
@@ -37,6 +37,6 @@ class MeterProvider implements API\MeterProvider
     protected function getCreatedMeter(string $name, string $version = null): API\Meter
     {
         // todo: once the Meter interface and an implementation are done, change this
-        return new Meter();
+        return new Meter($name, $version);
     }
 }

--- a/tests/Sdk/Unit/Metrics/MeterTest.php
+++ b/tests/Sdk/Unit/Metrics/MeterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\Metrics;
+
+use OpenTelemetry\Sdk\Metrics\Counter;
+use OpenTelemetry\Sdk\Metrics\Meter;
+use OpenTelemetry\Sdk\Metrics\UpDownCounter;
+use OpenTelemetry\Sdk\Metrics\ValueRecorder;
+use PHPUnit\Framework\TestCase;
+
+class MeterTest extends TestCase
+{
+    public function testMeterInstrumentCreation()
+    {
+        $meter = new Meter('Meter', '0.1');
+        $this->assertInstanceOf(Meter::class, $meter);
+
+        $meter_name = $meter->getName();
+        $this->assertSame('Meter', $meter_name);
+
+        $meter_version = $meter->getVersion();
+        $this->assertSame('0.1', $meter_version);
+
+        $counter = $meter->newCounter('Counter', 'A counter');
+        $this->assertInstanceOf(Counter::class, $counter);
+
+        $upDownCounter = $meter->newUpDownCounter('Updowncounter', 'An up/down counter');
+        $this->assertInstanceOf(UpDownCounter::class, $upDownCounter);
+
+        $valueRecorder = $meter->newValueRecorder('ValueRecorder', 'A value recorder');
+        $this->assertInstanceOf(ValueRecorder::class, $valueRecorder);
+    }
+}

--- a/tests/Sdk/Unit/Metrics/MeterTest.php
+++ b/tests/Sdk/Unit/Metrics/MeterTest.php
@@ -12,24 +12,47 @@ use PHPUnit\Framework\TestCase;
 
 class MeterTest extends TestCase
 {
-    public function testMeterInstrumentCreation()
+    public function testMeter()
     {
         $meter = new Meter('Meter', '0.1');
-        $this->assertInstanceOf(Meter::class, $meter);
 
-        $meter_name = $meter->getName();
-        $this->assertSame('Meter', $meter_name);
+        $this->assertSame('Meter', $meter->getName());
+        $this->assertSame('0.1', $meter->getVersion());
+    }
 
-        $meter_version = $meter->getVersion();
-        $this->assertSame('0.1', $meter_version);
+    public function testMeterCounter()
+    {
+        $meter = new Meter('Meter', '0.1');
 
-        $counter = $meter->newCounter('Counter', 'A counter');
+        $counterName = 'Counter';
+        $counterDescription = 'A counter';
+        $counter = $meter->newCounter($counterName, $counterDescription);
         $this->assertInstanceOf(Counter::class, $counter);
+        $this->assertEquals($counterName, $counter->getName());
+        $this->assertEquals($counterDescription, $counter->getDescription());
+    }
 
-        $upDownCounter = $meter->newUpDownCounter('Updowncounter', 'An up/down counter');
+    public function testMeterUpDownCounter()
+    {
+        $meter = new Meter('Meter', '0.1');
+
+        $upDownCounterName = 'Updowncounter';
+        $upDownCounterDescription = 'An up/down counter';
+        $upDownCounter = $meter->newUpDownCounter($upDownCounterName, $upDownCounterDescription);
         $this->assertInstanceOf(UpDownCounter::class, $upDownCounter);
+        $this->assertEquals($upDownCounterName, $upDownCounter->getName());
+        $this->assertEquals($upDownCounterDescription, $upDownCounter->getDescription());
+    }
 
-        $valueRecorder = $meter->newValueRecorder('ValueRecorder', 'A value recorder');
+    public function testMeterValueRecorder()
+    {
+        $meter = new Meter('Meter', '0.1');
+
+        $valueRecorderName = 'ValueRecorder';
+        $valueRecorderDescription = 'A value recorder';
+        $valueRecorder = $meter->newValueRecorder($valueRecorderName, $valueRecorderDescription);
         $this->assertInstanceOf(ValueRecorder::class, $valueRecorder);
+        $this->assertEquals($valueRecorderName, $valueRecorder->getName());
+        $this->assertEquals($valueRecorderDescription, $valueRecorder->getDescription());
     }
 }

--- a/tests/Sdk/Unit/Metrics/Providers/GlobalMeterProvicerTest.php
+++ b/tests/Sdk/Unit/Metrics/Providers/GlobalMeterProvicerTest.php
@@ -9,7 +9,7 @@ use OpenTelemetry\Sdk\Metrics\Providers\GlobalMeterProvider;
 use OpenTelemetry\Sdk\Metrics\Providers\MeterProvider;
 use PHPUnit\Framework\TestCase;
 
-class GlobalMeterProvicerTest extends TestCase
+class GlobalMeterProviderTest extends TestCase
 {
     public function testGLobalMeterProviderSettersAndGetters()
     {


### PR DESCRIPTION
This PR adds a [`Meter Interface`](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/api.md#meter-interface) that creates the `Counter`,` UpDownCounter`, and `ValueRecoder` [metric instruments](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/api.md#the-instruments) (the other metrics instruments will be added once their implementation is complete).

#113 