### PR TITLE
Implement links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ vendor
 .idea/
 coverage.clover
 tests/coverage
-.php_cs.cache
+.php-cs-fixer.cache
 
 # W3C Test Service build artifacts
 tests/TraceContext/W3CTestService/test_app

--- a/api/Trace/TraceState.php
+++ b/api/Trace/TraceState.php
@@ -55,9 +55,7 @@ interface TraceState
     public function getListMemberCount(): int;
 
     /**
-     * Build the TraceState header
-     *
-     * @return string|null
+     * Returns a string representation of this TraceSate
      */
-    public function build(): ?string;
+    public function __toString(): string;
 }

--- a/contrib/OtlpHttp/SpanConverter.php
+++ b/contrib/OtlpHttp/SpanConverter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\OtlpHttp;
 
+use function array_key_exists;
+use function hex2bin;
 use Opentelemetry\Proto;
 use Opentelemetry\Proto\Common\V1\AnyValue;
 use Opentelemetry\Proto\Common\V1\ArrayValue;
@@ -13,6 +15,7 @@ use Opentelemetry\Proto\Trace\V1\InstrumentationLibrarySpans;
 use Opentelemetry\Proto\Trace\V1\ResourceSpans;
 use Opentelemetry\Proto\Trace\V1\Span as CollectorSpan;
 use Opentelemetry\Proto\Trace\V1\Span\Event;
+use Opentelemetry\Proto\Trace\V1\Span\Link;
 use Opentelemetry\Proto\Trace\V1\Span\SpanKind;
 use Opentelemetry\Proto\Trace\V1\Status;
 use Opentelemetry\Proto\Trace\V1\Status\StatusCode;
@@ -37,7 +40,7 @@ class SpanConverter
             case is_array($value):
                 $values = [];
                 foreach ($value as $element) {
-                    array_push($values, $this->as_otlp_any_value($element));
+                    $values[] = $this->as_otlp_any_value($element);
                 }
                 $result->setArrayValue(new ArrayValue(['values' => $values]));
 
@@ -91,8 +94,7 @@ class SpanConverter
             'start_time_unix_nano' => $span->getStartEpochTimestamp(),
             'end_time_unix_nano' => $end_timestamp,
             'kind' => $this->as_otlp_span_kind($span->getSpanKind()),
-            // 'trace_state' => $span->getContext()
-            // 'links' =>
+            'trace_state' => (string) $span->getContext()->getTraceState(),
         ];
 
         foreach ($span->getEvents() as $event) {
@@ -102,7 +104,7 @@ class SpanConverter
             $attrs = [];
 
             foreach ($event->getAttributes() as $k => $v) {
-                array_push($attrs, $this->as_otlp_key_value($k, $v->getValue()));
+                $attrs[] = $this->as_otlp_key_value($k, $v->getValue());
             }
 
             $row['events'][] = new Event([
@@ -112,11 +114,29 @@ class SpanConverter
             ]);
         }
 
+        foreach ($span->getLinks() as $link) {
+            if (!array_key_exists('links', $row)) {
+                $row['links'] = [];
+            }
+            $attrs = [];
+
+            foreach ($link->getAttributes() as $k => $v) {
+                $attrs[] = $this->as_otlp_key_value($k, $v->getValue());
+            }
+
+            $row['links'][] = new Link([
+                'trace_id' => hex2bin($link->getSpanContext()->getTraceId()),
+                'span_id' => hex2bin($link->getSpanContext()->getSpanId()),
+                'trace_state' => (string) $link->getSpanContext()->getTraceState(),
+                'attributes' => $attrs,
+            ]);
+        }
+
         foreach ($span->getAttributes() as $k => $v) {
             if (!array_key_exists('attributes', $row)) {
                 $row['attributes'] = [];
             }
-            array_push($row['attributes'], $this->as_otlp_key_value($k, $v->getValue()));
+            $row['attributes'][] = $this->as_otlp_key_value($k, $v->getValue());
         }
 
         $status = new Status();
@@ -145,7 +165,7 @@ class SpanConverter
         $attrs = [];
         foreach ($spans as $span) {
             foreach ($span->getResource()->getAttributes() as $k => $v) {
-                array_push($attrs, $this->as_otlp_key_value($k, $v->getValue()));
+                $attrs[] = $this->as_otlp_key_value($k, $v->getValue());
             }
         }
 

--- a/sdk/Trace/Link.php
+++ b/sdk/Trace/Link.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+use OpenTelemetry\Trace as API;
+
+class Link implements API\Link
+{
+    private $attributes;
+    private $context;
+
+    public function __construct(API\SpanContext $context, ?API\Attributes $attributes = null)
+    {
+        $this->attributes = $attributes ?? new Attributes();
+        $this->context = $context;
+    }
+
+    public function getSpanContext(): API\SpanContext
+    {
+        return $this->context;
+    }
+
+    public function getAttributes(): API\Attributes
+    {
+        return $this->attributes;
+    }
+}

--- a/sdk/Trace/Links.php
+++ b/sdk/Trace/Links.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+use ArrayIterator;
+use function count;
+use OpenTelemetry\Trace as API;
+
+class Links implements API\Links
+{
+    /** @var list<API\Link> */
+    private $links = [];
+
+    /** @inheritDoc */
+    public function addLink(API\SpanContext $context, ?API\Attributes $attributes = null): API\Links
+    {
+        $this->links[] = new Link($context, $attributes);
+
+        return $this;
+    }
+
+    public function count(): int
+    {
+        return count($this->links);
+    }
+
+    public function getIterator(): API\LinksIterator
+    {
+        return new class($this->links) implements API\LinksIterator {
+            private $inner;
+            public function __construct($events)
+            {
+                $this->inner = new ArrayIterator($events);
+            }
+
+            public function key(): int
+            {
+                return $this->inner->key();
+            }
+
+            public function current(): API\Link
+            {
+                return $this->inner->current();
+            }
+
+            public function rewind(): void
+            {
+                $this->inner->rewind();
+            }
+
+            public function valid(): bool
+            {
+                return $this->inner->valid();
+            }
+
+            public function next(): void
+            {
+                $this->inner->next();
+            }
+        };
+    }
+}

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -40,25 +40,12 @@ class Span implements API\Span, ReadableSpan
 
     private $attributes;
     private $events;
-    private $links = null;
+    private $links;
 
     private $ended = false;
 
     /** @var ?SpanProcessor */
     private $spanProcessor;
-
-    // todo: missing links: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#add-links
-
-    // -> Need to understand the difference between SpanKind and links.  From the documentation:
-    // SpanKind
-    // describes the relationship between the Span, its parents, and its children in a Trace. SpanKind describes two independent properties that benefit tracing systems during analysis.
-    // This was also updated recently -> https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#spankind
-
-    // Links
-    // A Span may be linked to zero or more other Spans (defined by SpanContext) that are causally related. Links can point to SpanContexts inside a single Trace
-    // or across different Traces. Links can be used to represent batched operations where a Span was initiated by multiple initiating Spans,
-    // each representing a single incoming item being processed in the batch.
-    // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#links-between-spans
 
     public function __construct(
         string $name,
@@ -84,6 +71,7 @@ class Span implements API\Span, ReadableSpan
         // todo: set these to null until needed
         $this->attributes = new Attributes();
         $this->events = new Events();
+        $this->links = new Links();
     }
 
     /**
@@ -325,7 +313,6 @@ class Span implements API\Span, ReadableSpan
 
     public function getLinks(): API\Links
     {
-        // TODO: Implement getLinks() method.
         return $this->links;
     }
 
@@ -336,6 +323,8 @@ class Span implements API\Span, ReadableSpan
      */
     public function addLink(API\SpanContext $context, ?API\Attributes $attributes = null): API\Span
     {
+        $this->links->addLink($context, $attributes);
+
         return $this;
     }
 

--- a/sdk/Trace/TraceContext.php
+++ b/sdk/Trace/TraceContext.php
@@ -40,10 +40,9 @@ final class TraceContext implements API\TextMapFormatPropagator
         $setter->set($carrier, self::TRACEPARENT, $traceparent);
 
         // Build and inject the tracestate header
-        $tracestate = $context->getTraceState();
-        if ($tracestate !== null) {
-            $tracestateStr = $tracestate->build();
-            $setter->set($carrier, self::TRACESTATE, $tracestateStr ? $tracestateStr : '');
+        // Spec says to avoid sending empty tracestate headers
+        if ($tracestate = (string) $context->getTraceState()) {
+            $setter->set($carrier, self::TRACESTATE, $tracestate);
         }
     }
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -94,6 +94,10 @@ class Tracer implements API\Tracer
         $span->replaceAttributes($attributes);
         $span->setInstrumentationLibrary($this->instrumentationLibrary);
 
+        if ($links) {
+            $span->setLinks($links);
+        }
+
         $this->provider->getSpanProcessor()->onStart($span, $parentContext ?? Context::getCurrent());
 
         return $span;

--- a/tests/Sdk/Unit/Trace/TraceStateTest.php
+++ b/tests/Sdk/Unit/Trace/TraceStateTest.php
@@ -86,17 +86,22 @@ class TraceStateTest extends TestCase
     {
         // Build a tracestate with the max 32 values. Ex '0=0,1=1,...,31=31'
         $rawTraceState = range(0, TraceState::MAX_TRACESTATE_LIST_MEMBERS - 1);
-        array_walk($rawTraceState, function (&$v, $k) {
+        array_walk($rawTraceState, static function (&$v, $k) {
             $v = 'k' . $k . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . 'v' . $v;
         });
-        $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS, count($rawTraceState));
+
+        /**
+         * @var array $rawTraceState
+         * @see https://github.com/vimeo/psalm/issues/6394
+         */
+        $this->assertCount(TraceState::MAX_TRACESTATE_LIST_MEMBERS, $rawTraceState);
 
         $validTracestate = new TraceState(implode(Tracestate::LIST_MEMBERS_SEPARATOR, $rawTraceState));
         $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS, $validTracestate->getListMemberCount());
 
         // Add a list-member to the tracestate that exceeds the max of 32. This will cause it to be truncated
-        $rawTraceState['32'] = 'k32' . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . 'v32';
-        $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS + 1, count($rawTraceState));
+        $rawTraceState[32] = 'k32' . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . 'v32';
+        $this->assertCount(TraceState::MAX_TRACESTATE_LIST_MEMBERS + 1, $rawTraceState);
 
         $truncatedTracestate = new TraceState(implode(Tracestate::LIST_MEMBERS_SEPARATOR, $rawTraceState));
         $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS, $truncatedTracestate->getListMemberCount());

--- a/tests/Sdk/Unit/Trace/TraceStateTest.php
+++ b/tests/Sdk/Unit/Trace/TraceStateTest.php
@@ -32,24 +32,24 @@ class TraceStateTest extends TestCase
         $this->assertNull($tracestate->get('vendor2'));
 
         // New entry is placed at the beginning of the tracestate header
-        $this->assertSame('vendor2=value2,vendor1=value1', $tracestateWithNewValue->build());
+        $this->assertSame('vendor2=value2,vendor1=value1', (string) $tracestateWithNewValue);
 
         $tracestateWithUpdatedValue = $tracestateWithNewValue->with('vendor1', 'newValue1');
 
         // The updated entry is overwritten and placed at the beginning of the header
         $this->assertSame('value1', $tracestateWithNewValue->get('vendor1'));
         $this->assertSame('newValue1', $tracestateWithUpdatedValue->get('vendor1'));
-        $this->assertSame('vendor1=newValue1,vendor2=value2', $tracestateWithUpdatedValue->build());
+        $this->assertSame('vendor1=newValue1,vendor2=value2', (string) $tracestateWithUpdatedValue);
 
         // A new entry containing an invalid key will not be added
         $tracestateWithInvalidKey = $tracestate->with('@', 'value');
         $this->assertNull($tracestateWithInvalidKey->get('@'));
-        $this->assertSame($tracestate->build(), $tracestateWithInvalidKey->build());
+        $this->assertSame((string) $tracestate, (string) $tracestateWithInvalidKey);
 
         // A new entry containing an invalid value will not be added
         $tracestateWithInvalidValue = $tracestate->with('vendor2', 'value' . chr(0x19) . '1');
         $this->assertNull($tracestateWithInvalidValue->get('vendor2'));
-        $this->assertSame($tracestate->build(), $tracestateWithInvalidValue->build());
+        $this->assertSame((string) $tracestate, (string) $tracestateWithInvalidValue);
     }
 
     /**
@@ -69,14 +69,14 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testBuildTracestate()
+    public function testToStringTracestate()
     {
         $tracestate = new TraceState('vendor1=value1');
         $emptyTracestate = new TraceState();
 
-        $this->assertSame('vendor1=value1', $tracestate->build());
+        $this->assertSame('vendor1=value1', (string) $tracestate);
         $this->assertSame(0, $emptyTracestate->getListMemberCount());
-        $this->assertNull($emptyTracestate->build());
+        $this->assertEmpty((string) $emptyTracestate);
     }
 
     /**
@@ -125,7 +125,7 @@ class TraceStateTest extends TestCase
         $this->assertSame(TraceState::MAX_TRACESTATE_LENGTH, \strlen($rawTraceState));
 
         $validTracestate = new TraceState($rawTraceState);
-        $this->assertSame($rawTraceState, $validTracestate->build());
+        $this->assertSame($rawTraceState, (string) $validTracestate);
     }
 
     /**
@@ -142,7 +142,7 @@ class TraceStateTest extends TestCase
         $this->assertSame('3', $tracestate->get('e/f'));
         $this->assertSame('4', $tracestate->get('g_h'));
         $this->assertSame('5', $tracestate->get('01@i-j'));
-        $this->assertSame($validKeys, $tracestate->build());
+        $this->assertSame($validKeys, (string) $tracestate);
 
         // Mixed invalid keys in with valid ones
         $mixedInvalidKeys = 'a=1=,c*d=2,@e/f=3,g_h=4,I-j=5,k&l=6';
@@ -154,7 +154,7 @@ class TraceStateTest extends TestCase
         $this->assertNull($tracestate->get('k&l'));
         $this->assertSame('2', $tracestate->get('c*d'));
         $this->assertSame('4', $tracestate->get('g_h'));
-        $this->assertSame('c*d=2,g_h=4', $tracestate->build());
+        $this->assertSame('c*d=2,g_h=4', (string) $tracestate);
 
         // Tests a valid key with a length of 256 characters. The max characters allowed.
         $validKey = \str_repeat('k', 256);
@@ -163,7 +163,7 @@ class TraceStateTest extends TestCase
 
         $this->assertSame(256, \strlen($validKey));
         $this->assertSame($validValue, $tracestate->get($validKey));
-        $this->assertSame($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue, $tracestate->build());
+        $this->assertSame($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue, (string) $tracestate);
 
         // Tests an invalid key with a length of 257 characters. One more than the max characters allowed.
         $invalidKey = \str_repeat('k', 257);
@@ -190,7 +190,7 @@ class TraceStateTest extends TestCase
         $this->assertNull($parsedTracestate->get('char4'));
         $this->assertSame('value' . chr(0x20) . '2', $parsedTracestate->get('char2'));
         $this->assertSame('value' . chr(0x7E) . '3', $parsedTracestate->get('char3'));
-        $this->assertSame('char2=value' . chr(0x20) . '2,char3=value' . chr(0x7E) . '3', $parsedTracestate->build());
+        $this->assertSame('char2=value' . chr(0x20) . '2,char3=value' . chr(0x7E) . '3', (string) $parsedTracestate);
 
         // Tests a valid value with a length of 256 characters. The max allowed.
         $validValue = \str_repeat('v', 256);
@@ -199,7 +199,7 @@ class TraceStateTest extends TestCase
 
         $this->assertSame(256, \strlen($validValue));
         $this->assertSame($validValue, $tracestate->get($validKey));
-        $this->assertSame($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue, $tracestate->build());
+        $this->assertSame($validKey . TraceState::LIST_MEMBER_KEY_VALUE_SPLITTER . $validValue, (string) $tracestate);
 
         // Tests an invalid value with a length of 257 characters. One more than the max allowed.
         $invalidValue = \str_repeat('v', 257);

--- a/tests/Sdk/Unit/Trace/TracerTest.php
+++ b/tests/Sdk/Unit/Trace/TracerTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Links;
 use OpenTelemetry\Sdk\Trace\NoopSpan;
 use OpenTelemetry\Sdk\Trace\ReadableSpan;
 use OpenTelemetry\Sdk\Trace\Sampler;
@@ -153,6 +154,20 @@ class TracerTest extends TestCase
         $span = $tracer->startSpan('test.span', null, API\SpanKind::KIND_INTERNAL, new Attributes($attributes));
 
         $this->assertSame($attributes, $this->readSpanAttributesArray($span));
+    }
+
+    /**
+     * @test
+     */
+    public function startSpanLinksShouldBePropagatedToSpan()
+    {
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+
+        $links = new Links();
+        $span = $tracer->startSpan('test.span', null, API\SpanKind::KIND_INTERNAL, null, $links);
+
+        $this->assertSame($links, $span->getLinks());
     }
 
     /**

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -94,7 +94,7 @@ class TracingTest extends TestCase
  at PHPUnit.Framework.TestCase.runBare(TestCase.php:1133)
  at PHPUnit.Framework.TestResult.run(TestResult.php:722)
  at PHPUnit.Framework.TestCase.run(TestCase.php:885)
- at PHPUnit.Framework.TestSuite.run(TestSuite.php:677)
+ at PHPUnit.Framework.TestSuite.run(TestSuite.php:678)
  ... 6 more';
         $actualStacktrace = '';
 
@@ -131,7 +131,7 @@ class TracingTest extends TestCase
  at PHPUnit.Framework.TestCase.runBare(TestCase.php:1133)
  at PHPUnit.Framework.TestResult.run(TestResult.php:722)
  at PHPUnit.Framework.TestCase.run(TestCase.php:885)
- at PHPUnit.Framework.TestSuite.run(TestSuite.php:677)
+ at PHPUnit.Framework.TestSuite.run(TestSuite.php:678)
  ... 6 more
 Caused by: Exception: Thrown from fail2()
  at OpenTelemetry.Tests.Sdk.Unit.Trace.TracingTest.fail2(TracingTest.php:113)


### PR DESCRIPTION
First pass at supporting links.

* Add links to both otlp gprc and proto exporters
  * Also includes `trace_state` information as it was needed for links
* Replace `TraceState#build` with `TraceState#__toString`
  * This felt like a more idiomatic implementation because `null` gets casted to an empty string so you can just do `(string) $context->getTraceState()` versus needing to make sure it's not `null` before calling `build`. Similarly both `null` and `''` are falsely so conditional logic would treat them both the same.
* Update `TraceContext` to not include the `tracestate` header of the value would be empty
  * The spec says empty headers should avoid being sent

Some outstanding questions

* Should there be a `links` argument on the constructor of `Span`?
  * Currently the tracer is just calling `setLinks` if it's not `null`
* It seems `OpenTelemetry\Contrib\Otlp\SpanConverter` isn't up to date as it's using `annotations` versus `attributes`? From what I know it should be the same as the protobuf implementation but just JSON encoded
  * Can save this for a follow up PR if that's not expected