### PR TITLE
Add ContextValueTrait and Scope to store in Context

### DIFF
--- a/Context/ContextValueTrait.php
+++ b/Context/ContextValueTrait.php
@@ -9,6 +9,7 @@ trait ContextValueTrait
     /**
      * @param Context $context
      * @return mixed|null
+     * @phan-suppress PhanAbstractStaticMethodCallInTrait
      */
     public static function extract(Context $context)
     {
@@ -23,6 +24,7 @@ trait ContextValueTrait
      * @param mixed $value
      * @param Context $context
      * @return Context
+     * @phan-suppress PhanAbstractStaticMethodCallInTrait
      */
     public static function insert($value, Context $context): Context
     {
@@ -32,6 +34,7 @@ trait ContextValueTrait
     /**
      * @param mixed $value
      * @return Scope
+     * @phan-suppress PhanAbstractStaticMethodCallInTrait
      */
     public static function setCurrent($value): Scope
     {
@@ -42,6 +45,7 @@ trait ContextValueTrait
 
     /**
      * @return mixed|null
+     * @phan-suppress PhanAbstractStaticMethodCallInTrait
      */
     public static function getCurrent()
     {

--- a/Context/ContextValueTrait.php
+++ b/Context/ContextValueTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Context;
+
+trait ContextValueTrait
+{
+    /**
+     * @param mixed $value
+     * @param Context|null $context
+     * @return Scope
+     */
+    public static function setCurrent($value, ?Context $context = null): Scope
+    {
+        $context = $context ?? Context::getCurrent()->set(static::getContextKey(), $value);
+
+        return new Scope(Context::attach($context));
+    }
+
+    /**
+     * @param Context|null $context
+     * @return mixed|null
+     */
+    public static function getCurrent(?Context $context = null)
+    {
+        try {
+            return ($context ?? Context::getCurrent())->get(static::getContextKey());
+        } catch (ContextValueNotFoundException $e) {
+            return null;
+        }
+    }
+
+    abstract protected static function getContextKey(): ContextKey;
+}

--- a/Context/ContextValueTrait.php
+++ b/Context/ContextValueTrait.php
@@ -7,25 +7,46 @@ namespace OpenTelemetry\Context;
 trait ContextValueTrait
 {
     /**
+     * @param Context $context
+     * @return mixed|null
+     */
+    public static function extract(Context $context)
+    {
+        try {
+            return $context->get(static::getContextKey());
+        } catch (ContextValueNotFoundException $e) {
+            return null;
+        }
+    }
+
+    /**
      * @param mixed $value
-     * @param Context|null $context
+     * @param Context $context
+     * @return Context
+     */
+    public static function insert($value, Context $context): Context
+    {
+        return $context->set(static::getContextKey(), $value);
+    }
+
+    /**
+     * @param mixed $value
      * @return Scope
      */
-    public static function setCurrent($value, ?Context $context = null): Scope
+    public static function setCurrent($value): Scope
     {
-        $context = $context ?? Context::getCurrent()->set(static::getContextKey(), $value);
+        $context = Context::getCurrent()->set(static::getContextKey(), $value);
 
         return new Scope(Context::attach($context));
     }
 
     /**
-     * @param Context|null $context
      * @return mixed|null
      */
-    public static function getCurrent(?Context $context = null)
+    public static function getCurrent()
     {
         try {
-            return ($context ?? Context::getCurrent())->get(static::getContextKey());
+            return Context::getCurrent()->get(static::getContextKey());
         } catch (ContextValueNotFoundException $e) {
             return null;
         }

--- a/Context/Scope.php
+++ b/Context/Scope.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Context;
+
+class Scope
+{
+    /** @var callable Context token, result of Context::attach() */
+    private $contextToken;
+
+    public function __construct(callable $contextToken)
+    {
+        $this->contextToken = $contextToken;
+    }
+
+    public function close(): void
+    {
+        Context::detach($this->contextToken);
+    }
+}

--- a/api/Trace/Tracer.php
+++ b/api/Trace/Tracer.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Trace;
 
+use OpenTelemetry\Context\Context;
+
 interface Tracer
 {
+    public function startSpan(
+        string $name,
+        ?Context $parentContext = null,
+        int $spanKind = SpanKind::KIND_INTERNAL,
+        ?Attributes $attributes = null,
+        ?Links $links = null,
+        ?int $startTimestamp = null
+    ): Span;
+
     public function getActiveSpan(): Span;
 
     public function startAndActivateSpan(string $name): Span;

--- a/examples/ParentSpanExample.php
+++ b/examples/ParentSpanExample.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\Contrib\Jaeger\Exporter as JaegerExporter;
+use OpenTelemetry\Contrib\Zipkin\Exporter as ZipkinExporter;
+use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+
+$serviceName = 'ParentSpanExample';
+$resource = ResourceInfo::defaultResource();
+$sampler = new AlwaysOnSampler();
+$tracerProvider = new TracerProvider($resource, $sampler);
+
+// zipkin exporter
+$zipkinExporter = new ZipkinExporter(
+    $serviceName,
+    'http://zipkin:9411/api/v2/spans'
+);
+$tracerProvider->addSpanProcessor(new SimpleSpanProcessor($zipkinExporter));
+
+// jaeger exporter
+$jaegerExporter = new JaegerExporter(
+    $serviceName,
+    'http://jaeger:9412/api/v2/spans'
+);
+$tracerProvider->addSpanProcessor(new SimpleSpanProcessor($jaegerExporter));
+
+$tracer = $tracerProvider->getTracer('example.php.opentelemetry.io', '0.0.1');
+
+$rootSpan = $tracer->startSpan('root-span');
+sleep(1);
+
+$rootScope = Span::setCurrent($rootSpan); // set the root span active in the current context
+
+try {
+    $span1 = $tracer->startSpan('span-1');
+    $internalScope = Span::setCurrent($span1); // set the child span active in the context
+    try {
+        for ($i = 0; $i < 3; $i++) {
+            $loopSpan = $tracer->startSpan('loop-' . $i);
+            usleep((int) (0.5 * 1e6));
+            $loopSpan->end();
+        }
+    } finally {
+        $internalScope->close(); // deactivate child span, the rootSpan is set as active
+    }
+    $span1->end();
+    
+    $span2 = $tracer->startSpan('span-2');
+    sleep(1);
+    $span2->end();
+} finally {
+    $rootScope->close(); // close the scope of the root span, now active span in context now
+}
+$rootSpan->end();
+ 
+// start the second root span
+$secondRootSpan = $tracer->startSpan('span-out');
+sleep(2);
+$secondRootSpan->end();
+
+echo 'See the results at' . PHP_EOL;
+echo 'Jaeger: http://localhost:16686/' . PHP_EOL;;
+echo 'Zipkin: http://localhost:9411/' . PHP_EOL;;

--- a/examples/ParentSpanExample.php
+++ b/examples/ParentSpanExample.php
@@ -39,8 +39,9 @@ sleep(1);
 $rootScope = Span::setCurrent($rootSpan); // set the root span active in the current context
 
 try {
-    $span1 = $tracer->startSpan('span-1');
+    $span1 = $tracer->startSpan('child-span-1');
     $internalScope = Span::setCurrent($span1); // set the child span active in the context
+
     try {
         for ($i = 0; $i < 3; $i++) {
             $loopSpan = $tracer->startSpan('loop-' . $i);
@@ -48,23 +49,27 @@ try {
             $loopSpan->end();
         }
     } finally {
-        $internalScope->close(); // deactivate child span, the rootSpan is set as active
+        $internalScope->close(); // deactivate child span, the rootSpan is set back as active
     }
     $span1->end();
     
-    $span2 = $tracer->startSpan('span-2');
+    $span2 = $tracer->startSpan('child-span-2');
     sleep(1);
     $span2->end();
 } finally {
-    $rootScope->close(); // close the scope of the root span, now active span in context now
+    $rootScope->close(); // close the scope of the root span, no active span in the context now
 }
 $rootSpan->end();
  
 // start the second root span
-$secondRootSpan = $tracer->startSpan('span-out');
+$secondRootSpan = $tracer->startSpan('root-span-2');
 sleep(2);
 $secondRootSpan->end();
 
+echo 'This example generates two traces:' . PHP_EOL;
+echo '  - ' . $rootSpan->getContext()->getTraceId() . PHP_EOL;
+echo '  - ' . $secondRootSpan->getContext()->getTraceId() . PHP_EOL;
+echo PHP_EOL;
 echo 'See the results at' . PHP_EOL;
-echo 'Jaeger: http://localhost:16686/' . PHP_EOL;;
-echo 'Zipkin: http://localhost:9411/' . PHP_EOL;;
+echo 'Jaeger: http://localhost:16686/' . PHP_EOL;
+echo 'Zipkin: http://localhost:9411/' . PHP_EOL;

--- a/sdk/Trace/NoopSpan.php
+++ b/sdk/Trace/NoopSpan.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\Trace;
 
 use Exception;
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Context\ContextValueTrait;
 use OpenTelemetry\Trace as API;
 
-class NoopSpan implements \OpenTelemetry\Trace\Span
+class NoopSpan implements API\Span
 {
+    use ContextValueTrait;
+
     /** @var API\SpanContext */
     private $context;
 
@@ -182,5 +186,14 @@ class NoopSpan implements \OpenTelemetry\Trace\Span
     public function isStatusOk(): bool
     {
         return $this->status->isStatusOK();
+    }
+
+    /**
+     * @return ContextKey
+     * @phan-override
+     */
+    protected static function getContextKey(): ContextKey
+    {
+        return SpanContextKey::instance();
     }
 }

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -59,7 +59,7 @@ class Span implements API\Span
         ?API\SpanContext $parentSpanContext = null,
         ?Sampler $sampler = null,
         ?ResourceInfo $resource = null,
-        ?int $spanKind = API\SpanKind::KIND_INTERNAL,
+        int $spanKind = API\SpanKind::KIND_INTERNAL,
         ?SpanProcessor $spanProcessor = null
     ) {
         $this->name = $name;

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -74,6 +74,11 @@ final class SpanContext implements API\SpanContext
         $this->isValid = $this->traceId !== self::INVALID_TRACE && $this->spanId !== self::INVALID_SPAN;
     }
 
+    public static function getInvalid(): API\SpanContext
+    {
+        return new self(self::INVALID_TRACE, self::INVALID_SPAN, 0);
+    }
+
     /**
      * Creates a new context with random trace
      *

--- a/sdk/Trace/SpanContextKey.php
+++ b/sdk/Trace/SpanContextKey.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+use OpenTelemetry\Context\ContextKey;
+
+/**
+ * Class SpanContextKey
+ * @package OpenTelemetry\Sdk\Trace
+ * @internal
+ */
+class SpanContextKey extends ContextKey
+{
+    private const KEY_NAME = 'opentelemetry-trace-span-key';
+
+    /**
+     * @var ContextKey
+     */
+    private static $instance;
+    
+    public static function instance(): ContextKey
+    {
+        if (self::$instance === null) {
+            self::$instance = new ContextKey(self::KEY_NAME);
+        }
+        
+        return self::$instance;
+    }
+}

--- a/sdk/Trace/TracerProvider.php
+++ b/sdk/Trace/TracerProvider.php
@@ -60,7 +60,6 @@ final class TracerProvider implements API\TracerProvider
             return $this->tracers[$key];
         }
 
-        $spanContext = SpanContext::generateSampled();
         /*
          * A resource can be associated with the TracerProvider when the TracerProvider is created.
          * That association cannot be changed later. When associated with a TracerProvider, all
@@ -79,8 +78,7 @@ final class TracerProvider implements API\TracerProvider
 
         return $this->tracers[$key] = new Tracer(
             $this,
-            ResourceInfo::merge($primary, $resource),
-            $spanContext
+            ResourceInfo::merge($primary, $resource)
         );
     }
 

--- a/tests/Context/Unit/ContextValueTraitTest.php
+++ b/tests/Context/Unit/ContextValueTraitTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Context\Unit;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Context\ContextValueTrait;
+use PHPUnit\Framework\TestCase;
+
+class ContextValueTraitTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getContextKeyShouldBeCalledOnContextInteraction()
+    {
+        $ctxValue = new class() {
+            use ContextValueTrait;
+
+            private static $contextKey;
+
+            public static $invocations = 0; // spy counter
+
+            protected static function getContextKey(): ContextKey
+            {
+                self::$invocations++;
+
+                if (self::$contextKey === null) {
+                    self::$contextKey = new ContextKey('test-key');
+                }
+
+                return self::$contextKey;
+            }
+        };
+
+        $ctxValue::getCurrent();
+        $this->assertEquals(1, $ctxValue::$invocations);
+
+        $ctxValue::setCurrent($ctxValue);
+        $this->assertEquals(2, $ctxValue::$invocations);
+
+        $context = new Context();
+        $ctxValue::insert($ctxValue, $context);
+        $this->assertEquals(3, $ctxValue::$invocations);
+
+        $ctxValue::extract($context);
+        $this->assertEquals(4, $ctxValue::$invocations);
+    }
+}

--- a/tests/Context/Unit/ScopeTest.php
+++ b/tests/Context/Unit/ScopeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Context\Unit;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Context\ContextValueNotFoundException;
+use OpenTelemetry\Context\Scope;
+use PHPUnit\Framework\TestCase;
+
+class ScopeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function scopeCloseRestoresContext()
+    {
+        $key = new ContextKey();
+        $ctx = (new Context())->set($key, 'test');
+        $scope = new Scope(Context::attach($ctx));
+
+        $this->assertSame('test', Context::getValue($key));
+
+        $scope->close();
+
+        $this->expectException(ContextValueNotFoundException::class);
+        Context::getValue($key);
+    }
+
+    /**
+     * @test
+     */
+    public function testNestedScope()
+    {
+        $key = new ContextKey();
+        $ctx1 = (new Context())->set($key, 'test1');
+        $scope1 = new Scope(Context::attach($ctx1));
+        $this->assertSame('test1', Context::getValue($key));
+        
+        $ctx2 = (new Context())->set($key, 'test2');
+        $scope2 = new Scope(Context::attach($ctx2));
+        $this->assertSame('test2', Context::getValue($key));
+        
+        $scope2->close();
+        $this->assertSame('test1', Context::getValue($key));
+        
+        $scope1->close();
+        $this->expectException(ContextValueNotFoundException::class);
+        Context::getValue($key);
+    }
+}

--- a/tests/Sdk/Unit/Trace/TracerTest.php
+++ b/tests/Sdk/Unit/Trace/TracerTest.php
@@ -4,12 +4,112 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Sdk\Trace\NoopSpan;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
 class TracerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Context::attach(new Context()); // clean up the current Context
+    }
+
+    /**
+     * @test
+     */
+    public function spanProcessorsShouldBeCalledWhenNewSpanIsStarted()
+    {
+        $processor = self::createMock(SpanProcessor::class);
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($processor);
+
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+
+        $processor->expects($this->exactly(1))->method('onStart')->with($this->isInstanceOf(Span::class));
+        $tracer->startSpan('test.span');
+    }
+
+    /**
+     * @test
+     */
+    public function spanProcessorsShouldBeCalledWhenSpanEnded()
+    {
+        $processor = self::createMock(SpanProcessor::class);
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($processor);
+
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $span = $tracer->startSpan('test.span');
+
+        $processor->expects($this->exactly(1))->method('onEnd')->with($this->equalTo($span));
+        $span->end();
+    }
+
+    /**
+     * @test
+     */
+    public function activeSpanFromCurrentContextShouldBeUsedAsParent()
+    {
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $span1 = $tracer->startSpan('test.span.1');
+        Span::setCurrent($span1);
+        $span2 = $tracer->startSpan('test.span.2');
+
+        $this->assertEquals($span1->getContext()->getTraceId(), $span2->getContext()->getTraceId());
+        $this->assertNotEquals($span1->getContext()->getSpanId(), $span2->getContext()->getSpanId());
+
+        $span2ParentContext = $span2->getParent();
+        $this->assertNotNull($span2ParentContext);
+        $this->assertEquals($span1->getContext()->getSpanId(), $span2ParentContext->getSpanId());
+    }
+
+    /**
+     * @test
+     */
+    public function spanAndParentContextShouldHaveIdenticalTraceId()
+    {
+        $parentSpan = new NoopSpan(new SpanContext(
+            'faa0c74e14bd78114ec2bc447ad94ec9',
+            '50a75f197c3de59a',
+            SpanContext::TRACE_FLAG_SAMPLED
+        ));
+        $parentContext = (new Context());
+        $parentContext = Span::insert($parentSpan, $parentContext);
+
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $childSpan = $tracer->startSpan('test.span', $parentContext);
+
+        $this->assertEquals($parentSpan->getContext()->getTraceId(), $childSpan->getContext()->getTraceId());
+        $this->assertNotEquals($parentSpan->getContext()->getSpanId(), $childSpan->getContext()->getSpanId());
+
+        $parentSpanContext = $childSpan->getParent();
+        $this->assertNotNull($parentSpanContext);
+        $this->assertEquals($parentSpan->getContext()->getSpanId(), $parentSpanContext->getSpanId());
+    }
+
+    /**
+     * @test
+     */
+    public function rootSpansShouldHaveDifferentTraceId()
+    {
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $span1 = $tracer->startSpan('test.span.1');
+        $span2 = $tracer->startSpan('test.span.2');
+
+        $this->assertNotEquals($span1->getContext()->getTraceId(), $span2->getContext()->getTraceId());
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
This PR proposes an idea of `trait ContextValueTrait` and `class Scope` to interact with the current `Context`.

Usage example:
```php
class Span {
  use ContextValueTrait;
}

$span = $tracer->startSpan();
$scope = Span::setCurrent($span);
try {
  $activeSpan = Span::getCurrent(); // returns $span
} finally {
  $scope->close();
}
$activeSpan = Span::getCurrent(); // returns NoopSpan
$span->end();
```

This also can be used in implementation of [Baggage API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/baggage/api.md).