### PR TITLE
Changing master to main in CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,9 +3,9 @@ name: PHP Composer
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Our default branch has been renamed from `master` to `main`.  This PR makes the same update for our Github Actions for CI so it'll run on the main branch by default.

More discussion [here](https://github.com/open-telemetry/community/issues/402#issuecomment-765562382)