### PR TITLE
Make span.recordException accept Throwable

### DIFF
--- a/api/Trace/Span.php
+++ b/api/Trace/Span.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Trace;
 
-use Exception;
+use Throwable;
 
 interface Span extends SpanStatus, SpanKind
 {
@@ -62,10 +62,10 @@ interface Span extends SpanStatus, SpanKind
 
     /**
      *
-     * @param Exception $exception
+     * @param Throwable $exception
      * @return Span Must return $this to allow setting multiple attributes at once in a chain.
      */
-    public function recordException(Exception $exception, ?Attributes $attributes = null): Span;
+    public function recordException(Throwable $exception, ?Attributes $attributes = null): Span;
 
     /**
      * Calling this method is highly discouraged; the name should be set on creation and left alone.

--- a/sdk/Trace/NoopSpan.php
+++ b/sdk/Trace/NoopSpan.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace;
 
-use Exception;
 use OpenTelemetry\Context\ContextKey;
 use OpenTelemetry\Context\ContextValueTrait;
 use OpenTelemetry\Trace as API;
+use Throwable;
 
 class NoopSpan implements API\Span
 {
@@ -123,7 +123,7 @@ class NoopSpan implements API\Span
         return $this;
     }
 
-    public function recordException(Exception $exception, ?API\Attributes $attributes = null): API\Span
+    public function recordException(Throwable $exception, ?API\Attributes $attributes = null): API\Span
     {
         return $this;
     }

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace;
 
-use Exception;
 use OpenTelemetry\Context\ContextKey;
 use OpenTelemetry\Context\ContextValueTrait;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Trace as API;
+use Throwable;
 
 class Span implements API\Span
 {
@@ -219,7 +219,7 @@ class Span implements API\Span
         return $this;
     }
 
-    public function recordException(Exception $exception, ?API\Attributes $attributes = null): API\Span
+    public function recordException(Throwable $exception, ?API\Attributes $attributes = null): API\Span
     {
         $eventAttributes = new Attributes(
             [


### PR DESCRIPTION
By allowing recordException accept Throwable, we can record PHP internal errors in OpenTelemetry.