### PR TITLE
Reintroduce InstrumentationLibrary

### DIFF
--- a/sdk/InstrumentationLibrary.php
+++ b/sdk/InstrumentationLibrary.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk;
+
+/**
+ * Represents the instrumentation library information associated with the Tracer or Meter
+ */
+class InstrumentationLibrary
+{
+    private $name;
+
+    private $version;
+
+    public function __construct(string $name, ?string $version = null)
+    {
+        $this->name = $name;
+        $this->version = $version;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getVersion(): ?string
+    {
+        return $this->version;
+    }
+}

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Sdk\Trace;
 use Exception;
 use OpenTelemetry\Context\ContextKey;
 use OpenTelemetry\Context\ContextValueTrait;
+use OpenTelemetry\Sdk\InstrumentationLibrary;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Trace as API;
 
@@ -30,6 +31,11 @@ class Span implements API\Span
      * @var ResourceInfo
      */
     private $resource; // An immutable representation of the entity producing telemetry.
+
+    /**
+     * @var InstrumentationLibrary
+     */
+    private $instrumentationLibrary;
 
     private $attributes;
     private $events;
@@ -77,6 +83,22 @@ class Span implements API\Span
         // todo: set these to null until needed
         $this->attributes = new Attributes();
         $this->events = new Events();
+    }
+
+    /**
+     * @internal
+     */
+    public function setInstrumentationLibrary(InstrumentationLibrary $instrumentationLibrary)
+    {
+        $this->instrumentationLibrary = $instrumentationLibrary;
+    }
+
+    /**
+     * @internal
+     */
+    public function getInstrumentationLibrary(): InstrumentationLibrary
+    {
+        return $this->instrumentationLibrary;
     }
 
     public function getResource(): ResourceInfo

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\Trace;
 
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Sdk\InstrumentationLibrary;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Trace as API;
 
@@ -18,15 +19,19 @@ class Tracer implements API\Tracer
     private $provider;
     /** @var ResourceInfo */
     private $resource;
+    /** @var InstrumentationLibrary */
+    private $instrumentationLibrary;
     /** @var API\SpanContext|null  */
     private $importedContext;
 
     public function __construct(
         TracerProvider $provider,
+        InstrumentationLibrary $instrumentationLibrary,
         ResourceInfo $resource = null,
         API\SpanContext $context = null
     ) {
         $this->provider = $provider;
+        $this->instrumentationLibrary = $instrumentationLibrary;
         $this->resource = $resource ?? ResourceInfo::emptyResource();
         $this->importedContext = $context;
     }
@@ -84,6 +89,7 @@ class Tracer implements API\Tracer
             $this->provider->getSpanProcessor()
         );
         $span->replaceAttributes($attributes);
+        $span->setInstrumentationLibrary($this->instrumentationLibrary);
 
         $this->provider->getSpanProcessor()->onStart($span, $parentContext ?? Context::getCurrent());
 
@@ -254,6 +260,7 @@ class Tracer implements API\Tracer
             if ($attributes) {
                 $span->replaceAttributes($attributes);
             }
+            $span->setInstrumentationLibrary($this->instrumentationLibrary);
         }
         $this->spans[] = $span;
 

--- a/tests/Sdk/Integration/TracerTest.php
+++ b/tests/Sdk/Integration/TracerTest.php
@@ -67,4 +67,19 @@ class TracerTest extends TestCase
         $this->assertNotEquals($parentTraceState, $span->getContext()->getTraceState());
         $this->assertEquals($newTraceState, $span->getContext()->getTraceState());
     }
+
+    /**
+     * @test
+     */
+    public function spanShouldReceiveInstrumentationLibrary()
+    {
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest', 'dev');
+        /** @var Span $span */
+        $span = $tracer->startSpan('test.span');
+        $spanInstrumentationLibrary = $span->getInstrumentationLibrary();
+
+        $this->assertEquals('OpenTelemetry.TracerTest', $spanInstrumentationLibrary->getName());
+        $this->assertEquals('dev', $spanInstrumentationLibrary->getVersion());
+    }
 }

--- a/tests/Sdk/Unit/Trace/SpanContextTest.php
+++ b/tests/Sdk/Unit/Trace/SpanContextTest.php
@@ -58,7 +58,7 @@ class SpanContextTest extends TestCase
 
         $context = SpanContext::generate(true);
 
-        $activeSpan = new Span('test.span', $context);
+        $activeSpan = $tracer->startSpan('test.span');
 
         $tracer->setActiveSpan($activeSpan);
 

--- a/tests/Sdk/Unit/Trace/SpanProcessor/SimpleSpanProcessorTest.php
+++ b/tests/Sdk/Unit/Trace/SpanProcessor/SimpleSpanProcessorTest.php
@@ -6,7 +6,6 @@ namespace OpenTelemetry\Tests\Sdk\Unit\Trace\SpanProcessor;
 
 use OpenTelemetry\Sdk\Trace\Exporter;
 use OpenTelemetry\Sdk\Trace\Span;
-use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\SpanProcessor\SimpleSpanProcessor;
 use PHPUnit\Framework\TestCase;
 
@@ -20,9 +19,10 @@ class SimpleSpanProcessorTest extends TestCase
         $exporter = self::createMock(Exporter::class);
         $exporter->expects($this->atLeastOnce())->method('export');
 
-        (new SimpleSpanProcessor($exporter))->onEnd(
-            new Span('sampled_span', new SpanContext('40de9aea7305cced3bb10ed45ba6872d', '277c169397adf2ec', 1))
-        );
+        $span = self::createStub(Span::class);
+        $span->method('isSampled')->willReturn(true); // only sampled spans are exported
+
+        (new SimpleSpanProcessor($exporter))->onEnd($span);
     }
 
     /**
@@ -75,8 +75,9 @@ class SimpleSpanProcessorTest extends TestCase
         $exporter = self::createMock(Exporter::class);
         $exporter->expects($this->never())->method('export');
 
-        (new SimpleSpanProcessor($exporter))->onEnd(
-            new Span('sampled_span', new SpanContext('40de9aea7305cced3bb10ed45ba6870d', '277c169397adf2ec', 0))
-        );
+        $span = self::createStub(Span::class);
+        $span->method('isSampled')->willReturn(false);
+
+        (new SimpleSpanProcessor($exporter))->onEnd($span);
     }
 }

--- a/tests/Sdk/Unit/Trace/TracerProviderTest.php
+++ b/tests/Sdk/Unit/Trace/TracerProviderTest.php
@@ -131,19 +131,13 @@ class TracerProviderTest extends TestCase
         $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
         /** @var Attribute $sdkversion */
         $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
-        /** @var Attribute $servicename */
-        $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
-        /** @var Attribute $serviceversion */
-        $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
         $this->assertEquals($attributes, $resource->getAttributes());
 
         $this->assertEquals('opentelemetry', $sdkname->getValue());
         $this->assertEquals('php', $sdklanguage->getValue());
         $this->assertEquals('dev', $sdkversion->getValue());
-        $this->assertEquals('name', $servicename->getValue());
-        $this->assertEquals('version', $serviceversion->getValue());
 
-        $this->assertCount(6, $attributes);
+        $this->assertCount(3, $attributes);
     }
 
     /**
@@ -184,10 +178,6 @@ class TracerProviderTest extends TestCase
         $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
         /** @var Attribute $sdkversion */
         $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
-        /** @var Attribute $servicename */
-        $servicename = $attributes->getAttribute(ResourceConstants::SERVICE_NAME);
-        /** @var Attribute $serviceversion */
-        $serviceversion = $attributes->getAttribute(ResourceConstants::SERVICE_VERSION);
 
         /** @var Attribute $primary */
         $primary = $attributes->getAttribute('provider');
@@ -199,9 +189,7 @@ class TracerProviderTest extends TestCase
         $this->assertEquals('opentelemetry', $sdkname->getValue());
         $this->assertEquals('php', $sdklanguage->getValue());
         $this->assertEquals('dev', $sdkversion->getValue());
-        $this->assertEquals('name', $servicename->getValue());
-        $this->assertEquals('version', $serviceversion->getValue());
 
-        $this->assertCount(8, $attributes);
+        $this->assertCount(5, $attributes);
     }
 }

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -89,7 +89,7 @@ class TracingTest extends TestCase
     public function testGetStackTrace()
     {
         $stacktrace = 'Exception: Thrown from here
- at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.testGetStackTrace(TracingTest.php:101)
+ at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.testGetStackTrace(TracingTest.php:102)
  at PHPUnit.Framework.TestCase.runTest(TestCase.php:1527)
  at PHPUnit.Framework.TestCase.runBare(TestCase.php:1133)
  at PHPUnit.Framework.TestResult.run(TestResult.php:722)
@@ -97,7 +97,7 @@ class TracingTest extends TestCase
  at PHPUnit.Framework.TestSuite.run(TestSuite.php:677)
  ... 6 more';
         $actualStacktrace = '';
-        
+
         try {
             throw new \Exception('Thrown from here');
         } catch (\Exception $e) {
@@ -112,7 +112,7 @@ class TracingTest extends TestCase
     {
         throw new \Exception('Thrown from fail2()');
     }
-    
+
     private static function fail1()
     {
         try {
@@ -125,8 +125,8 @@ class TracingTest extends TestCase
     public function testGetStackTraceWithCause()
     {
         $stacktrace = 'Exception: Thrown from fail1()
- at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.fail1(TracingTest.php:120)
- at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.testGetStackTraceWithCause(TracingTest.php:143)
+ at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.fail1(TracingTest.php:121)
+ at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.testGetStackTraceWithCause(TracingTest.php:144)
  at PHPUnit.Framework.TestCase.runTest(TestCase.php:1527)
  at PHPUnit.Framework.TestCase.runBare(TestCase.php:1133)
  at PHPUnit.Framework.TestResult.run(TestResult.php:722)
@@ -134,10 +134,10 @@ class TracingTest extends TestCase
  at PHPUnit.Framework.TestSuite.run(TestSuite.php:677)
  ... 6 more
 Caused by: Exception: Thrown from fail2()
- at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.fail2(TracingTest.php:112)
- at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.fail1(TracingTest.php:118)
+ at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.fail2(TracingTest.php:113)
+ at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.fail1(TracingTest.php:119)
  ... 12 more';
- 
+
         $actualStacktrace = '';
 
         try {


### PR DESCRIPTION
Fixes #228.

An `InstrumentationLibrary` is associated with the `Tracer` on every `getTracer()` call and then with its' `Span`s.

This PR adds some "todo" with the `Span::setInstrumentationLibrary()` method. It should be a part of `Span` creation method, but the change of the `Span`'s constructor signature causes huge refactoring and adds a complexity for the code review at the current PR.