### PR TITLE
Update docs-update.yml

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
       - name: make-pr
         env:
-          API_TOKEN_GITHUB: ${{secrets.GITHUB_TOKEN}}
+          API_TOKEN_GITHUB: ${{secrets.GITHUB_PAT_TOKEN}}
           # Destination repo should always be 'open-telemetry/opentelemetry.io'
           DESTINATION_REPO: open-telemetry/opentelemetry.io
           # Destination path should be the absolute path to your language's friendly name in the docs tree (i.e, 'content/en/docs/java')


### PR DESCRIPTION
Disambiguate token name. A maintainer needs to create a PAT with `public_repo, write:org, read:org` scopes and set it to `GITHUB_PAT_TOKEN`.