### PR TITLE
ensure insecure variable is converted to bool

### DIFF
--- a/contrib/OtlpGrpc/Exporter.php
+++ b/contrib/OtlpGrpc/Exporter.php
@@ -81,7 +81,7 @@ class Exporter implements Trace\Exporter
         // Set default values based on presence of env variable
         $this->endpointURL = getenv('OTEL_EXPORTER_OTLP_ENDPOINT') ?: $endpointURL;
         $this->protocol = getenv('OTEL_EXPORTER_OTLP_PROTOCOL') ?: 'grpc'; // I guess this is redundant?
-        $this->insecure = getenv('OTEL_EXPORTER_OTLP_INSECURE') ?: $insecure;
+        $this->insecure = getenv('OTEL_EXPORTER_OTLP_INSECURE') ? filter_var(getenv('OTEL_EXPORTER_OTLP_INSECURE'), FILTER_VALIDATE_BOOLEAN): $insecure;
         $this->certificateFile = getenv('OTEL_EXPORTER_OTLP_CERTIFICATE') ?: $certificateFile;
         $this->headers = getenv('OTEL_EXPORTER_OTLP_HEADERS') ?: $headers;
         $this->compression = getenv('OTEL_EXPORTER_OTLP_COMPRESSION') ?: $compression;
@@ -91,6 +91,13 @@ class Exporter implements Trace\Exporter
 
         $this->metadata = $this->metadataFromHeaders($this->headers);
 
+        $opts = $this->getClientOptions();
+
+        $this->client = $client ?? new TraceServiceClient($this->endpointURL, $opts);
+    }
+
+    public function getClientOptions(): mixed
+    {
         $opts = [
             'update_metadata' => function () {
                 return $this->metadata;
@@ -103,7 +110,7 @@ class Exporter implements Trace\Exporter
             $opts['credentials'] = Grpc\ChannelCredentials::createSsl('');
         } elseif (!$this->insecure && $this->certificateFile !== '') {
             // Should we validate more?
-            $opts['credentials'] = Grpc\ChannelCredentials::createSsl(file_get_contents($certificateFile));
+            $opts['credentials'] = Grpc\ChannelCredentials::createSsl(file_get_contents($this->certificateFile));
         } else {
             $opts['credentials'] = Grpc\ChannelCredentials::createInsecure();
         }
@@ -113,7 +120,7 @@ class Exporter implements Trace\Exporter
             $opts['grpc.default_compression_algorithm'] = 2;
         }
 
-        $this->client = $client ?? new TraceServiceClient($this->endpointURL, $opts);
+        return $opts;
     }
 
     /**

--- a/contrib/OtlpGrpc/Exporter.php
+++ b/contrib/OtlpGrpc/Exporter.php
@@ -96,7 +96,7 @@ class Exporter implements Trace\Exporter
         $this->client = $client ?? new TraceServiceClient($this->endpointURL, $opts);
     }
 
-    public function getClientOptions(): mixed
+    public function getClientOptions(): array
     {
         $opts = [
             'update_metadata' => function () {

--- a/contrib/OtlpGrpc/Exporter.php
+++ b/contrib/OtlpGrpc/Exporter.php
@@ -81,7 +81,7 @@ class Exporter implements Trace\Exporter
         // Set default values based on presence of env variable
         $this->endpointURL = getenv('OTEL_EXPORTER_OTLP_ENDPOINT') ?: $endpointURL;
         $this->protocol = getenv('OTEL_EXPORTER_OTLP_PROTOCOL') ?: 'grpc'; // I guess this is redundant?
-        $this->insecure = getenv('OTEL_EXPORTER_OTLP_INSECURE') ? filter_var(getenv('OTEL_EXPORTER_OTLP_INSECURE'), FILTER_VALIDATE_BOOLEAN): $insecure;
+        $this->insecure = getenv('OTEL_EXPORTER_OTLP_INSECURE', true) ? filter_var(getenv('OTEL_EXPORTER_OTLP_INSECURE'), FILTER_VALIDATE_BOOLEAN): $insecure;
         $this->certificateFile = getenv('OTEL_EXPORTER_OTLP_CERTIFICATE') ?: $certificateFile;
         $this->headers = getenv('OTEL_EXPORTER_OTLP_HEADERS') ?: $headers;
         $this->compression = getenv('OTEL_EXPORTER_OTLP_COMPRESSION') ?: $compression;

--- a/contrib/OtlpGrpc/Exporter.php
+++ b/contrib/OtlpGrpc/Exporter.php
@@ -81,7 +81,7 @@ class Exporter implements Trace\Exporter
         // Set default values based on presence of env variable
         $this->endpointURL = getenv('OTEL_EXPORTER_OTLP_ENDPOINT') ?: $endpointURL;
         $this->protocol = getenv('OTEL_EXPORTER_OTLP_PROTOCOL') ?: 'grpc'; // I guess this is redundant?
-        $this->insecure = getenv('OTEL_EXPORTER_OTLP_INSECURE', true) ? filter_var(getenv('OTEL_EXPORTER_OTLP_INSECURE'), FILTER_VALIDATE_BOOLEAN): $insecure;
+        $this->insecure = getenv('OTEL_EXPORTER_OTLP_INSECURE') ? filter_var(getenv('OTEL_EXPORTER_OTLP_INSECURE'), FILTER_VALIDATE_BOOLEAN): $insecure;
         $this->certificateFile = getenv('OTEL_EXPORTER_OTLP_CERTIFICATE') ?: $certificateFile;
         $this->headers = getenv('OTEL_EXPORTER_OTLP_HEADERS') ?: $headers;
         $this->compression = getenv('OTEL_EXPORTER_OTLP_COMPRESSION') ?: $compression;

--- a/tests/Contrib/Unit/OTLPGrpcExporterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcExporterTest.php
@@ -117,7 +117,7 @@ class OTLPGrpcExporterTest extends TestCase
     public function testClientOptions()
     {
         // default options
-        $opts = (new Exporter())->getClientOptions();
+        $opts = (new Exporter('localhost:4317', true))->getClientOptions();
         $this->assertEquals(10, $opts['timeout']);
         $this->assertNull($opts['credentials']);
         $this->assertFalse(array_key_exists('grpc.default_compression_algorithm', $opts));

--- a/tests/Contrib/Unit/OTLPGrpcExporterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcExporterTest.php
@@ -122,7 +122,7 @@ class OTLPGrpcExporterTest extends TestCase
         $this->assertNull($opts['credentials']);
         $this->assertFalse(array_key_exists('grpc.default_compression_algorithm', $opts));
         // method args
-        $opts = (new Exporter(timeout:5, insecure:false, compression:true))->getClientOptions();
+        $opts = (new Exporter('localhost:4317', false, '', '', true, 5))->getClientOptions();
         $this->assertEquals(5, $opts['timeout']);
         $this->assertTrue(is_a($opts['credentials'], 'Grpc\ChannelCredentials'));
         $this->assertEquals(2, $opts['grpc.default_compression_algorithm']);

--- a/tests/Contrib/Unit/OTLPGrpcExporterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcExporterTest.php
@@ -117,7 +117,7 @@ class OTLPGrpcExporterTest extends TestCase
     public function testClientOptions()
     {
         // default options
-        $opts = (new Exporter('localhost:4317', true))->getClientOptions();
+        $opts = (new Exporter('localhost:4317'))->getClientOptions();
         $this->assertEquals(10, $opts['timeout']);
         $this->assertNull($opts['credentials']);
         $this->assertFalse(array_key_exists('grpc.default_compression_algorithm', $opts));


### PR DESCRIPTION
Added tests and refactored the code in the OtlpGrpc Exporter to ensure the environment variable for insecure was correctly used. I also fixed another bug I found, which was the incorrect $certificateFile variable was used in the case where `$this->certificateFile !== ''`.

Fixes #368