### PR TITLE
Updating PHP CS Fixer (PHP 8.0 support released)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -44,8 +44,6 @@ jobs:
       run: composer install --prefer-dist --no-progress --no-suggest
 
     - name: Check Style
-      env:
-        PHP_CS_FIXER_IGNORE_ENV: 1
       run: vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no
 
     - name: Run Phan

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpunit/phpunit": "^9.3",
         "composer/xdebug-handler": "^1.3",
         "phan/phan": "^3.0",
-        "friendsofphp/php-cs-fixer": "^2.17.1",
+        "friendsofphp/php-cs-fixer": "^2.18",
         "vimeo/psalm": "^4.0",
         "phpstan/phpstan": "^0.12.50",
         "phpstan/phpstan-phpunit": "^0.12.16",


### PR DESCRIPTION
@keradus opened https://github.com/open-telemetry/opentelemetry-php/pull/242 to update the version of PHP CS Fixer (which includes support for PHP 8.0) - This PR is a clone of his, mostly because the CLA bot wasn't working correctly for him.  Thank you for your contribution @keradus!