### PR TITLE
updating codecov.yml and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Most of our communication is done on CNCF Slack, in the [otel-php](https://cloud
 Our meetings are held weekly on zoom on Wednesdays at 10:30am PST / 1:30pm EST.  
 A Google calendar invite with the included zoom link can be found [here](https://calendar.google.com/event?action=TEMPLATE&tmeid=N2VtZXZmYnVmbzZkYjZkbTYxdjZvYTdxN21fMjAyMDA5MTZUMTczMDAwWiBrYXJlbnlyeHVAbQ&tmsrc=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com&scp=ALL)
 
-Our open issues can all be found in the [github issues tab](https://github.com/open-telemetry/opentelemetry-php/issues).  Feel free to reach out in gitter if you have any additional questions about these issues; we are always happy to talk through implementation details.
+Our open issues can all be found in the [github issues tab](https://github.com/open-telemetry/opentelemetry-php/issues).  Feel free to reach out on Slack if you have any additional questions about these issues; we are always happy to talk through implementation details.
 
 ## Installation
 The recommended way to install the library is through [Composer](http://getcomposer.org):
@@ -66,8 +66,7 @@ In order to update all the vendored libraries in the `/vendor` directory.
 
 ## Pull Requests
 
-Once you've made the update to the codebase that you'd like to submit, you may [create a pull request](https://docs.
-github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the opentelemetry-php project.
+Once you've made the update to the codebase that you'd like to submit, you may [create a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the opentelemetry-php project.
 
 After you open the pull request, the CI/CD pipeline will run all of the associated [github actions](https://github.com/open-telemetry/opentelemetry-php/actions/workflows/php.yml). 
   
@@ -125,11 +124,11 @@ Usually this process is performed as part of a code checkin.  This process runs 
 We also use [Psalm](https://psalm.dev/) as a second static analysis tool.  
 You can use our psalm docker wrapper to easily perform static analysis on your changes.
 
-Execute `make psalm` from your bash compatible shell. This process will return 0 on success. Usually this process is
-performed as part of a code checkin. This process runs during CI and is a required check. Code that doesn't match the
-standards that we have defined in
-our [psalm config](https://github.com/open-telemetry/opentelemetry-php/blob/main/psalm.xml.dist) will emit a failure
-in CI.
+To run Psalm, one can run the following command:
+```bash
+make psalm
+```
+from your bash compatible shell. This process will return 0 on success. Usually this process is performed as part of a code checkin. This process runs during CI and is a required check. Code that doesn't match the standards that we have defined in our [psalm config](https://github.com/open-telemetry/opentelemetry-php/blob/main/psalm.xml.dist) will emit a failure in CI.
 
 ## Testing
 To make sure the tests in this repo work as you expect, you can use the included docker test wrapper.  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project: true
+    patch: false
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      method: false
+      macro: false
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
This PR accomplishes two things:

* Fixes a couple typos and formatting issues in the `README.md`.
* Defines a `codecov.yml`, which makes codecov.io checks not required and updates the patch part of `codecov.io` to not execute.  This was confusing to new maintainers and didn't provide a ton of value.