### PR TITLE
Fix AlwaysOffTraceExample.php Sample

### DIFF
--- a/examples/AlwaysOffTraceExample.php
+++ b/examples/AlwaysOffTraceExample.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
 use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
@@ -20,23 +21,24 @@ $samplingResult = $sampler->shouldSample(
 
 if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult) {
     $tracer = (new TracerProvider())
-    ->getTracer('io.opentelemetry.contrib.php');
+        ->getTracer('io.opentelemetry.contrib.php');
 
     // start a span, register some events
     $span = $tracer->startAndActivateSpan('session.generate');
     $span->setAttribute('remote_ip', '1.2.3.4');
     $span->setAttribute('country', 'USA');
 
-    $span->addEvent('found_login', new Attributes([
-    'id' => 12345,
-    'username' => 'otuser',
-  ]));
-    $span->addEvent('generated_session', new Attributes([
-    'id' => md5(microtime(true)),
-  ]));
+    $timestamp = Clock::get()->timestamp();
+    $span->addEvent('found_login', $timestamp, new Attributes([
+        'id' => 12345,
+        'username' => 'otuser',
+      ]));
+    $span->addEvent('generated_session', $timestamp, new Attributes([
+        'id' => md5(microtime(true)),
+      ]));
 
     $span->end(); // pass status as an optional argument
-  print_r($span);  // print the span as a resulting output
+    print_r($span);  // print the span as a resulting output
 } else {
     echo PHP_EOL . 'Sampling is not enabled';
 }


### PR DESCRIPTION
The `$span->addEvent()` waits a $timestamp as second argument, but
we are sending `new Attributes([...` as parameter.

Original code:

![image](https://user-images.githubusercontent.com/1247724/94980901-3b6ded00-0504-11eb-8c3e-8b52c34593c0.png)
