### PR TITLE
chore: Force otel-collector to use linux/amd64 image in local dev

### DIFF
--- a/docker-compose-collector.yaml
+++ b/docker-compose-collector.yaml
@@ -20,6 +20,7 @@ services:
     - 9412:9412
     - 16686:16686
   otel-collector:
+    platform: linux/amd64
     image: otel/opentelemetry-collector-contrib
     command: ["--config=/etc/otel-collector-config.yml"]
     volumes:


### PR DESCRIPTION
Why? There are no linux/arm64 images for the collector yet: (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2379)

Developing on Apple M1 I found the container would core dump, passing this platform flag forces Docker to run the collector image under Rosetta 2: https://docs.docker.com/docker-for-mac/apple-silicon/#known-issues

I don't forsee any issues for users on Intel Mac, Linux or Windows as each of these platforms would also be required to run the linux/amd64 image.