### PR TITLE
Basic example to send zipkin style data to a New Relic backend.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ trace examples: FORCE
 	$(DC_RUN_PHP) php ./examples/AlwaysOnZipkinExample.php
 	$(DC_RUN_PHP) php ./examples/AlwaysOffTraceExample.php
 	$(DC_RUN_PHP) php ./examples/AlwaysOnJaegerExample.php
+        # The following examples do not use the DC_RUN_PHP global because they need environment variables.
+	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnNewrelicExample.php
+	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnZipkinToNewrelicExample.php
+
 metrics-prometheus-example:
 	@docker-compose -f docker-compose.prometheus.yaml up -d web
 	@docker-compose -f docker-compose.prometheus.yaml run php-prometheus php /var/www/public/examples/prometheus/PrometheusMetricsExample.php

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ You can use the [examples/AlwaysOnZipkinExample.php](/examples/AlwaysOnZipkinExa
 
 You can also use the [examples/AlwaysOnJaegerExample.php](/examples/AlwaysOnJaegerExample.php) file to test out the reference implementation we have for jaegar.  This example perfoms a sample trace with a grouping of 5 spans and POSTs the result to a local jaegar instance.
 
-The PHP for both examples should execute by itself (if you have a zipkin or jaegar instance running on localhost), but if you'd like a no-fuss way to test this out with docker and docker-compose, you can perform the following simple steps:
+You can use the [examples/AlwaysOnZipkinToNewrelicExample.php](/examples/AlwaysOnZipkinToNewrelicExample.php) file to test out the reference implementation we have for zipkin to Newrelic.  This example perfoms a sample trace with spans and POSTs the result to a Newrelic endpoint.  This requires a license key (free accounts available) to be set in the environment (NEW_RELIC_INSERT_KEY) to authenticate to the backend.
+
+You can use the [examples/AlwaysOnNewrelicExample.php](/examples/AlwaysOnNewrelicExample.php) file to test out the reference implementation we have for Newrelic.  This example perfoms a sample trace with spans and POSTs the result to a Newrelic endpoint.  This requires a license key (free accounts available) set in the environment (NEW_RELIC_INSERT_KEY) to authenticate to the backend.
+
+The PHP for all examples should execute by itself (if you have a zipkin or jaegar instance running on localhost), but if you'd like a no-fuss way to test this out with docker and docker-compose, you can perform the following simple steps:
 
 1.)  Install the necessary dependencies by running `make install`.  This will install the composer dependencies and store them in `/vendor`  
 2.)  Execute the example trace using `make trace examples`.

--- a/contrib/ZipkinToNewrelic/Exporter.php
+++ b/contrib/ZipkinToNewrelic/Exporter.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\ZipkinToNewrelic;
+
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use Http\Adapter\Guzzle7\Client;
+use InvalidArgumentException;
+use OpenTelemetry\Sdk\Trace;
+use OpenTelemetry\Trace as API;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * Class ZipkinExporter - implements the export interface for data transfer via Zipkin protocol
+ * @package OpenTelemetry\Exporter
+ *
+ * This is an experimental, non-supported exporter.
+ * It will send PHP Otel trace data end to end across the internet to a functional backend.
+ * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
+ */
+class Exporter implements Trace\Exporter
+{
+    /**
+     * @var string
+     */
+    private $endpointUrl;
+
+    /**
+     * @var string
+     */
+    private $licenseKey;
+
+    /**
+     * @var SpanConverter
+     */
+    private $spanConverter;
+
+    /**
+     * @var bool
+     */
+    private $running = true;
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    public function __construct(
+        $name,
+        string $endpointUrl,
+        string $licenseKey,
+        SpanConverter $spanConverter = null,
+        ClientInterface $client = null
+    ) {
+        $parsedDsn = parse_url($endpointUrl);
+
+        if (!is_array($parsedDsn)) {
+            throw new InvalidArgumentException('Unable to parse provided DSN');
+        }
+        if (
+            !isset($parsedDsn['scheme'])
+            || !isset($parsedDsn['host'])
+            || !isset($parsedDsn['path'])
+        ) {
+            throw new InvalidArgumentException('Endpoint should have scheme, host, port and path');
+        }
+
+        $this->licenseKey = $licenseKey;
+        $this->endpointUrl = $endpointUrl;
+        $this->client = $client ?? $this->createDefaultClient();
+        $this->spanConverter = $spanConverter ?? new SpanConverter($name);
+    }
+
+    /**
+     * Exports the provided Span data via the Zipkin protocol
+     *
+     * @param iterable<API\Span> $spans Array of Spans
+     * @return int return code, defined on the Exporter interface
+     */
+    public function export(iterable $spans): int
+    {
+        if (!$this->running) {
+            return Exporter::FAILED_NOT_RETRYABLE;
+        }
+
+        if (empty($spans)) {
+            return Trace\Exporter::SUCCESS;
+        }
+
+        $convertedSpans = [];
+        foreach ($spans as $span) {
+            array_push($convertedSpans, $this->spanConverter->convert($span));
+        }
+
+        try {
+            $json = json_encode($convertedSpans);
+            $headers = ['content-type' => 'application/json',
+                        'Api-Key' => $this->licenseKey,
+                        'Data-Format' => 'zipkin',
+                        'Data-Format-Version' => '2', ];
+            $request = new Request('POST', $this->endpointUrl, $headers, $json);
+            $response = $this->client->sendRequest($request);
+        } catch (RequestExceptionInterface $e) {
+            return Trace\Exporter::FAILED_NOT_RETRYABLE;
+        } catch (NetworkExceptionInterface | ClientExceptionInterface $e) {
+            return Trace\Exporter::FAILED_RETRYABLE;
+        }
+
+        $statusCode = $response->getStatusCode();
+        $reason = $response->getReasonPhrase();
+        echo "\nsendRequest response = " . $statusCode . "\n";
+        echo "\nsendRequest response = " . $reason . "\n";
+
+        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
+            return Trace\Exporter::FAILED_NOT_RETRYABLE;
+        }
+
+        if ($response->getStatusCode() >= 500 && $response->getStatusCode() < 600) {
+            return Trace\Exporter::FAILED_RETRYABLE;
+        }
+
+        return Trace\Exporter::SUCCESS;
+    }
+
+    public function shutdown(): void
+    {
+        $this->running = false;
+    }
+
+    protected function createDefaultClient(): ClientInterface
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create();
+        // Add the history middleware to the handler stack.
+        $stack->push($history);
+
+        return Client::createWithConfig([
+            'handler' => $stack,
+            'timeout' => 30,
+        ]);
+    }
+}

--- a/contrib/ZipkinToNewrelic/SpanConverter.php
+++ b/contrib/ZipkinToNewrelic/SpanConverter.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\ZipkinToNewrelic;
+
+use OpenTelemetry\Trace\Span;
+
+class SpanConverter
+{
+    const STATUS_CODE_TAG_KEY = 'otel.status_code';
+    const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
+    /**
+     * @var string
+     */
+    private $serviceName;
+
+    public function __construct(string $serviceName)
+    {
+        $this->serviceName = $serviceName;
+    }
+
+    private function sanitiseTagValue($value)
+    {
+        // Casting false to string makes an empty string
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        // Zipkin tags must be strings, but opentelemetry
+        // accepts strings, booleans, numbers, and lists of each.
+        if (is_array($value)) {
+            return join(',', array_map([$this, 'sanitiseTagValue'], $value));
+        }
+
+        // Floats will lose precision if their string representation
+        // is >=14 or >=17 digits, depending on PHP settings.
+        // Can also throw E_RECOVERABLE_ERROR if $value is an object
+        // without a __toString() method.
+        // This is possible because OpenTelemetry\Trace\Span does not verify
+        // setAttribute() $value input.
+        return (string) $value;
+    }
+
+    public function convert(Span $span)
+    {
+        $spanParent = $span->getParent();
+        $row = [
+            'id' => $span->getContext()->getSpanId(),
+            'traceId' => $span->getContext()->getTraceId(),
+            'parentId' => $spanParent ? $spanParent->getSpanId() : null,
+            'localEndpoint' => [
+                'serviceName' => $this->serviceName,
+            ],
+            'name' => $span->getSpanName(),
+            'timestamp' => (int) ($span->getStartEpochTimestamp() / 1e3), // RealtimeClock in microseconds
+            'duration' => (int) (($span->getEnd() - $span->getStart()) / 1e3), // Diff in microseconds
+            'tags' => [
+                self::STATUS_CODE_TAG_KEY => $span->getStatus()->getCanonicalStatusCode(),
+                self::STATUS_DESCRIPTION_TAG_KEY => $span->getStatus()->getStatusDescription(),
+            ],
+        ];
+
+        foreach ($span->getAttributes() as $k => $v) {
+            $row['tags'][$k] = $this->sanitiseTagValue($v->getValue());
+        }
+
+        foreach ($span->getEvents() as $event) {
+            if (!array_key_exists('annotations', $row)) {
+                $row['annotations'] = [];
+            }
+            $row['annotations'][] = [
+                'timestamp' => (int) ($event->getTimestamp() / 1e3), // RealtimeClock in microseconds
+                'value' => $event->getName(),
+            ];
+        }
+
+        return $row;
+    }
+}

--- a/examples/AlwaysOnZipkinToNewrelicExample.php
+++ b/examples/AlwaysOnZipkinToNewrelicExample.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\Contrib\ZipkinToNewrelic\Exporter as ZipkinToNewrelicExporter;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace as API;
+
+/*
+ * Experimental example to send trace data to New Relic.
+ * It will send PHP Otel trace data end to end across the internet to a functional backend.
+ * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
+ */
+
+$sampler = new AlwaysOnSampler();
+$samplingResult = $sampler->shouldSample(
+    null,
+    md5((string) microtime(true)),
+    substr(md5((string) microtime(true)), 16),
+    'io.opentelemetry.example',
+    API\SpanKind::KIND_INTERNAL
+);
+
+$licenseKey = getenv('NEW_RELIC_INSERT_KEY');
+
+// Needs a license key in the environment to connect to the backend server.
+
+if ($licenseKey == false) {
+    echo PHP_EOL . 'NEW_RELIC_INSERT_KEY not found in environment. Newrelic Example tracing is not enabled.';
+
+    return;
+}
+
+/*
+ * Default Trace API endpoint: https://trace-api.newrelic.com/trace/v1
+ * EU data centers: https://trace-api.eu.newrelic.com/trace/v1
+ */
+
+$endpointUrl =  getenv('NEW_RELIC_ENDPOINT');
+
+if ($endpointUrl == false) {
+    $endpointUrl = 'https://trace-api.newrelic.com/trace/v1';
+}
+
+$zipkinToNewrelicExporter = new ZipkinToNewrelicExporter(
+    'alwaysOnZipkinToNewrelicExample',
+    $endpointUrl,
+    $licenseKey
+);
+
+if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+    echo 'Starting AlwaysOnZipkinToNewRelicExample';
+    $tracer = (new TracerProvider())
+        ->addSpanProcessor(new SimpleSpanProcessor($zipkinToNewrelicExporter))
+        ->getTracer('io.opentelemetry.contrib.php');
+
+    for ($i = 0; $i < 5; $i++) {
+        // start a span, register some events
+        $timestamp = Clock::get()->timestamp();
+        $span = $tracer->startAndActivateSpan('session.generate.span.' . microtime(true));
+
+        $spanParent = $span->getParent();
+        echo sprintf(
+            PHP_EOL . 'Exporting Trace: %s, Parent: %s, Span: %s',
+            $span->getContext()->getTraceId(),
+            $spanParent ? $spanParent->getSpanId() : 'None',
+            $span->getContext()->getSpanId()
+        );
+
+        $span->setAttribute('remote_ip', '1.2.3.4')
+            ->setAttribute('country', 'USA');
+
+        $span->addEvent('found_login' . $i, $timestamp, new Attributes([
+            'id' => $i,
+            'username' => 'otuser' . $i,
+        ]));
+        $span->addEvent('generated_session', $timestamp, new Attributes([
+            'id' => md5((string) microtime(true)),
+        ]));
+
+        $tracer->endActiveSpan();
+    }
+    echo PHP_EOL . 'AlwaysOnZipkinToNewrelicExample complete!  See the results at https://one.newrelic.com/launcher/distributed-tracing.launcher?pane=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLmhvbWUiLCJzb3J0SW5kZXgiOjAsInNvcnREaXJlY3Rpb24iOiJERVNDIiwicXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJpbmRleFF1ZXJ5Ijp7ImNvbmRpdGlvblR5cGUiOiJJTkRFWCIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9uU2V0cyI6W119LCJzcGFuUXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJjb25kaXRpb25TZXRzIjpbeyJjb25kaXRpb25UeXBlIjoiU1BBTiIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9ucyI6W3siYXR0ciI6InNlcnZpY2UubmFtZSIsIm9wZXJhdG9yIjoiRVEiLCJ2YWx1ZSI6ImFsd2F5c09uWmlwa2luVG9OZXdyZWxpY0V4YW1wbGUifV19XX19fQ==&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true';
+} else {
+    echo PHP_EOL . 'AlwaysOnZipkinToNewrelicExample tracing is not enabled';
+}
+
+echo PHP_EOL;

--- a/tests/Contrib/Unit/ZipkinToNewrelicExporterTest.php
+++ b/tests/Contrib/Unit/ZipkinToNewrelicExporterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Unit;
+
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use OpenTelemetry\Contrib\ZipkinToNewrelic\Exporter;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+class ZipkinToNewrelicExporterTest extends TestCase
+{
+
+    /**
+     * @test
+     * @dataProvider exporterResponseStatusesDataProvider
+     */
+    public function exporterResponseStatuses($responseStatus, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willReturn(
+            new Response($responseStatus)
+        );
+
+        $exporter = new Exporter('test.zipkinToNR', 'scheme://host:123/path', '', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.zipkin.span', SpanContext::generate())])
+        );
+    }
+
+    public function exporterResponseStatusesDataProvider()
+    {
+        return [
+            'ok'                => [200, Exporter::SUCCESS],
+            'not found'         => [404, Exporter::FAILED_NOT_RETRYABLE],
+            'not authorized'    => [401, Exporter::FAILED_NOT_RETRYABLE],
+            'bad request'       => [402, Exporter::FAILED_NOT_RETRYABLE],
+            'too many requests' => [429, Exporter::FAILED_NOT_RETRYABLE],
+            'server error'      => [500, Exporter::FAILED_RETRYABLE],
+            'timeout'           => [503, Exporter::FAILED_RETRYABLE],
+            'bad gateway'       => [502, Exporter::FAILED_RETRYABLE],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider clientExceptionsShouldDecideReturnCodeDataProvider
+     */
+    public function clientExceptionsShouldDecideReturnCode($exception, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willThrowException($exception);
+
+        $exporter = new Exporter('test.zipkinToNR', 'scheme://host:123/path', '', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.zipkinToNR.span', SpanContext::generate())])
+        );
+    }
+
+    public function clientExceptionsShouldDecideReturnCodeDataProvider()
+    {
+        return [
+            'client'    => [
+                self::createMock(ClientExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'network'   => [
+                self::createMock(NetworkExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'request'   => [
+                self::createMock(RequestExceptionInterface::class),
+                Exporter::FAILED_NOT_RETRYABLE,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBeOkToExporterEmptySpansCollection()
+    {
+        $this->assertEquals(
+            Exporter::SUCCESS,
+            (new Exporter('test.zipkinToNR', 'scheme://host:123/path', ''))->export([])
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDsnDataProvider
+     */
+    public function shouldThrowExceptionIfInvalidDsnIsPassed(string $invalidDsn)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Exporter('test.zipkinToNR', $invalidDsn, '');
+    }
+
+    public function invalidDsnDataProvider()
+    {
+        return [
+            'missing scheme' => ['host/path'],
+            'missing host' => ['scheme://path'],
+            'missing path' => ['scheme://host'],
+            'invalid scheme' => ['1234://host:port/path'],
+            'invalid host' => ['scheme:///end:1234/path'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function failsIfNotRunning()
+    {
+        $exporter = new Exporter('test.zipkinToNr', 'scheme://host/path', '');
+        $span = $this->createMock(Span::class);
+        $exporter->shutdown();
+
+        $this->assertEquals($exporter->export([$span]), \OpenTelemetry\Sdk\Trace\Exporter::FAILED_NOT_RETRYABLE);
+    }
+}

--- a/tests/Contrib/Unit/ZipkinToNrSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinToNrSpanConverterTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Unit;
+
+use OpenTelemetry\Contrib\ZipkinToNewrelic\SpanConverter;
+use OpenTelemetry\Sdk\Trace\Attribute;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use PHPUnit\Framework\TestCase;
+
+class ZipkinToNewrelicSpanConverterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldConvertASpanToAPayloadForZipkin()
+    {
+        $tracer = (new TracerProvider())->getTracer('OpenTelemetry.ZipkinToNewrelicTest');
+
+        $timestamp = Clock::get()->timestamp();
+
+        /** @var Span $span */
+        $span = $tracer->startAndActivateSpan('guard.validate');
+        $span->setAttribute('service', 'guard');
+        $span->addEvent('validators.list', $timestamp, new Attributes(['job' => 'stage.updateTime']));
+        $span->end();
+
+        $converter = new SpanConverter('test.name');
+        $row = $converter->convert($span);
+
+        $this->assertSame($span->getContext()->getSpanId(), $row['id']);
+        $this->assertSame($span->getContext()->getTraceId(), $row['traceId']);
+
+        $this->assertSame('test.name', $row['localEndpoint']['serviceName']);
+        $this->assertSame($span->getSpanName(), $row['name']);
+
+        $this->assertIsInt($row['timestamp']);
+        // timestamp should be in microseconds
+        $this->assertGreaterThan(1e15, $row['timestamp']);
+
+        $this->assertIsInt($row['duration']);
+        $this->assertGreaterThan(0, $row['duration']);
+
+        $this->assertCount(3, $row['tags']);
+
+        /** @var Attribute $attribute */
+        $attribute = $span->getAttribute('service');
+        $this->assertEquals($attribute->getValue(), $row['tags']['service']);
+
+        $this->assertCount(1, $row['annotations']);
+        [$annotation] = $row['annotations'];
+        $this->assertEquals('validators.list', $annotation['value']);
+
+        [$event] = \iterator_to_array($span->getEvents());
+        $this->assertIsInt($annotation['timestamp']);
+
+        // timestamp should be in microseconds
+        $this->assertGreaterThan(1e15, $annotation['timestamp']);
+    }
+
+    /**
+     * @test
+     */
+    public function durationShouldBeInMicroseconds()
+    {
+        $span = new Span('duration.test', SpanContext::generate());
+
+        $row = (new SpanConverter('duration.test'))->convert($span);
+
+        $this->assertEquals(
+            (int) (($span->getEnd() - $span->getStart()) / 1000),
+            $row['duration']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function tagsAreCoercedCorrectlyToStrings()
+    {
+        $span = new Span('tags.test', SpanContext::generate());
+
+        $listOfStrings = ['string-1','string-2'];
+        $listOfNumbers = [1,2,3,3.1415,42];
+        $listOfBooleans = [true,true,false,true];
+        $listOfRandoms = [true,[1,2,3],false,'string-1',3.1415];
+
+        $span->setAttribute('string', 'string');
+        $span->setAttribute('integer-1', 1024);
+        $span->setAttribute('integer-2', 0);
+        $span->setAttribute('float', '1.2345');
+        $span->setAttribute('boolean-1', true);
+        $span->setAttribute('boolean-2', false);
+        $span->setAttribute('list-of-strings', $listOfStrings);
+        $span->setAttribute('list-of-numbers', $listOfNumbers);
+        $span->setAttribute('list-of-booleans', $listOfBooleans);
+        $span->setAttribute('list-of-random', $listOfRandoms);
+
+        $tags = (new SpanConverter('tags.test'))->convert($span)['tags'];
+
+        // Check that we can convert all attributes to tags
+        $this->assertCount(12, $tags);
+
+        // Tags destined for Zipkin must be pairs of strings
+        foreach ($tags as $tagKey => $tagValue) {
+            $this->assertIsString($tagKey);
+            $this->assertIsString($tagValue);
+        }
+
+        $this->assertEquals($tags['string'], 'string');
+        $this->assertEquals($tags['integer-1'], '1024');
+        $this->assertEquals($tags['integer-2'], '0');
+        $this->assertEquals($tags['float'], '1.2345');
+        $this->assertEquals($tags['boolean-1'], 'true');
+        $this->assertEquals($tags['boolean-2'], 'false');
+
+        // Lists must be casted to strings and joined with a separator
+        $this->assertEquals($tags['list-of-strings'], join(',', $listOfStrings));
+        $this->assertEquals($tags['list-of-numbers'], join(',', $listOfNumbers));
+        $this->assertEquals($tags['list-of-booleans'], 'true,true,false,true');
+
+        // This currently works, but OpenTelemetry\Trace\Span should stop arrays
+        // containing multiple value types from being passed to the Exporter.
+        $this->assertEquals($tags['list-of-random'], 'true,1,2,3,false,string-1,3.1415');
+    }
+}


### PR DESCRIPTION
1) Added a basic zipkin to New Relic exporter to the `contrib` directory and also associated tests.
2) Can easily run from `make trace`
3) It requires an environment variable (`NEW_RELIC_INSERT_KEY`) be set to successfully run.
4) If the env var isn't set, it just skips the example.