### PR TITLE
Trace Context Tracestate header propagation Part 2

### DIFF
--- a/sdk/Trace/TraceState.php
+++ b/sdk/Trace/TraceState.php
@@ -46,7 +46,7 @@ class TraceState implements API\TraceState
                 unset($clonedTracestate->traceState[$key]);
             }
 
-            // Add new or updated entry to the back.
+            // Add new or updated entry to the back of the list.
             $clonedTracestate->traceState[$key] = $value;
         }
 
@@ -111,8 +111,8 @@ class TraceState implements API\TraceState
     /**
      * Parse the raw tracestate header into the TraceState object. Since new or updated entries must
      * be added to the beginning of the list, the key-value pairs in the TraceState object will be
-     * in stored in reverse order. This ensures new entries added to the TraceState object are at
-     * the beginning when we reverse the order back again while building the final tracestate header.
+     * stored in reverse order. This ensures new entries added to the TraceState object are at the
+     * beginning when we reverse the order back again while building the final tracestate header.
      *
      * Ex:
      *      tracestate = 'vendor1=value1,vendor2=value2'

--- a/sdk/Trace/TraceState.php
+++ b/sdk/Trace/TraceState.php
@@ -130,8 +130,7 @@ class TraceState implements API\TraceState
         if (\strlen($rawTracestate) <= self::MAX_TRACESTATE_LENGTH) {
             $listMembers = explode(self::LIST_MEMBERS_SEPARATOR, $rawTracestate);
 
-            $listMembersCount = count($listMembers);
-            if ($listMembersCount > self::MAX_TRACESTATE_LIST_MEMBERS) {
+            if (count($listMembers) > self::MAX_TRACESTATE_LIST_MEMBERS) {
 
                 // Truncate the tracestate if it exceeds the maximum list-members allowed
                 // TODO: Log a message when truncation occurs

--- a/sdk/Trace/TraceState.php
+++ b/sdk/Trace/TraceState.php
@@ -41,7 +41,12 @@ class TraceState implements API\TraceState
         //TODO: Log if we can't set the value
         if (self::validateKey($key) && self::validateValue($value)) {
 
-            // Overwrite the vendor entry if the key already exists
+            /*
+             * Only one entry per key is allowed. In this case we need to overwrite the vendor entry
+             * upon reentry to the tracing system and ensure the updated entry is at the beginning of
+             * the list. This means we place it the back for now and it will be at the beginning once
+             * we reverse the order back during build().
+             */
             if (array_key_exists($key, $clonedTracestate->traceState)) {
                 unset($clonedTracestate->traceState[$key]);
             }
@@ -151,6 +156,10 @@ class TraceState implements API\TraceState
             }
         }
 
+        /*
+         * Reversing the tracestate ensures the new entries added to the TraceState object are at
+         * the beginning when we reverse it back during build().
+        */
         return array_reverse($parsedTracestate);
     }
 

--- a/tests/Sdk/Unit/Trace/TraceStateTest.php
+++ b/tests/Sdk/Unit/Trace/TraceStateTest.php
@@ -27,8 +27,29 @@ class TraceStateTest extends TestCase
         $tracestate = new TraceState('vendor1=value1');
         $tracestateWithNewValue = $tracestate->with('vendor2', 'value2');
 
+        // New entry is included in the new TraceState object
         $this->assertSame('value2', $tracestateWithNewValue->get('vendor2'));
         $this->assertNull($tracestate->get('vendor2'));
+
+        // New entry is placed at the beginning of the tracestate header
+        $this->assertSame('vendor2=value2,vendor1=value1', $tracestateWithNewValue->build());
+
+        $tracestateWithUpdatedValue = $tracestateWithNewValue->with('vendor1', 'newValue1');
+
+        // The updated entry is overwritten and placed at the beginning of the header
+        $this->assertSame('value1', $tracestateWithNewValue->get('vendor1'));
+        $this->assertSame('newValue1', $tracestateWithUpdatedValue->get('vendor1'));
+        $this->assertSame('vendor1=newValue1,vendor2=value2', $tracestateWithUpdatedValue->build());
+
+        // A new entry containing an invalid key will not be added
+        $tracestateWithInvalidKey = $tracestate->with('@', 'value');
+        $this->assertNull($tracestateWithInvalidKey->get('@'));
+        $this->assertSame($tracestate->build(), $tracestateWithInvalidKey->build());
+
+        // A new entry containing an invalid value will not be added
+        $tracestateWithInvalidValue = $tracestate->with('vendor2', 'value' . chr(0x19) . '1');
+        $this->assertNull($tracestateWithInvalidValue->get('vendor2'));
+        $this->assertSame($tracestate->build(), $tracestateWithInvalidValue->build());
     }
 
     /**
@@ -87,13 +108,13 @@ class TraceStateTest extends TestCase
     public function testMaxTracestateLength()
     {
         // Build a vendor key with a length of 256 characters. The max characters allowed.
-        $vendorKey = \str_repeat('v', TraceState::MAX_TRACESTATE_LENGTH / 2);
+        $vendorKey = \str_repeat('k', TraceState::MAX_TRACESTATE_LENGTH / 2);
 
         // Build a vendor value with a length of 255 characters. One below the max allowed.
-        $vendorValue = \str_repeat('a', TraceState::MAX_TRACESTATE_LENGTH / 2 - 1);
+        $vendorValue = \str_repeat('v', TraceState::MAX_TRACESTATE_LENGTH / 2 - 1);
 
         // tracestate length = 513 characters (not accepted).
-        $rawTraceState = $vendorKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $vendorValue . 'a';
+        $rawTraceState = $vendorKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $vendorValue . 'v';
         $this->assertGreaterThan(TraceState::MAX_TRACESTATE_LENGTH, \strlen($rawTraceState));
 
         $validTracestate = new TraceState($rawTraceState);
@@ -134,6 +155,22 @@ class TraceStateTest extends TestCase
         $this->assertSame('2', $tracestate->get('c*d'));
         $this->assertSame('4', $tracestate->get('g_h'));
         $this->assertSame('c*d=2,g_h=4', $tracestate->build());
+
+        // Tests a valid key with a length of 256 characters. The max characters allowed.
+        $validKey = \str_repeat('k', 256);
+        $validValue = 'v';
+        $tracestate = new TraceState($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue);
+
+        $this->assertSame(256, \strlen($validKey));
+        $this->assertSame($validValue, $tracestate->get($validKey));
+        $this->assertSame($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue, $tracestate->build());
+
+        // Tests an invalid key with a length of 257 characters. One more than the max characters allowed.
+        $invalidKey = \str_repeat('k', 257);
+        $tracestate = new TraceState($invalidKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue);
+
+        $this->assertSame(257, \strlen($invalidKey));
+        $this->assertNull($tracestate->get($invalidKey));
     }
 
     /**
@@ -154,5 +191,21 @@ class TraceStateTest extends TestCase
         $this->assertSame('value' . chr(0x20) . '2', $parsedTracestate->get('char2'));
         $this->assertSame('value' . chr(0x7E) . '3', $parsedTracestate->get('char3'));
         $this->assertSame('char2=value' . chr(0x20) . '2,char3=value' . chr(0x7E) . '3', $parsedTracestate->build());
+
+        // Tests a valid value with a length of 256 characters. The max allowed.
+        $validValue = \str_repeat('v', 256);
+        $validKey = 'k';
+        $tracestate = new TraceState($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue);
+
+        $this->assertSame(256, \strlen($validValue));
+        $this->assertSame($validValue, $tracestate->get($validKey));
+        $this->assertSame($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue, $tracestate->build());
+
+        // Tests an invalid value with a length of 257 characters. One more than the max allowed.
+        $invalidValue = \str_repeat('v', 257);
+        $tracestate = new TraceState($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $invalidValue);
+
+        $this->assertSame(257, \strlen($invalidValue));
+        $this->assertNull($tracestate->get($validKey));
     }
 }


### PR DESCRIPTION
This adds the second part of `Tracestate` header propagation (Part 1 was added in #233). The following is included:

1. [Further validation of tracestate limits (max 512 characters)](https://www.w3.org/TR/trace-context/#tracestate-limits).
2. [Validate new key/value entries and ensure they are placed at the beginning of the header](https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field).
3. [Ensure vendors overwrite their previous entry upon reentry to their tracing system](https://www.w3.org/TR/trace-context/#combined-header-value).