### PR TITLE
Update ParentBased sampler according to specs

### DIFF
--- a/sdk/Trace/Sampler/ParentBased.php
+++ b/sdk/Trace/Sampler/ParentBased.php
@@ -9,17 +9,70 @@ use OpenTelemetry\Sdk\Trace\SamplingResult;
 use OpenTelemetry\Trace as API;
 
 /**
- * This implementation of the SamplerInterface always records.
+ * This implementation of the SamplerInterface that respects parent context's sampling decision
+ * and delegates for the root span.
  * Example:
  * ```
  * use OpenTelemetry\Trace\ParentBased;
- * $sampler = new ParentBased();
+ * use OpenTelemetry\Trace\AlwaysOnSampler
+ *
+ * $rootSampler = new AlwaysOnSampler();
+ * $sampler = new ParentBased($rootSampler);
  * ```
  */
 class ParentBased implements Sampler
 {
+
     /**
-     * Returns `RECORD_AND_SAMPLED` if SampledFlag is set to true on parent SpanContext and `NOT_RECORD` otherwise.
+     * @var Sampler
+     */
+    private $root;
+
+    /**
+     * @var Sampler
+     */
+    private $remoteParentSampled;
+
+    /**
+     * @var Sampler
+     */
+    private $remoteParentNotSampled;
+
+    /**
+     * @var Sampler
+     */
+    private $localParentSampled;
+
+    /**
+     * @var Sampler
+     */
+    private $localParentNotSampled;
+
+    /**
+     * ParentBased sampler delegates the sampling decision based on the parent context.
+     *
+     * @param Sampler $root Sampler called for the span with no parent (root span).
+     * @param Sampler|null $remoteParentSampled Sampler called for the span with the remote sampled parent. When null, `AlwaysOnSampler` is used.
+     * @param Sampler|null $remoteParentNotSampled Sampler called for the span with the remote not sampled parent. When null, `AlwaysOffSampler` is used.
+     * @param Sampler|null $localParentSampled Sampler called for the span with local the sampled parent. When null, `AlwaysOnSampler` is used.
+     * @param Sampler|null $localParentNotSampled Sampler called for the span with the local not sampled parent. When null, `AlwaysOffSampler` is used.
+     */
+    public function __construct(
+        Sampler $root,
+        ?Sampler $remoteParentSampled = null,
+        ?Sampler $remoteParentNotSampled = null,
+        ?Sampler $localParentSampled = null,
+        ?Sampler $localParentNotSampled = null
+    ) {
+        $this->root = $root;
+        $this->remoteParentSampled = $remoteParentSampled ?? new AlwaysOnSampler();
+        $this->remoteParentNotSampled = $remoteParentNotSampled ?? new AlwaysOffSampler();
+        $this->localParentSampled = $localParentSampled ?? new AlwaysOnSampler();
+        $this->localParentNotSampled = $localParentNotSampled ?? new AlwaysOffSampler();
+    }
+
+    /**
+     * Invokes the respective delegate sampler when parent is set or uses root sampler for the root span.
      * {@inheritdoc}
      */
     public function shouldSample(
@@ -31,11 +84,19 @@ class ParentBased implements Sampler
         ?API\Attributes $attributes = null,
         ?API\Links $links = null
     ): SamplingResult {
-        if (null !== $parentContext && ($parentContext->getTraceFlags() & API\SpanContext::TRACE_FLAG_SAMPLED)) {
-            return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED, $attributes, $links);
+        if ($parentContext === null) {
+            return $this->root->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links);
         }
 
-        return new SamplingResult(SamplingResult::NOT_RECORD, $attributes, $links);
+        if ($parentContext->isRemoteContext()) {
+            return $parentContext->isSampled()
+                ? $this->remoteParentSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links)
+                : $this->remoteParentNotSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links);
+        }
+
+        return $parentContext->isSampled()
+            ? $this->localParentSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links)
+            : $this->localParentNotSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links);
     }
 
     public function getDescription(): string

--- a/tests/Sdk/Integration/ParentBasedTest.php
+++ b/tests/Sdk/Integration/ParentBasedTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Integration;
 
+use OpenTelemetry\Sdk\Trace\Sampler;
 use OpenTelemetry\Sdk\Trace\Sampler\ParentBased;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
 use OpenTelemetry\Sdk\Trace\SpanContext;
@@ -12,58 +13,103 @@ use PHPUnit\Framework\TestCase;
 
 class ParentBasedTest extends TestCase
 {
-    public function testRecordParentBasedDecision()
+    /**
+     * @test
+     */
+    public function testParentBasedRootSpan()
     {
-        $parentContext = new SpanContext(
-            '4bf92f3577b34da6a3ce929d0e0e4736',
-            '00f067aa0ba902b7',
-            0x1
-        );
-        $sampler = new ParentBased();
-        $decision = $sampler->shouldSample(
-            $parentContext,
-            '4bf92f3577b34da6a3ce929d0e0e4736',
-            '00f067aa0ba902b7',
-            'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
-        );
-        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLED, $decision->getDecision());
-    }
+        $rootSampler = $this->createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLED);
 
-    public function testSkipParentBasedDecision()
-    {
-        $parentContext = new SpanContext(
-            '4bf92f3577b34da6a3ce929d0e0e4736',
-            '00f067aa0ba902b7',
-            0
-        );
-        $sampler = new ParentBased();
-        $decision = $sampler->shouldSample(
-            $parentContext,
-            '4bf92f3577b34da6a3ce929d0e0e4736',
-            '00f067aa0ba902b7',
-            'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
-        );
-        $this->assertEquals(SamplingResult::NOT_RECORD, $decision->getDecision());
-    }
-
-    public function testNullParentBasedDecision()
-    {
-        $sampler = new ParentBased();
-        $decision = $sampler->shouldSample(
+        $sampler = new ParentBased($rootSampler);
+        $sampler->shouldSample(
             null,
             '4bf92f3577b34da6a3ce929d0e0e4736',
             '00f067aa0ba902b7',
             'test.opentelemetry.io',
             API\SpanKind::KIND_INTERNAL
         );
-        $this->assertEquals(SamplingResult::NOT_RECORD, $decision->getDecision());
     }
 
+    /**
+     * @dataProvider parentContextData
+     */
+    public function testParentBased(
+        $parentContext,
+        ?Sampler $remoteParentSampled = null,
+        ?Sampler $remoteParentNotSampled = null,
+        ?Sampler $localParentSampled = null,
+        ?Sampler $localParentNotSampled = null,
+        $expectedDdecision
+    ) {
+        $rootSampler = $this->createMockSamplerNeverInvoked();
+
+        $sampler = new ParentBased($rootSampler, $remoteParentSampled, $remoteParentNotSampled, $localParentSampled, $localParentNotSampled);
+        $decision = $sampler->shouldSample(
+            $parentContext,
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            '00f067aa0ba902b7',
+            'test.opentelemetry.io',
+            API\SpanKind::KIND_INTERNAL
+        );
+        $this->assertEquals($expectedDdecision, $decision->getDecision());
+    }
+
+    public function parentContextData(): array
+    {
+        return [
+            // remote, sampled, default sampler
+            [$this->createParentContext(true, true), null, null, null, null, SamplingResult::RECORD_AND_SAMPLED],
+            // remote, not sampled, default sampler
+            [$this->createParentContext(false, true), null, null, null, null, SamplingResult::NOT_RECORD],
+            // local, sampled, default sampler
+            [$this->createParentContext(true, false), null, null, null, null, SamplingResult::RECORD_AND_SAMPLED],
+            // local, not sampled, default sampler
+            [$this->createParentContext(false, false), null, null, null, null, SamplingResult::NOT_RECORD],
+            // remote, sampled
+            [$this->createParentContext(true, true), $this->createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLED), null, null, null, SamplingResult::RECORD_AND_SAMPLED],
+            // remote, not sampled
+            [$this->createParentContext(false, true), null, $this->createMockSamplerInvokedOnce(SamplingResult::NOT_RECORD), null, null, SamplingResult::NOT_RECORD],
+            // local, sampled
+            [$this->createParentContext(true, false), null, null, $this->createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLED), null, SamplingResult::RECORD_AND_SAMPLED],
+            // local, not sampled
+            [$this->createParentContext(false, false), null, null, null, $this->createMockSamplerInvokedOnce(SamplingResult::NOT_RECORD), SamplingResult::NOT_RECORD],
+        ];
+    }
+
+    /**
+     * @test
+     */
     public function testParentBasedDescription()
     {
-        $sampler = new ParentBased();
+        $rootSampler = self::createMock(Sampler::class);
+        $sampler = new ParentBased($rootSampler);
         $this->assertEquals('ParentBased', $sampler->getDescription());
+    }
+
+    private function createParentContext(bool $sampled, bool $isRemote): SpanContext
+    {
+        return SpanContext::restore(
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            '00f067aa0ba902b7',
+            $sampled,
+            $isRemote
+        );
+    }
+
+    private function createMockSamplerNeverInvoked(): Sampler
+    {
+        $sampler = self::createMock(Sampler::class);
+        $sampler->expects($this->never())->method('shouldSample');
+
+        return $sampler;
+    }
+
+    private function createMockSamplerInvokedOnce(int $resultDecision): Sampler
+    {
+        $sampler = self::createMock(Sampler::class);
+        $sampler->expects($this->once())->method('shouldSample')
+            ->willReturn(new SamplingResult($resultDecision));
+
+        return $sampler;
     }
 }

--- a/tests/Sdk/Unit/Trace/TracerProviderTest.php
+++ b/tests/Sdk/Unit/Trace/TracerProviderTest.php
@@ -52,7 +52,7 @@ class TracerProviderTest extends TestCase
 
         self::assertSame($description, 'AlwaysOffSampler');
 
-        $traceProvider = new TracerProvider(null, new ParentBased());
+        $traceProvider = new TracerProvider(null, new ParentBased(new AlwaysOffSampler()));
         $description = $traceProvider->getSampler()->getDescription();
 
         self::assertSame($description, 'ParentBased');


### PR DESCRIPTION
This updates `PasentBased` sampler according to the current [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/a72807982622260a1a56e106f1f943a5f330894d/specification/trace/sdk.md#parentbased).
`ParentBased` sampler is a composite and it delegates a decision based on the parent `Span` sampled flag.