### PR TITLE
Use Clock to get timestamp for events

### DIFF
--- a/sdk/Trace/Events.php
+++ b/sdk/Trace/Events.php
@@ -15,7 +15,7 @@ class Events implements API\Events
         ?API\Attributes $attributes = null,
         int $timestamp = null
     ): API\Events {
-        $this->events[] = new Event($name, $timestamp ?? time(), $attributes);
+        $this->events[] = new Event($name, $timestamp ?? Clock::get()->timestamp(), $attributes);
 
         return $this;
     }

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -281,9 +281,8 @@ class Span implements API\Span, ReadableSpan
         foreach ($attributes ?? [] as $attribute) {
             $eventAttributes->setAttribute($attribute->getKey(), $attribute->getValue());
         }
-        $timestamp = time();
 
-        return $this->addEvent('exception', $timestamp, $eventAttributes);
+        return $this->addEvent('exception', Clock::get()->timestamp(), $eventAttributes);
     }
 
     public function getEvents(): API\Events

--- a/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Contrib\Unit;
 
+use function bin2hex;
 use OpenTelemetry\Contrib\OtlpHttp\SpanConverter;
 use Opentelemetry\Proto\Trace\V1;
 use Opentelemetry\Proto\Trace\V1\InstrumentationLibrarySpans;
@@ -12,14 +13,13 @@ use OpenTelemetry\Sdk\InstrumentationLibrary;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Sdk\Trace\Attributes;
 use OpenTelemetry\Sdk\Trace\Clock;
-use OpenTelemetry\Sdk\Trace\Span;
 
+use OpenTelemetry\Sdk\Trace\Span;
 use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\SpanStatus;
-use OpenTelemetry\Sdk\Trace\TracerProvider;
 
+use OpenTelemetry\Sdk\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
-use function bin2hex;
 
 class OTLPHttpSpanConverterTest extends TestCase
 {

--- a/tests/Sdk/Unit/Trace/SpanTest.php
+++ b/tests/Sdk/Unit/Trace/SpanTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
+
+use Exception;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Trace as API;
+use PHPUnit\Framework\TestCase;
+
+class SpanTest extends TestCase
+{
+    public function testRecordExceptionEventTimestamp(): void
+    {
+        $span = new Span('span', new SpanContext(
+            'faa0c74e14bd78114ec2bc447ad94ec9',
+            '50a75f197c3de59a',
+            API\SpanContext::TRACE_FLAG_SAMPLED
+        ));
+
+        $span->recordException(new Exception('err'));
+
+        // The timestamp of the event should be greater than the start time of the span.
+        $this->assertGreaterThan(
+            $span->getStart(),
+            $span->getEvents()->getIterator()->current()->getTimestamp()
+        );
+    }
+}


### PR DESCRIPTION
Took me a while to figure out why my recorded exception wasn't showing up in the backend, but it turns out the event's timestamp wasn't in the duration of the span so it wasn't rendered as such.

This PR updates `renderException` and `Events#addEvent` to use `Clock#timestamp` instead of `time()`.

This probably fixes: https://github.com/open-telemetry/opentelemetry-php/issues/227#issuecomment-795151796.