### PR TITLE
W3c trace context test service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ coverage.clover
 tests/coverage
 .php_cs.cache
 proto/*
+
+# W3C Test Service build artifacts
+tests/TraceContext/W3CTestService/test_app
+tests/TraceContext/W3CTestService/trace-context

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,7 @@ bash:
 	$(DC_RUN_PHP) bash
 style:
 	$(DC_RUN_PHP) php ./vendor/bin/php-cs-fixer fix
+w3c-test-service:
+	docker-compose up -d
+	$(DC_RUN_PHP) ./tests/TraceContext/W3CTestService/symfony-setup
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,5 @@ bash:
 style:
 	$(DC_RUN_PHP) php ./vendor/bin/php-cs-fixer fix
 w3c-test-service:
-	docker-compose up -d
-	$(DC_RUN_PHP) ./tests/TraceContext/W3CTestService/symfony-setup
+	@docker-compose -f docker-compose.w3cTraceContext.yaml run --rm php ./tests/TraceContext/W3CTestService/symfony-setup
 FORCE:

--- a/docker-compose.w3cTraceContext.yaml
+++ b/docker-compose.w3cTraceContext.yaml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+  php:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    volumes:
+    - ./:/usr/src/myapp
+    - ./:/usr/src/open-telemetry/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,8 +9,7 @@ parameters:
     excludes_analyse:
         - var
         - vendor
-        - '%currentWorkingDirectory%/tests/TraceContext/W3CTestService/TestController.php'
-        - '%currentWorkingDirectory%/tests/TraceContext/W3CTestService/index.php'
+        - tests/TraceContext/W3CTestService
     ignoreErrors:
         # PHPStan false positive
         - message: '#Call to an undefined static method OpenTelemetry\\Sdk\\Metrics\\Providers\\GlobalMeterProvider\:\:getMeter\(\)\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,8 +9,8 @@ parameters:
     excludes_analyse:
         - var
         - vendor
-        - tests/TraceContext/W3CTestService/TestController.php
-        - tests/TraceContext/W3CTestService/index.php
+        - '%currentWorkingDirectory%/tests/TraceContext/W3CTestService/TestController.php'
+        - '%currentWorkingDirectory%/tests/TraceContext/W3CTestService/index.php'
     ignoreErrors:
         # PHPStan false positive
         - message: '#Call to an undefined static method OpenTelemetry\\Sdk\\Metrics\\Providers\\GlobalMeterProvider\:\:getMeter\(\)\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,8 @@ parameters:
     excludes_analyse:
         - var
         - vendor
+        - tests/TraceContext/W3CTestService/TestController.php
+        - tests/TraceContext/W3CTestService/index.php
     ignoreErrors:
         # PHPStan false positive
         - message: '#Call to an undefined static method OpenTelemetry\\Sdk\\Metrics\\Providers\\GlobalMeterProvider\:\:getMeter\(\)\.#'

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -10,6 +10,7 @@
         <ignoreFiles>
             <directory name="var"/>
             <directory name="vendor"/>
+            <directory name="tests/TraceContext/W3CTestService"/>
         </ignoreFiles>
     </projectFiles>
     <plugins>

--- a/tests/TraceContext/W3CTestService/README.md
+++ b/tests/TraceContext/W3CTestService/README.md
@@ -1,0 +1,43 @@
+# W3C Trace Context test service
+
+This test service works with the [W3C distributed tracing validation service](https://github.com/w3c/trace-context/tree/master/test). It confirms that the the OpenTelemetry php library meets the requirements for trace context propagation according to the [Trace Context spec](https://www.w3.org/TR/trace-context/).
+
+## Test Run
+
+1.) Ensure the necessary dependencies are installed by running `make install`.  This will install the composer dependencies and store them in `/vendor`.
+
+2.) Execute the test by using `make w3c-test-service`.
+
+## Test service architecture
+
+This test service acts as an endpoint that responds to requests from the [W3C distributed tracing validation service](https://github.com/w3c/trace-context/tree/master/test). The validation service uses HTTP POST to communicate with the test service endpoint, giving instructions via the POST body, and waiting for the service to callback to the harness.
+
+### HTTP POST body format
+
+The HTTP POST request body from the validation service is a JSON array and each element in the array is an object with two properties `url` and `arguments`. The test service iterates through the JSON array, and for each element, sends a HTTP POST to the specified `url`, with `arguments` as the request body.
+
+Below is a sample request from the test harness:
+
+```
+POST /test HTTP/1.1
+Accept: application/json
+Accept-Encoding: gzip, deflate
+Host: 127.0.0.1:5000
+User-Agent: Python/3.7 aiohttp/3.3.2
+Content-Length: 118
+Content-Type: application/json
+
+[
+    {"url": url1, "arguments": [
+        {"url": url2, "arguments": []}
+    ]},
+    {"url": url3, "arguments": []}
+]
+```
+
+The validation service then checks the `traceparent` and `tracestate` headers in the response from the test service. For more information on the test cases, please reference the [validation service](https://github.com/w3c/trace-context/tree/master/test#run-test-cases) docs. 
+
+### Test service
+
+The test service is created using a `symfony` application that has a `/test` endpoint. Once this endpoint is hit by the validation service, the test service creates a `SpanContext` using the received `traceparent` and `tracestate` headers. These headers are used to propagate the trace.
+

--- a/tests/TraceContext/W3CTestService/TestController.php
+++ b/tests/TraceContext/W3CTestService/TestController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Controller;
+
+use OpenTelemetry\Sdk\Trace\PropagationMap;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TraceContext;
+use OpenTelemetry\Sdk\Trace\TraceState;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+use GuzzleHttp\Client;
+
+class TestController
+{
+    /**
+     * @Route("/test")
+     */
+    public function index(Request $request): Response
+    {
+        global $tracer;
+
+        $array = $request->request->all();
+        $body = json_decode($request->getContent(), true);
+        
+        foreach ($body as $case) {
+            if ($tracer) {
+                $context;
+                $headers = ['content-type' => 'application/json'];
+                $url = $case['url'];
+                $arguments = $case['arguments'];
+                
+                $carrier = new PropagationMap();
+
+                try {
+                    $context = TraceContext::extract($request->headers->all(), $carrier);
+                } catch (\InvalidArgumentException $th) {
+                    $context = SpanContext::generate();
+                }
+
+                $span = $tracer->startAndActivateSpanFromContext($url, $context, true);
+                TraceContext::inject($context, $headers, $carrier);
+                
+                $client = new Client([
+                    'base_uri' => $url,
+                    'timeout'  => 2.0,
+                ]);
+
+                $testServiceRequest = new \GuzzleHttp\Psr7\Request('POST', $url, $headers, json_encode($arguments));
+                $response = $client->sendRequest($testServiceRequest);
+
+                $tracer->endActiveSpan();
+            }
+        }
+    
+        return new Response(
+            'Subsequent calls from the trace-context test service are dispatched',
+            Response::HTTP_OK,
+            ['content-type' => 'text/html']
+        );
+    }
+}

--- a/tests/TraceContext/W3CTestService/TestController.php
+++ b/tests/TraceContext/W3CTestService/TestController.php
@@ -1,18 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
+use GuzzleHttp\Client;
 use OpenTelemetry\Sdk\Trace\PropagationMap;
-use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\SpanContext;
-use OpenTelemetry\Sdk\Trace\TraceContext;
-use OpenTelemetry\Sdk\Trace\TraceState;
 
+use OpenTelemetry\Sdk\Trace\TraceContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
 
-use GuzzleHttp\Client;
+use Symfony\Component\Routing\Annotation\Route;
 
 class TestController
 {

--- a/tests/TraceContext/W3CTestService/TestController.php
+++ b/tests/TraceContext/W3CTestService/TestController.php
@@ -7,11 +7,9 @@ namespace App\Controller;
 use GuzzleHttp\Client;
 use OpenTelemetry\Sdk\Trace\PropagationMap;
 use OpenTelemetry\Sdk\Trace\SpanContext;
-
 use OpenTelemetry\Sdk\Trace\TraceContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-
 use Symfony\Component\Routing\Annotation\Route;
 
 class TestController

--- a/tests/TraceContext/W3CTestService/index.php
+++ b/tests/TraceContext/W3CTestService/index.php
@@ -18,12 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
 
-if ($_SERVER['APP_DEBUG']) {
-    umask(0000);
-
-    Debug::enable();
-}
-
 $sampler = new AlwaysOnSampler();
 $samplingResult = $sampler->shouldSample(
     Context::getCurrent(),

--- a/tests/TraceContext/W3CTestService/index.php
+++ b/tests/TraceContext/W3CTestService/index.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use App\Kernel;
@@ -13,8 +15,7 @@ use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
-
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+(new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
 
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);

--- a/tests/TraceContext/W3CTestService/index.php
+++ b/tests/TraceContext/W3CTestService/index.php
@@ -13,7 +13,6 @@ use OpenTelemetry\Sdk\Trace\SpanProcessor\BatchSpanProcessor;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
 use OpenTelemetry\Trace as API;
 use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
 (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');

--- a/tests/TraceContext/W3CTestService/index.php
+++ b/tests/TraceContext/W3CTestService/index.php
@@ -1,0 +1,55 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Kernel;
+use OpenTelemetry\Contrib\Jaeger\Exporter as JaegerExporter;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace as API;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\HttpFoundation\Request;
+
+
+(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+
+    Debug::enable();
+}
+
+$sampler = new AlwaysOnSampler();
+$samplingResult = $sampler->shouldSample(
+    null,
+    md5((string) microtime(true)),
+    substr(md5((string) microtime(true)), 16),
+    'io.opentelemetry.example',
+    API\SpanKind::KIND_INTERNAL
+);
+
+$exporter = new JaegerExporter(
+    'W3C Trace-Context Test Service',
+    'http://localhost:9412/api/v2/spans'
+);
+
+if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+    $tracer = (new TracerProvider())
+        ->addSpanProcessor(new BatchSpanProcessor($exporter, Clock::get()))
+        ->getTracer('io.opentelemetry.contrib.php');
+
+    $request = Request::createFromGlobals();
+    $span = $tracer->startAndActivateSpan($request->getUri());
+}
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);
+
+if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+    $tracer->endActiveSpan();
+}

--- a/tests/TraceContext/W3CTestService/symfony-setup
+++ b/tests/TraceContext/W3CTestService/symfony-setup
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Install Symfony
+curl -sS https://get.symfony.com/cli/installer | bash
+mv /root/.symfony/bin/symfony /usr/local/bin/symfony
+
+# Set up Symfony test application
+cd tests/TraceContext/W3CTestService
+rm -rf test_app
+composer create-project symfony/skeleton test_app
+
+# Move our files into the test application
+cp index.php test_app/public/index.php
+cp TestController.php test_app/src/Controller/TestController.php
+cd test_app
+
+composer require annotations
+composer require open-telemetry/opentelemetry
+
+# Start the server to start listening in the background
+symfony server:start -d --port=8001
+
+# Setup the TraceContext Test Service
+apt-get install -y python3-pip 
+pip3 install aiohttp
+
+cd ..
+rm -rf trace-context
+git clone https://github.com/w3c/trace-context.git
+
+cd trace-context/test
+
+# Run the test
+python3 test.py http://127.0.0.1:8001/test

--- a/tests/TraceContext/W3CTestService/symfony-setup
+++ b/tests/TraceContext/W3CTestService/symfony-setup
@@ -7,7 +7,7 @@ mv /root/.symfony/bin/symfony /usr/local/bin/symfony
 # Set up Symfony test application
 cd tests/TraceContext/W3CTestService
 rm -rf test_app
-composer create-project symfony/skeleton test_app
+symfony new test_app --version=5.2
 
 # Move our files into the test application
 cp index.php test_app/public/index.php

--- a/tests/TraceContext/W3CTestService/symfony-setup
+++ b/tests/TraceContext/W3CTestService/symfony-setup
@@ -15,7 +15,15 @@ cp TestController.php test_app/src/Controller/TestController.php
 cd test_app
 
 composer require annotations
-composer require open-telemetry/opentelemetry
+
+# Link the local opentelemetry changes to vendor/open-telemetry
+composer require open-telemetry/opentelemetry "*"
+composer config repositories.local \
+    '{"type": "path", "url": "/usr/src/open-telemetry/", "options": {"symLink": true }}' \
+    --file composer.json
+rm composer.lock
+composer clearcache
+composer install
 
 # Start the server to start listening in the background
 symfony server:start -d --port=8001


### PR DESCRIPTION
This fixes #217.

There are currently 11 tests (out of 40) that are failing. These are mostly related to the `tracestate` header and will be fixed as part of #181. See the `README` for info on how to run the test. 