### PR TITLE
Adding a github security scan for psalm

### DIFF
--- a/.github/workflows/psalm-security-analysis.yml
+++ b/.github/workflows/psalm-security-analysis.yml
@@ -1,0 +1,24 @@
+name: Psalm Security Analysis
+
+on: [push, pull_request]
+
+jobs:
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Psalm
+        uses: docker://vimeo/psalm-github-actions
+        with:
+          composer_require_dev: true
+          composer_ignore_platform_reqs: true
+          security_analysis: true
+          report_file: results.sarif
+
+      - name: Upload Security Analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-php/issues/339.

Adding  the psalm security scan tool for PHP.