### PR TITLE
Update Project Status and Specification Matrix Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ![CI Build](https://github.com/open-telemetry/opentelemetry-php/workflows/PHP%20Composer/badge.svg)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-php/branch/master/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-php)
 
+## Current Project Status
+This project currently lives in a pre-alpha status.  We keep the [OpenTelemetry Specification Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/master/spec-compliance-matrix.md) up to date in order to show
+ which features are available and which have not yet been implemented.
+ 
 ## Communication
 Most of our communication is done on gitter.im in the [opentelemetry-php](https://gitter.im/open-telemetry/opentelemetry-php) channel.
 


### PR DESCRIPTION
Updating the README.md to include the current project status and a link to the specification matrix.  I have another [PR](https://github.com/open-telemetry/opentelemetry-specification/pull/876) open for the specification matrix update.