### PR TITLE
Fix merging of attributes provided within SamplingResult in Tracer

### DIFF
--- a/docs/laravel-integration.md
+++ b/docs/laravel-integration.md
@@ -147,11 +147,11 @@ Next, we create a trace then add processors for each trace(One for Jaeger and an
 ```php
 if (SamplingResult::RECORD_AND_SAMPLE === $samplingResult->getDecision()) {
 
-    $jaegerTracer = (new TracerProvider())
+    $jaegerTracer = (new TracerProvider(null, $sampler))
         ->addSpanProcessor(new BatchSpanProcessor($jaegerExporter, Clock::get()))
         ->getTracer('io.opentelemetry.contrib.php');
 
-    $zipkinTracer = (new TracerProvider())
+    $zipkinTracer = (new TracerProvider(null, $sampler))
     ->addSpanProcessor(new BatchSpanProcessor($zipkinExporter, Clock::get()))
     ->getTracer('io.opentelemetry.contrib.php');
 

--- a/docs/symfony-integration.md
+++ b/docs/symfony-integration.md
@@ -156,11 +156,11 @@ Next we create a trace, and add processors for each trace(One for Jaeger and ano
 ```php
 if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
 
-    $jaegerTracer = (new TracerProvider())
+    $jaegerTracer = (new TracerProvider(null, $sampler))
         ->addSpanProcessor(new BatchSpanProcessor($jaegerExporter, Clock::get()))
         ->getTracer('io.opentelemetry.contrib.php');
 
-    $zipkinTracer = (new TracerProvider())
+    $zipkinTracer = (new TracerProvider(null, $sampler))
     ->addSpanProcessor(new BatchSpanProcessor($zipkinExporter, Clock::get()))
     ->getTracer('io.opentelemetry.contrib.php');
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -62,7 +62,7 @@ class Tracer implements API\Tracer
         $sampleAttributes = $sampleResult->getAttributes();
         if ($sampleAttributes !== null) {
             foreach ($sampleAttributes as $name => $value) {
-                $attributes->setAttribute($name, $value);
+                $attributes->setAttribute($name, $value->getValue());
             }
         }
 
@@ -141,7 +141,7 @@ class Tracer implements API\Tracer
         if (SamplingResult::DROP == $samplingResult->getDecision()) {
             $span = $this->generateSpanInstance('', $context);
         } else {
-            $span = $this->generateSpanInstance($name, $context, $parentContext, $sampler, $this->resource, $spanKind);
+            $span = $this->generateSpanInstance($name, $context, $parentContext, $sampler, $this->resource, $spanKind, $samplingResult->getAttributes());
 
             if ($span->isRecording()) {
                 $this->provider->getSpanProcessor()->onStart($span);
@@ -237,7 +237,7 @@ class Tracer implements API\Tracer
         return $this->provider;
     }
 
-    private function generateSpanInstance(string $name, API\SpanContext $context, API\SpanContext $parentContext = null, Sampler $sampler = null, ResourceInfo $resource = null, int $spanKind = API\SpanKind::KIND_INTERNAL): API\Span
+    private function generateSpanInstance(string $name, API\SpanContext $context, API\SpanContext $parentContext = null, Sampler $sampler = null, ResourceInfo $resource = null, int $spanKind = API\SpanKind::KIND_INTERNAL, ?API\Attributes $attributes = null): API\Span
     {
         $parent = null;
 
@@ -251,6 +251,9 @@ class Tracer implements API\Tracer
             }
 
             $span = new Span($name, $context, $parent, $sampler, $resource, $spanKind, $this->provider->getSpanProcessor());
+            if ($attributes) {
+                $span->replaceAttributes($attributes);
+            }
         }
         $this->spans[] = $span;
 


### PR DESCRIPTION
This fixes processing of attributes provided in the SamplingResult. Previously they were either broken (Attribute instance as value) or not present at all.

I also added `null, $sampler` to the TracerProvider args in the examples, so that one is not confused why e.g. attributes are not applied when trying another sampler than the AlwaysOnSampler.