### PR TITLE
Fix jaeger zipkin-port environment variable

### DIFF
--- a/docker-compose-collector.yaml
+++ b/docker-compose-collector.yaml
@@ -15,7 +15,7 @@ services:
   jaeger:
     image: jaegertracing/all-in-one
     environment:
-      COLLECTOR_ZIPKIN_HTTP_PORT: 9412
+      COLLECTOR_ZIPKIN_HOST_PORT: 9412
     ports:
     - 9412:9412
     - 16686:16686

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
   jaeger:
     image: jaegertracing/all-in-one
     environment:
-      COLLECTOR_ZIPKIN_HTTP_PORT: 9412
+      COLLECTOR_ZIPKIN_HOST_PORT: 9412
     ports:
     - 9412:9412
     - 16686:16686


### PR DESCRIPTION
Changed in jaeger v1.22, https://github.com/jaegertracing/jaeger/blob/master/CHANGELOG.md#1220-2021-02-23
> --collector.zipkin.http-port is replaced by --collector.zipkin.host-port

Resolves https://github.com/open-telemetry/opentelemetry-php/issues/358#issuecomment-861508716.