### PR TITLE
Export SpanStatus

### DIFF
--- a/api/Trace/Span.php
+++ b/api/Trace/Span.php
@@ -68,11 +68,11 @@ interface Span extends SpanStatus, SpanKind
     /**
      * Sets the Status of the Span. If used, this will override the default Span status, which is OK.
      * Only the value of the last call will be recorded, and implementations are free to ignore previous calls.
-     * @param int $code
+     * @param string $code
      * @param string|null $description
      * @return Span Must return $this
      */
-    public function setSpanStatus(int $code, ?string $description = null): Span;
+    public function setSpanStatus(string $code, ?string $description = null): Span;
 
     /**
      * @param int|null $timestamp

--- a/api/Trace/SpanStatus.php
+++ b/api/Trace/SpanStatus.php
@@ -6,45 +6,45 @@ namespace OpenTelemetry\Trace;
 
 interface SpanStatus
 {
-    const OK = 0;
-    const CANCELLED = 1;
-    const UNKNOWN = 2;
-    const INVALID_ARGUMENT = 3;
-    const DEADLINE_EXCEEDED = 4;
-    const NOT_FOUND = 5;
-    const ALREADY_EXISTS = 6;
-    const PERMISSION_DENIED = 7;
-    const RESOURCE_EXHAUSTED = 8;
-    const FAILED_PRECONDITION = 9;
-    const ABORTED = 10;
-    const OUT_OF_RANGE = 11;
-    const UNIMPLEMENTED = 12;
-    const INTERNAL = 13;
-    const UNAVAILABLE = 14;
-    const DATA_LOSS = 15;
-    const UNAUTHENTICATED = 16;
+    const OK = 'Ok';
+    const CANCELLED = 'Cancelled';
+    const UNKNOWN = 'Unknown';
+    const INVALID_ARGUMENT = 'InvalidArgument';
+    const DEADLINE_EXCEEDED = 'DeadlineExceeded';
+    const NOT_FOUND = 'NotFound';
+    const ALREADY_EXISTS = 'AlreadyExists';
+    const PERMISSION_DENIED = 'PermissionDenied';
+    const RESOURCE_EXHAUSTED = 'ResourceExhausted';
+    const FAILED_PRECONDITION = 'FailedPrecondition';
+    const ABORTED = 'Aborted';
+    const OUT_OF_RANGE = 'OutOfRange';
+    const UNIMPLEMENTED = 'Unimplemented';
+    const INTERNAL = 'Internal';
+    const UNAVAILABLE = 'Unavailable';
+    const DATA_LOSS = 'DataLoss';
+    const UNAUTHENTICATED = 'Unauthenticated';
 
     const DESCRIPTION = [
-        0 => 'Not an error; returned on success.',
-        1 => 'The operation was cancelled, typically by the caller.',
-        2 => 'Unknown error. For example, this error may be returned when a Status value received from another address space belongs to an error space that is not known in this address space. Also errors raised by APIs that do not return enough error information may be converted to this error.',
-        3 => 'The client specified an invalid argument. Note that this differs from FAILED_PRECONDITION. INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the system (e.g., a malformed file name).',
-        4 => 'The deadline expired before the operation could complete. For operations that change the state of the system, this error may be returned even if the operation has completed successfully. For example, a successful response from a server could have been delayed long',
-        5 => 'Some requested entity (e.g., file or directory) was not found. Note to server developers: if a request is denied for an entire class of users, such as gradual feature rollout or undocumented allowlist, NOT_FOUND may be used. If a request is denied for some users within a class of users, such as user-based access control, PERMISSION_DENIED must be used.',
-        6 => 'The entity that a client attempted to create (e.g., file or directory) already exists.',
-        7 => 'The caller does not have permission to execute the specified operation. PERMISSION_DENIED must not be used for rejections caused by exhausting some resource (use RESOURCE_EXHAUSTED instead for those errors). PERMISSION_DENIED must not be used if the caller can not be identified (use UNAUTHENTICATED instead for those errors). This error code does not imply the request is valid or the requested entity exists or satisfies other pre-conditions.',
-        8 => 'Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system is out of space.',
-        9 => 'The operation was rejected because the system is not in a state required for the operation\'s execution. For example, the directory to be deleted is non-empty, an rmdir operation is applied to a non-directory, etc. Service implementors can use the following guidelines to decide between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE: (a) Use UNAVAILABLE if the client can retry just the failing call. (b) Use ABORTED if the client should retry at a higher level (e.g., when a client-specified test-and-set fails, indicating the client should restart a read-modify-write sequence). (c) Use FAILED_PRECONDITION if the client should not retry until the system state has been explicitly fixed. E.g., if an "rmdir" fails because the directory is non-empty, FAILED_PRECONDITION should be returned since the client should not retry unless the files are deleted from the directory.',
-        10 => 'The operation was aborted, typically due to a concurrency issue such as a sequencer check failure or transaction abort. See the guidelines above for deciding between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE.',
-        11 => 'The operation was attempted past the valid range. E.g., seeking or reading past end-of-file. Unlike INVALID_ARGUMENT, this error indicates a problem that may be fixed if the system state changes. For example, a 32-bit file system will generate INVALID_ARGUMENT if asked to read at an offset that is not in the range [0,2^32-1], but it will generate OUT_OF_RANGE if asked to read from an offset past the current file size. There is a fair bit of overlap between FAILED_PRECONDITION and OUT_OF_RANGE. We recommend using OUT_OF_RANGE (the more specific error) when it applies so that callers who are iterating through a space can easily look for an OUT_OF_RANGE error to detect when they are done.',
-        12 => 'The operation is not implemented or is not supported/enabled in this service.',
-        13 => 'Internal errors. This means that some invariants expected by the underlying system have been broken. This error code is reserved for serious errors.',
-        14 => 'The service is currently unavailable. This is most likely a transient condition, which can be corrected by retrying with a backoff. Note that it is not always safe to retry non-idempotent operations.',
-        15 => 'Unrecoverable data loss or corruption.',
-        16 => 'The request does not have valid authentication credentials for the operation.',
+        self::OK            => 'Not an error; returned on success.',
+        self::CANCELLED     => 'The operation was cancelled, typically by the caller.',
+        self::UNKNOWN       => 'Unknown error. For example, this error may be returned when a Status value received from another address space belongs to an error space that is not known in this address space. Also errors raised by APIs that do not return enough error information may be converted to this error.',
+        self::INVALID_ARGUMENT => 'The client specified an invalid argument. Note that this differs from FAILED_PRECONDITION. INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the system (e.g., a malformed file name).',
+        self::DEADLINE_EXCEEDED => 'The deadline expired before the operation could complete. For operations that change the state of the system, this error may be returned even if the operation has completed successfully. For example, a successful response from a server could have been delayed long',
+        self::NOT_FOUND => 'Some requested entity (e.g., file or directory) was not found. Note to server developers: if a request is denied for an entire class of users, such as gradual feature rollout or undocumented allowlist, NOT_FOUND may be used. If a request is denied for some users within a class of users, such as user-based access control, PERMISSION_DENIED must be used.',
+        self::ALREADY_EXISTS => 'The entity that a client attempted to create (e.g., file or directory) already exists.',
+        self::PERMISSION_DENIED => 'The caller does not have permission to execute the specified operation. PERMISSION_DENIED must not be used for rejections caused by exhausting some resource (use RESOURCE_EXHAUSTED instead for those errors). PERMISSION_DENIED must not be used if the caller can not be identified (use UNAUTHENTICATED instead for those errors). This error code does not imply the request is valid or the requested entity exists or satisfies other pre-conditions.',
+        self::RESOURCE_EXHAUSTED => 'Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system is out of space.',
+        self::FAILED_PRECONDITION => 'The operation was rejected because the system is not in a state required for the operation\'s execution. For example, the directory to be deleted is non-empty, an rmdir operation is applied to a non-directory, etc. Service implementors can use the following guidelines to decide between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE: (a) Use UNAVAILABLE if the client can retry just the failing call. (b) Use ABORTED if the client should retry at a higher level (e.g., when a client-specified test-and-set fails, indicating the client should restart a read-modify-write sequence). (c) Use FAILED_PRECONDITION if the client should not retry until the system state has been explicitly fixed. E.g., if an "rmdir" fails because the directory is non-empty, FAILED_PRECONDITION should be returned since the client should not retry unless the files are deleted from the directory.',
+        self::ABORTED => 'The operation was aborted, typically due to a concurrency issue such as a sequencer check failure or transaction abort. See the guidelines above for deciding between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE.',
+        self::OUT_OF_RANGE => 'The operation was attempted past the valid range. E.g., seeking or reading past end-of-file. Unlike INVALID_ARGUMENT, this error indicates a problem that may be fixed if the system state changes. For example, a 32-bit file system will generate INVALID_ARGUMENT if asked to read at an offset that is not in the range [0,2^32-1], but it will generate OUT_OF_RANGE if asked to read from an offset past the current file size. There is a fair bit of overlap between FAILED_PRECONDITION and OUT_OF_RANGE. We recommend using OUT_OF_RANGE (the more specific error) when it applies so that callers who are iterating through a space can easily look for an OUT_OF_RANGE error to detect when they are done.',
+        self::UNIMPLEMENTED => 'The operation is not implemented or is not supported/enabled in this service.',
+        self::INTERNAL => 'Internal errors. This means that some invariants expected by the underlying system have been broken. This error code is reserved for serious errors.',
+        self::UNAVAILABLE => 'The service is currently unavailable. This is most likely a transient condition, which can be corrected by retrying with a backoff. Note that it is not always safe to retry non-idempotent operations.',
+        self::DATA_LOSS => 'Unrecoverable data loss or corruption.',
+        self::UNAUTHENTICATED => 'The request does not have valid authentication credentials for the operation.',
     ];
 
-    public function getCanonicalStatusCode(): int;
+    public function getCanonicalStatusCode(): string;
     public function getStatusDescription(): string;
     public function isStatusOk(): bool;
 }

--- a/contrib/Zipkin/SpanConverter.php
+++ b/contrib/Zipkin/SpanConverter.php
@@ -8,6 +8,8 @@ use OpenTelemetry\Trace\Span;
 
 class SpanConverter
 {
+    const STATUS_CODE_TAG_KEY = 'op.status_code';
+    const STATUS_DESCRIPTION_TAG_KEY = 'op.status_description';
     /**
      * @var string
      */
@@ -52,12 +54,13 @@ class SpanConverter
             'name' => $span->getSpanName(),
             'timestamp' => (int) ($span->getStartEpochTimestamp() / 1e3), // RealtimeClock in microseconds
             'duration' => (int) (($span->getEnd() - $span->getStart()) / 1e3), // Diff in microseconds
+            'tags' => [
+                self::STATUS_CODE_TAG_KEY => $span->getStatus()->getCanonicalStatusCode(),
+                self::STATUS_DESCRIPTION_TAG_KEY => $span->getStatus()->getStatusDescription(),
+            ],
         ];
 
         foreach ($span->getAttributes() as $k => $v) {
-            if (!array_key_exists('tags', $row)) {
-                $row['tags'] = [];
-            }
             $row['tags'][$k] = $this->sanitiseTagValue($v->getValue());
         }
 

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -16,10 +16,8 @@ class Span implements API\Span
     private $startEpochTimestamp;
     private $start;
     private $end;
-    private $statusCode = API\SpanStatus::OK;
-
-    /** @var string  */
-    private $statusDescription = API\SpanStatus::DESCRIPTION[API\SpanStatus::UNKNOWN];
+    private $statusCode;
+    private $statusDescription;
 
     private $attributes;
     private $events;
@@ -70,7 +68,7 @@ class Span implements API\Span
         return $this->parentSpanContext !== null ? clone $this->parentSpanContext : null;
     }
 
-    public function setSpanStatus(int $code, ?string $description = null): API\Span
+    public function setSpanStatus(string $code, ?string $description = null): API\Span
     {
         if ($this->isRecording()) {
             $this->statusCode = $code;
@@ -233,7 +231,7 @@ class Span implements API\Span
         return $this->spanKind;
     }
 
-    public function getCanonicalStatusCode(): int
+    public function getCanonicalStatusCode(): string
     {
         return $this->statusCode;
     }

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -78,7 +78,7 @@ final class SpanContext implements API\SpanContext
     /**
      * Creates a new context with random trace
      *
-     * @param boolean $sampled Default: false
+     * @param bool $sampled Default: false
      * @return SpanContext
      */
     public static function generate(bool $sampled = false): SpanContext
@@ -100,7 +100,7 @@ final class SpanContext implements API\SpanContext
      * Creates a new context with random span on the same trace
      *
      * @param string $traceId Existing trace
-     * @param boolean $sampled Default: false
+     * @param bool $sampled Default: false
      * @return SpanContext
      */
     public static function fork(string $traceId, bool $sampled = false): SpanContext

--- a/sdk/Trace/SpanStatus.php
+++ b/sdk/Trace/SpanStatus.php
@@ -14,7 +14,7 @@ final class SpanStatus implements API\SpanStatus
     private static $map;
 
     /**
-     * @var int
+     * @var string
      */
     private $code;
 
@@ -23,13 +23,13 @@ final class SpanStatus implements API\SpanStatus
      */
     private $description;
 
-    private function __construct(int $code, string $description = null)
+    private function __construct(string $code, string $description = null)
     {
         $this->code = $code;
         $this->description = $description ?? self::DESCRIPTION[self::UNKNOWN];
     }
 
-    public static function new(int $code, string $description = null): SpanStatus
+    public static function new(string $code, string $description = null): SpanStatus
     {
         if (!$description) {
             $description = self::DESCRIPTION[$code] ?? self::DESCRIPTION[self::UNKNOWN];
@@ -45,7 +45,7 @@ final class SpanStatus implements API\SpanStatus
         return self::new(self::OK);
     }
 
-    public function getCanonicalStatusCode(): int
+    public function getCanonicalStatusCode(): string
     {
         return $this->code;
     }

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -44,7 +44,7 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertIsInt($row['duration']);
         $this->assertGreaterThan(0, $row['duration']);
 
-        $this->assertCount(1, $row['tags']);
+        $this->assertCount(3, $row['tags']);
         $this->assertEquals($span->getAttribute('service')->getValue(), $row['tags']['service']);
 
         $this->assertCount(1, $row['annotations']);
@@ -99,7 +99,7 @@ class ZipkinSpanConverterTest extends TestCase
         $tags = (new SpanConverter('tags.test'))->convert($span)['tags'];
 
         // Check that we can convert all attributes to tags
-        $this->assertCount(10, $tags);
+        $this->assertCount(12, $tags);
 
         // Tags destined for Zipkin must be pairs of strings
         foreach ($tags as $tagKey => $tagValue) {

--- a/tests/Sdk/Unit/Support/HasTraceProvider.php
+++ b/tests/Sdk/Unit/Support/HasTraceProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Unit\Support;
 
-use OpenTelemetry\Sdk\Trace\TracerProvider;
 use OpenTelemetry\Sdk\Trace\Tracer;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
 
 trait HasTraceProvider
 {

--- a/tests/Sdk/Unit/Trace/SpanContextTest.php
+++ b/tests/Sdk/Unit/Trace/SpanContextTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
+use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Tests\Sdk\Unit\Support\HasTraceProvider;
-use OpenTelemetry\Sdk\Trace\Span;
 use PHPUnit\Framework\TestCase;
 
 class SpanContextTest extends TestCase

--- a/tests/Sdk/Unit/Trace/SpanOptionsTest.php
+++ b/tests/Sdk/Unit/Trace/SpanOptionsTest.php
@@ -6,10 +6,8 @@ namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\SpanOptions;
-use OpenTelemetry\Sdk\Trace\Tracer;
-use OpenTelemetry\Sdk\Trace\TracerProvider;
-use OpenTelemetry\Trace\SpanKind;
 use OpenTelemetry\Tests\Sdk\Unit\Support\HasTraceProvider;
+use OpenTelemetry\Trace\SpanKind;
 use PHPUnit\Framework\TestCase;
 
 class SpanOptionsTest extends TestCase

--- a/tests/Sdk/Unit/Trace/SpanStatusTest.php
+++ b/tests/Sdk/Unit/Trace/SpanStatusTest.php
@@ -12,14 +12,14 @@ class SpanStatusTest extends TestCase
     public function testGetCanonicalCode()
     {
         // todo: what's the point of SpanStatus::UNKNOWN if an unknown code gets propagated as some other code?
-        $status = SpanStatus::new(99);
-        self::assertEquals(99, $status->getCanonicalStatusCode());
+        $status = SpanStatus::new('MY_CODE');
+        self::assertEquals('MY_CODE', $status->getCanonicalStatusCode());
         self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNKNOWN], $status->getStatusDescription());
     }
 
     public function testGetDescription()
     {
-        $status = SpanStatus::new(99, 'Neunundneunzig Luftballons');
+        $status = SpanStatus::new('MY_CODE', 'Neunundneunzig Luftballons');
         self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
     }
 


### PR DESCRIPTION
 I implemented SpanStatus exporting in ZipkinExporter and fixed some deprecation in unit tests.

Because the StatusCode needs to be exported as Code Name I had to change SpanStatus API and some other implementation in the SDK and convert the code int to string. Here are the specs [Status](https://github.com/open-telemetry/opentelemetry-specification/blob/e0bd41739a92304c0be5d68840f434e281b5f8b2/specification/trace/sdk_exporters/zipkin.md#status).

I am aware that this change may impact the memory footprint and I am open to new solutions.