### PR TITLE
Associating Spans with their TracerProvider

### DIFF
--- a/sdk/Resource/ResourceInfo.php
+++ b/sdk/Resource/ResourceInfo.php
@@ -24,7 +24,15 @@ class ResourceInfo
 
     public static function create(Attributes $attributes): self
     {
-        return new ResourceInfo(clone $attributes);
+        $resource = self::merge(self::defaultResource(), new ResourceInfo(clone $attributes));
+        /*
+         * The SDK MUST extract information from the OTEL_RESOURCE_ATTRIBUTES environment
+         * variable and merge this.
+         * todo: after resource detection is implemented, merge it here.
+         * return $resource.merge(....);
+         *
+         */
+        return $resource;
     }
 
     /**
@@ -51,6 +59,17 @@ class ResourceInfo
         }
 
         return new ResourceInfo($mergedAttributes);
+    }
+
+    public static function defaultResource(): self
+    {
+        return new ResourceInfo(new Attributes(
+            [
+                ResourceConstants::TELEMETRY_SDK_NAME => 'opentelemetry',
+                ResourceConstants::TELEMETRY_SDK_LANGUAGE => 'php',
+                ResourceConstants::TELEMETRY_SDK_VERSION => 'dev',
+            ]
+        ));
     }
 
     public static function emptyResource(): self

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -21,6 +21,9 @@ class Span implements API\Span
     private $statusCode;
     private $statusDescription;
 
+    /**
+     * @var ResourceInfo
+     */
     private $resource; // An immutable representation of the entity producing telemetry.
 
     private $attributes;

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace;
 
+use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Trace as API;
 
 class Span implements API\Span
@@ -19,6 +20,8 @@ class Span implements API\Span
     private $end;
     private $statusCode;
     private $statusDescription;
+
+    private $resource; // An immutable representation of the entity producing telemetry.
 
     private $attributes;
     private $events;
@@ -44,6 +47,7 @@ class Span implements API\Span
         API\SpanContext $spanContext,
         ?API\SpanContext $parentSpanContext = null,
         ?Sampler $sampler = null,
+        ?ResourceInfo $resource = null,
         int $spanKind = API\SpanKind::KIND_INTERNAL
     ) {
         $this->name = $name;
@@ -51,6 +55,7 @@ class Span implements API\Span
         $this->parentSpanContext = $parentSpanContext;
         $this->spanKind = $spanKind;
         $this->sampler = $sampler;
+        $this->resource =  $resource ?? ResourceInfo::emptyResource();
         $moment = Clock::get()->moment();
         $this->startEpochTimestamp = $moment[0];
         $this->start = $moment[1];
@@ -60,6 +65,11 @@ class Span implements API\Span
         // todo: set these to null until needed
         $this->attributes = new Attributes();
         $this->events = new Events();
+    }
+
+    public function getResource(): ResourceInfo
+    {
+        return clone $this->resource;
     }
 
     public function getContext(): API\SpanContext

--- a/sdk/Trace/SpanOptions.php
+++ b/sdk/Trace/SpanOptions.php
@@ -96,7 +96,7 @@ final class SpanOptions implements API\SpanOptions
             ? SpanContext::fork($span->getContext()->getTraceId())
             : SpanContext::generate();
 
-        $span = new Span($this->name, $context, $this->parent, null, $this->kind);
+        $span = new Span($this->name, $context, $this->parent, null, $this->tracer->getResource(), $this->kind);
 
         if ($this->startEpochTimestamp !== null) {
             $span->setStartEpochTimestamp($this->startEpochTimestamp);

--- a/sdk/Trace/TracerProvider.php
+++ b/sdk/Trace/TracerProvider.php
@@ -54,13 +54,15 @@ final class TracerProvider implements API\TracerProvider
         }
 
         $spanContext = SpanContext::generateSampled();
-
+        /*
+         * A resource can be associated with the TracerProvider when the TracerProvider is created.
+         * That association cannot be changed later. When associated with a TracerProvider, all
+         * Spans produced by any Tracer from the provider MUST be associated with this Resource.
+         */
+        $primary = $this->getResource();
         $resource = ResourceInfo::create(
             new Attributes(
                 [
-                    ResourceConstants::TELEMETRY_SDK_NAME => 'opentelemetry',
-                    ResourceConstants::TELEMETRY_SDK_LANGUAGE => 'php',
-                    ResourceConstants::TELEMETRY_SDK_VERSION => 'dev',
                     ResourceConstants::SERVICE_NAME => $name,
                     ResourceConstants::SERVICE_VERSION => $version,
                     ResourceConstants::SERVICE_INSTANCE_ID => uniqid($name . $version),
@@ -70,7 +72,7 @@ final class TracerProvider implements API\TracerProvider
 
         return $this->tracers[$name] = new Tracer(
             $this,
-            ResourceInfo::merge($this->getResource(), $resource),
+            ResourceInfo::merge($primary, $resource),
             $spanContext
         );
     }
@@ -94,6 +96,6 @@ final class TracerProvider implements API\TracerProvider
 
     public function getResource(): ResourceInfo
     {
-        return $this->resource;
+        return clone $this->resource;
     }
 }

--- a/tests/Sdk/Unit/Resource/ResourceTest.php
+++ b/tests/Sdk/Unit/Resource/ResourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Unit\Resource;
 
+use OpenTelemetry\Sdk\Resource\ResourceConstants;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Sdk\Trace\Attribute;
 use OpenTelemetry\Sdk\Trace\Attributes;
@@ -19,7 +20,9 @@ class ResourceTest extends TestCase
         $resource = ResourceInfo::emptyResource();
         $this->assertEmpty($resource->getAttributes());
     }
-
+    /**
+     * @test
+     */
     public function testGetAttributes()
     {
         $attributes = new Attributes();
@@ -29,10 +32,49 @@ class ResourceTest extends TestCase
         /** @var Attribute $name */
         $name = $resource->getAttributes()->getAttribute('name');
 
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+
+        $attributes->setAttribute(ResourceConstants::TELEMETRY_SDK_NAME, 'opentelemetry');
+        $attributes->setAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE, 'php');
+        $attributes->setAttribute(ResourceConstants::TELEMETRY_SDK_VERSION, 'dev');
+
+        $this->assertEquals($attributes, $resource->getAttributes());
+        $this->assertEquals('opentelemetry', $sdkname->getValue());
+        $this->assertEquals('php', $sdklanguage->getValue());
+        $this->assertEquals('dev', $sdkversion->getValue());
         $this->assertEquals($attributes, $resource->getAttributes());
         $this->assertEquals('test', $name->getValue());
     }
 
+    /**
+     * @test
+     */
+    public function testDefaultResource()
+    {
+        $attributes = new Attributes(
+            [
+                ResourceConstants::TELEMETRY_SDK_NAME => 'opentelemetry',
+                ResourceConstants::TELEMETRY_SDK_LANGUAGE => 'php',
+                ResourceConstants::TELEMETRY_SDK_VERSION => 'dev',
+            ]
+        );
+        $resource = ResourceInfo::create(new Attributes());
+
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+
+        $this->assertEquals($attributes, $resource->getAttributes());
+        $this->assertEquals('opentelemetry', $sdkname->getValue());
+        $this->assertEquals('php', $sdklanguage->getValue());
+        $this->assertEquals('dev', $sdkversion->getValue());
+    }
+
+    /**
+     * @test
+     */
     public function testMerge()
     {
         $primary = ResourceInfo::create(new Attributes(['name' => 'primary', 'empty' => '']));
@@ -46,12 +88,15 @@ class ResourceTest extends TestCase
         /** @var Attribute $empty */
         $empty = $result->getAttributes()->getAttribute('empty');
 
-        $this->assertCount(3, $result->getAttributes());
+        $this->assertCount(6, $result->getAttributes());
         $this->assertEquals('primary', $name->getValue());
         $this->assertEquals('1.0.0', $version->getValue());
         $this->assertEquals('value', $empty->getValue());
     }
 
+    /**
+     * @test
+     */
     public function testImmutableCreate()
     {
         $attributes = new Attributes();

--- a/tests/Sdk/Unit/Resource/ResourceTest.php
+++ b/tests/Sdk/Unit/Resource/ResourceTest.php
@@ -31,9 +31,11 @@ class ResourceTest extends TestCase
 
         /** @var Attribute $name */
         $name = $resource->getAttributes()->getAttribute('name');
-
+        /** @var Attribute $sdkname */
         $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
         $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
         $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
 
         $attributes->setAttribute(ResourceConstants::TELEMETRY_SDK_NAME, 'opentelemetry');
@@ -61,9 +63,11 @@ class ResourceTest extends TestCase
             ]
         );
         $resource = ResourceInfo::create(new Attributes());
-
+        /** @var Attribute $sdkname */
         $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
         $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
         $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
 
         $this->assertEquals($attributes, $resource->getAttributes());

--- a/tests/Sdk/Unit/Trace/TracerProviderTest.php
+++ b/tests/Sdk/Unit/Trace/TracerProviderTest.php
@@ -84,16 +84,21 @@ class TracerProviderTest extends TestCase
     public function newTraceProviderWithTracerProvidesNonEmptyResource()
     {
         $traceProvider = new TracerProvider();
+        /** @var Tracer $tracer */
         $tracer = $traceProvider->getTracer('name', 'version');
         $resource = $tracer->getResource();
         $attributes = $resource->getAttributes();
 
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
-
         $this->assertEquals($attributes, $resource->getAttributes());
 
         $this->assertEquals('opentelemetry', $sdkname->getValue());
@@ -130,13 +135,12 @@ class TracerProviderTest extends TestCase
         $this->assertEquals('', $empty->getValue());
 
         // Add a Tracer.  The trace provider should add its resource to the new Tracer.
+        /** @var Tracer $tracer */
         $tracer = $traceProvider->getTracer('name', 'version');
         $resource = $tracer->getResource();
         $attributes = $resource->getAttributes();
 
         // Verify the resource associated with the tracer.
-        /** @var Attribute $name */
-        $name = $resource->getAttributes()->getAttribute('name');
         /** @var Attribute $sdkname */
         $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
         /** @var Attribute $sdklanguage */
@@ -148,7 +152,9 @@ class TracerProviderTest extends TestCase
         /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
+        /** @var Attribute $primary */
         $primary = $attributes->getAttribute('provider');
+        /** @var Attribute $empty */
         $empty = $attributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());

--- a/tests/Sdk/Unit/Trace/TracerProviderTest.php
+++ b/tests/Sdk/Unit/Trace/TracerProviderTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
+use OpenTelemetry\Sdk\Resource\ResourceConstants;
+use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\Sdk\Trace\Sampler\ParentBased;
 use OpenTelemetry\Sdk\Trace\Sampler\TraceIdRatioBasedSampler;
+use OpenTelemetry\Sdk\Trace\Tracer;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -61,5 +65,90 @@ class TracerProviderTest extends TestCase
         $description = $traceProvider->getSampler()->getDescription();
 
         self::assertSame($description, 'TraceIdRatioBasedSampler{0.500000}');
+    }
+    /**
+     * @test
+     */
+    public function newTraceProvidersProvidesEmptyResource()
+    {
+        $traceProvider = new TracerProvider();
+        $resource = $traceProvider->getResource();
+        $attributes = $resource->getAttributes();
+
+        $this->assertCount(0, $attributes);
+    }
+    /**
+     * @test
+     */
+    public function newTraceProviderWithTracerProvidesNonEmptyResource()
+    {
+        $traceProvider = new TracerProvider();
+        $tracer = $traceProvider->getTracer('name', 'version');
+        $resource = $tracer->getResource();
+        $attributes = $resource->getAttributes();
+
+        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
+
+        $this->assertEquals($attributes, $resource->getAttributes());
+
+        $this->assertEquals('opentelemetry', $sdkname->getValue());
+        $this->assertEquals('php', $sdklanguage->getValue());
+        $this->assertEquals('dev', $sdkversion->getValue());
+        $this->assertEquals('name', $servicename->getValue());
+        $this->assertEquals('version', $serviceversion->getValue());
+
+        $this->assertCount(6, $attributes);
+    }
+    /**
+     * @test
+     */
+    public function tracerFromTraceProviderAssociatesWithTraceProviderResource()
+    {
+        /*
+         * A resource can be associated with the TracerProvider when the TracerProvider is created.
+         * That association cannot be changed later. When associated with a TracerProvider, all
+         * Spans produced by any Tracer from the provider MUST be associated with this Resource.
+         */
+
+        // Create a new provider with a resource containing 2 attributes.
+        $providerResource = ResourceInfo::create(new Attributes(['provider' => 'primary', 'empty' => '']));
+        $traceProvider = new TracerProvider($providerResource);
+        $tpAttributes = $traceProvider->getResource()->getAttributes();
+
+        // Verify the resource associated with the trace provider.
+        $this->assertCount(5, $tpAttributes);
+        $primary = $tpAttributes->getAttribute('provider');
+        $empty = $tpAttributes->getAttribute('empty');
+        $this->assertEquals('primary', $primary->getValue());
+        $this->assertEquals('', $empty->getValue());
+
+        // Add a Tracer.  The trace provider should add its resource to the new Tracer.
+        $tracer = $traceProvider->getTracer('name', 'version');
+        $resource = $tracer->getResource();
+        $attributes = $resource->getAttributes();
+
+        // Verify the resource associated with the tracer.
+        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
+
+        $primary = $attributes->getAttribute('provider');
+        $empty = $attributes->getAttribute('empty');
+        $this->assertEquals('primary', $primary->getValue());
+        $this->assertEquals('', $empty->getValue());
+
+        $this->assertEquals('opentelemetry', $sdkname->getValue());
+        $this->assertEquals('php', $sdklanguage->getValue());
+        $this->assertEquals('dev', $sdkversion->getValue());
+        $this->assertEquals('name', $servicename->getValue());
+        $this->assertEquals('version', $serviceversion->getValue());
+
+        $this->assertCount(8, $attributes);
     }
 }

--- a/tests/Sdk/Unit/Trace/TracerProviderTest.php
+++ b/tests/Sdk/Unit/Trace/TracerProviderTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
 use OpenTelemetry\Sdk\Resource\ResourceConstants;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Attribute;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
@@ -121,7 +122,9 @@ class TracerProviderTest extends TestCase
 
         // Verify the resource associated with the trace provider.
         $this->assertCount(5, $tpAttributes);
+        /** @var Attribute $primary */
         $primary = $tpAttributes->getAttribute('provider');
+        /** @var Attribute $empty */
         $empty = $tpAttributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());
@@ -132,10 +135,17 @@ class TracerProviderTest extends TestCase
         $attributes = $resource->getAttributes();
 
         // Verify the resource associated with the tracer.
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $name */
+        $name = $resource->getAttributes()->getAttribute('name');
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
         $primary = $attributes->getAttribute('provider');

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -11,6 +11,7 @@ use OpenTelemetry\Sdk\Trace as SDK;
 use OpenTelemetry\Sdk\Trace\Attribute;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\SpanStatus;
 use OpenTelemetry\Sdk\Trace\Tracer;
@@ -362,6 +363,7 @@ class TracingTest extends TestCase
         $this->assertEquals('', $empty->getValue());
 
         // Add a Tracer.  The trace provider should add its resource to the new Tracer.
+        /** @var Tracer $tracer */
         $tracer = $traceProvider->getTracer('name', 'version');
         $resource = $tracer->getResource();
         $attributes = $resource->getAttributes();
@@ -380,7 +382,9 @@ class TracingTest extends TestCase
         /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
+        /** @var Attribute $primary */
         $primary = $attributes->getAttribute('provider');
+        /** @var Attribute $empty */
         $empty = $attributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());
@@ -396,6 +400,7 @@ class TracingTest extends TestCase
         // Start a span with the tracer.
         $tracer->startAndActivateSpan('firstSpan');
 
+        /** @var Span $global */
         $global = $tracer->getActiveSpan();
         $this->assertSame($tracer->getActiveSpan(), $global);
 
@@ -448,15 +453,21 @@ class TracingTest extends TestCase
         $this->assertCount(0, $tpAttributes);
 
         // Add a Tracer.  The trace provider should merge its resource one inherited from the traceprovider.
+        /** @var Tracer $tracer */
         $tracer = $traceProvider->getTracer('name');
         $resource = $tracer->getResource();
         $attributes = $resource->getAttributes();
 
         // Verify the resource associated with the tracer.
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
         $this->assertEquals('opentelemetry', $sdkname->getValue());
@@ -469,7 +480,7 @@ class TracingTest extends TestCase
 
         // Start a span with the tracer.
         $tracer->startAndActivateSpan('firstSpan');
-
+        /** @var Span $global */
         $global = $tracer->getActiveSpan();
         $this->assertSame($tracer->getActiveSpan(), $global);
 
@@ -477,10 +488,15 @@ class TracingTest extends TestCase
 
         $attributes = $global->getResource()->getAttributes();
 
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
         $this->assertEquals('opentelemetry', $sdkname->getValue());
@@ -516,6 +532,7 @@ class TracingTest extends TestCase
         $this->assertEquals('', $empty->getValue());
 
         // Add a Tracer.  The trace provider should add its resource to the new Tracer.
+        /** @var Tracer $tracer */
         $tracer = $traceProvider->getTracer('name');
         $resource = $tracer->getResource();
         $attributes = $resource->getAttributes();
@@ -536,7 +553,7 @@ class TracingTest extends TestCase
 
         /** @var Attribute $primary */
         $primary = $attributes->getAttribute('provider');
-        /** @var Attribute $serviceversion */
+        /** @var Attribute $empty */
         $empty = $attributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());
@@ -552,6 +569,7 @@ class TracingTest extends TestCase
         // Start a span with the tracer.
         $tracer->startAndActivateSpan('firstSpan');
 
+        /** @var Span $global */
         $global = $tracer->getActiveSpan();
         $this->assertSame($tracer->getActiveSpan(), $global);
 
@@ -559,13 +577,20 @@ class TracingTest extends TestCase
 
         $attributes = $global->getResource()->getAttributes();
 
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
+        /** @var Attribute $primary */
         $primary = $attributes->getAttribute('provider');
+        /** @var Attribute $empty */
         $empty = $attributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());
@@ -595,15 +620,21 @@ class TracingTest extends TestCase
         $this->assertCount(0, $tpAttributes);
 
         // Add a Tracer.  The trace provider should merge its resource one inherited from the traceprovider.
+        /** @var Tracer $tracer */
         $tracer = $traceProvider->getTracer('name', 'version');
         $resource = $tracer->getResource();
         $attributes = $resource->getAttributes();
 
         // Verify the resource associated with the tracer.
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
         $this->assertEquals('opentelemetry', $sdkname->getValue());
@@ -617,6 +648,7 @@ class TracingTest extends TestCase
         // Start a span with the tracer.
         $tracer->startAndActivateSpan('firstSpan');
 
+        /** @var Span $global */
         $global = $tracer->getActiveSpan();
         $this->assertSame($tracer->getActiveSpan(), $global);
 
@@ -624,10 +656,15 @@ class TracingTest extends TestCase
 
         $attributes = $global->getResource()->getAttributes();
 
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
         $this->assertEquals('opentelemetry', $sdkname->getValue());

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -354,7 +354,9 @@ class TracingTest extends TestCase
 
         // Verify the resource associated with the trace provider.
         $this->assertCount(5, $tpAttributes);
+        /** @var Attribute $primary */
         $primary = $tpAttributes->getAttribute('provider');
+        /** @var Attribute $empty */
         $empty = $tpAttributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());
@@ -365,10 +367,17 @@ class TracingTest extends TestCase
         $attributes = $resource->getAttributes();
 
         // Verify the resource associated with the tracer.
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $name */
+        $name = $resource->getAttributes()->getAttribute('name');
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
         $primary = $attributes->getAttribute('provider');
@@ -391,16 +400,25 @@ class TracingTest extends TestCase
         $this->assertSame($tracer->getActiveSpan(), $global);
 
         // Verify the resource associated with the span.
-
+        /** @var Attributes $attributes */
         $attributes = $global->getResource()->getAttributes();
 
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $name */
+        $name = $resource->getAttributes()->getAttribute('name');
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
+        /** @var Attribute $primary */
         $primary = $attributes->getAttribute('provider');
+        /** @var Attribute $empty */
         $empty = $attributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());
@@ -489,7 +507,10 @@ class TracingTest extends TestCase
 
         // Verify the resource associated with the trace provider.
         $this->assertCount(5, $tpAttributes);
+
+        /** @var Attribute $primary */
         $primary = $tpAttributes->getAttribute('provider');
+        /** @var Attribute $empty */
         $empty = $tpAttributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());
@@ -500,13 +521,22 @@ class TracingTest extends TestCase
         $attributes = $resource->getAttributes();
 
         // Verify the resource associated with the tracer.
-        $sdkname = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
-        $sdklanguage = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
-        $sdkversion = $attributes->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $name */
+        $name = $resource->getAttributes()->getAttribute('name');
+        /** @var Attribute $sdkname */
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        /** @var Attribute $sdklanguage */
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        /** @var Attribute $sdkversion */
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        /** @var Attribute $servicename */
         $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
+        /** @var Attribute $serviceversion */
         $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
+        /** @var Attribute $primary */
         $primary = $attributes->getAttribute('provider');
+        /** @var Attribute $serviceversion */
         $empty = $attributes->getAttribute('empty');
         $this->assertEquals('primary', $primary->getValue());
         $this->assertEquals('', $empty->getValue());


### PR DESCRIPTION
* Added functionality to associate a traceprovider resource on a tracer and a tracer resource with a span.

* Added a `defaultResource` method to `ResourceInfo`.

* Added test cases to ‘ResourceTest.php`, `TracerProviderTest.php`, `TracingTest.php`.