### PR TITLE
Modified SpanStatus to conform with the feature-freeze specs.

### DIFF
--- a/api/Trace/SpanStatus.php
+++ b/api/Trace/SpanStatus.php
@@ -6,42 +6,14 @@ namespace OpenTelemetry\Trace;
 
 interface SpanStatus
 {
+    const UNSET = 'Unset';
     const OK = 'Ok';
-    const CANCELLED = 'Cancelled';
-    const UNKNOWN = 'Unknown';
-    const INVALID_ARGUMENT = 'InvalidArgument';
-    const DEADLINE_EXCEEDED = 'DeadlineExceeded';
-    const NOT_FOUND = 'NotFound';
-    const ALREADY_EXISTS = 'AlreadyExists';
-    const PERMISSION_DENIED = 'PermissionDenied';
-    const RESOURCE_EXHAUSTED = 'ResourceExhausted';
-    const FAILED_PRECONDITION = 'FailedPrecondition';
-    const ABORTED = 'Aborted';
-    const OUT_OF_RANGE = 'OutOfRange';
-    const UNIMPLEMENTED = 'Unimplemented';
-    const INTERNAL = 'Internal';
-    const UNAVAILABLE = 'Unavailable';
-    const DATA_LOSS = 'DataLoss';
-    const UNAUTHENTICATED = 'Unauthenticated';
+    const ERROR = 'Error';
 
     const DESCRIPTION = [
+        self::UNSET            => 'The default unset status.',
         self::OK            => 'Not an error; returned on success.',
-        self::CANCELLED     => 'The operation was cancelled, typically by the caller.',
-        self::UNKNOWN       => 'Unknown error. For example, this error may be returned when a Status value received from another address space belongs to an error space that is not known in this address space. Also errors raised by APIs that do not return enough error information may be converted to this error.',
-        self::INVALID_ARGUMENT => 'The client specified an invalid argument. Note that this differs from FAILED_PRECONDITION. INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the system (e.g., a malformed file name).',
-        self::DEADLINE_EXCEEDED => 'The deadline expired before the operation could complete. For operations that change the state of the system, this error may be returned even if the operation has completed successfully. For example, a successful response from a server could have been delayed long',
-        self::NOT_FOUND => 'Some requested entity (e.g., file or directory) was not found. Note to server developers: if a request is denied for an entire class of users, such as gradual feature rollout or undocumented allowlist, NOT_FOUND may be used. If a request is denied for some users within a class of users, such as user-based access control, PERMISSION_DENIED must be used.',
-        self::ALREADY_EXISTS => 'The entity that a client attempted to create (e.g., file or directory) already exists.',
-        self::PERMISSION_DENIED => 'The caller does not have permission to execute the specified operation. PERMISSION_DENIED must not be used for rejections caused by exhausting some resource (use RESOURCE_EXHAUSTED instead for those errors). PERMISSION_DENIED must not be used if the caller can not be identified (use UNAUTHENTICATED instead for those errors). This error code does not imply the request is valid or the requested entity exists or satisfies other pre-conditions.',
-        self::RESOURCE_EXHAUSTED => 'Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system is out of space.',
-        self::FAILED_PRECONDITION => 'The operation was rejected because the system is not in a state required for the operation\'s execution. For example, the directory to be deleted is non-empty, an rmdir operation is applied to a non-directory, etc. Service implementors can use the following guidelines to decide between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE: (a) Use UNAVAILABLE if the client can retry just the failing call. (b) Use ABORTED if the client should retry at a higher level (e.g., when a client-specified test-and-set fails, indicating the client should restart a read-modify-write sequence). (c) Use FAILED_PRECONDITION if the client should not retry until the system state has been explicitly fixed. E.g., if an "rmdir" fails because the directory is non-empty, FAILED_PRECONDITION should be returned since the client should not retry unless the files are deleted from the directory.',
-        self::ABORTED => 'The operation was aborted, typically due to a concurrency issue such as a sequencer check failure or transaction abort. See the guidelines above for deciding between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE.',
-        self::OUT_OF_RANGE => 'The operation was attempted past the valid range. E.g., seeking or reading past end-of-file. Unlike INVALID_ARGUMENT, this error indicates a problem that may be fixed if the system state changes. For example, a 32-bit file system will generate INVALID_ARGUMENT if asked to read at an offset that is not in the range [0,2^32-1], but it will generate OUT_OF_RANGE if asked to read from an offset past the current file size. There is a fair bit of overlap between FAILED_PRECONDITION and OUT_OF_RANGE. We recommend using OUT_OF_RANGE (the more specific error) when it applies so that callers who are iterating through a space can easily look for an OUT_OF_RANGE error to detect when they are done.',
-        self::UNIMPLEMENTED => 'The operation is not implemented or is not supported/enabled in this service.',
-        self::INTERNAL => 'Internal errors. This means that some invariants expected by the underlying system have been broken. This error code is reserved for serious errors.',
-        self::UNAVAILABLE => 'The service is currently unavailable. This is most likely a transient condition, which can be corrected by retrying with a backoff. Note that it is not always safe to retry non-idempotent operations.',
-        self::DATA_LOSS => 'Unrecoverable data loss or corruption.',
-        self::UNAUTHENTICATED => 'The request does not have valid authentication credentials for the operation.',
+        self::ERROR            => 'The operation contains an error.',
     ];
 
     public function getCanonicalStatusCode(): string;

--- a/api/Trace/SpanStatus.php
+++ b/api/Trace/SpanStatus.php
@@ -19,4 +19,5 @@ interface SpanStatus
     public function getCanonicalStatusCode(): string;
     public function getStatusDescription(): string;
     public function isStatusOk(): bool;
+    public function setStatus(string $code = self::UNSET, string $description = null): void;
 }

--- a/api/Trace/SpanStatus.php
+++ b/api/Trace/SpanStatus.php
@@ -19,5 +19,5 @@ interface SpanStatus
     public function getCanonicalStatusCode(): string;
     public function getStatusDescription(): string;
     public function isStatusOk(): bool;
-    public function setStatus(string $code = self::UNSET, string $description = null): void;
+//    public function setStatus(string $code = self::UNSET, string $description = null): void;
 }

--- a/sdk/Trace/NoopSpan.php
+++ b/sdk/Trace/NoopSpan.php
@@ -46,7 +46,7 @@ class NoopSpan implements \OpenTelemetry\Trace\Span
         }
         $this->attributes = new Attributes();
         $this->events = new Events();
-        $this->status = SpanStatus::ok();
+        $this->status = new SpanStatus();
     }
 
     public function getSpanName(): string

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -19,8 +19,7 @@ class Span implements API\Span
     private $start;
     private $end;
 
-    /** @var API\SpanStatus */
-    private $status;
+    private $spanStatus;
 
     /**
      * @var ResourceInfo
@@ -63,7 +62,7 @@ class Span implements API\Span
         $moment = Clock::get()->moment();
         $this->startEpochTimestamp = $moment[0];
         $this->start = $moment[1];
-        $this->status = new SpanStatus();
+        $this->spanStatus = new SpanStatus();
 
         // todo: set these to null until needed
         $this->attributes = new Attributes();
@@ -89,7 +88,7 @@ class Span implements API\Span
     public function setSpanStatus(string $code, ?string $description = null): API\Span
     {
         if ($this->isRecording()) {
-            $this->status->setStatus($code, $description);
+            $this->spanStatus->setStatus($code, $description);
         }
 
         return $this;
@@ -139,7 +138,7 @@ class Span implements API\Span
 
     public function getStatus(): API\SpanStatus
     {
-        return $this->status;
+        return $this->spanStatus;
     }
 
     public function isRecording(): bool
@@ -257,16 +256,16 @@ class Span implements API\Span
 
     public function getCanonicalStatusCode(): string
     {
-        return $this->status->getCanonicalStatusCode();
+        return $this->spanStatus->getCanonicalStatusCode();
     }
 
     public function getStatusDescription(): string
     {
-        return $this->status->getStatusDescription();
+        return $this->spanStatus->getStatusDescription();
     }
 
     public function isStatusOk(): bool
     {
-        return $this->status->isStatusOK();
+        return $this->spanStatus->isStatusOK();
     }
 }

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -18,8 +18,9 @@ class Span implements API\Span
     private $startEpochTimestamp;
     private $start;
     private $end;
-    private $statusCode;
-    private $statusDescription;
+
+    /** @var API\SpanStatus */
+    private $status;
 
     /**
      * @var ResourceInfo
@@ -62,8 +63,7 @@ class Span implements API\Span
         $moment = Clock::get()->moment();
         $this->startEpochTimestamp = $moment[0];
         $this->start = $moment[1];
-        $this->statusCode = API\SpanStatus::OK;
-        $this->statusDescription = API\SpanStatus::DESCRIPTION[$this->statusCode];
+        $this->status = new SpanStatus();
 
         // todo: set these to null until needed
         $this->attributes = new Attributes();
@@ -89,8 +89,7 @@ class Span implements API\Span
     public function setSpanStatus(string $code, ?string $description = null): API\Span
     {
         if ($this->isRecording()) {
-            $this->statusCode = $code;
-            $this->statusDescription = $description ?? self::DESCRIPTION[$code] ?? self::DESCRIPTION[self::UNKNOWN];
+            $this->status->setStatus($code, $description);
         }
 
         return $this;
@@ -140,7 +139,7 @@ class Span implements API\Span
 
     public function getStatus(): API\SpanStatus
     {
-        return SpanStatus::new($this->statusCode, $this->statusDescription);
+        return $this->status;
     }
 
     public function isRecording(): bool
@@ -258,16 +257,16 @@ class Span implements API\Span
 
     public function getCanonicalStatusCode(): string
     {
-        return $this->statusCode;
+        return $this->status->getCanonicalStatusCode();
     }
 
     public function getStatusDescription(): string
     {
-        return $this->statusDescription;
+        return $this->status->getStatusDescription();
     }
 
     public function isStatusOk(): bool
     {
-        return $this->statusCode == API\SpanStatus::OK;
+        return $this->status->isStatusOK();
     }
 }

--- a/tests/Sdk/Unit/Trace/NoopSpanTest.php
+++ b/tests/Sdk/Unit/Trace/NoopSpanTest.php
@@ -65,6 +65,50 @@ class NoopSpanTest extends TestCase
         self::assertEquals(SpanStatus::UNSET, $this->span->getCanonicalStatusCode());
 
         $this->assertFalse($this->span->isStatusOk());
+
+        $this->span->setSpanStatus(\OpenTelemetry\Trace\SpanStatus::OK);
+
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $this->span->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $this->span->getCanonicalStatusCode());
+
+        $this->assertFalse($this->span->isStatusOk());
+
+        $this->span->setSpanStatus('mycode');
+
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $this->span->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $this->span->getCanonicalStatusCode());
+
+        $this->assertFalse($this->span->isStatusOk());
+    }
+
+    /** @test */
+    public function testGetStatusStaysSameAndNoUpdatesShouldChangeIt()
+    {
+        $status = $this->span->getStatus();
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $this->span->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $this->span->getCanonicalStatusCode());
+
+        $this->span->setSpanStatus(\OpenTelemetry\Trace\SpanStatus::ERROR);
+        $status2 = $this->span->getStatus();
+
+        self::assertEquals($status->getStatusDescription(), $status2->getStatusDescription());
+        self::assertEquals($status->getCanonicalStatusCode(), $status2->getCanonicalStatusCode());
+
+        $this->assertFalse($this->span->isStatusOk());
+
+        $this->span->setSpanStatus(\OpenTelemetry\Trace\SpanStatus::OK);
+        $status2 = $this->span->getStatus();
+
+        self::assertEquals($status->getStatusDescription(), $status2->getStatusDescription());
+        self::assertEquals($status->getCanonicalStatusCode(), $status2->getCanonicalStatusCode());
+
+        $this->span->setSpanStatus('mycode');
+        $status2 = $this->span->getStatus();
+
+        self::assertEquals($status->getStatusDescription(), $status2->getStatusDescription());
+        self::assertEquals($status->getCanonicalStatusCode(), $status2->getCanonicalStatusCode());
+
+        $this->assertFalse($this->span->isStatusOk());
     }
 
     /** @test */

--- a/tests/Sdk/Unit/Trace/NoopSpanTest.php
+++ b/tests/Sdk/Unit/Trace/NoopSpanTest.php
@@ -52,33 +52,19 @@ class NoopSpanTest extends TestCase
     }
 
     /** @test */
-    public function itsStatusShouldBeOkAndNoUpdatesShouldChangeIt()
+    public function itsStatusShouldBeUnsetAndNoUpdatesShouldChangeIt()
     {
-        $this->assertEquals(
-            SpanStatus::ok(),
-            $this->span->getStatus()
-        );
+        $this->assertFalse($this->span->isStatusOk());
 
-        $this->assertTrue($this->span->isStatusOk());
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $this->span->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $this->span->getCanonicalStatusCode());
 
-        $this->assertEquals(
-            SpanStatus::ok()->getStatusDescription(),
-            $this->span->getStatusDescription()
-        );
+        $this->span->setSpanStatus(\OpenTelemetry\Trace\SpanStatus::ERROR);
 
-        $this->assertEquals(
-            SpanStatus::ok()->getCanonicalStatusCode(),
-            $this->span->getCanonicalStatusCode()
-        );
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $this->span->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $this->span->getCanonicalStatusCode());
 
-        $this->span->setSpanStatus(\OpenTelemetry\Trace\SpanStatus::ABORTED);
-
-        $this->assertEquals(
-            SpanStatus::ok(),
-            $this->span->getStatus()
-        );
-
-        $this->assertTrue($this->span->isStatusOk());
+        $this->assertFalse($this->span->isStatusOk());
     }
 
     /** @test */

--- a/tests/Sdk/Unit/Trace/SpanStatusTest.php
+++ b/tests/Sdk/Unit/Trace/SpanStatusTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class SpanStatusTest extends TestCase
 {
-    public function testGetCanonicalCodeAfterFunctionNew()
+    public function testGetCanonicalCode()
     {
         // If an invalid code is given, SpanStatus should be/remain UNSET.
         $status = SpanStatus::new('MY_CODE');
@@ -25,6 +25,24 @@ class SpanStatusTest extends TestCase
         self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
 
         $status = SpanStatus::new(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        // Using new SpanStatus
+        // If an invalid code is given, SpanStatus should be/remain UNSET.
+        $status = new SpanStatus('MY_CODE');
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+
+        $status = new SpanStatus(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::ERROR);
         self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
         self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
     }
@@ -69,32 +87,16 @@ class SpanStatusTest extends TestCase
         self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
     }
 
-    public function testGetCanonicalCode()
-    {
-        // If an invalid code is given, SpanStatus should be/remain UNSET.
-        $status = new SpanStatus('MY_CODE');
-        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
-        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
-
-        $status = new SpanStatus(SpanStatus::UNSET);
-        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
-        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
-
-        $status = new SpanStatus(SpanStatus::OK);
-        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
-        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
-
-        $status = new SpanStatus(SpanStatus::ERROR);
-        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
-        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
-    }
-
     public function testGetDescription()
     {
         /*
          * Only ERROR codes should modify span status description.
          * Description MUST only be used with the Error.
          */
+        $status = new SpanStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
         $status = new SpanStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
         self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
         self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
@@ -107,7 +109,6 @@ class SpanStatusTest extends TestCase
         self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
         self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
     }
-
     public function testSetStatusWithoutDescription()
     {
         /*

--- a/tests/Sdk/Unit/Trace/SpanStatusTest.php
+++ b/tests/Sdk/Unit/Trace/SpanStatusTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class SpanStatusTest extends TestCase
 {
-    public function testGetCanonicalCode()
+    public function testGetCanonicalCodeAfterFunctionNew()
     {
         // If an invalid code is given, SpanStatus should be/remain UNSET.
         $status = SpanStatus::new('MY_CODE');
@@ -29,7 +29,7 @@ class SpanStatusTest extends TestCase
         self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
     }
 
-    public function testGetDescription()
+    public function testGetDescriptionAfterFunctionNew()
     {
         /*
          * Only ERROR codes should modify span status description.
@@ -46,6 +46,102 @@ class SpanStatusTest extends TestCase
         $status = SpanStatus::new(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
         self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
         self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+    }
+
+    public function testGetCanonicalCode()
+    {
+        // If an invalid code is given, SpanStatus should be/remain UNSET.
+        $status = new SpanStatus('MY_CODE');
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+
+        $status = new SpanStatus(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+    }
+
+    public function testGetDescription()
+    {
+        /*
+         * Only ERROR codes should modify span status description.
+         * Description MUST only be used with the Error.
+         */
+        $status = new SpanStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+    }
+
+    public function testSetStatusWithoutDescription()
+    {
+        /*
+         * Only ERROR codes should modify span status description.
+         * Description MUST only be used with the Error.
+         */
+
+        $status = new SpanStatus(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+    }
+
+    public function testSetStatusWithDescription()
+    {
+        /*
+         * Only ERROR codes should modify span status description.
+         * Description MUST only be used with the Error.
+         */
+        $status = new SpanStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
     }
 
     public function testIsOKReturnsTrueForOkStatus()

--- a/tests/Sdk/Unit/Trace/SpanStatusTest.php
+++ b/tests/Sdk/Unit/Trace/SpanStatusTest.php
@@ -29,6 +29,22 @@ class SpanStatusTest extends TestCase
         self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
     }
 
+    public function testNoParamsToFunctionNew()
+    {
+        // If an invalid code is given, SpanStatus should be/remain UNSET.
+        $status = SpanStatus::new();
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+    }
+
+    public function testNoParams()
+    {
+        // If an invalid code is given, SpanStatus should be/remain UNSET.
+        $status = new SpanStatus();
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+    }
+
     public function testGetDescriptionAfterFunctionNew()
     {
         /*
@@ -46,6 +62,11 @@ class SpanStatusTest extends TestCase
         $status = SpanStatus::new(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
         self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
         self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        // Invalid should return UNSET.
+        $status = SpanStatus::new('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
     }
 
     public function testGetCanonicalCode()
@@ -94,21 +115,57 @@ class SpanStatusTest extends TestCase
          * Description MUST only be used with the Error.
          */
 
-        $status = new SpanStatus(SpanStatus::OK);
-        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
-        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
-        $status->setStatus(SpanStatus::UNSET);
-        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
-        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
-
-        $status = new SpanStatus(SpanStatus::UNSET);
+        $status = SpanStatus::new('mycode');
         self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
         self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
         $status->setStatus(SpanStatus::ERROR);
         self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
         self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
 
-        $status = new SpanStatus(SpanStatus::ERROR);
+        $status = SpanStatus::new(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+
+        // With SpanStatus::new
+        $status = SpanStatus::new('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::ERROR);
         self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
         self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
         $status->setStatus(SpanStatus::OK);
@@ -122,6 +179,14 @@ class SpanStatusTest extends TestCase
          * Only ERROR codes should modify span status description.
          * Description MUST only be used with the Error.
          */
+
+        $status = new SpanStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
         $status = new SpanStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
         self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
         self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
@@ -142,17 +207,280 @@ class SpanStatusTest extends TestCase
         $status->setStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
         self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
         self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+
+        // With SpanStatus::new
+
+        $status = SpanStatus::new('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status =SpanStatus::new(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+    }
+
+    public function testSetStatusWithoutDescriptionWithInvalidCode()
+    {
+        /*
+         * Only ERROR codes should modify span status description.
+         * Description MUST only be used with the Error.
+         */
+
+        $status = new SpanStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        // With SpanStatus::new
+
+        $status = SpanStatus::new('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::OK);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::UNSET);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::ERROR);
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::ERROR], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+    }
+
+    public function testSetStatusWithDescriptionWithInvalidCode()
+    {
+        /*
+         * Only ERROR codes should modify span status description.
+         * Description MUST only be used with the Error.
+         */
+
+        $status = new SpanStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = new SpanStatus(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        // With SpanStatus::new
+        $status = SpanStatus::new(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status =SpanStatus::new(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::OK, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::OK], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::OK, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::UNSET, 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
+
+        $status = SpanStatus::new(SpanStatus::ERROR, 'Neunundneunzig Luftballons');
+        self::assertEquals('Neunundneunzig Luftballons', $status->getStatusDescription());
+        self::assertEquals(SpanStatus::ERROR, $status->getCanonicalStatusCode());
+        $status->setStatus('mycode', 'Neunundneunzig Luftballons');
+        self::assertEquals(SpanStatus::DESCRIPTION[SpanStatus::UNSET], $status->getStatusDescription());
+        self::assertEquals(SpanStatus::UNSET, $status->getCanonicalStatusCode());
     }
 
     public function testIsOKReturnsTrueForOkStatus()
     {
         $status = SpanStatus::new(SpanStatus::OK);
         $this->assertTrue($status->isStatusOK());
+
+        $status = new SpanStatus(SpanStatus::OK);
+        $this->assertTrue($status->isStatusOK());
+
+        $status = SpanStatus::new(SpanStatus::OK, 'description');
+        $this->assertTrue($status->isStatusOK());
+
+        $status = new SpanStatus(SpanStatus::OK, 'description');
+        $this->assertTrue($status->isStatusOK());
     }
 
     public function testIsOKReturnsFalseForNonOkStatus()
     {
         $status = SpanStatus::new();
+        $this->assertFalse($status->isStatusOK());
+
+        $status = new SpanStatus(SpanStatus::UNSET);
+        $this->assertFalse($status->isStatusOK());
+
+        $status = SpanStatus::new(SpanStatus::ERROR, 'description');
+        $this->assertFalse($status->isStatusOK());
+
+        $status = new SpanStatus(SpanStatus::UNSET, 'description');
         $this->assertFalse($status->isStatusOK());
     }
 

--- a/tests/Sdk/Unit/Trace/TracerProviderTest.php
+++ b/tests/Sdk/Unit/Trace/TracerProviderTest.php
@@ -69,6 +69,18 @@ class TracerProviderTest extends TestCase
     /**
      * @test
      */
+    public function newTraceProviderGetIdGenerator()
+    {
+        $traceProvider = new TracerProvider();
+        $idGen = $traceProvider->getIdGenerator();
+        $spanID = $idGen->generateSpanID();
+        $traceId = $idGen->generateTraceId();
+        self::assertTrue(true, 'Not implemented yet but code coverage noticed.');
+    }
+
+    /**
+     * @test
+     */
     public function newTraceProviderAcceptsOtherSamplers()
     {
         $traceProvider = new TracerProvider(null, new AlwaysOffSampler());
@@ -133,6 +145,7 @@ class TracerProviderTest extends TestCase
 
         $this->assertCount(6, $attributes);
     }
+
     /**
      * @test
      */


### PR DESCRIPTION
1) Updated SpanStatus to adhere to the latest [specs](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/api.md#set-status).

a) Made `UNSET` the statusCode default.
b) Removed significant amount of status codes that were removed from the [spec](https://github.com/open-telemetry/opentelemetry-specification/commit/30eb18a30dff36422de9a2a851010a87e66e4d9d#diff-1c55a70901ca0a001050f25ba8881a9b841777e6d8eaab500faf20230765ff76).
c) Only allowed `ERROR` codes to set descriptions.

The key points in the spec to notice were:
```
The Span interface MUST provide:
	•	An API to set the Status. This SHOULD be called SetStatus. This API takes the StatusCode, and an optional Description, either as individual parameters or as an immutable object encapsulating them, whichever is most appropriate for the language. Description MUST be IGNORED for StatusCode Ok & Unset values.
```
Additionally, opted for the following behavior:
```
If invalid status codes were given, the default behavior is to set status code/description to the default (UNSET).
```

2) Some refactoring in `Span.php` to actually utilize `SpanStatus` (similar to what the NoopSpan was doing) vs setting private variables code and description in the span itself.

3) Updated Tests to account for the changes.