### PR TITLE
Rename SpanContext methods isValidContext and isRemoteContext to be a…

### DIFF
--- a/api/Trace/SpanContext.php
+++ b/api/Trace/SpanContext.php
@@ -12,7 +12,7 @@ interface SpanContext
     public function getSpanId(): string;
     public function getTraceFlags(): int;
     public function getTraceState(): ?TraceState;
-    public function isValidContext(): bool;
-    public function isRemoteContext(): bool;
+    public function isValid(): bool;
+    public function isRemote(): bool;
     public function isSampled(): bool;
 }

--- a/sdk/Trace/Sampler/ParentBased.php
+++ b/sdk/Trace/Sampler/ParentBased.php
@@ -88,7 +88,7 @@ class ParentBased implements Sampler
             return $this->root->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links);
         }
 
-        if ($parentContext->isRemoteContext()) {
+        if ($parentContext->isRemote()) {
             return $parentContext->isSampled()
                 ? $this->remoteParentSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links)
                 : $this->remoteParentNotSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links);

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -222,7 +222,7 @@ class Span implements API\Span
     */
     public function isRemote(): bool
     {
-        return $this->spanContext->isRemoteContext();
+        return $this->spanContext->isRemote();
     }
 
     public function isSampled(): bool

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -162,7 +162,7 @@ final class SpanContext implements API\SpanContext
     /**
      * @return bool Returns a value that indicates if the context has non-zero trace and span
      */
-    public function isValidContext(): bool
+    public function isValid(): bool
     {
         return $this->isValid;
     }
@@ -170,7 +170,7 @@ final class SpanContext implements API\SpanContext
     /**
      * @return bool Returns a value that indicates if the context was created from a previously existing trace
      */
-    public function isRemoteContext(): bool
+    public function isRemote(): bool
     {
         return $this->isRemote;
     }

--- a/sdk/Trace/SpanOptions.php
+++ b/sdk/Trace/SpanOptions.php
@@ -92,7 +92,7 @@ final class SpanOptions implements API\SpanOptions
     public function toSpan(): API\Span
     {
         $span = $this->tracer->getActiveSpan();
-        $context = $span->getContext()->IsValidContext()
+        $context = $span->getContext()->isValid()
             ? SpanContext::fork($span->getContext()->getTraceId())
             : SpanContext::generate();
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -56,7 +56,7 @@ class Tracer implements API\Tracer
 
     public function startActiveSpan(string $name, API\SpanContext $parentContext, bool $isRemote = false, int $spanKind = API\SpanKind::KIND_INTERNAL): API\Span
     {
-        $parentContextIsNoopSpan = !$parentContext->isValidContext();
+        $parentContextIsNoopSpan = !$parentContext->isValid();
 
         if ($parentContextIsNoopSpan) {
             $parentContext = $this->importedContext ?? SpanContext::generate(true);

--- a/tests/Sdk/Integration/Context/SpanContextTest.php
+++ b/tests/Sdk/Integration/Context/SpanContextTest.php
@@ -41,19 +41,19 @@ class SpanContextTest extends TestCase
     public function testValidSpan(): void
     {
         $spanContext = new SpanContext('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', 1);
-        $this->assertTrue($spanContext->isValidContext());
+        $this->assertTrue($spanContext->isValid());
     }
 
     public function testContextIsRemoteFromRestore(): void
     {
         $spanContext = SpanContext::restore('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', true, true);
-        $this->assertTrue($spanContext->isRemoteContext());
+        $this->assertTrue($spanContext->isRemote());
     }
 
     public function testContextIsNotRemoteFromConstructor(): void
     {
         $spanContext = new SpanContext('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', 1);
-        $this->assertFalse($spanContext->isRemoteContext());
+        $this->assertFalse($spanContext->isRemote());
     }
 
     public function testSampledSpan(): void
@@ -77,7 +77,7 @@ class SpanContextTest extends TestCase
     public function testGenerateReturnsNonSampledValidContext()
     {
         $spanContext = SpanContext::generate();
-        $this->assertTrue($spanContext->isValidContext());
+        $this->assertTrue($spanContext->isValid());
         $this->assertFalse($spanContext->isSampled());
     }
 }

--- a/tests/Sdk/Unit/Trace/NoopSpanTest.php
+++ b/tests/Sdk/Unit/Trace/NoopSpanTest.php
@@ -108,7 +108,7 @@ class NoopSpanTest extends TestCase
     /** @test */
     public function itShouldHaveAnInvalidSpanContext()
     {
-        $this->assertFalse($this->span->getContext()->isValidContext());
+        $this->assertFalse($this->span->getContext()->isValid());
     }
 
     /** @test */


### PR DESCRIPTION
According to https://github.com/open-telemetry/opentelemetry-php/issues/235 
`isRemoteContext` and `isValidContext` methods must not contain `Context` as a part of method name