### PR TITLE
Fix Tracer Interface

### DIFF
--- a/api/Trace/Tracer.php
+++ b/api/Trace/Tracer.php
@@ -19,6 +19,7 @@ interface Tracer
 
     public function getActiveSpan(): Span;
 
+    public function startActiveSpan(string $name, SpanContext $parentContext, bool $isRemote = false, int $spanKind = SpanKind::KIND_INTERNAL): Span;
     public function startAndActivateSpan(string $name, int $spanKind = SpanKind::KIND_INTERNAL): Span;
     public function startSpanWithOptions(string $name): SpanOptions;
 


### PR DESCRIPTION
This PR adds a method defined within the Tracer file called startActiveSpan to the interface that Tracer implements. The reason this is done is so that psalm does not throw an error for using a function not defined within the interface.

Currently the Tracer.php file has many vestigial functions. However, this PR provides a temporary fix for the addition of sample apps to the contrib repository.