### PR TITLE
Fix tracecontext header extraction

### DIFF
--- a/sdk/Trace/PropagationMap.php
+++ b/sdk/Trace/PropagationMap.php
@@ -26,6 +26,10 @@ class PropagationMap implements API\PropagationGetter, API\PropagationSetter
 
             foreach ($carrier as $k => $value) {
                 if (strtolower($k) === $lKey) {
+                    if (\is_array($value)) {
+                        return empty($value) ? null : $value[0];
+                    }
+
                     return $value;
                 }
             }

--- a/sdk/Trace/TraceContext.php
+++ b/sdk/Trace/TraceContext.php
@@ -18,8 +18,8 @@ use OpenTelemetry\Trace as API;
  */
 final class TraceContext implements API\TextMapFormatPropagator
 {
-    public const TRACEPARENT = 'http_traceparent';
-    public const TRACESTATE = 'http_tracestate';
+    public const TRACEPARENT = 'traceparent';
+    public const TRACESTATE = 'tracestate';
     private const VERSION = '00'; // Currently only '00' is supported
     private const VALID_VERSION = '/^[0-9a-f]{2}$/';
     private const VALID_TRACEFLAGS = '/^[0-9a-f]{2}$/';

--- a/tests/Sdk/Unit/Trace/PropagationMapTest.php
+++ b/tests/Sdk/Unit/Trace/PropagationMapTest.php
@@ -110,4 +110,19 @@ class PropagationMapTest extends TestCase
         $this->expectExceptionMessage('Unable to set value with an empty key');
         $map->set($carrier, '', 'alpha');
     }
+
+    /**
+     * @test
+     */
+    public function testGetArrayValuesFromCarrier()
+    {
+        // Carrier contains an array as one of the values
+        $carrier = [
+            'a' => 'alpha',
+            'b' => ['bravo'],
+        ];
+        $map = new PropagationMap();
+        $this->assertSame('alpha', $map->get($carrier, 'a'));
+        $this->assertSame('bravo', $map->get($carrier, 'b'));
+    }
 }


### PR DESCRIPTION
This fixes issues with exctracting the `traceparent` and `tracestate` headers. This includes:

- Using the correct `traceparent` and `tracestate` header names.
- Account for a case where each header value is represented as an array instead of a string.