### PR TITLE
Update sampling behavior

### DIFF
--- a/examples/AlwaysOffTraceExample.php
+++ b/examples/AlwaysOffTraceExample.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOffSampler;
@@ -12,14 +13,13 @@ use OpenTelemetry\Trace as API;
 
 $sampler = new AlwaysOffSampler();
 $samplingResult = $sampler->shouldSample(
-    null,
+    Context::getCurrent(),
     md5((string) microtime(true)),
-    substr(md5((string) microtime(true)), 16),
     'io.opentelemetry.example',
     API\SpanKind::KIND_INTERNAL
 );
 
-if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+if (SamplingResult::RECORD_AND_SAMPLE === $samplingResult->getDecision()) {
     $tracer = (new TracerProvider())
         ->getTracer('io.opentelemetry.contrib.php');
 

--- a/examples/AlwaysOnJaegerExample.php
+++ b/examples/AlwaysOnJaegerExample.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Contrib\Jaeger\Exporter as JaegerExporter;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
@@ -14,9 +15,8 @@ use OpenTelemetry\Trace as API;
 
 $sampler = new AlwaysOnSampler();
 $samplingResult = $sampler->shouldSample(
-    null,
+    Context::getCurrent(),
     md5((string) microtime(true)),
-    substr(md5((string) microtime(true)), 16),
     'io.opentelemetry.example',
     API\SpanKind::KIND_INTERNAL
 );
@@ -26,7 +26,7 @@ $exporter = new JaegerExporter(
     'http://jaeger:9412/api/v2/spans'
 );
 
-if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+if (SamplingResult::RECORD_AND_SAMPLE === $samplingResult->getDecision()) {
     echo 'Starting AlwaysOnJaegerExample';
     $tracer = (new TracerProvider())
         ->addSpanProcessor(new BatchSpanProcessor($exporter, Clock::get()))

--- a/examples/AlwaysOnNewrelicExample.php
+++ b/examples/AlwaysOnNewrelicExample.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Contrib\Newrelic\Exporter as NewrelicExporter;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
@@ -20,9 +21,8 @@ use OpenTelemetry\Trace as API;
 
 $sampler = new AlwaysOnSampler();
 $samplingResult = $sampler->shouldSample(
-    null,
+    Context::getCurrent(),
     md5((string) microtime(true)),
-    substr(md5((string) microtime(true)), 16),
     'io.opentelemetry.example',
     API\SpanKind::KIND_INTERNAL
 );
@@ -54,7 +54,7 @@ $newrelicExporter = new NewrelicExporter(
     $licenseKey
 );
 
-if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+if (SamplingResult::RECORD_AND_SAMPLE === $samplingResult->getDecision()) {
     echo 'Starting AlwaysOnNewrelicExample';
     $tracer = (new TracerProvider())
         ->addSpanProcessor(new SimpleSpanProcessor($newrelicExporter))

--- a/examples/AlwaysOnOTLPExample.php
+++ b/examples/AlwaysOnOTLPExample.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Contrib\Otlp\Exporter as OTLPExporter;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
@@ -14,9 +15,8 @@ use OpenTelemetry\Trace as API;
 
 $sampler = new AlwaysOnSampler();
 $samplingResult = $sampler->shouldSample(
-    null,
+    Context::getCurrent(),
     md5((string) microtime(true)),
-    substr(md5((string) microtime(true)), 16),
     'io.opentelemetry.example',
     API\SpanKind::KIND_INTERNAL
 );
@@ -24,7 +24,7 @@ $Exporter = new OTLPExporter(
     'OTLP Example Service'
 );
 
-if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+if (SamplingResult::RECORD_AND_SAMPLE === $samplingResult->getDecision()) {
     echo 'Starting OTLPExample';
     $tracer = (new TracerProvider())
         ->addSpanProcessor(new SimpleSpanProcessor($Exporter))

--- a/examples/AlwaysOnZipkinExample.php
+++ b/examples/AlwaysOnZipkinExample.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Contrib\Zipkin\Exporter as ZipkinExporter;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
@@ -14,9 +15,8 @@ use OpenTelemetry\Trace as API;
 
 $sampler = new AlwaysOnSampler();
 $samplingResult = $sampler->shouldSample(
-    null,
+    Context::getCurrent(),
     md5((string) microtime(true)),
-    substr(md5((string) microtime(true)), 16),
     'io.opentelemetry.example',
     API\SpanKind::KIND_INTERNAL
 );
@@ -26,7 +26,7 @@ $zipkinExporter = new ZipkinExporter(
     'http://zipkin:9411/api/v2/spans'
 );
 
-if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+if (SamplingResult::RECORD_AND_SAMPLE === $samplingResult->getDecision()) {
     echo 'Starting AlwaysOnZipkinExample';
     $tracer = (new TracerProvider())
         ->addSpanProcessor(new SimpleSpanProcessor($zipkinExporter))
@@ -61,7 +61,7 @@ if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
         } catch (Exception $exception) {
             $span->recordException($exception);
         }
-        
+
         $tracer->endActiveSpan();
     }
     echo PHP_EOL . 'AlwaysOnZipkinExample complete!  See the results at http://localhost:9411/';

--- a/examples/AlwaysOnZipkinToNewrelicExample.php
+++ b/examples/AlwaysOnZipkinToNewrelicExample.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Contrib\ZipkinToNewrelic\Exporter as ZipkinToNewrelicExporter;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
@@ -20,9 +21,8 @@ use OpenTelemetry\Trace as API;
 
 $sampler = new AlwaysOnSampler();
 $samplingResult = $sampler->shouldSample(
-    null,
+    Context::getCurrent(),
     md5((string) microtime(true)),
-    substr(md5((string) microtime(true)), 16),
     'io.opentelemetry.example',
     API\SpanKind::KIND_INTERNAL
 );
@@ -54,7 +54,7 @@ $zipkinToNewrelicExporter = new ZipkinToNewrelicExporter(
     $licenseKey
 );
 
-if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+if (SamplingResult::RECORD_AND_SAMPLE === $samplingResult->getDecision()) {
     echo 'Starting AlwaysOnZipkinToNewRelicExample';
     $tracer = (new TracerProvider())
         ->addSpanProcessor(new SimpleSpanProcessor($zipkinToNewrelicExporter))

--- a/sdk/Trace/NoopSpan.php
+++ b/sdk/Trace/NoopSpan.php
@@ -163,6 +163,11 @@ class NoopSpan implements API\Span
         return false;
     }
 
+    public function isRemote(): bool
+    {
+        return $this->context->isRemote();
+    }
+
     public function isSampled(): bool
     {
         return false;

--- a/sdk/Trace/Sampler.php
+++ b/sdk/Trace/Sampler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Trace as API;
 
 /**
@@ -16,10 +17,9 @@ interface Sampler
     /**
      * Returns SamplingResult.
      *
-     * @param API\SpanContext|null $parentContext `SpanContext` of a parent Span. Typically extracted from the wire. Can be null.
+     * @param Context $parentContext Context with parent Span. The Span's SpanContext may be invalid to indicate a root span.
      * @param string $traceId TraceId of the Span to be created. It can be different from the TraceId in the SpanContext.
      *                        Typically in situations when the Span to be created starts a new Trace.
-     * @param string $spanId SpanId of the Span to be created.
      * @param string $spanName Name of the Span to be created.
      * @param int $spanKind Span kind.
      * @param API\Attributes|null $attributes Initial set of Attributes for the Span being constructed.
@@ -29,9 +29,8 @@ interface Sampler
      * @return SamplingResult
      */
     public function shouldSample(
-        ?API\SpanContext $parentContext,
+        Context $parentContext,
         string $traceId,
-        string $spanId,
         string $spanName,
         int $spanKind,
         ?API\Attributes $attributes = null,

--- a/sdk/Trace/Sampler/AlwaysOffSampler.php
+++ b/sdk/Trace/Sampler/AlwaysOffSampler.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace\Sampler;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Sampler;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Trace as API;
 
 /**
@@ -23,15 +26,22 @@ class AlwaysOffSampler implements Sampler
      * {@inheritdoc}
      */
     public function shouldSample(
-        ?API\SpanContext $parentContext,
+        Context $parentContext,
         string $traceId,
-        string $spanId,
         string $spanName,
         int $spanKind,
         ?API\Attributes $attributes = null,
         ?API\Links $links = null
     ): SamplingResult {
-        return new SamplingResult(SamplingResult::NOT_RECORD);
+        $parentSpan = Span::extract($parentContext);
+        $parentSpanContext = $parentSpan !== null ? $parentSpan->getContext() : SpanContext::getInvalid();
+        $traceState = $parentSpanContext->getTraceState();
+
+        return new SamplingResult(
+            SamplingResult::DROP,
+            null,
+            $traceState
+        );
     }
 
     public function getDescription(): string

--- a/sdk/Trace/Sampler/AlwaysOnSampler.php
+++ b/sdk/Trace/Sampler/AlwaysOnSampler.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace\Sampler;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Sampler;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Trace as API;
 
 /**
@@ -23,15 +26,22 @@ class AlwaysOnSampler implements Sampler
      * {@inheritdoc}
      */
     public function shouldSample(
-        ?API\SpanContext $parentContext,
+        Context $parentContext,
         string $traceId,
-        string $spanId,
         string $spanName,
         int $spanKind,
         ?API\Attributes $attributes = null,
         ?API\Links $links = null
     ): SamplingResult {
-        return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED, $attributes, $links);
+        $parentSpan = Span::extract($parentContext);
+        $parentSpanContext = $parentSpan !== null ? $parentSpan->getContext() : SpanContext::getInvalid();
+        $traceState = $parentSpanContext->getTraceState();
+
+        return new SamplingResult(
+            SamplingResult::RECORD_AND_SAMPLE,
+            null,
+            $traceState
+        );
     }
 
     public function getDescription(): string

--- a/sdk/Trace/Sampler/ParentBased.php
+++ b/sdk/Trace/Sampler/ParentBased.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace\Sampler;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Sampler;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Trace as API;
 
 /**
@@ -76,27 +79,30 @@ class ParentBased implements Sampler
      * {@inheritdoc}
      */
     public function shouldSample(
-        ?API\SpanContext $parentContext,
+        Context $parentContext,
         string $traceId,
-        string $spanId,
         string $spanName,
         int $spanKind,
         ?API\Attributes $attributes = null,
         ?API\Links $links = null
     ): SamplingResult {
-        if ($parentContext === null) {
-            return $this->root->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links);
+        $parentSpan = Span::extract($parentContext);
+        $parentSpanContext = $parentSpan !== null ? $parentSpan->getContext() : SpanContext::getInvalid();
+        
+        // Invalid parent SpanContext indicates root span is being created
+        if (!$parentSpanContext->isValid()) {
+            return $this->root->shouldSample(...func_get_args());
         }
 
-        if ($parentContext->isRemote()) {
-            return $parentContext->isSampled()
-                ? $this->remoteParentSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links)
-                : $this->remoteParentNotSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links);
+        if ($parentSpanContext->isRemote()) {
+            return $parentSpanContext->isSampled()
+                ? $this->remoteParentSampled->shouldSample(...func_get_args())
+                : $this->remoteParentNotSampled->shouldSample(...func_get_args());
         }
 
-        return $parentContext->isSampled()
-            ? $this->localParentSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links)
-            : $this->localParentNotSampled->shouldSample($parentContext, $traceId, $spanId, $spanName, $spanKind, $attributes, $links);
+        return $parentSpanContext->isSampled()
+            ? $this->localParentSampled->shouldSample(...func_get_args())
+            : $this->localParentNotSampled->shouldSample(...func_get_args());
     }
 
     public function getDescription(): string

--- a/sdk/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/sdk/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\Trace\Sampler;
 
 use InvalidArgumentException;
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Sampler;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Trace as API;
 
 /**
@@ -41,31 +44,27 @@ class TraceIdRatioBasedSampler implements Sampler
      * {@inheritdoc}
      */
     public function shouldSample(
-        ?API\SpanContext $parentContext,
+        Context $parentContext,
         string $traceId,
-        string $spanId,
         string $spanName,
         int $spanKind,
         ?API\Attributes $attributes = null,
         ?API\Links $links = null
     ): SamplingResult {
         // TODO: Add config to adjust which spans get sampled (only default from specification is implemented)
-        if (null !== $parentContext && ($parentContext->getTraceFlags() & API\SpanContext::TRACE_FLAG_SAMPLED)) {
-            return new SamplingResult(SamplingResult::RECORD_AND_SAMPLED, $attributes, $links);
-        }
+        $parentSpan = Span::extract($parentContext);
+        $parentSpanContext = $parentSpan !== null ? $parentSpan->getContext() : SpanContext::getInvalid();
+        $traceState = $parentSpanContext->getTraceState();
+
         /**
          * Since php can only store up to 63 bit positive integers
          */
         $traceIdLimit = (1 << 60) - 1;
         $lowerOrderBytes = hexdec(substr($traceId, strlen($traceId) - 15, 15));
         $traceIdCondition = $lowerOrderBytes < round($this->probability * $traceIdLimit);
-        $decision = SamplingResult::NOT_RECORD;
-        // TODO: Also sample Spans with remote parent
-        if (null == $parentContext && $traceIdCondition) {
-            $decision = SamplingResult::RECORD_AND_SAMPLED;
-        }
+        $decision = $traceIdCondition ? SamplingResult::RECORD_AND_SAMPLE : SamplingResult::DROP;
 
-        return new SamplingResult($decision, $attributes, $links);
+        return new SamplingResult($decision, $attributes, $traceState);
     }
 
     public function getDescription(): string

--- a/sdk/Trace/SamplingResult.php
+++ b/sdk/Trace/SamplingResult.php
@@ -9,19 +9,19 @@ use OpenTelemetry\Trace as API;
 final class SamplingResult
 {
     /**
-     * Span will not be recorded and all events and attributes will be dropped
+     * Span will not be recorded and all events and attributes will be dropped.
      */
-    public const NOT_RECORD = 0;
+    public const DROP = 0;
 
     /**
-     * Span will be recorded but SpanExporters will not receive this Span
+     * Span will be recorded but SpanExporters will not receive this Span.
      */
-    public const RECORD = 1;
+    public const RECORD_ONLY = 1;
 
     /**
      * Span will be recorder and exported.
      */
-    public const RECORD_AND_SAMPLED = 2;
+    public const RECORD_AND_SAMPLE = 2;
 
     /**
      * @var int A sampling Decision.
@@ -34,15 +34,15 @@ final class SamplingResult
     private $attributes;
 
     /**
-     * @var ?API\Links Collection of links that will be associated with the Span to be created.
+     * @var ?API\TraceState A Tracestate that will be associated with the Span through the new SpanContext.
      */
-    private $links;
+    private $traceState;
 
-    public function __construct(int $decision, ?API\Attributes $attributes = null, ?API\Links $links = null)
+    public function __construct(int $decision, ?API\Attributes $attributes = null, ?API\TraceState $traceState = null)
     {
         $this->decision = $decision;
         $this->attributes = $attributes;
-        $this->links = $links;
+        $this->traceState = $traceState;
     }
 
     /**
@@ -64,8 +64,8 @@ final class SamplingResult
     /**
      * Return a collection of links that will be associated with the Span to be created.
      */
-    public function getLinks(): ?API\Links
+    public function getTraceState(): ?API\TraceState
     {
-        return $this->links;
+        return $this->traceState;
     }
 }

--- a/sdk/Trace/TracerProvider.php
+++ b/sdk/Trace/TracerProvider.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Sdk\Trace;
 use OpenTelemetry\Sdk\Resource\ResourceConstants;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\Sdk\Trace\Sampler\ParentBased;
 use OpenTelemetry\Sdk\Trace\SpanProcessor\SpanMultiProcessor;
 use OpenTelemetry\Trace as API;
 
@@ -41,7 +42,7 @@ final class TracerProvider implements API\TracerProvider
     {
         $this->spanProcessors = new SpanMultiProcessor();
         $this->resource = $resource ?? ResourceInfo::emptyResource();
-        $this->sampler = $sampler ?? new AlwaysOnSampler();
+        $this->sampler = $sampler ?? new ParentBased(new AlwaysOnSampler());
         $this->idGenerator = $idGenerator ?? new RandomIdGenerator();
 
         register_shutdown_function([$this, 'shutdown']);

--- a/tests/Sdk/Integration/AlwaysOffSamplerTest.php
+++ b/tests/Sdk/Integration/AlwaysOffSamplerTest.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Integration;
 
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Sdk\Trace\NoopSpan;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TraceState;
 use OpenTelemetry\Trace as API;
 use PHPUnit\Framework\TestCase;
 
@@ -13,20 +18,33 @@ class AlwaysOffSamplerTest extends TestCase
 {
     public function testAlwaysOffSampler()
     {
+        $parentTraceState = $this->createMock(TraceState::class);
         $sampler = new AlwaysOffSampler();
         $decision = $sampler->shouldSample(
-            null,
+            $this->createParentContext(true, false, $parentTraceState),
             '4bf92f3577b34da6a3ce929d0e0e4736',
-            '00f067aa0ba902b7',
             'test.opentelemetry.io',
             API\SpanKind::KIND_INTERNAL
         );
-        $this->assertEquals(SamplingResult::NOT_RECORD, $decision->getDecision());
+
+        $this->assertEquals(SamplingResult::DROP, $decision->getDecision());
+        $this->assertEquals($parentTraceState, $decision->getTraceState());
     }
 
     public function testAlwaysOnSamplerDescription()
     {
         $sampler = new AlwaysOffSampler();
         $this->assertEquals('AlwaysOffSampler', $sampler->getDescription());
+    }
+
+    private function createParentContext(bool $sampled, bool $isRemote, ?API\TraceState $traceState = null): Context
+    {
+        return Span::insert(new NoopSpan(SpanContext::restore(
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            '00f067aa0ba902b7',
+            $sampled,
+            $isRemote,
+            $traceState
+        )), new Context());
     }
 }

--- a/tests/Sdk/Integration/AlwaysOnSamplerTest.php
+++ b/tests/Sdk/Integration/AlwaysOnSamplerTest.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Integration;
 
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Sdk\Trace\NoopSpan;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TraceState;
 use OpenTelemetry\Trace as API;
 use PHPUnit\Framework\TestCase;
 
@@ -13,20 +18,33 @@ class AlwaysOnSamplerTest extends TestCase
 {
     public function testAlwaysOnSamplerDecision()
     {
+        $parentTraceState = $this->createMock(TraceState::class);
         $sampler = new AlwaysOnSampler();
         $decision = $sampler->shouldSample(
-            null,
+            $this->createParentContext(true, false, $parentTraceState),
             '4bf92f3577b34da6a3ce929d0e0e4736',
-            '00f067aa0ba902b7',
             'test.opentelemetry.io',
             API\SpanKind::KIND_INTERNAL
         );
-        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLED, $decision->getDecision());
+
+        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
+        $this->assertEquals($parentTraceState, $decision->getTraceState());
     }
 
     public function testAlwaysOnSamplerDescription()
     {
         $sampler = new AlwaysOnSampler();
         $this->assertEquals('AlwaysOnSampler', $sampler->getDescription());
+    }
+
+    private function createParentContext(bool $sampled, bool $isRemote, ?API\TraceState $traceState = null): Context
+    {
+        return Span::insert(new NoopSpan(SpanContext::restore(
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            '00f067aa0ba902b7',
+            $sampled,
+            $isRemote,
+            $traceState
+        )), new Context());
     }
 }

--- a/tests/Sdk/Integration/TraceIdRatioBasedSamplerTest.php
+++ b/tests/Sdk/Integration/TraceIdRatioBasedSamplerTest.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Sdk\Integration;
 
 use InvalidArgumentException;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Sdk\Trace\NoopSpan;
 use OpenTelemetry\Sdk\Trace\Sampler\TraceIdRatioBasedSampler;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TraceState;
 use OpenTelemetry\Trace as API;
 use PHPUnit\Framework\TestCase;
 
@@ -24,57 +29,79 @@ class TraceIdRatioBasedSamplerTest extends TestCase
     {
         $sampler = new TraceIdRatioBasedSampler(0.0);
         $decision = $sampler->shouldSample(
-            null,
+            new Context(),
             '4bf92f3577b34da6a3ce929d0e0e4736',
-            '00f067aa0ba902b7',
             'test.opentelemetry.io',
             API\SpanKind::KIND_INTERNAL
         );
-        $this->assertEquals(SamplingResult::NOT_RECORD, $decision->getDecision());
+        $this->assertEquals(SamplingResult::DROP, $decision->getDecision());
     }
 
     public function testAlwaysTraceIdRatioBasedSamplerDecision()
     {
         $sampler = new TraceIdRatioBasedSampler(1.0);
         $decision = $sampler->shouldSample(
-            null,
+            new Context(),
             '4bf92f3577b34da6a3ce929d0e0e4736',
-            '00f067aa0ba902b7',
             'test.opentelemetry.io',
             API\SpanKind::KIND_INTERNAL
         );
-        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLED, $decision->getDecision());
+        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
     }
 
     public function testFailingTraceIdRatioBasedSamplerDecision()
     {
         $sampler = new TraceIdRatioBasedSampler(0.99);
         $decision = $sampler->shouldSample(
-            null,
+            new Context(),
             '4bf92f3577b34da6afffffffffffffff',
-            '00f067aa0ba902b7',
             'test.opentelemetry.io',
             API\SpanKind::KIND_INTERNAL
         );
-        $this->assertEquals(SamplingResult::NOT_RECORD, $decision->getDecision());
+        $this->assertEquals(SamplingResult::DROP, $decision->getDecision());
     }
 
     public function testPassingTraceIdRatioBasedSamplerDecision()
     {
         $sampler = new TraceIdRatioBasedSampler(0.01);
         $decision = $sampler->shouldSample(
-            null,
+            new Context(),
             '4bf92f3577b34da6a000000000000000',
-            '00f067aa0ba902b7',
             'test.opentelemetry.io',
             API\SpanKind::KIND_INTERNAL
         );
-        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLED, $decision->getDecision());
+        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
+    }
+
+    public function testIgnoreParentSampledFlag()
+    {
+        $parentTraceState = $this->createMock(TraceState::class);
+        $sampler = new TraceIdRatioBasedSampler(0.0);
+        $samplingResult = $sampler->shouldSample(
+            $this->createParentContext(true, true, $parentTraceState),
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            'test.opentelemetry.io',
+            API\SpanKind::KIND_INTERNAL
+        );
+
+        $this->assertEquals(SamplingResult::DROP, $samplingResult->getDecision());
+        $this->assertEquals($parentTraceState, $samplingResult->getTraceState());
     }
 
     public function testTraceIdRatioBasedSamplerDescription()
     {
         $sampler = new TraceIdRatioBasedSampler(0.0001);
         $this->assertEquals('TraceIdRatioBasedSampler{0.000100}', $sampler->getDescription());
+    }
+
+    private function createParentContext(bool $sampled, bool $isRemote, ?API\TraceState $traceState = null): Context
+    {
+        return Span::insert(new NoopSpan(SpanContext::restore(
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            '00f067aa0ba902b7',
+            $sampled,
+            $isRemote,
+            $traceState
+        )), new Context());
     }
 }

--- a/tests/Sdk/Integration/TracerTest.php
+++ b/tests/Sdk/Integration/TracerTest.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Integration\Trace;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\NoopSpan;
+use OpenTelemetry\Sdk\Trace\Sampler;
 use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOffSampler;
+use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Sdk\Trace\TraceState;
 use OpenTelemetry\Trace\SpanContext;
 use PHPUnit\Framework\TestCase;
 
@@ -29,5 +34,37 @@ class TracerTest extends TestCase
 
         $this->assertInstanceOf(NoopSpan::class, $span);
         $this->assertNotEquals(SpanContext::TRACE_FLAG_SAMPLED, $span->getContext()->getTraceFlags());
+    }
+
+    /**
+     * @test
+     */
+    public function samplerMayOverrideParentsTraceState()
+    {
+        $parentTraceState = new TraceState('orig-key=orig_value');
+        $parentContext = Span::insert(new NoopSpan(\OpenTelemetry\Sdk\Trace\SpanContext::restore(
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            '00f067aa0ba902b7',
+            true,
+            false,
+            $parentTraceState
+        )), new Context());
+
+        $newTraceState = new TraceState('new-key=new_value');
+
+        $sampler = $this->createMock(Sampler::class);
+        $sampler->method('shouldSample')
+            ->willReturn(new SamplingResult(
+                SamplingResult::RECORD_AND_SAMPLE,
+                null,
+                $newTraceState
+            ));
+
+        $tracerProvider = new TracerProvider(null, $sampler);
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $span = $tracer->startSpan('test.span', $parentContext);
+
+        $this->assertNotEquals($parentTraceState, $span->getContext()->getTraceState());
+        $this->assertEquals($newTraceState, $span->getContext()->getTraceState());
     }
 }

--- a/tests/Sdk/Integration/TracerTest.php
+++ b/tests/Sdk/Integration/TracerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Integration\Trace;
+
+use OpenTelemetry\Sdk\Trace\NoopSpan;
+use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOffSampler;
+use OpenTelemetry\Sdk\Trace\SpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace\SpanContext;
+use PHPUnit\Framework\TestCase;
+
+class TracerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function noopSpanShouldBeStartedWhenSamplingResultIsDrop()
+    {
+        $alwaysOffSampler = new AlwaysOffSampler();
+        $tracerProvider = new TracerProvider(null, $alwaysOffSampler);
+        $processor = self::createMock(SpanProcessor::class);
+        $tracerProvider->addSpanProcessor($processor);
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+
+        $processor->expects($this->never())->method('onStart');
+        $span = $tracer->startSpan('test.span');
+
+        $this->assertInstanceOf(NoopSpan::class, $span);
+        $this->assertNotEquals(SpanContext::TRACE_FLAG_SAMPLED, $span->getContext()->getTraceFlags());
+    }
+}

--- a/tests/Sdk/Unit/Trace/SamplingResultTest.php
+++ b/tests/Sdk/Unit/Trace/SamplingResultTest.php
@@ -6,20 +6,20 @@ namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\SamplingResult;
-use OpenTelemetry\Trace\Links;
+use OpenTelemetry\Trace\TraceState;
 use PHPUnit\Framework\TestCase;
 
-class SpanResultTest extends TestCase
+class SamplingResultTest extends TestCase
 {
     /**
      * @dataProvider provideAttributesAndLinks
      */
-    public function testAttributesAndLinksGetters($attributes, $links)
+    public function testAttributesAndLinksGetters($attributes, $traceState)
     {
-        $result = new SamplingResult(SamplingResult::NOT_RECORD, $attributes, $links);
+        $result = new SamplingResult(SamplingResult::DROP, $attributes, $traceState);
 
         $this->assertSame($attributes, $result->getAttributes());
-        $this->assertSame($links, $result->getLinks());
+        $this->assertSame($traceState, $result->getTraceState());
     }
 
     /**
@@ -30,7 +30,7 @@ class SpanResultTest extends TestCase
         return [
             [
                 new Attributes(['foo' => 'bar']),
-                $this->createMock(Links::class),
+                $this->createMock(TraceState::class),
             ],
             [
                 null,

--- a/tests/Sdk/Unit/Trace/TracerProviderTest.php
+++ b/tests/Sdk/Unit/Trace/TracerProviderTest.php
@@ -58,12 +58,12 @@ class TracerProviderTest extends TestCase
     /**
      * @test
      */
-    public function newTraceProviderDefaultsToAlwaysOnSampler()
+    public function newTraceProviderDefaultsToParentBasedSampler()
     {
         $traceProvider = new TracerProvider();
         $description = $traceProvider->getSampler()->getDescription();
 
-        self::assertSame($description, 'AlwaysOnSampler');
+        self::assertSame($description, 'ParentBased');
     }
 
     /**


### PR DESCRIPTION
* Change shouldSample() method signature to accept the Context
* Default sampler is ParentBased(root=AlwaysOn)
* Avoid to start sampled and non-recording span, return NooSpan
* Change names of SamplingResult constants: DROP, RECORD_ONLY, RECORD_AND_SAMPLE
* Return an updated TraceState in SamplingResult (parent TraceState by default)
* Merge Attributes from the SamplingResult with the Attributes provided in the startSpan method

Fixes #268