### PR TITLE
Change Random Hex generator to public function

### DIFF
--- a/sdk/Trace/RandomIdGenerator.php
+++ b/sdk/Trace/RandomIdGenerator.php
@@ -19,7 +19,7 @@ class RandomIdGenerator implements IdGenerator
         return $this->randomHex(self::SPAN_ID_HEX_LENGTH);
     }
 
-    private function randomHex(int $hexLength): string
+    public function randomHex(int $hexLength): string
     {
         try {
             return bin2hex(random_bytes(intdiv($hexLength, 2)));


### PR DESCRIPTION
This simply makes a random hex generator function from private to public. This was checked to be alright with maintainer @bobstrecansky 