### PR TITLE
Update Phan to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.3",
         "composer/xdebug-handler": "^2.0",
-        "phan/phan": "^4.1",
+        "phan/phan": "^5.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "vimeo/psalm": "^4.0",
         "phpstan/phpstan": "^0.12.50",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -y update && apt-get -y install git zip && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
     chmod +x /usr/local/bin/composer && \
-    pecl install ast-1.0.10 xdebug && \
+    pecl install ast-1.0.14 xdebug && \
     docker-php-ext-enable ast xdebug && \
     # The pcntl extension is used for speeding up `make phan`
     docker-php-ext-install pcntl


### PR DESCRIPTION
Needed to also update the version of the `ast` extension, that's at the latest version as well. Didn't find any additional errors so :+1:.