### PR TITLE
Add Trace Context Tracestate header propagation Part 1

### DIFF
--- a/api/Trace/SpanContext.php
+++ b/api/Trace/SpanContext.php
@@ -11,7 +11,7 @@ interface SpanContext
     public function getTraceId(): string;
     public function getSpanId(): string;
     public function getTraceFlags(): int;
-    public function getTracestate(): array;
+    public function getTraceState(): ?TraceState;
     public function isValidContext(): bool;
     public function isRemoteContext(): bool;
     public function isSampled(): bool;

--- a/api/Trace/TraceState.php
+++ b/api/Trace/TraceState.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Trace;
+
+/**
+ * TraceState parses and stores the tracestate header as an immutable list of string
+ * key/value pairs. It provides the following operations following the rules described
+ * in the W3C Trace Context specification:
+ *      - Get value for a given key
+ *      - Add a new key/value pair
+ *      - Update an existing value for a given key
+ *      - Delete a key/value pair
+ *
+ * All mutating operations return a new TraceState with the modifications applied.
+ *
+ * @see https://www.w3.org/TR/trace-context/#tracestate-header
+ * @see https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracestate
+ */
+interface TraceState
+{
+    /**
+     * Return a new TraceState object that inherits from this TraceState
+     * and contains the given key value pair.
+     *
+     * @param string $key
+     * @param string $value
+     * @return TraceState
+     */
+    public function with(string $key, string $value): TraceState;
+
+    /**
+     * Return a new TraceState object that inherits from this TraceState
+     * without the given key value pair.
+     *
+     * @param string $key
+     * @return TraceState
+     */
+    public function without(string $key): TraceState;
+
+    /**
+     * Return the value of a given key from this TraceState if it exists
+     *
+     * @param string $key
+     * @return string|null
+     */
+    public function get(string $key): ?string;
+
+    /**
+     * Get the list-member count in this TraceState
+     *
+     * @return int
+     */
+    public function getListMemberCount(): int;
+
+    /**
+     * Build the TraceState header
+     *
+     * @return string|null
+     */
+    public function build(): ?string;
+}

--- a/sdk/Trace/NoopSpan.php
+++ b/sdk/Trace/NoopSpan.php
@@ -39,8 +39,7 @@ class NoopSpan implements \OpenTelemetry\Trace\Span
             $this->context = new SpanContext(
                 SpanContext::INVALID_TRACE,
                 SpanContext::INVALID_SPAN,
-                0,
-                []
+                0
             );
         } else {
             $this->context = $spanContext;

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -10,10 +10,10 @@ use Throwable;
 final class SpanContext implements API\SpanContext
 {
     public const INVALID_TRACE = '00000000000000000000000000000000';
-    private const VALID_TRACE = '/^[0-9a-f]{32}$/';
+    public const VALID_TRACE = '/^[0-9a-f]{32}$/';
     public const INVALID_SPAN = '0000000000000000';
-    private const VALID_SPAN = '/^[0-9a-f]{16}$/';
-    private const SAMPLED_FLAG = 1;
+    public const VALID_SPAN = '/^[0-9a-f]{16}$/';
+    public const SAMPLED_FLAG = 1;
 
     /**
      * @var string
@@ -24,8 +24,7 @@ final class SpanContext implements API\SpanContext
      */
     private $spanId;
     /**
-     * @var string[]
-     * @see https://www.w3.org/TR/trace-context/#tracestate-header
+     * @var API\TraceState
      */
     private $traceState;
     /**
@@ -51,9 +50,9 @@ final class SpanContext implements API\SpanContext
      * @param string $traceId
      * @param string $spanId
      * @param int $traceFlags
-     * @param array $traceState
+     * @param API\TraceState|null $traceState
      */
-    public function __construct(string $traceId, string $spanId, int $traceFlags, array $traceState = [])
+    public function __construct(string $traceId, string $spanId, int $traceFlags, ?API\TraceState $traceState = null)
     {
         if (preg_match(self::VALID_TRACE, $traceId) === 0) {
             throw new \InvalidArgumentException(
@@ -116,12 +115,13 @@ final class SpanContext implements API\SpanContext
      * @param string $spanId
      * @param bool $sampled
      * @param bool $isRemote Default: false
+     * @param API\TraceState|null $traceState
      * @return SpanContext
      */
-    public static function restore(string $traceId, string $spanId, bool $sampled = false, bool $isRemote = false): SpanContext
+    public static function restore(string $traceId, string $spanId, bool $sampled = false, bool $isRemote = false, ?API\TraceState $traceState = null): SpanContext
     {
         $sampleFlag = $sampled ? 1 : 0;
-        $trace = new self($traceId, $spanId, $sampleFlag, []);
+        $trace = new self($traceId, $spanId, $sampleFlag, $traceState);
         $trace->isRemote = $isRemote;
 
         return $trace;
@@ -144,9 +144,9 @@ final class SpanContext implements API\SpanContext
     }
 
     /**
-     * @return string[] Returns a key-value array of extra vendor headers
+     * @return API\TraceState Returns a Tracestate object containing parsed list-members
      */
-    public function getTraceState(): array
+    public function getTraceState(): ?API\TraceState
     {
         return $this->traceState;
     }

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -24,7 +24,7 @@ final class SpanContext implements API\SpanContext
      */
     private $spanId;
     /**
-     * @var API\TraceState
+     * @var API\TraceState|null
      */
     private $traceState;
     /**

--- a/sdk/Trace/TraceContext.php
+++ b/sdk/Trace/TraceContext.php
@@ -44,7 +44,8 @@ final class TraceContext implements API\TextMapFormatPropagator
         // Build and inject the tracestate header
         $tracestate = $context->getTraceState();
         if ($tracestate !== null) {
-            $setter->set($carrier, self::TRACESTATE, $tracestate->build());
+            $tracestateStr = $tracestate->build();
+            $setter->set($carrier, self::TRACESTATE, $tracestateStr ? $tracestateStr : '');
         }
     }
 

--- a/sdk/Trace/TraceContext.php
+++ b/sdk/Trace/TraceContext.php
@@ -6,20 +6,23 @@ namespace OpenTelemetry\Sdk\Trace;
 
 use OpenTelemetry\Trace as API;
 
+/**
+ * TraceContext is a propagator that supports the W3C Trace Context format
+ * (https://www.w3.org/TR/trace-context/)
+ *
+ * This propagator will propagate the traceparent and tracestate headers to
+ * guarantee traces are not broken. It is up to the users of this propagator
+ * to choose if they want to participate in a trace by modifying the
+ * traceparent header and relevant parts of the tracestate header containing
+ * their proprietary information.
+ */
 final class TraceContext implements API\TextMapFormatPropagator
 {
     public const TRACEPARENT = 'http_traceparent';
     public const TRACESTATE = 'http_tracestate';
-
-    // TODO Consolidate these and the validity checks in SpanContext.php
-    private const SUPPORTED_VERSION = '00';
-    private const INVALID_TRACE = '00000000000000000000000000000000';
-    private const INVALID_SPAN = '0000000000000000';
+    private const VERSION = '00'; // Currently only '00' is supported
     private const VALID_VERSION = '/^[0-9a-f]{2}$/';
-    private const VALID_TRACE = '/^[0-9a-f]{32}$/';
-    private const VALID_SPAN = '/^[0-9a-f]{16}$/';
     private const VALID_TRACEFLAGS = '/^[0-9a-f]{2}$/';
-    private const SAMPLED_FLAG = 1;
 
     /**
      * {@inheritdoc}
@@ -34,8 +37,15 @@ final class TraceContext implements API\TextMapFormatPropagator
      */
     public static function inject(API\SpanContext $context, &$carrier, API\PropagationSetter $setter): void
     {
-        $traceparent = self::SUPPORTED_VERSION . '-' . $context->getTraceId() . '-' . $context->getSpanId() . '-' . ($context->isSampled() ? '01' : '00');
+        // Build and inject the traceparent header
+        $traceparent = self::VERSION . '-' . $context->getTraceId() . '-' . $context->getSpanId() . '-' . ($context->isSampled() ? '01' : '00');
         $setter->set($carrier, self::TRACEPARENT, $traceparent);
+
+        // Build and inject the tracestate header
+        $tracestate = $context->getTraceState();
+        if ($tracestate !== null) {
+            $setter->set($carrier, self::TRACESTATE, $tracestate->build());
+        }
     }
 
     /**
@@ -51,30 +61,29 @@ final class TraceContext implements API\TextMapFormatPropagator
         // Traceparent = {version}-{trace-id}-{parent-id}-{trace-flags}
         $pieces = explode('-', $traceparent);
 
-        $peicesCount = count($pieces);
-        if ($peicesCount != 4) {
+        $piecesCount = count($pieces);
+        if ($piecesCount != 4) {
             throw new \InvalidArgumentException(
-                sprintf('Unable to extract traceparent. Expected 4 values, got %d', $peicesCount)
+                sprintf('Unable to extract traceparent. Expected 4 values, got %d', $piecesCount)
             );
         }
 
-        // Parse the traceparent version. Currently only '00' is supported.
         $version = $pieces[0];
-        if ((preg_match(self::VALID_VERSION, $version) === 0) || ($version !== self::SUPPORTED_VERSION)) {
+        if ((preg_match(self::VALID_VERSION, $version) === 0) || ($version !== self::VERSION)) {
             throw new \InvalidArgumentException(
                 sprintf('Only version 00 is supported, got %s', $version)
             );
         }
 
         $traceId = $pieces[1];
-        if ((preg_match(self::VALID_TRACE, $traceId) === 0) || ($traceId === self::INVALID_TRACE)) {
+        if ((preg_match(SpanContext::VALID_TRACE, $traceId) === 0) || ($traceId === SpanContext::INVALID_TRACE)) {
             throw new \InvalidArgumentException(
                 sprintf('TraceID must be exactly 16 bytes (32 chars) and at least one non-zero byte, got %s', $traceId)
             );
         }
 
         $spanId = $pieces[2];
-        if ((preg_match(self::VALID_SPAN, $spanId) === 0) || ($spanId === self::INVALID_SPAN)) {
+        if ((preg_match(SpanContext::VALID_SPAN, $spanId) === 0) || ($spanId === SpanContext::INVALID_SPAN)) {
             throw new \InvalidArgumentException(
                 sprintf('SpanID must be exactly 8 bytes (16 chars) and at least one non-zero byte, got %s', $spanId)
             );
@@ -89,8 +98,17 @@ final class TraceContext implements API\TextMapFormatPropagator
 
         // Only the sampled flag is extracted from the traceFlags (00000001)
         $convertedTraceFlags = hexdec($traceFlags);
-        $isSampled = ($convertedTraceFlags & self::SAMPLED_FLAG) === self::SAMPLED_FLAG;
+        $isSampled = ($convertedTraceFlags & SpanContext::SAMPLED_FLAG) === SpanContext::SAMPLED_FLAG;
 
+        // Tracestate = 'Vendor1=Value1,...,VendorN=ValueN'
+        $rawTracestate = $getter->get($carrier, self::TRACESTATE);
+        if ($rawTracestate !== null) {
+            $tracestate = new TraceState($rawTracestate);
+
+            return SpanContext::restore($traceId, $spanId, $isSampled, true, $tracestate);
+        }
+
+        // Only traceparent header is extracted. No tracestate.
         return SpanContext::restore($traceId, $spanId, $isSampled, true);
     }
 }

--- a/sdk/Trace/TraceState.php
+++ b/sdk/Trace/TraceState.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+use OpenTelemetry\Trace as API;
+
+class TraceState implements API\TraceState
+{
+    public const MAX_TRACESTATE_LIST_MEMBERS = 32;
+    public const LIST_MEMBERS_SEPARATOR = ',';
+    public const LIST_MEMBER_KEY_VALUE_SPLITTER = '=';
+    private const VALID_KEY_CHAR_RANGE = '[_0-9a-z-*\/]';
+    private const VALID_KEY = '[a-z]' . self::VALID_KEY_CHAR_RANGE . '{0,255}';
+    private const VALID_VENDOR_KEY = '[a-z0-9]' . self::VALID_KEY_CHAR_RANGE . '{0,240}@[a-z]' . self::VALID_KEY_CHAR_RANGE . '{0,13}';
+    private const VALID_KEY_REGEX = '/^(?:' . self::VALID_KEY . '|' . self::VALID_VENDOR_KEY . ')$/';
+    private const VALID_VALUE_BASE_REGEX = '/^[ -~]{0,255}[!-~]$/';
+    private const INVALID_VALUE_COMMA_EQUAL_REGEX = '/,|=/';
+
+    /**
+     * @var string[]
+     */
+    private $traceState = [];
+
+    public function __construct(string $rawTracestate = null)
+    {
+        if ($rawTracestate != null) {
+            $this->traceState = self::parse($rawTracestate);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function with(string $key, string $value): API\TraceState
+    {
+        $clonedTracestate = clone $this;
+
+        //TODO: Log if we can't set the value
+        if ($key !== '') {
+            $clonedTracestate->traceState[$key] = $value;
+        }
+
+        return $clonedTracestate;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function without(string $key): API\TraceState
+    {
+        $clonedTracestate = clone $this;
+
+        //TODO: Log if we can't unset the value
+        if ($key !== '') {
+            unset($clonedTracestate->traceState[$key]);
+        }
+
+        return $clonedTracestate;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(string $key): ?string
+    {
+        return $this->traceState[$key] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListMemberCount(): int
+    {
+        return count($this->traceState);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(): ?string
+    {
+        if (!empty($this->traceState)) {
+            $clonedTracestate = clone $this;
+            array_walk(
+                $clonedTracestate->traceState,
+                function (&$v, $k) {
+                    $v = $k . self::LIST_MEMBER_KEY_VALUE_SPLITTER . $v;
+                }
+            );
+
+            return implode(self::LIST_MEMBERS_SEPARATOR, $clonedTracestate->traceState);
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse the raw tracestate header into the TraceState object.
+     *
+     * Ex:
+     *      tracestate = 'vendor1=value1,vendor2=value2'
+     *
+     *                              ||
+     *                              \/
+     *
+     *      $this->tracestate = ['vendor1' => 'value1' ,'vendor2' => 'value2']
+     *
+     */
+    private function parse(string $rawTracestate): array
+    {
+        $parsedTracestate = [];
+        $listMembers = explode(self::LIST_MEMBERS_SEPARATOR, $rawTracestate);
+
+        $listMembersCount = count($listMembers);
+        if ($listMembersCount > self::MAX_TRACESTATE_LIST_MEMBERS) {
+            
+            // Truncate the tracestate if it exceeds the maximum list-members allowed
+            // TODO: Log a message when truncation occurs
+            $listMembers = array_slice($listMembers, 0, self::MAX_TRACESTATE_LIST_MEMBERS);
+        }
+
+        foreach ($listMembers as $listMember) {
+            $vendor = explode(self::LIST_MEMBER_KEY_VALUE_SPLITTER, $listMember);
+            
+            // There should only be one list-member per vendor separated by '='
+            if (count($vendor) == 2) {
+
+                // TODO: Log if we can't validate the key and value
+                if (self::validateKey($vendor[0]) && self::validateValue($vendor[1])) {
+                    $parsedTracestate[$vendor[0]] = $vendor[1];
+                }
+            }
+        }
+
+        return $parsedTracestate;
+    }
+
+    /**
+     * The Key is opaque string that is an identifier for a vendor. It can be up
+     * to 256 characters and MUST begin with a lowercase letter or a digit, and can
+     * only contain lowercase letters (a-z), digits (0-9), underscores (_), dashes (-),
+     * asterisks (*), and forward slashes (/). For multi-tenant vendor scenarios, an at
+     * sign (@) can be used to prefix the vendor name. Vendors SHOULD set the tenant ID
+     * at the beginning of the key.
+     *
+     * @see https://www.w3.org/TR/trace-context/#key
+     */
+    private function validateKey(string $key): bool
+    {
+        return preg_match(self::VALID_KEY_REGEX, $key) !== 0;
+    }
+
+    /**
+     * The value is an opaque string containing up to 256 printable ASCII [RFC0020]
+     * characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=). Note that
+     * this also excludes tabs, newlines, carriage returns, etc.
+     *
+     * @see https://www.w3.org/TR/trace-context/#value
+     */
+    private function validateValue(string $key): bool
+    {
+        return (preg_match(self::VALID_VALUE_BASE_REGEX, $key) !== 0)
+            && (!preg_match(self::INVALID_VALUE_COMMA_EQUAL_REGEX, $key) !== 0);
+    }
+}

--- a/sdk/Trace/TraceState.php
+++ b/sdk/Trace/TraceState.php
@@ -162,6 +162,6 @@ class TraceState implements API\TraceState
     private function validateValue(string $key): bool
     {
         return (preg_match(self::VALID_VALUE_BASE_REGEX, $key) !== 0)
-            && (!preg_match(self::INVALID_VALUE_COMMA_EQUAL_REGEX, $key) !== 0);
+            && (preg_match(self::INVALID_VALUE_COMMA_EQUAL_REGEX, $key) === 0);
     }
 }

--- a/tests/Sdk/Integration/Context/SpanContextTest.php
+++ b/tests/Sdk/Integration/Context/SpanContextTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Sdk\Integration\Context;
 
 use InvalidArgumentException;
 use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TraceState;
 use PHPUnit\Framework\TestCase;
 
 class SpanContextTest extends TestCase
@@ -65,11 +66,11 @@ class SpanContextTest extends TestCase
     {
         $trace = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
         $span = 'bbbbbbbbbbbbbbbb';
-        $state = ['a' => 'b'];
-        $spanContext = new SpanContext($trace, $span, 0, $state);
+        $tracestate = new TraceState('a=b');
+        $spanContext = new SpanContext($trace, $span, 0, $tracestate);
         $this->assertSame($trace, $spanContext->getTraceId());
         $this->assertSame($span, $spanContext->getSpanId());
-        $this->assertSame($state, $spanContext->getTraceState());
+        $this->assertSame($tracestate, $spanContext->getTraceState());
         $this->assertFalse($spanContext->isSampled());
     }
 

--- a/tests/Sdk/Unit/Trace/TraceContextTest.php
+++ b/tests/Sdk/Unit/Trace/TraceContextTest.php
@@ -60,7 +60,8 @@ class TraceContextTest extends TestCase
             $map = new PropagationMap();
             $context = TraceContext::extract($carrier, $map);
 
-            $this->assertSame($tracestate, $context->getTraceState()->build());
+            $extractedTracestate = $context->getTraceState();
+            $this->assertSame($tracestate, $extractedTracestate ? $extractedTracestate->build() : '');
         }
     }
 
@@ -90,7 +91,8 @@ class TraceContextTest extends TestCase
         $context = TraceContext::extract($carrier, $map);
 
         // Invalid list-member should be dropped
-        $this->assertSame('vendor2=opaqueValue2', $context->getTraceState()->build());
+        $extractedTracestate = $context->getTraceState();
+        $this->assertSame('vendor2=opaqueValue2', $extractedTracestate ? $extractedTracestate->build() : '');
 
         // Tracestate with an invalid value
         $carrier = [TraceContext::TRACEPARENT => self::TRACEPARENTVALUE,
@@ -100,7 +102,8 @@ class TraceContextTest extends TestCase
         $context = TraceContext::extract($carrier, $map);
 
         // Invalid list-member should be dropped
-        $this->assertSame('vendor3=opaqueValue3', $context->getTraceState()->build());
+        $extractedTracestate = $context->getTraceState();
+        $this->assertSame('vendor3=opaqueValue3', $extractedTracestate ? $extractedTracestate->build() : '');
     }
 
     /**

--- a/tests/Sdk/Unit/Trace/TraceContextTest.php
+++ b/tests/Sdk/Unit/Trace/TraceContextTest.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 use OpenTelemetry\Sdk\Trace\PropagationMap;
 use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\TraceContext;
+use OpenTelemetry\Sdk\Trace\TraceState;
 use PHPUnit\Framework\TestCase;
 
 class TraceContextTest extends TestCase
@@ -30,9 +31,9 @@ class TraceContextTest extends TestCase
     /**
      * @test
      */
-    public function testExtractValidTraceContext()
+    public function testExtractValidTraceparent()
     {
-        $traceparentValues = [self::TRACEPARENTVALUE,                                               // sampled == true
+        $traceparentValues = [self::TRACEPARENTVALUE,
                               self::VERSION . '-' . self::TRACEID . '-' . self::SPANID . '-00', ];  // sampled == false
 
         foreach ($traceparentValues as $traceparentValue) {
@@ -47,7 +48,26 @@ class TraceContextTest extends TestCase
     /**
      * @test
      */
-    public function testExtractInvalidTraceContext()
+    public function testExtractValidTracestate()
+    {
+        $tracestateValues = ['vendor1=opaqueValue1',
+                             'vendor2=opaqueValue2,vendor3=opaqueValue3', ];
+
+        foreach ($tracestateValues as $tracestate) {
+            $carrier = [TraceContext::TRACEPARENT => self::TRACEPARENTVALUE,
+                        TraceContext::TRACESTATE => $tracestate, ];
+
+            $map = new PropagationMap();
+            $context = TraceContext::extract($carrier, $map);
+
+            $this->assertSame($tracestate, $context->getTraceState()->build());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function testExtractInvalidTraceparent()
     {
         $carrier = [];
         $map = new PropagationMap();
@@ -60,7 +80,33 @@ class TraceContextTest extends TestCase
     /**
      * @test
      */
-    public function testInjectValidTraceContext()
+    public function testExtractInvalidTracestate()
+    {
+        // Tracestate with an invalid key
+        $carrier = [TraceContext::TRACEPARENT => self::TRACEPARENTVALUE,
+                    TraceContext::TRACESTATE => '@vendor1=opaqueValue1,vendor2=opaqueValue2', ];
+
+        $map = new PropagationMap();
+        $context = TraceContext::extract($carrier, $map);
+
+        // Invalid list-member should be dropped
+        $this->assertSame('vendor2=opaqueValue2', $context->getTraceState()->build());
+
+        // Tracestate with an invalid value
+        $carrier = [TraceContext::TRACEPARENT => self::TRACEPARENTVALUE,
+                    TraceContext::TRACESTATE => 'vendor3=opaqueValue3,vendor4=' . chr(0x7F) . 'opaqueValue4', ];
+
+        $map = new PropagationMap();
+        $context = TraceContext::extract($carrier, $map);
+
+        // Invalid list-member should be dropped
+        $this->assertSame('vendor3=opaqueValue3', $context->getTraceState()->build());
+    }
+
+    /**
+     * @test
+     */
+    public function testInjectValidTraceparent()
     {
         $carrier = [];
         $map = new PropagationMap();
@@ -73,7 +119,21 @@ class TraceContextTest extends TestCase
     /**
      * @test
      */
-    public function testTraceparentLength()
+    public function testInjectValidTracestate()
+    {
+        $carrier = [];
+        $map = new PropagationMap();
+        $tracestate = new TraceState('vendor1=opaqueValue1');
+        $context = SpanContext::restore(self::TRACEID, self::SPANID, true, false, $tracestate);
+        TraceContext::inject($context, $carrier, $map);
+
+        $this->assertSame('vendor1=opaqueValue1', $map->get($carrier, TraceContext::TRACESTATE));
+    }
+
+    /**
+     * @test
+     */
+    public function testInvalidTraceparentLength()
     {
         $invalidValues = [self::TRACEPARENTVALUE . '-extra',                            // Length > 4 values
                           self::VERSION . '-' . self::SPANID . '-' . self::SAMPLED, ];  // Length < 4 values
@@ -96,7 +156,7 @@ class TraceContextTest extends TestCase
         $invalidValues = ['ff',     // invalid hex value
                           '003',    // Length > 2
                           '1',      // Length < 2
-                          '0j', ];  // Hex character != 'a - f or 0 - 9'
+                          '0j', ];  // Hex character != 'a - f' or '0 - 9'
 
         $buildTraceparent = self::TRACEID . '-' . self::SPANID . '-' . self::SAMPLED;
 
@@ -156,7 +216,7 @@ class TraceContextTest extends TestCase
     /**
      * @test
      */
-    public function testInvalidTraceFlags()
+    public function testInvalidTraceparentTraceFlags()
     {
         $invalidValues = ['003',    // Length > 2
                           '1',      // Length < 2

--- a/tests/Sdk/Unit/Trace/TraceStateTest.php
+++ b/tests/Sdk/Unit/Trace/TraceStateTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
+
+use OpenTelemetry\Sdk\Trace\TraceState;
+use PHPUnit\Framework\TestCase;
+
+class TraceStateTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testGetTracestateValue()
+    {
+        $tracestate = new TraceState('vendor1=value1');
+
+        $this->assertSame('value1', $tracestate->get('vendor1'));
+    }
+
+    /**
+     * @test
+     */
+    public function testWithTracestateValue()
+    {
+        $tracestate = new TraceState('vendor1=value1');
+        $tracestateWithNewValue = $tracestate->with('vendor2', 'value2');
+
+        $this->assertSame('value2', $tracestateWithNewValue->get('vendor2'));
+        $this->assertNull($tracestate->get('vendor2'));
+    }
+
+    /**
+     * @test
+     */
+    public function testWithoutTracestateValue()
+    {
+        $tracestate = new TraceState('vendor1=value1,vendor2=value2');
+        $tracestateWithoutNewValue = $tracestate->without('vendor1', 'value1');
+
+        $this->assertNull($tracestateWithoutNewValue->get('vendor1'));
+        $this->assertSame('value2', $tracestateWithoutNewValue->get('vendor2'));
+        $this->assertSame('value1', $tracestate->get('vendor1'));
+        $this->assertSame('value2', $tracestate->get('vendor2'));
+    }
+
+    /**
+     * @test
+     */
+    public function testMaxTracestateListMembers()
+    {
+        // Build a tracestate with the max 32 values. Ex '0=0,1=1,...,31=31'
+        $rawTraceState = range(0, TraceState::MAX_TRACESTATE_LIST_MEMBERS - 1);
+        array_walk($rawTraceState, function (&$v, $k) {
+            $v = 'vendor' . $k . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . 'value' . $v;
+        });
+        $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS, count($rawTraceState));
+
+        $validTracestate = new TraceState(implode(Tracestate::LIST_MEMBERS_SEPARATOR, $rawTraceState));
+        $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS, $validTracestate->getListMemberCount());
+
+        // Add a list-member to the tracestate that exceeds the max of 32. This will cause it to be truncated
+        $rawTraceState['32'] = 'vendor32' . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . 'value32';
+        $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS + 1, count($rawTraceState));
+
+        $truncatedTracestate = new TraceState(implode(Tracestate::LIST_MEMBERS_SEPARATOR, $rawTraceState));
+        $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS, $truncatedTracestate->getListMemberCount());
+    }
+
+    /**
+     * @test
+     */
+    public function testValidateKey()
+    {
+        // Valid keys
+        $validKeys = 'a-b=1,c*d=2,e/f=3,g_h=4,01@i-j=5';
+        $tracestate = new TraceState($validKeys);
+
+        $this->assertSame('1', $tracestate->get('a-b'));
+        $this->assertSame('2', $tracestate->get('c*d'));
+        $this->assertSame('3', $tracestate->get('e/f'));
+        $this->assertSame('4', $tracestate->get('g_h'));
+        $this->assertSame('5', $tracestate->get('01@i-j'));
+        $this->assertSame($validKeys, $tracestate->build());
+
+        // Mixed invalid keys in with valid ones
+        $mixedInvalidKeys = 'a=1=,c*d=2,@e/f=3,g_h=4,I-j=5,k&l=6';
+        $tracestate = new TraceState($mixedInvalidKeys);
+
+        $this->assertNull($tracestate->get('a=1'));
+        $this->assertNull($tracestate->get('@e'));
+        $this->assertNull($tracestate->get('I-j'));
+        $this->assertNull($tracestate->get('k&l'));
+        $this->assertSame('2', $tracestate->get('c*d'));
+        $this->assertSame('4', $tracestate->get('g_h'));
+        $this->assertSame('c*d=2,g_h=4', $tracestate->build());
+    }
+
+    /**
+     * @test
+     */
+    public function testvalidateValue()
+    {
+        // Tests values are within the range of 0x20 to 0x7E characters
+        $tracestate =   'char1=value' . chr(0x19) . '1'
+                      . ',char2=value' . chr(0x20) . '2'
+                      . ',char3=value' . chr(0x7E) . '3'
+                      . ',char4=value' . chr(0x7F) . '4';
+
+        $parsedTracestate = new TraceState($tracestate);
+
+        $this->assertNull($parsedTracestate->get('char1'));
+        $this->assertNull($parsedTracestate->get('char4'));
+        $this->assertSame('value' . chr(0x20) . '2', $parsedTracestate->get('char2'));
+        $this->assertSame('value' . chr(0x7E) . '3', $parsedTracestate->get('char3'));
+        $this->assertSame('char2=value' . chr(0x20) . '2,char3=value' . chr(0x7E) . '3', $parsedTracestate->build());
+    }
+}

--- a/tests/Sdk/Unit/Trace/TraceStateTest.php
+++ b/tests/Sdk/Unit/Trace/TraceStateTest.php
@@ -48,6 +48,19 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
+    public function testBuildTracestate()
+    {
+        $tracestate = new TraceState('vendor1=value1');
+        $emptyTracestate = new TraceState();
+
+        $this->assertSame('vendor1=value1', $tracestate->build());
+        $this->assertSame(0, $emptyTracestate->getListMemberCount());
+        $this->assertNull($emptyTracestate->build());
+    }
+
+    /**
+     * @test
+     */
     public function testMaxTracestateListMembers()
     {
         // Build a tracestate with the max 32 values. Ex '0=0,1=1,...,31=31'

--- a/tests/Sdk/Unit/Trace/TraceStateTest.php
+++ b/tests/Sdk/Unit/Trace/TraceStateTest.php
@@ -37,7 +37,7 @@ class TraceStateTest extends TestCase
     public function testWithoutTracestateValue()
     {
         $tracestate = new TraceState('vendor1=value1,vendor2=value2');
-        $tracestateWithoutNewValue = $tracestate->without('vendor1', 'value1');
+        $tracestateWithoutNewValue = $tracestate->without('vendor1');
 
         $this->assertNull($tracestateWithoutNewValue->get('vendor1'));
         $this->assertSame('value2', $tracestateWithoutNewValue->get('vendor2'));


### PR DESCRIPTION
This adds the first part of `Tracestate` header propagation according to the [W3C Trace Context spec](https://www.w3.org/TR/trace-context/#tracestate-header). The following [operations](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracestate) on the `Tracestate` header are also included:

- Get value for a given key
- Add a new key/value pair
- Update an existing value for a given key
- Delete a key/value pair

**Note**: This does not yet include a few more pieces of work that will come in a follow-up PR. (These were split out of this PR to make it a bit easier to review):

1. [Further validation of tracestate limits (max 512 characters)](https://www.w3.org/TR/trace-context/#tracestate-limits).
2. [Validate new key/value entries and ensure they are placed at the beginning of the header](https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field).
3. [Ensure vendors overwrite their previous entry upon reentry to their tracing system](https://www.w3.org/TR/trace-context/#combined-header-value).

After the above work is merged and once #217 is complete (currently in-flight), it will likely expose some edge cases that have yet to be accounted for. Those will be fixed in a follow-up PR.