### PR TITLE
NoSpansCreatedException

### DIFF
--- a/sdk/Trace/Exceptions/NoSpansCreatedException.php
+++ b/sdk/Trace/Exceptions/NoSpansCreatedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace\Exceptions;
+
+use Exception;
+
+class NoSpansCreatedException extends Exception
+{
+}

--- a/sdk/Trace/SpanOptions.php
+++ b/sdk/Trace/SpanOptions.php
@@ -12,7 +12,7 @@ final class SpanOptions implements API\SpanOptions
     /**
      * @var string
      */
-    private $name;
+    private $name = null;
     private $parent = null;
     private $attributes = null;
     private $links = null;
@@ -91,7 +91,13 @@ final class SpanOptions implements API\SpanOptions
 
     public function toSpan(): API\Span
     {
-        $span = $this->tracer->getActiveSpan();
+        if ($this->tracer->spansCreated() == true) {
+            $span = $this->tracer->getActiveSpan();
+        } else {
+            $span = new NoopSpan();
+        }
+        //amber
+        //$span = $this->tracer->getActiveSpan();
         $context = $span->getContext()->isValid()
             ? SpanContext::fork($span->getContext()->getTraceId())
             : SpanContext::generate();

--- a/sdk/Trace/SpanOptions.php
+++ b/sdk/Trace/SpanOptions.php
@@ -96,8 +96,7 @@ final class SpanOptions implements API\SpanOptions
         } else {
             $span = new NoopSpan();
         }
-        //amber
-        //$span = $this->tracer->getActiveSpan();
+
         $context = $span->getContext()->isValid()
             ? SpanContext::fork($span->getContext()->getTraceId())
             : SpanContext::generate();

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -106,7 +106,7 @@ class Tracer implements API\Tracer
                 $this->provider->getSpanProcessor()->onStart($span);
             }
         }
-        //amber
+
         $this->setActiveSpan($span, false);
 
         return $this->active;

--- a/sdk/Trace/TracerProvider.php
+++ b/sdk/Trace/TracerProvider.php
@@ -48,7 +48,10 @@ final class TracerProvider implements API\TracerProvider
 
     public function getTracer(string $name, ?string $version = ''): API\Tracer
     {
-        $key = sprintf("%s@%s", $name, $version);
+        if ($version == null) {
+            $version = '';
+        }
+        $key = sprintf('%s@%s', $name, $version);
 
         if (isset($this->tracers[$key]) && $this->tracers[$key] instanceof API\Tracer) {
             return $this->tracers[$key];

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -11,6 +11,7 @@ use OpenTelemetry\Sdk\Trace as SDK;
 use OpenTelemetry\Sdk\Trace\Attribute;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Exceptions\NoSpansCreatedException;
 use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\SpanStatus;
@@ -330,14 +331,40 @@ class TracingTest extends TestCase
         $this->assertNull($global->getParent());
     }
 
-    public function testActiveRootSpanIsNoopSpanIfNoParentProvided()
+    public function testGetActiveSpanThrowsExceptionWhenNoSpans()
     {
         $tracer = (new SDK\TracerProvider())->getTracer('OpenTelemetry.TracingTest');
 
-        $this->assertInstanceOf(
-            SDK\NoopSpan::class,
-            $tracer->getActiveSpan()
-        );
+        $this->expectException(NoSpansCreatedException::class);
+
+        $tracer->getActiveSpan();
+    }
+
+    public function testGetSpansThrowsExceptionWhenNoSpans()
+    {
+        $tracer = (new SDK\TracerProvider())->getTracer('OpenTelemetry.TracingTest');
+
+        $this->expectException(NoSpansCreatedException::class);
+
+        $tracer->getSpans();
+    }
+
+    public function testEndActiveSpanThrowsExceptionWhenNoSpans()
+    {
+        $tracer = (new SDK\TracerProvider())->getTracer('OpenTelemetry.TracingTest');
+
+        $this->expectException(NoSpansCreatedException::class);
+
+        $tracer->endActiveSpan();
+    }
+
+    public function testDeactivateActiveSpanThrowsExceptionWhenNoSpans()
+    {
+        $tracer = (new SDK\TracerProvider())->getTracer('OpenTelemetry.TracingTest');
+
+        $this->expectException(NoSpansCreatedException::class);
+
+        $tracer->deactivateActiveSpan();
     }
 
     public function testCreateSpanResourceNonDefaultTraceProviderNonDefaultTrace()


### PR DESCRIPTION
See issue #219 

When calling tracer functions that deal with spans, `NoSpansCreatedException` is now thrown if no spans have been created.  Previously, `NoopSpans` were being silently returned, leaving the user no way of knowing whether a span was explicitly created or not.

Regarding adding `InvalidExporterEndpointException`, it seems like the exporters should handle their own endpoint validations, like the exception generated here for an invalid endpoint:
https://github.com/open-telemetry/opentelemetry-php/blob/main/contrib/Zipkin/Exporter.php#L63

It seems like it would be an exporter case by case basis depending what they need for their endpoints.

Added test cases.
Removed one test case (testActiveRootSpanParentIsNoopSpanIfNoParentProvided
) because it didn’t actually show what the code(https://github.com/open-telemetry/opentelemetry-php/blob/main/sdk/Trace/Tracer.php#L59) was doing where if no parent was passed in, the code sends in noop, but then a boilerplate context is generated.