### PR TITLE
Add InstrumentationLibrary in OTLP exporter

### DIFF
--- a/contrib/OtlpGrpc/SpanConverter.php
+++ b/contrib/OtlpGrpc/SpanConverter.php
@@ -159,29 +159,31 @@ class SpanConverter
         // TODO: Should return an empty ResourceSpans when $spans is empty
         // At the minute it returns an semi populated ResourceSpan
 
-        $convertedSpans = [];
+        $ils = $convertedSpans = [];
         foreach ($spans as $span) {
-            array_push($convertedSpans, $this->as_otlp_span($span));
+            /** @var \OpenTelemetry\Sdk\InstrumentationLibrary $il */
+            $il = $span->getInstrumentationLibrary();
+            $ilKey = sprintf('%s@%s', $il->getName(), $il->getVersion()??'');
+            if (!isset($ils[$ilKey])) {
+                $convertedSpans[$ilKey] = [];
+                $ils[$ilKey] = new InstrumentationLibrary(['name' => $il->getName(), 'version' => $il->getVersion()??'']);
+            }
+            $convertedSpans[$ilKey][] = $this->as_otlp_span($span);
         }
 
-        // TODO: Fetch InstrumentationLibrary from the TracerProvider
-        $il = new InstrumentationLibrary([]);
-
-        $ilspans = [];
-        foreach ($convertedSpans as $convertedSpan) {
-            $ilspan = new InstrumentationLibrarySpans([
+        $ilSpans = [];
+        foreach ($ils as $ilKey => $il) {
+            $ilSpans[] = new InstrumentationLibrarySpans([
                 'instrumentation_library' => $il,
-                'spans' => [$convertedSpan],
+                'spans' => $convertedSpans[$ilKey],
             ]);
-
-            array_push($ilspans, $ilspan);
         }
 
         return new Proto\Trace\V1\ResourceSpans([
             'resource' => new Proto\Resource\V1\Resource([
                 'attributes' => $this->as_otlp_resource_attributes($spans),
             ]),
-            'instrumentation_library_spans' => $ilspans,
+            'instrumentation_library_spans' => $ilSpans,
         ]);
     }
 }

--- a/tests/Contrib/Unit/OTLPGrpcSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcSpanConverterTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\Contrib\OtlpGrpc\SpanConverter;
 use Opentelemetry\Proto\Trace\V1;
 use Opentelemetry\Proto\Trace\V1\InstrumentationLibrarySpans;
 use Opentelemetry\Proto\Trace\V1\ResourceSpans;
+use OpenTelemetry\Sdk\InstrumentationLibrary;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Sdk\Trace\Attribute;
 use OpenTelemetry\Sdk\Trace\Attributes;
@@ -55,7 +56,7 @@ class OTLPGrpcSpanConverterTest extends TestCase
         // $this->assertGreaterThan(0, $row['duration']);
 
         // $this->assertCount(1, $row['tags']);
-        
+
         // /** @var Attribute $attribute */
         // $attribute = $span->getAttribute('service');
         // $this->assertEquals($attribute->getValue(), $row['tags']['service']);
@@ -159,6 +160,7 @@ class OTLPGrpcSpanConverterTest extends TestCase
                 ])
             )
         );
+        $sdk->setInstrumentationLibrary(new InstrumentationLibrary('lib-test', 'v0.1.0'));
 
         // We have to set the time twice here due to the way PHP deals with Monotonic Clock and Realtime Clock.
         $sdk->setStartEpochTimestamp($start_time);
@@ -199,9 +201,8 @@ class OTLPGrpcSpanConverterTest extends TestCase
             'instrumentation_library_spans' => [
                 new InstrumentationLibrarySpans([
                     'instrumentation_library' => new \Opentelemetry\Proto\Common\V1\InstrumentationLibrary([
-                        // TODO: Fetch instrumentation library from TracerProvider
-                        // 'name' => 'lib-a',
-                        // 'version' => 'v0.1.0',
+                        'name' => 'lib-test',
+                        'version' => 'v0.1.0',
                     ]),
                     'spans' => [
                         new V1\Span([

--- a/tests/Contrib/Unit/OTLPHttpExporterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpExporterTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Response;
 use OpenTelemetry\Contrib\OtlpHttp\Exporter;
+use OpenTelemetry\Sdk\InstrumentationLibrary;
 use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\SpanContext;
 use PHPUnit\Framework\TestCase;
@@ -47,10 +48,12 @@ class OTLPHttpExporterTest extends TestCase
         );
         /** @var ClientInterface $client */
         $exporter = new Exporter($client, new HttpFactory(), new HttpFactory());
+        $span = new Span('test.otlp.span', SpanContext::generate());
+        $span->setInstrumentationLibrary(new InstrumentationLibrary('lib-test', 'v0.1.0'));
 
         $this->assertEquals(
             $expected,
-            $exporter->export([new Span('test.otlp.span', SpanContext::generate())])
+            $exporter->export([$span])
         );
     }
 
@@ -79,10 +82,12 @@ class OTLPHttpExporterTest extends TestCase
 
         /** @var ClientInterface $client */
         $exporter = new Exporter($client, new HttpFactory(), new HttpFactory());
+        $span = new Span('test.otlp.span', SpanContext::generate());
+        $span->setInstrumentationLibrary(new InstrumentationLibrary('lib-test', 'v0.1.0'));
 
         $this->assertEquals(
             $expected,
-            $exporter->export([new Span('test.otlp.span', SpanContext::generate())])
+            $exporter->export([$span])
         );
     }
 
@@ -163,8 +168,10 @@ class OTLPHttpExporterTest extends TestCase
 
         $client = new Client(['handler' => $stack]);
         $exporter = new Exporter($client, new HttpFactory(), new HttpFactory());
+        $span = new Span('test.otlp.span', SpanContext::generate());
+        $span->setInstrumentationLibrary(new InstrumentationLibrary('lib-test', 'v0.1.0'));
 
-        $exporter->export([new Span('test.otlp.span', SpanContext::generate())]);
+        $exporter->export([$span]);
 
         $request = $container[0]['request'];
 

--- a/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\Contrib\OtlpHttp\SpanConverter;
 use Opentelemetry\Proto\Trace\V1;
 use Opentelemetry\Proto\Trace\V1\InstrumentationLibrarySpans;
 use Opentelemetry\Proto\Trace\V1\ResourceSpans;
+use OpenTelemetry\Sdk\InstrumentationLibrary;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
@@ -19,7 +20,7 @@ use OpenTelemetry\Sdk\Trace\TracerProvider;
 
 use PHPUnit\Framework\TestCase;
 
-class OTLPhttpSpanConverterTest extends TestCase
+class OTLPHttpSpanConverterTest extends TestCase
 {
     /**
      * @test
@@ -151,6 +152,7 @@ class OTLPhttpSpanConverterTest extends TestCase
                 ])
             )
         );
+        $sdk->setInstrumentationLibrary(new InstrumentationLibrary('lib-test', 'v0.1.0'));
 
         // We have to set the time twice here due to the way PHP deals with Monotonic Clock and Realtime Clock.
         $sdk->setStartEpochTimestamp($start_time);
@@ -191,9 +193,8 @@ class OTLPhttpSpanConverterTest extends TestCase
             'instrumentation_library_spans' => [
                 new InstrumentationLibrarySpans([
                     'instrumentation_library' => new \Opentelemetry\Proto\Common\V1\InstrumentationLibrary([
-                        // TODO: Fetch instrumentation library from TracerProvider
-                        // 'name' => 'lib-a',
-                        // 'version' => 'v0.1.0',
+                        'name' => 'lib-test',
+                        'version' => 'v0.1.0',
                     ]),
                     'spans' => [
                         new V1\Span([


### PR DESCRIPTION
Fixes #325

This PR adds `InstrumentationLibrary` information to the OTLP-exported `Span`s.
It also fixes the way how exported `Span`s are combined — by the `InstrumentationLIbrary` produced these `Span`s.