### PR TITLE
Trace context key extraction fix

### DIFF
--- a/sdk/Trace/PropagationMap.php
+++ b/sdk/Trace/PropagationMap.php
@@ -25,12 +25,15 @@ class PropagationMap implements API\PropagationGetter, API\PropagationSetter
             }
 
             foreach ($carrier as $k => $value) {
-                if (strtolower($k) === $lKey) {
-                    if (\is_array($value)) {
-                        return empty($value) ? null : $value[0];
-                    }
+                // Ensure traceparent and tracestate header keys are lowercase
+                if (is_string($k)) {
+                    if (strtolower($k) === $lKey) {
+                        if (\is_array($value)) {
+                            return empty($value) ? null : $value[0];
+                        }
 
-                    return $value;
+                        return $value;
+                    }
                 }
             }
 

--- a/sdk/Trace/PropagationMap.php
+++ b/sdk/Trace/PropagationMap.php
@@ -26,8 +26,8 @@ class PropagationMap implements API\PropagationGetter, API\PropagationSetter
 
             foreach ($carrier as $k => $value) {
                 // Ensure traceparent and tracestate header keys are lowercase
-                if (is_string($k)) {
-                    if (strtolower($k) === $lKey) {
+                if (\is_string($k)) {
+                    if (\strtolower($k) === $lKey) {
                         if (\is_array($value)) {
                             return empty($value) ? null : $value[0];
                         }

--- a/tests/Sdk/Unit/Trace/PropagationMapTest.php
+++ b/tests/Sdk/Unit/Trace/PropagationMapTest.php
@@ -56,7 +56,7 @@ class PropagationMapTest extends TestCase
 
         $this->assertNull($map->get([], 'a'));
         $this->assertNull($map->get($carrier, 'b'));
-         
+
         $this->expectException(\InvalidArgumentException::class);
         $value = $map->get('invalid carrier', 'a');
     }
@@ -123,6 +123,22 @@ class PropagationMapTest extends TestCase
         ];
         $map = new PropagationMap();
         $this->assertSame('alpha', $map->get($carrier, 'a'));
+        $this->assertSame('bravo', $map->get($carrier, 'b'));
+    }
+
+    /**
+     * @test
+     */
+    public function testGetNumericalKeyFromCarrier()
+    {
+        // Carrier contains an array as one of the values
+        $carrier = [
+            1 => ['alpha'],
+            'b' => 'bravo',
+        ];
+        var_dump($carrier);
+        $map = new PropagationMap();
+        $this->assertNull($map->get($carrier, '1'));
         $this->assertSame('bravo', $map->get($carrier, 'b'));
     }
 }

--- a/tests/Sdk/Unit/Trace/TraceContextTest.php
+++ b/tests/Sdk/Unit/Trace/TraceContextTest.php
@@ -68,6 +68,26 @@ class TraceContextTest extends TestCase
     /**
      * @test
      */
+    public function testExtractCaseInsensitiveHeaders()
+    {
+        $tracestateValue = 'vendor2=opaqueValue2,vendor3=opaqueValue3';
+
+        $carrier = ['TrAcEpArEnT' => self::TRACEPARENTVALUE,
+                    'TrAcEsTaTe' => $tracestateValue, ];
+
+        $map = new PropagationMap();
+        $context = TraceContext::extract($carrier, $map);
+
+        $extractedTraceparent = '00-' . $context->getTraceId() . '-' . $context->getSpanId() . '-' . ($context->isSampled() ? '01' : '00');
+        $this->assertSame(self::TRACEPARENTVALUE, $extractedTraceparent);
+
+        $extractedTracestate = $context->getTraceState();
+        $this->assertSame($tracestateValue, $extractedTracestate ? $extractedTracestate->build() : '');
+    }
+
+    /**
+     * @test
+     */
     public function testExtractInvalidTraceparent()
     {
         $carrier = [];


### PR DESCRIPTION
There are instances where a `$carrier` containing both string and integer header keys was generating an error when it was extracting a TraceContext header. This is now fixed by ensuring the key is a string before converting it to lowercase. See #321  for more information.

```
Uncaught TypeError: strtolower() expects parameter 1 to be string,
int given in /vendor/open-telemetry/opentelemetry/sdk/Trace/PropagationMap.php:28
```