### PR TITLE
Remove not implemented Tracer::finishSpan() and ::deactivateActiveSpan()

### DIFF
--- a/api/Trace/Tracer.php
+++ b/api/Trace/Tracer.php
@@ -24,8 +24,5 @@ interface Tracer
 
     public function setActiveSpan(Span $span): void;
 
-    // "finished vs "active" is a bit murky to me
-    public function finishSpan(Span $span, ?int $timestamp = null): void;
-    public function deactivateActiveSpan(): void;
     public function endActiveSpan(?int $timestamp = null);
 }

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -261,14 +261,4 @@ class Tracer implements API\Tracer
     {
         return new SpanOptions($this, $name, $this->provider->getSpanProcessor());
     }
-
-    public function finishSpan(API\Span $span, ?int $timestamp = null): void
-    {
-        // TODO: Implement finishSpan() method.
-    }
-
-    public function deactivateActiveSpan(): void
-    {
-        // TODO: Implement deactivateActiveSpan() method.
-    }
 }


### PR DESCRIPTION
These two methods are neither used, nor implemented, nor required by spec.
#363 