### PR TITLE
fix: confusing comment in spanoptions test

### DIFF
--- a/tests/Sdk/Unit/Trace/SpanOptionsTest.php
+++ b/tests/Sdk/Unit/Trace/SpanOptionsTest.php
@@ -48,7 +48,7 @@ class SpanOptionsTest extends TestCase
 
         $web = $spanOptions->toActiveSpan();
 
-        // Make sure created span is not activated
+        // Make sure span is activated
         $this->assertSame($tracer->getActiveSpan(), $web);
 
         // Assert previously set vars


### PR DESCRIPTION
Fix for incorrectly c+p'd comment in `SpanOptions` tests as discussed in gitter.