### PR TITLE
Update SpanProcessor parameters onStart

### DIFF
--- a/sdk/Trace/SpanProcessor.php
+++ b/sdk/Trace/SpanProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Trace as API;
 
 interface SpanProcessor
@@ -13,7 +14,7 @@ interface SpanProcessor
      * This method is called synchronously on the thread that started the span,
      * therefore it should not block or throw exceptions.
      */
-    public function onStart(API\Span $span): void;
+    public function onStart(API\Span $span, ?Context $parentContext = null): void;
 
     /**
      * This method  is called when a span is ended.

--- a/sdk/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/sdk/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Sdk\Trace\SpanProcessor;
 
 use InvalidArgumentException;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Clock;
 use OpenTelemetry\Sdk\Trace\Exporter;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
@@ -76,7 +77,7 @@ class BatchSpanProcessor implements SpanProcessor
     /**
      * @inheritDoc
      */
-    public function onStart(API\Span $span): void
+    public function onStart(API\Span $span, ?Context $parentContext = null): void
     {
     }
 

--- a/sdk/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/sdk/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace\SpanProcessor;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Exporter;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
 use OpenTelemetry\Trace as API;
@@ -28,7 +29,7 @@ class SimpleSpanProcessor implements SpanProcessor
     /**
      * @inheritDoc
      */
-    public function onStart(API\Span $span): void
+    public function onStart(API\Span $span, ?Context $parentContext = null): void
     {
     }
 

--- a/sdk/Trace/SpanProcessor/SpanMultiProcessor.php
+++ b/sdk/Trace/SpanProcessor/SpanMultiProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace\SpanProcessor;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
 use OpenTelemetry\Trace as API;
 
@@ -31,10 +32,10 @@ final class SpanMultiProcessor implements SpanProcessor
         return $this->processors;
     }
 
-    public function onStart(API\Span $span): void
+    public function onStart(API\Span $span, ?Context $parentContext = null): void
     {
         foreach ($this->processors as $processor) {
-            $processor->onStart($span);
+            $processor->onStart($span, $parentContext);
         }
     }
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -74,7 +74,7 @@ class Tracer implements API\Tracer
             $this->provider->getSpanProcessor()
         );
 
-        $this->provider->getSpanProcessor()->onStart($span);
+        $this->provider->getSpanProcessor()->onStart($span, $parentContext ?? Context::getCurrent());
 
         return $span;
     }

--- a/tests/Sdk/Integration/SpanProcessorTest.php
+++ b/tests/Sdk/Integration/SpanProcessorTest.php
@@ -18,7 +18,7 @@ class SpanProcessorTest extends TestCase
     public function parentContextShouldBePassedToSpanProcessor()
     {
         $parentContext = new Context();
-        
+
         $spanProcessor = $this->createMock(SpanProcessor::class);
         $spanProcessor
             ->expects($this->once())
@@ -30,5 +30,25 @@ class SpanProcessorTest extends TestCase
         $tracerProvider->addSpanProcessor($spanProcessor);
         $tracer = $tracerProvider->getTracer('OpenTelemetry.Test');
         $tracer->startSpan('test.span', $parentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function currentContextShouldBePassedToSpanProcessorByDefault()
+    {
+        $currentContext = Context::getCurrent();
+
+        $spanProcessor = $this->createMock(SpanProcessor::class);
+        $spanProcessor
+            ->expects($this->once())
+            ->method('onStart')
+            ->with($this->isInstanceOf(Span::class), $this->equalTo($currentContext))
+        ;
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($spanProcessor);
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.Test');
+        $tracer->startSpan('test.span', null);
     }
 }

--- a/tests/Sdk/Integration/SpanProcessorTest.php
+++ b/tests/Sdk/Integration/SpanProcessorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Integration;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Sdk\Trace\SpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace\Span;
+use PHPUnit\Framework\TestCase;
+
+class SpanProcessorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function parentContextShouldBePassedToSpanProcessor()
+    {
+        $parentContext = new Context();
+        
+        $spanProcessor = $this->createMock(SpanProcessor::class);
+        $spanProcessor
+            ->expects($this->once())
+            ->method('onStart')
+            ->with($this->isInstanceOf(Span::class), $this->equalTo($parentContext))
+        ;
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($spanProcessor);
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.Test');
+        $tracer->startSpan('test.span', $parentContext);
+    }
+}


### PR DESCRIPTION
Pass the parent Context to the SpanProcessor on Span start.

Fixes #278