### PR TITLE
Span context trace context update

### DIFF
--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -182,14 +182,16 @@ final class SpanContext implements API\SpanContext
     /**
      * @return bool Returns a value that indicates whether a trace id is valid
      */
-    public static function isValidTraceId($traceId): bool {
+    public static function isValidTraceId($traceId): bool
+    {
         return ctype_xdigit($traceId) && strlen($traceId) === self::TRACE_LENGTH && $traceId !== self::INVALID_TRACE && $traceId === strtolower($traceId);
     }
 
     /**
      * @return bool Returns a value that indicates whether a span id is valid
      */
-    public static function isValidSpanId($spanId): bool {
+    public static function isValidSpanId($spanId): bool
+    {
         return ctype_xdigit($spanId) && strlen($spanId) === self::SPAN_LENGTH && $spanId !== self::INVALID_SPAN && $spanId === strtolower($spanId);
     }
 
@@ -197,7 +199,8 @@ final class SpanContext implements API\SpanContext
      * @return bool Returns a value that indicates whether trace flag is valid
      * TraceFlags must be exactly 1 bytes (1 char) representing a bit field
      */
-    public static function isValidTraceFlag($traceFlag): bool {
+    public static function isValidTraceFlag($traceFlag): bool
+    {
         return ctype_xdigit($traceFlag) && strlen($traceFlag) === self::TRACE_FLAG_LENGTH;
     }
 

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -11,9 +11,12 @@ final class SpanContext implements API\SpanContext
 {
     public const INVALID_TRACE = '00000000000000000000000000000000';
     public const VALID_TRACE = '/^[0-9a-f]{32}$/';
+    public const TRACE_LENGTH = 32;
     public const INVALID_SPAN = '0000000000000000';
     public const VALID_SPAN = '/^[0-9a-f]{16}$/';
+    public const SPAN_LENGTH = 16;
     public const SAMPLED_FLAG = 1;
+    public const TRACE_FLAG_LENGTH = 2;
 
     /**
      * @var string
@@ -54,15 +57,11 @@ final class SpanContext implements API\SpanContext
      */
     public function __construct(string $traceId, string $spanId, int $traceFlags, ?API\TraceState $traceState = null)
     {
-        if (preg_match(self::VALID_TRACE, $traceId) === 0) {
-            throw new \InvalidArgumentException(
-                sprintf('TraceID must be exactly 16 bytes (32 chars) and at least one non-zero byte, got %s', $traceId)
-            );
-        }
-        if (preg_match(self::VALID_SPAN, $spanId) === 0) {
-            throw new \InvalidArgumentException(
-                sprintf('SpanID must be exactly 8 bytes (16 chars) and at least one non-zero byte, got %s', $spanId)
-            );
+        // TraceId must be exactly 16 bytes (32 chars) and at least one non-zero byte
+        // SpanId must be exactly 8 bytes (16 chars) and at least one non-zero byte
+        if (!self::isValidTraceId($traceId) || !self::isValidSpanId($spanId)) {
+            $traceId = self::INVALID_TRACE;
+            $spanId = self::INVALID_SPAN;
         }
 
         $this->traceId = $traceId;
@@ -87,7 +86,7 @@ final class SpanContext implements API\SpanContext
      */
     public static function generate(bool $sampled = false): SpanContext
     {
-        return self::fork(self::randomHex(16), $sampled);
+        return self::fork(self::randomHex(self::SPAN_LENGTH), $sampled);
     }
 
     /**
@@ -178,6 +177,28 @@ final class SpanContext implements API\SpanContext
     public function isRemote(): bool
     {
         return $this->isRemote;
+    }
+
+    /**
+     * @return bool Returns a value that indicates whether a trace id is valid
+     */
+    public static function isValidTraceId($traceId): bool {
+        return ctype_xdigit($traceId) && strlen($traceId) === self::TRACE_LENGTH && $traceId !== self::INVALID_TRACE && $traceId === strtolower($traceId);
+    }
+
+    /**
+     * @return bool Returns a value that indicates whether a span id is valid
+     */
+    public static function isValidSpanId($spanId): bool {
+        return ctype_xdigit($spanId) && strlen($spanId) === self::SPAN_LENGTH && $spanId !== self::INVALID_SPAN && $spanId === strtolower($spanId);
+    }
+
+    /**
+     * @return bool Returns a value that indicates whether trace flag is valid
+     * TraceFlags must be exactly 1 bytes (1 char) representing a bit field
+     */
+    public static function isValidTraceFlag($traceFlag): bool {
+        return ctype_xdigit($traceFlag) && strlen($traceFlag) === self::TRACE_FLAG_LENGTH;
     }
 
     /**

--- a/sdk/Trace/TraceContext.php
+++ b/sdk/Trace/TraceContext.php
@@ -21,8 +21,6 @@ final class TraceContext implements API\TextMapFormatPropagator
     public const TRACEPARENT = 'traceparent';
     public const TRACESTATE = 'tracestate';
     private const VERSION = '00'; // Currently only '00' is supported
-    private const VALID_VERSION = '/^[0-9a-f]{2}$/';
-    private const VALID_TRACEFLAGS = '/^[0-9a-f]{2}$/';
 
     /**
      * {@inheritdoc}
@@ -56,60 +54,44 @@ final class TraceContext implements API\TextMapFormatPropagator
     {
         $traceparent = $getter->get($carrier, self::TRACEPARENT);
         if ($traceparent === null) {
-            throw new \InvalidArgumentException('Traceparent not present');
+            return SpanContext::getInvalid();
         }
 
         // Traceparent = {version}-{trace-id}-{parent-id}-{trace-flags}
         $pieces = explode('-', $traceparent);
 
+        // Unable to extract traceparent. Expected 4 values
         $piecesCount = count($pieces);
-        if ($piecesCount != 4) {
-            throw new \InvalidArgumentException(
-                sprintf('Unable to extract traceparent. Expected 4 values, got %d', $piecesCount)
-            );
+        if ($piecesCount !== 4) {
+            return SpanContext::getInvalid();
         }
 
         $version = $pieces[0];
-        if ((preg_match(self::VALID_VERSION, $version) === 0) || ($version !== self::VERSION)) {
-            throw new \InvalidArgumentException(
-                sprintf('Only version 00 is supported, got %s', $version)
-            );
-        }
-
         $traceId = $pieces[1];
-        if ((preg_match(SpanContext::VALID_TRACE, $traceId) === 0) || ($traceId === SpanContext::INVALID_TRACE)) {
-            throw new \InvalidArgumentException(
-                sprintf('TraceID must be exactly 16 bytes (32 chars) and at least one non-zero byte, got %s', $traceId)
-            );
-        }
-
         $spanId = $pieces[2];
-        if ((preg_match(SpanContext::VALID_SPAN, $spanId) === 0) || ($spanId === SpanContext::INVALID_SPAN)) {
-            throw new \InvalidArgumentException(
-                sprintf('SpanID must be exactly 8 bytes (16 chars) and at least one non-zero byte, got %s', $spanId)
-            );
-        }
-
         $traceFlags = $pieces[3];
-        if (preg_match(self::VALID_TRACEFLAGS, $traceFlags) === 0) {
-            throw new \InvalidArgumentException(
-                sprintf('TraceFlags must be exactly 1 bytes (1 char) representing a bit field, got %s', $traceFlags)
-            );
+
+        // Validates the version, traceId, spanId and traceFlags 
+        // If successful, returns a new span context with new context
+        if ($version === self::VERSION && SpanContext::isValidTraceId($traceId) && 
+            SpanContext::isValidSpanId($spanId) && SpanContext::isValidTraceFlag($traceFlags)) {
+            
+            // Only the sampled flag is extracted from the traceFlags (00000001)
+            $convertedTraceFlags = hexdec($traceFlags);
+            $isSampled = ($convertedTraceFlags & SpanContext::SAMPLED_FLAG) === SpanContext::SAMPLED_FLAG;
+
+            // Tracestate = 'Vendor1=Value1,...,VendorN=ValueN'
+            $rawTracestate = $getter->get($carrier, self::TRACESTATE);
+            if ($rawTracestate !== null) {
+                $tracestate = new TraceState($rawTracestate);
+
+                return SpanContext::restore($traceId, $spanId, $isSampled, true, $tracestate);
+            }
+
+            // Only traceparent header is extracted. No tracestate.
+            return SpanContext::restore($traceId, $spanId, $isSampled, true);
         }
 
-        // Only the sampled flag is extracted from the traceFlags (00000001)
-        $convertedTraceFlags = hexdec($traceFlags);
-        $isSampled = ($convertedTraceFlags & SpanContext::SAMPLED_FLAG) === SpanContext::SAMPLED_FLAG;
-
-        // Tracestate = 'Vendor1=Value1,...,VendorN=ValueN'
-        $rawTracestate = $getter->get($carrier, self::TRACESTATE);
-        if ($rawTracestate !== null) {
-            $tracestate = new TraceState($rawTracestate);
-
-            return SpanContext::restore($traceId, $spanId, $isSampled, true, $tracestate);
-        }
-
-        // Only traceparent header is extracted. No tracestate.
-        return SpanContext::restore($traceId, $spanId, $isSampled, true);
+        return SpanContext::getInvalid();
     }
 }

--- a/sdk/Trace/TraceContext.php
+++ b/sdk/Trace/TraceContext.php
@@ -71,10 +71,10 @@ final class TraceContext implements API\TextMapFormatPropagator
         $spanId = $pieces[2];
         $traceFlags = $pieces[3];
 
-        // Validates the version, traceId, spanId and traceFlags 
+        // Validates the version, traceId, spanId and traceFlags
         // Returns an invalid spanContext if any of the checks fail
-        if ($version !== self::VERSION || !SpanContext::isValidTraceId($traceId) || 
-            !SpanContext::isValidSpanId($spanId) || !SpanContext::isValidTraceFlag($traceFlags)) {   
+        if ($version !== self::VERSION || !SpanContext::isValidTraceId($traceId) ||
+            !SpanContext::isValidSpanId($spanId) || !SpanContext::isValidTraceFlag($traceFlags)) {
             return SpanContext::getInvalid();
         }
 

--- a/tests/Sdk/Integration/Context/SpanContextTest.php
+++ b/tests/Sdk/Integration/Context/SpanContextTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Integration\Context;
 
-use InvalidArgumentException;
 use OpenTelemetry\Sdk\Trace\RandomIdGenerator;
 use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\TraceState;

--- a/tests/Sdk/Integration/Context/SpanContextTest.php
+++ b/tests/Sdk/Integration/Context/SpanContextTest.php
@@ -13,8 +13,8 @@ class SpanContextTest extends TestCase
 {
     /**
      * @dataProvider invalidSpanData
-     * @param string $traceID
-     * @param string $spanID
+     * @param string $traceId
+     * @param string $spanId
      */
     public function testInvalidSpan(string $traceId, string $spanId): void
     {

--- a/tests/Sdk/Integration/Context/SpanContextTest.php
+++ b/tests/Sdk/Integration/Context/SpanContextTest.php
@@ -16,13 +16,12 @@ class SpanContextTest extends TestCase
      * @dataProvider invalidSpanData
      * @param string $traceID
      * @param string $spanID
-     * @param string $errorRegex
      */
-    public function testInvalidSpan(string $traceID, string $spanID, string $errorRegex): void
+    public function testInvalidSpan(string $traceId, string $spanId): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches($errorRegex);
-        SpanContext::restore($traceID, $spanID);
+        $spanContext = SpanContext::restore($traceId, $spanId);
+        $this->assertSame(SpanContext::INVALID_TRACE, $spanContext->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $spanContext->getSpanId());
     }
 
     public function invalidSpanData(): array

--- a/tests/Sdk/Unit/Trace/SpanContextTest.php
+++ b/tests/Sdk/Unit/Trace/SpanContextTest.php
@@ -105,6 +105,68 @@ class SpanContextTest extends TestCase
     /**
      * @test
      */
+    public function testValidSpanId()
+    {
+        $spanId = '53995c3f42cd8ad8';
+
+        $this->assertTrue(SpanContext::isValidSpanId($spanId));
+    }
+    /**
+     * @test
+     */
+    public function testInvalidSpanId()
+    {
+        $spanIds = ['0000000000000000', '539g5c3f42cdpad8', '123fgh', ' '];
+        
+        foreach ($spanIds as $spanId) {
+            $this->assertFalse(SpanContext::isValidSpanId($spanId));
+        }
+    }
+    /**
+     * @test
+     */
+    public function testValidTraceId()
+    {
+        $traceId = '5759e988bd862e3fe1be46a994272793';
+
+        $this->assertTrue(SpanContext::isValidTraceId($traceId));
+    }
+    /**
+     * @test
+     */
+    public function testInvalidTraceId()
+    {
+        $traceIds = ['00000000000000000000000000000000', ' ', '123fgh', '5759e988bdhjk62e3fe1be46a994272793'];
+        
+        foreach ($traceIds as $traceId) {
+            $this->assertFalse(SpanContext::isValidTraceId($traceId));
+        }
+    }
+    /**
+     * @test
+     */
+    public function testValidTraceFlag()
+    {
+        $traceFlags = ['f0', 'ff', '00', '01'];
+        
+        foreach ($traceFlags as $traceFlag) {
+            $this->assertTrue(SpanContext::isValidTraceFlag($traceFlag));
+        }
+    }
+    /**
+     * @test
+     */
+    public function testInvalidTraceFlag()
+    {
+        $traceFlags = ['0000000000000000', ' ', 'gg', 'abc123'];
+        
+        foreach ($traceFlags as $traceFlag) {
+            $this->assertFalse(SpanContext::isValidTraceFlag($traceFlag));
+        }
+    }
+    /**
+     * @test
+     */
     public function testIsRemoteStatus()
     {
         /*

--- a/tests/Sdk/Unit/Trace/TraceContextTest.php
+++ b/tests/Sdk/Unit/Trace/TraceContextTest.php
@@ -98,7 +98,7 @@ class TraceContextTest extends TestCase
         $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
         $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
         $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
-        $this->assertSame(false, $context->isRemote());
+        $this->assertFalse($context->isRemote());
     }
 
     /**
@@ -173,7 +173,7 @@ class TraceContextTest extends TestCase
             $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
             $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
             $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
-            $this->assertSame(false, $context->isRemote());
+            $this->assertFalse($context->isRemote());
         }
     }
 
@@ -199,7 +199,7 @@ class TraceContextTest extends TestCase
             $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
             $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
             $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
-            $this->assertSame(false, $context->isRemote());
+            $this->assertFalse($context->isRemote());
         }
     }
 
@@ -223,7 +223,7 @@ class TraceContextTest extends TestCase
             $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
             $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
             $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
-            $this->assertSame(false, $context->isRemote());
+            $this->assertFalse($context->isRemote());
         }
     }
 
@@ -247,7 +247,7 @@ class TraceContextTest extends TestCase
             $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
             $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
             $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
-            $this->assertSame(false, $context->isRemote());
+            $this->assertFalse($context->isRemote());
         }
     }
 
@@ -271,7 +271,7 @@ class TraceContextTest extends TestCase
             $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
             $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
             $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
-            $this->assertSame(false, $context->isRemote());
+            $this->assertFalse($context->isRemote());
         }
     }
 }

--- a/tests/Sdk/Unit/Trace/TraceContextTest.php
+++ b/tests/Sdk/Unit/Trace/TraceContextTest.php
@@ -93,9 +93,12 @@ class TraceContextTest extends TestCase
         $carrier = [];
         $map = new PropagationMap();
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Traceparent not present');
         $context = TraceContext::extract($carrier, $map);
+
+        $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+        $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+        $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
+        $this->assertSame(false, $context->isRemote());
     }
 
     /**
@@ -165,9 +168,12 @@ class TraceContextTest extends TestCase
             $carrier = [TraceContext::TRACEPARENT => $invalidTraceparentValue];
             $map = new PropagationMap();
 
-            $this->expectException(\InvalidArgumentException::class);
-            $this->expectExceptionMessage('Unable to extract traceparent. Expected 4 values, got ' . 5);
             $context = TraceContext::extract($carrier, $map);
+
+            $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+            $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+            $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
+            $this->assertSame(false, $context->isRemote());
         }
     }
 
@@ -188,9 +194,12 @@ class TraceContextTest extends TestCase
             $carrier = [TraceContext::TRACEPARENT => $traceparentValue];
             $map = new PropagationMap();
 
-            $this->expectException(\InvalidArgumentException::class);
-            $this->expectExceptionMessage('Only version 00 is supported, got ' . $invalidVersion);
             $context = TraceContext::extract($carrier, $map);
+
+            $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+            $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+            $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
+            $this->assertSame(false, $context->isRemote());
         }
     }
 
@@ -209,9 +218,12 @@ class TraceContextTest extends TestCase
             $carrier = [TraceContext::TRACEPARENT => $traceparentValue];
             $map = new PropagationMap();
 
-            $this->expectException(\InvalidArgumentException::class);
-            $this->expectExceptionMessage('TraceID must be exactly 16 bytes (32 chars) and at least one non-zero byte, got ' . $invalidTraceId);
             $context = TraceContext::extract($carrier, $map);
+
+            $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+            $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+            $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
+            $this->assertSame(false, $context->isRemote());
         }
     }
 
@@ -230,9 +242,12 @@ class TraceContextTest extends TestCase
             $carrier = [TraceContext::TRACEPARENT => $traceparentValue];
             $map = new PropagationMap();
 
-            $this->expectException(\InvalidArgumentException::class);
-            $this->expectExceptionMessage('SpanID must be exactly 8 bytes (16 chars) and at least one non-zero byte, got ' . $invalidSpanId);
             $context = TraceContext::extract($carrier, $map);
+
+            $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+            $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+            $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
+            $this->assertSame(false, $context->isRemote());
         }
     }
 
@@ -251,9 +266,12 @@ class TraceContextTest extends TestCase
             $carrier = [TraceContext::TRACEPARENT => $traceparentValue];
             $map = new PropagationMap();
 
-            $this->expectException(\InvalidArgumentException::class);
-            $this->expectExceptionMessage('TraceFlags must be exactly 1 bytes (1 char) representing a bit field, got ' . $invalidTraceFlag);
             $context = TraceContext::extract($carrier, $map);
+
+            $this->assertSame(SpanContext::INVALID_TRACE, $context->getTraceId());
+            $this->assertSame(SpanContext::INVALID_SPAN, $context->getSpanId());
+            $this->assertSame(self::VERSION, ($context->isSampled() ? '01' : '00'));
+            $this->assertSame(false, $context->isRemote());
         }
     }
 }


### PR DESCRIPTION
Fixes #371 

This addresses all problems brought up in the above issue.

Updates the `TraceContext` file to conform to specifications. `SpanContext` file was given additional helper functions that are useful for future necessary Id validation.

Tests were updated accordingly. All tests pass.

@Fahmy-Mohammed @bobstrecansky 