### PR TITLE
Fix span processors being called twice on Tracer::endActiveSpan()

### DIFF
--- a/sdk/Trace/SpanOptions.php
+++ b/sdk/Trace/SpanOptions.php
@@ -23,10 +23,14 @@ final class SpanOptions implements API\SpanOptions
     /** @var int|null */
     private $start = null;
 
-    public function __construct(Tracer $tracer, string $name)
+    /** @var SpanProcessor|null */
+    private $spanProcessor;
+
+    public function __construct(Tracer $tracer, string $name, ?SpanProcessor $spanProcessor = null)
     {
         $this->tracer = $tracer;
         $this->name = $name;
+        $this->spanProcessor = $spanProcessor;
     }
 
     public function setSpanName(string $name): API\SpanOptions
@@ -96,7 +100,7 @@ final class SpanOptions implements API\SpanOptions
             ? SpanContext::fork($span->getContext()->getTraceId())
             : SpanContext::generate();
 
-        $span = new Span($this->name, $context, $this->parent, null, $this->tracer->getResource(), $this->kind);
+        $span = new Span($this->name, $context, $this->parent, null, $this->tracer->getResource(), $this->kind, $this->spanProcessor);
 
         if ($this->startEpochTimestamp !== null) {
             $span->setStartEpochTimestamp($this->startEpochTimestamp);

--- a/tests/Sdk/Unit/Trace/TracerTest.php
+++ b/tests/Sdk/Unit/Trace/TracerTest.php
@@ -143,4 +143,23 @@ class TracerTest extends TestCase
         $tracer->startAndActivateSpan('test.span');
         $tracer->endActiveSpan();
     }
+
+    /**
+     * @test
+     */
+    public function spanProcessorsShouldBeCalledWhenSetActiveSpanIsEnded()
+    {
+        $processor = self::createMock(SpanProcessor::class);
+
+        $processor->expects($this->exactly(1))->method('onEnd');
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($processor);
+
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+
+        $span = $tracer->startSpan('test.span');
+        $tracer->setActiveSpan($span);
+        $tracer->endActiveSpan();
+    }
 }


### PR DESCRIPTION
Resolves span processors being called twice when a `Tracer::startSpan()` span is finished with `Tracer::endActiveSpan()`.

---

Should the `Tracer::endActiveSpan()` method be removed as it is just `::getActiveSpan()->end()` now? The [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.4.0/specification/trace/api.md#tracer-operations) specifies only a create span operation for tracers.
