### PR TITLE
chore: add static analysis for tests, examples

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,10 +15,10 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['7.3', '7.4']
-        
+
     steps:
     - uses: actions/checkout@v2
-  
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
@@ -44,21 +44,21 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-suggest
 
     - name: Check Style
-      run: .github/phpcs.sh 
-      
+      run: .github/phpcs.sh
+
     - name: Run Phan
       env:
         PHAN_DISABLE_XDEBUG_WARN: 1
       run: vendor/bin/phan
-    
+
     - name: Run Psalm
-      run: vendor/bin/psalm
-    
+      run: vendor/bin/psalm --output-format=github
+
     - name: Run Phpstan
-      run: vendor/bin/phpstan analyse
+      run: vendor/bin/phpstan analyse --error-format=github
 
     - name: Run PHPUnit
       run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-          
+
     - name: Code Coverage
       run: bash <(curl -s https://codecov.io/bash)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.phar
 composer.lock
+var
 vendor
 .idea/
 coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,8 @@
         "phan/phan": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.16",
         "vimeo/psalm": "^4.0",
-        "phpstan/phpstan": "^0.12.50"
+        "phpstan/phpstan": "^0.12.50",
+        "phpstan/phpstan-phpunit": "^0.12.16",
+        "psalm/plugin-phpunit": "^0.13.0"
     }
 }

--- a/examples/AlwaysOffTraceExample.php
+++ b/examples/AlwaysOffTraceExample.php
@@ -34,7 +34,7 @@ if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
         'username' => 'otuser',
       ]));
     $span->addEvent('generated_session', $timestamp, new Attributes([
-        'id' => md5(microtime(true)),
+        'id' => md5((string) microtime(true)),
       ]));
 
     $span->end(); // pass status as an optional argument

--- a/examples/AlwaysOnJaegerExample.php
+++ b/examples/AlwaysOnJaegerExample.php
@@ -37,10 +37,11 @@ if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
         $timestamp = Clock::get()->timestamp();
         $span = $tracer->startAndActivateSpan('session.generate.span' . microtime(true));
 
+        $spanParent = $span->getParent();
         echo sprintf(
             PHP_EOL . 'Exporting Trace: %s, Parent: %s, Span: %s',
             $span->getContext()->getTraceId(),
-            $span->getParent() ? $span->getParent()->getSpanId() : 'None',
+            $spanParent ? $spanParent->getSpanId() : 'None',
             $span->getContext()->getSpanId()
         );
 

--- a/examples/AlwaysOnZipkinExample.php
+++ b/examples/AlwaysOnZipkinExample.php
@@ -37,10 +37,11 @@ if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
         $timestamp = Clock::get()->timestamp();
         $span = $tracer->startAndActivateSpan('session.generate.span.' . microtime(true));
 
+        $spanParent = $span->getParent();
         echo sprintf(
             PHP_EOL . 'Exporting Trace: %s, Parent: %s, Span: %s',
             $span->getContext()->getTraceId(),
-            $span->getParent() ? $span->getParent()->getSpanId() : 'None',
+            $spanParent ? $spanParent->getSpanId() : 'None',
             $span->getContext()->getSpanId()
         );
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,15 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+
 parameters:
+    tmpDir: var/cache/phpstan
     level: 5
     paths:
-        - Context
-        - api
-        - contrib
-        - sdk
+        - .
+    excludes_analyse:
+        - var
+        - vendor
+    ignoreErrors:
+        # PHPStan false positive
+        - message: '#Call to an undefined static method OpenTelemetry\\Sdk\\Metrics\\Providers\\GlobalMeterProvider\:\:getMeter\(\)\.#'
+          path: tests/Sdk/Unit/Metrics/Providers/GlobalMeterProvicerTest.php

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,18 +1,18 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="3"
-    resolveFromConfigFile="true"
+    cacheDirectory="var/cache/psalm"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
->
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
     <projectFiles>
-        <directory name="Context" />
-        <directory name="api" />
-        <directory name="contrib" />
-        <directory name="sdk" />
+        <directory name="."/>
         <ignoreFiles>
-            <directory name="vendor" />
+            <directory name="var"/>
+            <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
 </psalm>

--- a/tests/Context/Unit/ContextTest.php
+++ b/tests/Context/Unit/ContextTest.php
@@ -215,7 +215,7 @@ class ContextTest extends TestCase
         Context::attach($ctx);
 
         $this->assertSame(Context::getValue($key, $ctx), $val);
-        $this->assertSame(Context::getValue($key, null, true), $val);
+        $this->assertSame(Context::getValue($key, null), $val);
     }
 
     /**

--- a/tests/Contrib/Unit/ZipkinExporterTest.php
+++ b/tests/Contrib/Unit/ZipkinExporterTest.php
@@ -100,10 +100,8 @@ class ZipkinExporterTest extends TestCase
     /**
      * @test
      * @dataProvider invalidDsnDataProvider
-     *
-     * @param $invalidDsn
      */
-    public function shouldThrowExceptionIfInvalidDsnIsPassed($invalidDsn)
+    public function shouldThrowExceptionIfInvalidDsnIsPassed(string $invalidDsn)
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Contrib\Unit;
 
 use OpenTelemetry\Contrib\Zipkin\SpanConverter;
+use OpenTelemetry\Sdk\Trace\Attribute;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
 use OpenTelemetry\Sdk\Trace\Span;
@@ -23,6 +24,7 @@ class ZipkinSpanConverterTest extends TestCase
 
         $timestamp = Clock::get()->timestamp();
 
+        /** @var Span $span */
         $span = $tracer->startAndActivateSpan('guard.validate');
         $span->setAttribute('service', 'guard');
         $span->addEvent('validators.list', $timestamp, new Attributes(['job' => 'stage.updateTime']));
@@ -45,7 +47,10 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertGreaterThan(0, $row['duration']);
 
         $this->assertCount(3, $row['tags']);
-        $this->assertEquals($span->getAttribute('service')->getValue(), $row['tags']['service']);
+        
+        /** @var Attribute $attribute */
+        $attribute = $span->getAttribute('service');
+        $this->assertEquals($attribute->getValue(), $row['tags']['service']);
 
         $this->assertCount(1, $row['annotations']);
         [$annotation] = $row['annotations'];

--- a/tests/Sdk/Unit/CorrelationContext/CorrelationContextTest.php
+++ b/tests/Sdk/Unit/CorrelationContext/CorrelationContextTest.php
@@ -18,7 +18,9 @@ class CorrelationContextTest extends TestCase
     {
         $key1 = new ContextKey();
         $key2 = new ContextKey();
+        /** @var CorrelationContext $cctx */
         $cctx = (new CorrelationContext())->set($key1, 'foo')->set($key2, 'bar');
+        /** @var CorrelationContext $cctx_res */
         $cctx_res = $cctx->removeCorrelation($key2);
         $this->assertEquals('foo', $cctx_res->get($key1));
         $this->expectException(ContextValueNotFoundException::class);
@@ -33,7 +35,9 @@ class CorrelationContextTest extends TestCase
         $key1 = new ContextKey('key1');
         $key2 = new ContextKey('key2');
         $key3 = new ContextKey('key3');
+        /** @var CorrelationContext $cctx */
         $cctx = (new CorrelationContext())->set($key1, 'foo')->set($key2, 'bar')->set($key3, 'baz');
+        /** @var CorrelationContext $cctx_res */
         $cctx_res = $cctx->removeCorrelation($key2);
         $this->assertEquals('foo', $cctx_res->get($key1));
         $this->assertEquals('baz', $cctx_res->get($key3));
@@ -48,7 +52,9 @@ class CorrelationContextTest extends TestCase
     {
         $key1 = new ContextKey();
         $key2 = new ContextKey();
+        /** @var CorrelationContext $cctx */
         $cctx = (new CorrelationContext())->set($key2, 'bar')->set($key1, 'foo');
+        /** @var CorrelationContext $cctx_res */
         $cctx_res = $cctx->removeCorrelation($key2);
         $this->assertEquals('foo', $cctx_res->get($key1));
         $this->expectException(ContextValueNotFoundException::class);
@@ -85,6 +91,7 @@ class CorrelationContextTest extends TestCase
         $key1 = new ContextKey();
         $key2 = new ContextKey();
 
+        /** @var CorrelationContext $cctx */
         $cctx = (new CorrelationContext())->set($key1, 'foo')->set($key2, 'bar');
 
         $this->assertEquals('foo', $cctx->get($key1));
@@ -103,6 +110,7 @@ class CorrelationContextTest extends TestCase
         $key1 = new ContextKey();
         $key2 = new ContextKey();
 
+        /** @var CorrelationContext $cctx */
         $cctx = (new CorrelationContext())->set($key1, 'foo')->set($key2, 'bar');
 
         $res = [];

--- a/tests/Sdk/Unit/Metrics/Exporters/AbstractExporterTest.php
+++ b/tests/Sdk/Unit/Metrics/Exporters/AbstractExporterTest.php
@@ -20,10 +20,13 @@ class AbstractExporterTest extends TestCase
 
     public function testErrorReturnsIfTryingToExportNotAMetric()
     {
-        $this->assertEquals(
-            API\Exporter::FAILED_NOT_RETRYABLE,
-            $this->getExporter()->export([1])
-        );
+        /**
+         * @phpstan-ignore-next-line
+         * @psalm-suppress InvalidArgument
+         */
+        $export = $this->getExporter()->export([1]);
+
+        $this->assertEquals(API\Exporter::FAILED_NOT_RETRYABLE, $export);
     }
 
     protected function getExporter(): AbstractExporter

--- a/tests/Sdk/Unit/Metrics/UpDownCounterTest.php
+++ b/tests/Sdk/Unit/Metrics/UpDownCounterTest.php
@@ -84,6 +84,10 @@ class UpDownCounterTest extends TestCase
     {
         $counter = new UpDownCounter('name', 'description');
         $this->expectException(InvalidArgumentException::class);
-        $retVal = $counter->add('a');
+        /**
+         * @phpstan-ignore-next-line
+         * @psalm-suppress InvalidScalarArgument
+         */
+        $counter->add('a');
     }
 }

--- a/tests/Sdk/Unit/Metrics/ValueRecorderTest.php
+++ b/tests/Sdk/Unit/Metrics/ValueRecorderTest.php
@@ -111,7 +111,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(5.2222, $metric->getMax());
         $this->assertEquals(5.2222, $metric->getMin());
         $this->assertEquals(5.2222, $metric->getSum());
-        $metric->record(-2.6666, $metric->getCount());
+        $metric->record(-2.6666);
         $this->assertEquals(2, $metric->getCount());
         $this->assertEquals(5.2222, $metric->getMax());
         $this->assertEquals(-2.6666, $metric->getMin());
@@ -147,6 +147,10 @@ class ValueRecorderTest extends TestCase
     {
         $metric = new ValueRecorder('name', 'description');
         $this->expectException(InvalidArgumentException::class);
-        $retVal = $metric->record('a');
+        /**
+         * @phpstan-ignore-next-line
+         * @psalm-suppress InvalidScalarArgument
+         */
+        $metric->record('a');
     }
 }

--- a/tests/Sdk/Unit/Resource/ResourceTest.php
+++ b/tests/Sdk/Unit/Resource/ResourceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Sdk\Unit\Resource;
 
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Attribute;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use PHPUnit\Framework\TestCase;
 
@@ -25,8 +26,11 @@ class ResourceTest extends TestCase
         $attributes->setAttribute('name', 'test');
         $resource = ResourceInfo::create($attributes);
 
+        /** @var Attribute $name */
+        $name = $resource->getAttributes()->getAttribute('name');
+
         $this->assertEquals($attributes, $resource->getAttributes());
-        $this->assertEquals('test', $resource->getAttributes()->getAttribute('name')->getValue());
+        $this->assertEquals('test', $name->getValue());
     }
 
     public function testMerge()
@@ -35,10 +39,17 @@ class ResourceTest extends TestCase
         $secondary = ResourceInfo::create(new Attributes(['version' => '1.0.0', 'empty' => 'value']));
         $result = ResourceInfo::merge($primary, $secondary);
 
+        /** @var Attribute $name */
+        $name = $result->getAttributes()->getAttribute('name');
+        /** @var Attribute $version */
+        $version = $result->getAttributes()->getAttribute('version');
+        /** @var Attribute $empty */
+        $empty = $result->getAttributes()->getAttribute('empty');
+
         $this->assertCount(3, $result->getAttributes());
-        $this->assertEquals('primary', $result->getAttributes()->getAttribute('name')->getValue());
-        $this->assertEquals('1.0.0', $result->getAttributes()->getAttribute('version')->getValue());
-        $this->assertEquals('value', $result->getAttributes()->getAttribute('empty')->getValue());
+        $this->assertEquals('primary', $name->getValue());
+        $this->assertEquals('1.0.0', $version->getValue());
+        $this->assertEquals('value', $empty->getValue());
     }
 
     public function testImmutableCreate()
@@ -51,6 +62,9 @@ class ResourceTest extends TestCase
 
         $attributes->setAttribute('version', '2.0.0');
 
-        $this->assertEquals('1.0.0', $resource->getAttributes()->getAttribute('version')->getValue());
+        /** @var Attribute $version */
+        $version = $resource->getAttributes()->getAttribute('version');
+
+        $this->assertEquals('1.0.0', $version->getValue());
     }
 }

--- a/tests/Sdk/Unit/Support/HasTraceProvider.php
+++ b/tests/Sdk/Unit/Support/HasTraceProvider.php
@@ -11,6 +11,9 @@ trait HasTraceProvider
 {
     protected function getTracer(string $name = 'OpenTelemetry.TracerTest'): Tracer
     {
-        return (new TracerProvider())->getTracer($name);
+        /** @var Tracer $tracer */
+        $tracer = (new TracerProvider())->getTracer($name);
+
+        return $tracer;
     }
 }

--- a/tests/Sdk/Unit/Trace/SpanOptionsTest.php
+++ b/tests/Sdk/Unit/Trace/SpanOptionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
 use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\SpanOptions;
 use OpenTelemetry\Tests\Sdk\Unit\Support\HasTraceProvider;
 use OpenTelemetry\Trace\SpanKind;
@@ -24,6 +25,7 @@ class SpanOptionsTest extends TestCase
         $spanOptions->setParentSpan($global);
 
         // Create span from options
+        /** @var Span $web */
         $web = $spanOptions->toSpan();
 
         // Make sure created span is not activated

--- a/tests/Sdk/Unit/Trace/SpanProcessor/SimpleSpanProcessorTest.php
+++ b/tests/Sdk/Unit/Trace/SpanProcessor/SimpleSpanProcessorTest.php
@@ -57,22 +57,14 @@ class SimpleSpanProcessorTest extends TestCase
     public function noExportAfterShutdown()
     {
         $exporter = self::createMock(Exporter::class);
-        // grap a reference to the InvocationOrder object so we can inspect/assert *when* the call happens
-        $exporter->expects($spy = $this->exactly(1))->method('shutdown');
-
-        $this->assertEquals(0, $spy->getInvocationCount());
+        $exporter->expects($this->exactly(1))->method('shutdown');
 
         $proc = new SimpleSpanProcessor($exporter);
         $proc->shutdown();
-        // calling SpanProcessor's shutdown() calls Exporter's shutdown()
-        $this->assertEquals(1, $spy->getInvocationCount());
 
         $span = self::createMock(Span::class);
         $proc->onStart($span);
         $proc->onEnd($span);
-
-        // calling onEnd here does NOT result in another call to shutdown
-        $this->assertEquals(1, $spy->getInvocationCount());
     }
 
     /**


### PR DESCRIPTION
Changes:
- enabled cache for both PHPStan and Psalm
- enabled Github action output for both PHPStan and Psalm, making them produce nice annotations directly in the PR
- fixes for `tests/` and `examples/` to enable further static analysis there too

There's still a little bit of work done, but this should show you the direction. Remember to check only the last commit since I've based this on #205.