### PR TITLE
Add attributes parameter to Span::recordException()

### DIFF
--- a/api/Trace/Span.php
+++ b/api/Trace/Span.php
@@ -65,7 +65,7 @@ interface Span extends SpanStatus, SpanKind
      * @param Exception $exception
      * @return Span Must return $this to allow setting multiple attributes at once in a chain.
      */
-    public function recordException(Exception $exception): Span;
+    public function recordException(Exception $exception, ?Attributes $attributes = null): Span;
 
     /**
      * Calling this method is highly discouraged; the name should be set on creation and left alone.

--- a/sdk/Trace/NoopSpan.php
+++ b/sdk/Trace/NoopSpan.php
@@ -123,18 +123,9 @@ class NoopSpan implements API\Span
         return $this;
     }
 
-    public function recordException(Exception $exception): API\Span
+    public function recordException(Exception $exception, ?API\Attributes $attributes = null): API\Span
     {
-        $attributes = new Attributes(
-            [
-                'exception.type' => get_class($exception),
-                'exception.message' => $exception->getMessage(),
-                'exception.stacktrace' => $exception->getTraceAsString(),
-            ]
-        );
-        $timestamp = time();
-
-        return  $this->addEvent('exception', $timestamp, $attributes);
+        return $this;
     }
 
     public function updateName(string $name): API\Span

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -219,18 +219,21 @@ class Span implements API\Span
         return $this;
     }
 
-    public function recordException(Exception $exception): API\Span
+    public function recordException(Exception $exception, ?API\Attributes $attributes = null): API\Span
     {
-        $attributes = new Attributes(
+        $eventAttributes = new Attributes(
             [
                 'exception.type' => get_class($exception),
                 'exception.message' => $exception->getMessage(),
                 'exception.stacktrace' => $exception->getTraceAsString(),
             ]
         );
+        foreach ($attributes ?? [] as $attribute) {
+            $eventAttributes->setAttribute($attribute->getKey(), $attribute->getValue());
+        }
         $timestamp = time();
 
-        return  $this->addEvent('exception', $timestamp, $attributes);
+        return $this->addEvent('exception', $timestamp, $eventAttributes);
     }
 
     public function getEvents(): API\Events

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -414,6 +414,28 @@ class TracingTest extends TestCase
         $this->assertCount(2, $span->getEvents());
     }
 
+    public function testRecordExceptionEventAdditionalAttributes()
+    {
+        $tracerProvider = new SDK\TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracingTest');
+        $span = $tracer->startSpan('span');
+
+        $span->recordException(new Exception('exception'), new Attributes([
+            'exception.message' => 'message',
+            'exception.escaped' => true,
+        ]));
+
+        [$event] = iterator_to_array($span->getEvents());
+
+        $this->assertArrayHasKey('exception.type', iterator_to_array($event->getAttributes()));
+        $this->assertArrayHasKey('exception.message', iterator_to_array($event->getAttributes()));
+        $this->assertArrayHasKey('exception.stacktrace', iterator_to_array($event->getAttributes()));
+        $this->assertArrayHasKey('exception.escaped', iterator_to_array($event->getAttributes()));
+
+        $this->assertSame('message', iterator_to_array($event->getAttributes())['exception.message']->getValue());
+        $this->assertTrue(iterator_to_array($event->getAttributes())['exception.escaped']->getValue());
+    }
+
     public function testAddEventWhenNotRecording()
     {
         $tracerProvider = new SDK\TracerProvider();


### PR DESCRIPTION
[Spec RecordException](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.4.0/specification/trace/api.md#record-exception):
> If RecordException is provided, the method MUST accept an optional parameter to provide any additional event attributes (this SHOULD be done in the same way as for the AddEvent method). If attributes with the same name would be generated by the method already, the additional attributes take precedence.