### PR TITLE
Experimental exporter, span converter, example, and tests.

### DIFF
--- a/contrib/Newrelic/Exporter.php
+++ b/contrib/Newrelic/Exporter.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Newrelic;
+
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use Http\Adapter\Guzzle7\Client;
+use InvalidArgumentException;
+use OpenTelemetry\Sdk\Trace;
+use OpenTelemetry\Trace as API;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * Class NewrelicExporter - implements the export interface for data transfer via Newrelic protocol
+ * @package OpenTelemetry\Exporter
+ *
+ * This is an experimental, non-supported exporter.
+ * It will send PHP Otel trace data end to end across the internet to a functional backend.
+ * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
+ */
+class Exporter implements Trace\Exporter
+{
+    /**
+     * @var string
+     */
+    private $endpointUrl;
+
+    /**
+     * @var string
+     */
+    private $licenseKey;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var SpanConverter
+     */
+    private $spanConverter;
+
+    /**
+     * @var bool
+     */
+    private $running = true;
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    public function __construct(
+        $name,
+        string $endpointUrl,
+        string $licenseKey,
+        SpanConverter $spanConverter = null,
+        ClientInterface $client = null
+    ) {
+        $parsedDsn = parse_url($endpointUrl);
+
+        if (!is_array($parsedDsn)) {
+            throw new InvalidArgumentException('Unable to parse provided DSN');
+        }
+        if (
+            !isset($parsedDsn['scheme'])
+            || !isset($parsedDsn['host'])
+            || !isset($parsedDsn['path'])
+        ) {
+            throw new InvalidArgumentException('Endpoint should have scheme, host, port and path');
+        }
+
+        $this->licenseKey = $licenseKey;
+        $this->endpointUrl = $endpointUrl;
+        $this->name = $name;
+        $this->client = $client ?? $this->createDefaultClient();
+        $this->spanConverter = $spanConverter ?? new SpanConverter($name);
+    }
+
+    /**
+     * Exports the provided Span data via the Newrelic protocol
+     *
+     * @param iterable<API\Span> $spans Array of Spans
+     * @return int return code, defined on the Exporter interface
+     */
+    public function export(iterable $spans): int
+    {
+        if (!$this->running) {
+            return Exporter::FAILED_NOT_RETRYABLE;
+        }
+
+        if (empty($spans)) {
+            return Trace\Exporter::SUCCESS;
+        }
+
+        $convertedSpans = [];
+        foreach ($spans as $span) {
+            array_push($convertedSpans, $this->spanConverter->convert($span));
+        }
+        $commonAttributes = ['attributes' => [ 'service.name' => $this->name,
+                                                'host' => $this->endpointUrl, ]];
+        $payload = [[ 'common' => $commonAttributes,
+                     'spans' => $convertedSpans, ]];
+
+        try {
+            $json = json_encode($payload);
+            $headers = ['content-type' => 'application/json',
+                        'Api-Key' => $this->licenseKey,
+                        'Data-Format' => 'newrelic',
+                        'Data-Format-Version' => '1', ];
+            $request = new Request('POST', $this->endpointUrl, $headers, $json);
+            $response = $this->client->sendRequest($request);
+        } catch (RequestExceptionInterface $e) {
+            return Trace\Exporter::FAILED_NOT_RETRYABLE;
+        } catch (NetworkExceptionInterface | ClientExceptionInterface $e) {
+            return Trace\Exporter::FAILED_RETRYABLE;
+        }
+
+        $statusCode = $response->getStatusCode();
+        $reason = $response->getReasonPhrase();
+        echo "\nsendRequest response = " . $statusCode . "\n";
+        echo "\nsendRequest response = " . $reason . "\n";
+
+        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
+            return Trace\Exporter::FAILED_NOT_RETRYABLE;
+        }
+
+        if ($response->getStatusCode() >= 500 && $response->getStatusCode() < 600) {
+            return Trace\Exporter::FAILED_RETRYABLE;
+        }
+
+        return Trace\Exporter::SUCCESS;
+    }
+
+    public function shutdown(): void
+    {
+        $this->running = false;
+    }
+
+    protected function createDefaultClient(): ClientInterface
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create();
+        // Add the history middleware to the handler stack.
+        $stack->push($history);
+
+        return Client::createWithConfig([
+            'handler' => $stack,
+            'timeout' => 30,
+        ]);
+    }
+}

--- a/contrib/Newrelic/SpanConverter.php
+++ b/contrib/Newrelic/SpanConverter.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Newrelic;
+
+use OpenTelemetry\Trace\Span;
+
+class SpanConverter
+{
+    const STATUS_CODE_TAG_KEY = 'otel.status_code';
+    const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
+
+    /**
+     * @var string
+     */
+    private $serviceName;
+
+    public function __construct(string $serviceName)
+    {
+        $this->serviceName = $serviceName;
+    }
+
+    public function convert(Span $span)
+    {
+        $spanParent = $span->getParent();
+        $row = [
+            'id' => $span->getContext()->getSpanId(),
+            'trace.id' => $span->getContext()->getTraceId(),
+            'attributes' => [
+                'name' => $span->getSpanName(),
+                'service.name' => $this->serviceName,
+                'parent.id' => $spanParent ? $spanParent->getSpanId() : null,
+                'timestamp' => ($span->getStartEpochTimestamp()  / 1e6), // RealtimeClock in milliseconds
+                'duration.ms' => (($span->getEnd() - $span->getStart())  / 1e6), // Diff in milliseconds
+                self::STATUS_CODE_TAG_KEY => $span->getStatus()->getCanonicalStatusCode(),
+                self::STATUS_DESCRIPTION_TAG_KEY => $span->getStatus()->getStatusDescription(),
+            ],
+        ];
+
+        foreach ($span->getAttributes() as $k => $v) {
+            $row['attributes'][$k] = $v->getValue();
+        }
+
+        /*
+        foreach ($span->getEvents() as $event) {
+            if (!array_key_exists('annotations', $row)) {
+                $row['annotations'] = [];
+            }
+            $row['annotations'][] = [
+                'timestamp' => (int) ($event->getTimestamp() / 1e6), // RealtimeClock in milliseconds
+                'value' => $event->getName(),
+            ];
+        }
+    */
+        return $row;
+    }
+}

--- a/examples/AlwaysOnNewrelicExample.php
+++ b/examples/AlwaysOnNewrelicExample.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\Contrib\Newrelic\Exporter as NewrelicExporter;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace as API;
+
+/*
+ * Experimental example to send trace data to New Relic.
+ * It will send PHP Otel trace data end to end across the internet to a functional backend.
+ * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
+ */
+
+$sampler = new AlwaysOnSampler();
+$samplingResult = $sampler->shouldSample(
+    null,
+    md5((string) microtime(true)),
+    substr(md5((string) microtime(true)), 16),
+    'io.opentelemetry.example',
+    API\SpanKind::KIND_INTERNAL
+);
+
+$licenseKey = getenv('NEW_RELIC_INSERT_KEY');
+
+// Needs a license key in the environment to connect to the backend server.
+
+if ($licenseKey == false) {
+    echo PHP_EOL . 'NEW_RELIC_INSERT_KEY not found in environment. Newrelic Example tracing is not enabled.';
+
+    return;
+}
+
+/*
+ * Default Trace API endpoint: https://trace-api.newrelic.com/trace/v1
+ * EU data centers: https://trace-api.eu.newrelic.com/trace/v1
+ */
+
+$endpointUrl =  getenv('NEW_RELIC_ENDPOINT');
+
+if ($endpointUrl == false) {
+    $endpointUrl = 'https://trace-api.newrelic.com/trace/v1';
+}
+
+$newrelicExporter = new NewrelicExporter(
+    'alwaysOnNewrelicExample',
+    $endpointUrl,
+    $licenseKey
+);
+
+if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+    echo 'Starting AlwaysOnNewrelicExample';
+    $tracer = (new TracerProvider())
+        ->addSpanProcessor(new SimpleSpanProcessor($newrelicExporter))
+        ->getTracer('io.opentelemetry.contrib.php');
+
+    for ($i = 0; $i < 5; $i++) {
+        // start a span, register some events
+        $timestamp = Clock::get()->timestamp();
+        $span = $tracer->startAndActivateSpan('session.generate.span.' . microtime(true));
+
+        $spanParent = $span->getParent();
+        echo sprintf(
+            PHP_EOL . 'Exporting Trace: %s, Parent: %s, Span: %s',
+            $span->getContext()->getTraceId(),
+            $spanParent ? $spanParent->getSpanId() : 'None',
+            $span->getContext()->getSpanId()
+        );
+
+        $span->setAttribute('remote_ip', '1.2.3.4')
+            ->setAttribute('country', 'USA');
+
+        $span->addEvent('found_login' . $i, $timestamp, new Attributes([
+            'id' => $i,
+            'username' => 'otuser' . $i,
+        ]));
+        $span->addEvent('generated_session', $timestamp, new Attributes([
+            'id' => md5((string) microtime(true)),
+        ]));
+
+        $tracer->endActiveSpan();
+    }
+    echo PHP_EOL . 'NewrelicExample complete!  See the results at https://one.newrelic.com/launcher/distributed-tracing.launcher?pane=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLmhvbWUiLCJzb3J0SW5kZXgiOjAsInNvcnREaXJlY3Rpb24iOiJERVNDIiwicXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJpbmRleFF1ZXJ5Ijp7ImNvbmRpdGlvblR5cGUiOiJJTkRFWCIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9uU2V0cyI6W119LCJzcGFuUXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJjb25kaXRpb25TZXRzIjpbeyJjb25kaXRpb25UeXBlIjoiU1BBTiIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9ucyI6W3siYXR0ciI6InNlcnZpY2UubmFtZSIsIm9wZXJhdG9yIjoiRVEiLCJ2YWx1ZSI6ImFsd2F5c09uTmV3cmVsaWNFeGFtcGxlIn1dfV19fX0=&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true';
+} else {
+    echo PHP_EOL . 'NewrelicExample tracing is not enabled';
+}
+
+echo PHP_EOL;

--- a/tests/Contrib/Unit/NewrelicExporterTest.php
+++ b/tests/Contrib/Unit/NewrelicExporterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Unit;
+
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use OpenTelemetry\Contrib\Newrelic\Exporter;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+class NewrelicExporterTest extends TestCase
+{
+
+    /**
+     * @test
+     * @dataProvider exporterResponseStatusesDataProvider
+     */
+    public function exporterResponseStatuses($responseStatus, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willReturn(
+            new Response($responseStatus)
+        );
+
+        $exporter = new Exporter('test.newrelic', 'scheme://host:123/path', '', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.newrelic.span', SpanContext::generate())])
+        );
+    }
+
+    public function exporterResponseStatusesDataProvider()
+    {
+        return [
+            'ok'                => [200, Exporter::SUCCESS],
+            'not found'         => [404, Exporter::FAILED_NOT_RETRYABLE],
+            'not authorized'    => [401, Exporter::FAILED_NOT_RETRYABLE],
+            'bad request'       => [402, Exporter::FAILED_NOT_RETRYABLE],
+            'too many requests' => [429, Exporter::FAILED_NOT_RETRYABLE],
+            'server error'      => [500, Exporter::FAILED_RETRYABLE],
+            'timeout'           => [503, Exporter::FAILED_RETRYABLE],
+            'bad gateway'       => [502, Exporter::FAILED_RETRYABLE],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider clientExceptionsShouldDecideReturnCodeDataProvider
+     */
+    public function clientExceptionsShouldDecideReturnCode($exception, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willThrowException($exception);
+
+        $exporter = new Exporter('test.newrelic', 'scheme://host:123/path', '', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.newrelic.span', SpanContext::generate())])
+        );
+    }
+
+    public function clientExceptionsShouldDecideReturnCodeDataProvider()
+    {
+        return [
+            'client'    => [
+                self::createMock(ClientExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'network'   => [
+                self::createMock(NetworkExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'request'   => [
+                self::createMock(RequestExceptionInterface::class),
+                Exporter::FAILED_NOT_RETRYABLE,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBeOkToExporterEmptySpansCollection()
+    {
+        $this->assertEquals(
+            Exporter::SUCCESS,
+            (new Exporter('test.newrelic', 'scheme://host:123/path', ''))->export([])
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDsnDataProvider
+     */
+    public function shouldThrowExceptionIfInvalidDsnIsPassed(string $invalidDsn)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Exporter('test.newrelic', $invalidDsn, '');
+    }
+
+    public function invalidDsnDataProvider()
+    {
+        return [
+            'missing scheme' => ['host/path'],
+            'missing host' => ['scheme://path'],
+            'missing path' => ['scheme://host'],
+            'invalid scheme' => ['1234://host:port/path'],
+            'invalid host' => ['scheme:///end:1234/path'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function failsIfNotRunning()
+    {
+        $exporter = new Exporter('test.newrelic', 'scheme://host/path', '');
+        $span = $this->createMock(Span::class);
+        $exporter->shutdown();
+
+        $this->assertEquals($exporter->export([$span]), \OpenTelemetry\Sdk\Trace\Exporter::FAILED_NOT_RETRYABLE);
+    }
+}

--- a/tests/Contrib/Unit/NewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/NewrelicSpanConverterTest.php
@@ -41,12 +41,12 @@ class NewrelicSpanConverterTest extends TestCase
         $this->assertNull($row['attributes']['parent.id']);
         $this->assertSame($span->getSpanName(), $row['attributes']['name']);
 
-        $this->assertIsInt($row['attributes']['timestamp']);
+        $this->assertIsFloat($row['attributes']['timestamp']);
         // timestamp should be in milliseconds
         $this->assertGreaterThan(1e12, $row['attributes']['timestamp']);
 
-        $this->assertIsInt($row['attributes']['duration.ms']);
-        $this->assertEquals(0, $row['attributes']['duration.ms']);
+        $this->assertIsFloat($row['attributes']['duration.ms']);
+        $this->assertGreaterThan(0, $row['attributes']['duration.ms']);
 
         /** @var Attribute $attribute */
         $attribute = $span->getAttribute('service');
@@ -63,7 +63,7 @@ class NewrelicSpanConverterTest extends TestCase
         $row = (new SpanConverter('duration.test'))->convert($span);
 
         $this->assertEquals(
-            (int) (($span->getEnd() - $span->getStart()) / 1000000),
+            (($span->getEnd() - $span->getStart()) / 1000000),
             $row['attributes']['duration.ms']
         );
     }

--- a/tests/Contrib/Unit/NewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/NewrelicSpanConverterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Unit;
+
+use OpenTelemetry\Contrib\Newrelic\SpanConverter;
+use OpenTelemetry\Sdk\Trace\Attribute;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use PHPUnit\Framework\TestCase;
+
+class NewrelicSpanConverterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldConvertASpanToAPayloadForNewrelic()
+    {
+        $tracer = (new TracerProvider())->getTracer('OpenTelemetry.NewrelicTest');
+
+        $timestamp = Clock::get()->timestamp();
+
+        /** @var Span $span */
+        $span = $tracer->startAndActivateSpan('guard.validate');
+        $span->setAttribute('service', 'guard');
+        $span->addEvent('validators.list', $timestamp, new Attributes(['job' => 'stage.updateTime']));
+        $span->end();
+
+        $converter = new SpanConverter('test.name');
+        $row = $converter->convert($span);
+
+        $this->assertSame($span->getContext()->getSpanId(), $row['id']);
+        $this->assertSame($span->getContext()->getTraceId(), $row['trace.id']);
+
+        $this->assertSame('test.name', $row['attributes']['service.name']);
+        $this->assertSame($span->getSpanName(), $row['attributes']['name']);
+        $this->assertNull($row['attributes']['parent.id']);
+        $this->assertSame($span->getSpanName(), $row['attributes']['name']);
+
+        $this->assertIsInt($row['attributes']['timestamp']);
+        // timestamp should be in milliseconds
+        $this->assertGreaterThan(1e12, $row['attributes']['timestamp']);
+
+        $this->assertIsInt($row['attributes']['duration.ms']);
+        $this->assertEquals(0, $row['attributes']['duration.ms']);
+
+        /** @var Attribute $attribute */
+        $attribute = $span->getAttribute('service');
+        $this->assertEquals($attribute->getValue(), $row['attributes']['service']);
+    }
+
+    /**
+     * @test
+     */
+    public function durationShouldBeInMilliseconds()
+    {
+        $span = new Span('duration.test', SpanContext::generate());
+
+        $row = (new SpanConverter('duration.test'))->convert($span);
+
+        $this->assertEquals(
+            (int) (($span->getEnd() - $span->getStart()) / 1000000),
+            $row['attributes']['duration.ms']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function attributesMaintainTypes()
+    {
+        $span = new Span('attributes.test', SpanContext::generate());
+
+        $listOfStrings = ['string-1','string-2'];
+        $listOfNumbers = [1,2,3,3.1415,42];
+        $listOfBooleans = [true,true,false,true];
+        $listOfRandoms = [true,[1,2,3],false,'string-1',3.1415];
+
+        $span->setAttribute('string', 'string');
+        $span->setAttribute('integer-1', 1024);
+        $span->setAttribute('integer-2', 0);
+        $span->setAttribute('float', '1.2345');
+        $span->setAttribute('boolean-1', true);
+        $span->setAttribute('boolean-2', false);
+        $span->setAttribute('list-of-strings', $listOfStrings);
+        $span->setAttribute('list-of-numbers', $listOfNumbers);
+        $span->setAttribute('list-of-booleans', $listOfBooleans);
+        $span->setAttribute('list-of-random', $listOfRandoms);
+
+        $attributes = (new SpanConverter('tags.test'))->convert($span)['attributes'];
+
+        // Check that we can convert all attributes to tags
+        $this->assertCount(17, $attributes);
+
+        // Attributes destined for Newrelic must be key/value pairs
+
+        $this->assertEquals($attributes['string'], 'string');
+        $this->assertEquals($attributes['integer-1'], 1024);
+        $this->assertEquals($attributes['integer-2'], 0);
+        $this->assertEquals($attributes['float'], 1.2345);
+        $this->assertEquals($attributes['boolean-1'], true);
+        $this->assertEquals($attributes['boolean-2'], false);
+
+        // Lists must be casted to strings and joined with a separator
+        $this->assertEquals($attributes['list-of-strings'], $listOfStrings);
+        $this->assertEquals($attributes['list-of-numbers'], $listOfNumbers);
+        $this->assertEquals($attributes['list-of-booleans'], $listOfBooleans);
+
+        // This currently works, but OpenTelemetry\Trace\Span should stop arrays
+        // containing multiple value types from being passed to the Exporter.
+        $this->assertEquals($attributes['list-of-random'], $listOfRandoms);
+    }
+}

--- a/tests/Contrib/Unit/NewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/NewrelicSpanConverterTest.php
@@ -105,7 +105,7 @@ class NewrelicSpanConverterTest extends TestCase
         $this->assertEquals($attributes['boolean-1'], true);
         $this->assertEquals($attributes['boolean-2'], false);
 
-        // Lists must be casted to strings and joined with a separator
+        // Lists are accepted
         $this->assertEquals($attributes['list-of-strings'], $listOfStrings);
         $this->assertEquals($attributes['list-of-numbers'], $listOfNumbers);
         $this->assertEquals($attributes['list-of-booleans'], $listOfBooleans);


### PR DESCRIPTION
1) Added an experimental New Relic exporter, span converter, example, and tests.
2) Can run from `make trace`
3) It requires an environment variable (`NEW_RELIC_INSERT_KEY`) be set to successfully run.
4) If the env var isn't set, it just skips the example.