### PR TITLE
fix: sprintf() is locale-sensitive

### DIFF
--- a/sdk/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/sdk/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -59,6 +59,6 @@ class TraceIdRatioBasedSampler implements Sampler
 
     public function getDescription(): string
     {
-        return sprintf('%s{%.6f}', 'TraceIdRatioBasedSampler', $this->probability);
+        return sprintf('%s{%.6F}', 'TraceIdRatioBasedSampler', $this->probability);
     }
 }


### PR DESCRIPTION
When running tests directly on my host via `vendor/bin/phpunit` with `hr_HR.UTF-8` locale, it fails since [`sprintf('%f')` is locale-sensitive](https://www.php.net/manual/en/function.sprintf.php). This uses the non-sensitive `%F`.