### PR TITLE
Propagate SpanKind to Span constructor

### DIFF
--- a/api/Trace/Tracer.php
+++ b/api/Trace/Tracer.php
@@ -8,7 +8,7 @@ interface Tracer
 {
     public function getActiveSpan(): Span;
 
-    public function startAndActivateSpan(string $name): Span;
+    public function startAndActivateSpan(string $name, int $spanKind = SpanKind::KIND_INTERNAL): Span;
     public function startSpanWithOptions(string $name): SpanOptions;
 
     public function setActiveSpan(Span $span): void;

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -82,7 +82,7 @@ class Tracer implements API\Tracer
         if (SamplingResult::NOT_RECORD == $samplingResult->getDecision()) {
             $span = $this->generateSpanInstance('', $context);
         } else {
-            $span = $this->generateSpanInstance($name, $context, $sampler, $this->resource);
+            $span = $this->generateSpanInstance($name, $context, $sampler, $this->resource, $spanKind);
 
             if ($span->isRecording()) {
                 $this->provider->getSpanProcessor()->onStart($span);
@@ -186,7 +186,7 @@ class Tracer implements API\Tracer
         }
     }
 
-    private function generateSpanInstance(string $name, API\SpanContext $context, Sampler $sampler = null, ResourceInfo $resource = null): API\Span
+    private function generateSpanInstance(string $name, API\SpanContext $context, Sampler $sampler = null, ResourceInfo $resource = null, int $spanKind = API\SpanKind::KIND_INTERNAL): API\Span
     {
         $parent = null;
 
@@ -197,7 +197,7 @@ class Tracer implements API\Tracer
                 $parent = $this->getActiveSpan()->getContext();
             }
 
-            $span = new Span($name, $context, $parent, $sampler, $resource);
+            $span = new Span($name, $context, $parent, $sampler, $resource, $spanKind);
         }
         $this->spans[] = $span;
 

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -17,6 +17,7 @@ use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\SpanStatus;
 use OpenTelemetry\Sdk\Trace\Tracer;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace as API;
 use PHPUnit\Framework\TestCase;
 
 class TracingTest extends TestCase
@@ -143,6 +144,32 @@ class TracingTest extends TestCase
 
         // active span rolled back
         $this->assertSame($tracer->getActiveSpan(), $global);
+    }
+
+    public function testCreateSpanWithSpanKind()
+    {
+        $tracerProvider = new SDK\TracerProvider(null, new SDK\Sampler\AlwaysOnSampler());
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracingTest');
+
+        $span = $tracer->startAndActivateSpan('someSpan');
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_INTERNAL);
+        $span->end();
+
+        $span = $tracer->startAndActivateSpan('someSpan', API\SpanKind::KIND_CLIENT);
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_CLIENT);
+        $span->end();
+
+        $span = $tracer->startAndActivateSpan('someSpan', API\SpanKind::KIND_SERVER);
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_SERVER);
+        $span->end();
+
+        $span = $tracer->startAndActivateSpan('someSpan', API\SpanKind::KIND_PRODUCER);
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_PRODUCER);
+        $span->end();
+
+        $span = $tracer->startAndActivateSpan('someSpan', API\SpanKind::KIND_CONSUMER);
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_CONSUMER);
+        $span->end();
     }
 
     public function testGetStatus()


### PR DESCRIPTION
1. Pass SpanKind through Tracer span creations functions to Span constructor.
2. Add unit test checking SpanKind after creation.