### PR TITLE
Add psalm static analysis tool to codebase

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,6 +50,9 @@ jobs:
       env:
         PHAN_DISABLE_XDEBUG_WARN: 1
       run: vendor/bin/phan
+    
+    - name: Run Psalm
+      run: vendor/bin/psalm
 
     - name: Run PHPUnit
       run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ test:
 	$(DC_RUN_PHP) php ./vendor/bin/phpunit --colors=always --coverage-text --testdox --coverage-clover coverage.clover
 phan:
 	$(DC_RUN_PHP) env PHAN_DISABLE_XDEBUG_WARN=1 php ./vendor/bin/phan
+psalm:
+	$(DC_RUN_PHP) php ./vendor/bin/psalm
+psalm-info:
+	$(DC_RUN_PHP) php ./vendor/bin/psalm --show-info=true
 trace examples: FORCE
 	docker-compose up -d
 	$(DC_RUN_PHP) php ./examples/AlwaysOnZipkinExample.php

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "phpunit/phpunit": "^9.3",
         "composer/xdebug-handler": "^1.3",
         "phan/phan": "^3.0",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "vimeo/psalm": "^4.0"
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="4"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="Context" />
+        <directory name="api" />
+        <directory name="contrib" />
+        <directory name="sdk" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/sdk/Metrics/HasLabels.php
+++ b/sdk/Metrics/HasLabels.php
@@ -12,7 +12,7 @@ trait HasLabels
     protected $labels = [];
 
     /**
-     * {@inheritDoc}
+     * @return	array<string>
      */
     public function getLabels(): array
     {


### PR DESCRIPTION
Fixes #196 
hello @dkarlovi  @bobstrecansky this PR adds Psalm

running 
`make psalm` or  `./vendor/bin/psalm`

```
Scanning files...
Analyzing files...



ERROR: LessSpecificImplementedReturnType - sdk/Metrics/HasLabels.php:17:34 - The inherited return type 'array<array-key, string>' for OpenTelemetry\Metrics\LabelableMetric::getLabels is more specific than the implemented return type for OpenTelemetry\Sdk\Metrics\HasLabels::getlabels 'array<array-key, mixed>' (see https://psalm.dev/166)
    public function getLabels(): array


------------------------------
1 errors found
------------------------------
87 other issues found.
You can display them with --show-info=true
------------------------------

Checks took 0.03 seconds and used 5.745MB of memory

```

On the other hand running

`make psalm-info` or ` ./vendor/bin/psalm --show-info=true`

returns more extensive info as seen here https://pastebin.com/4wy2yHV6

