### PR TITLE
Updated components of automated examples.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ trace examples: FORCE
         # The following examples do not use the DC_RUN_PHP global because they need environment variables.
 	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnNewrelicExample.php
 	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnZipkinToNewrelicExample.php
+i	docker-compose run -e OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317 --rm php php ./examples/AlwaysOnOTLPGrpcExample.php
+
 
 metrics-prometheus-example:
 	@docker-compose -f docker-compose.prometheus.yaml up -d web

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ trace examples: FORCE
         # The following examples do not use the DC_RUN_PHP global because they need environment variables.
 	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnNewrelicExample.php
 	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnZipkinToNewrelicExample.php
-i	docker-compose run -e OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317 --rm php php ./examples/AlwaysOnOTLPGrpcExample.php
+	docker-compose run -e OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317 --rm php php ./examples/AlwaysOnOTLPGrpcExample.php
 
 
 metrics-prometheus-example:

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ trace examples: FORCE
         # The following examples do not use the DC_RUN_PHP global because they need environment variables.
 	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnNewrelicExample.php
 	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnZipkinToNewrelicExample.php
-	docker-compose run -e OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317 --rm php php ./examples/AlwaysOnOTLPGrpcExample.php
-
+	docker-compose -f docker-compose-collector.yaml run -e OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317 --rm php php ./examples/AlwaysOnOTLPGrpcExample.php
 
 metrics-prometheus-example:
 	@docker-compose -f docker-compose.prometheus.yaml up -d web

--- a/docker-compose-collector.yaml
+++ b/docker-compose-collector.yaml
@@ -1,0 +1,34 @@
+version: '3.7'
+services:
+  php:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    volumes:
+    - ./:/usr/src/myapp
+    depends_on:
+      - otel-collector
+  zipkin:
+    image: openzipkin/zipkin-slim
+    ports:
+    - 9411:9411
+  jaeger:
+    image: jaegertracing/all-in-one
+    environment:
+      COLLECTOR_ZIPKIN_HTTP_PORT: 9412
+    ports:
+    - 9412:9412
+    - 16686:16686
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib
+    command: ["--config=/etc/otel-collector-config.yml"]
+    volumes:
+      - ./files/collector/otel-collector-config.yml:/etc/otel-collector-config.yml
+    ports:
+      - "1888:1888"   # pprof extension
+      - "8888:8888"   # Prometheus metrics exposed by the collector
+      - "8889:8889"   # Prometheus exporter metrics
+      - "13133:13133" # health_check extension
+      - "9411"   # Zipkin receiver
+      - "4317:4317"        # OTLP gRPC receiver
+      - "55680:55679" # zpages extension

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,6 @@ services:
       dockerfile: docker/Dockerfile
     volumes:
     - ./:/usr/src/myapp
-    depends_on:
-      - otel-collector
   zipkin:
     image: openzipkin/zipkin-slim
     ports:
@@ -19,16 +17,3 @@ services:
     ports:
     - 9412:9412
     - 16686:16686
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib
-    command: ["--config=/etc/otel-collector-config.yml"]
-    volumes:
-      - ./files/collector/otel-collector-config.yml:/etc/otel-collector-config.yml
-    ports:
-      - "1888:1888"   # pprof extension
-      - "8888:8888"   # Prometheus metrics exposed by the collector
-      - "8889:8889"   # Prometheus exporter metrics
-      - "13133:13133" # health_check extension
-      - "9411"   # Zipkin receiver
-      - "4317:4317"        # OTLP gRPC receiver
-      - "55680:55679" # zpages extension

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
       dockerfile: docker/Dockerfile
     volumes:
     - ./:/usr/src/myapp
+    depends_on:
+      - otel-collector
   zipkin:
     image: openzipkin/zipkin-slim
     ports:
@@ -17,3 +19,16 @@ services:
     ports:
     - 9412:9412
     - 16686:16686
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib
+    command: ["--config=/etc/otel-collector-config.yml"]
+    volumes:
+      - ./files/collector/otel-collector-config.yml:/etc/otel-collector-config.yml
+    ports:
+      - "1888:1888"   # pprof extension
+      - "8888:8888"   # Prometheus metrics exposed by the collector
+      - "8889:8889"   # Prometheus exporter metrics
+      - "13133:13133" # health_check extension
+      - "9411"   # Zipkin receiver
+      - "4317:4317"        # OTLP gRPC receiver
+      - "55680:55679" # zpages extension

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,4 +9,9 @@ docker-php-ext-enable ast xdebug && \
 # The pcntl extension is used for speeding up `make phan`
 docker-php-ext-install pcntl
 
+# install GRPC
+RUN apt install -y --no-install-recommends zlib1g-dev && \
+    pecl install grpc && \
+    docker-php-ext-enable grpc
+
 WORKDIR /usr/src/myapp

--- a/files/collector/otel-collector-config.yml
+++ b/files/collector/otel-collector-config.yml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+  zipkin:
+
+exporters:
+  zipkin:
+    endpoint: "http://zipkin:9411/api/v2/spans"
+  logging:
+    loglevel: debug
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+  zpages:
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp, zipkin]
+      exporters: [zipkin, logging]
+      processors: [batch]

--- a/files/collector/otel-collector-config.yml
+++ b/files/collector/otel-collector-config.yml
@@ -7,6 +7,10 @@ receivers:
 exporters:
   zipkin:
     endpoint: "http://zipkin:9411/api/v2/spans"
++  newrelic:
++    apikey: 'ADD_A_LICENSE_KEY_HERE'
++    timeout: 30s
++    spans_host_override: "trace-api.newrelic.com"
   logging:
     loglevel: debug
 
@@ -23,5 +27,5 @@ service:
   pipelines:
     traces:
       receivers: [otlp, zipkin]
-      exporters: [zipkin, logging]
+      exporters: [zipkin, logging, newrelic]
       processors: [batch]

--- a/files/collector/otel-collector-config.yml
+++ b/files/collector/otel-collector-config.yml
@@ -7,10 +7,10 @@ receivers:
 exporters:
   zipkin:
     endpoint: "http://zipkin:9411/api/v2/spans"
-+  newrelic:
-+    apikey: 'ADD_A_LICENSE_KEY_HERE'
-+    timeout: 30s
-+    spans_host_override: "trace-api.newrelic.com"
+  newrelic:
+    apikey: 'ADD_A_LICENSE_KEY_HERE'
+    timeout: 30s
+    spans_host_override: "trace-api.newrelic.com"
   logging:
     loglevel: debug
 


### PR DESCRIPTION
* Added grpc capabilities to the PHP container dockerfile.
* Added an otel collector (exports to `logging`) to `docker-compose.yaml` to exercise the OTLPGrpc Exporter.
* Edited Makefile to call the OTLPGrpc example.
* Added a file needed to configure the otel collector to send traces directly to logging.

This will automatically spin up an `otel/opentelemetry-collector-contrib` otel [collector](https://github.com/open-telemetry/opentelemetry-collector-contrib) and functional backends to easily demonstrate the newest functionality of the OTLP Grpc Exporter once #272  is merged. This streamlines the process by adding it to the examples in the Makefile.  If users want to experiment with their own credentials/otel backends, they just need to modify `files/collector/otel-collector-config.yml` with the specific information and that will be automatically spun up the next time they run 'make trace'