### PR TITLE
Return empty objects when no spans are passed in OTLP/GRPC exporter implementation

### DIFF
--- a/contrib/OtlpGrpc/SpanConverter.php
+++ b/contrib/OtlpGrpc/SpanConverter.php
@@ -176,11 +176,12 @@ class SpanConverter
 
     public function as_otlp_resource_span(iterable $spans): ResourceSpans
     {
-        // TODO: Should return an empty ResourceSpans when $spans is empty
-        // At the minute it returns an semi populated ResourceSpan
+        $isSpansEmpty = true; //Waiting for the loop to prove otherwise
 
         $ils = $convertedSpans = [];
         foreach ($spans as $span) {
+            $isSpansEmpty = false;
+
             /** @var \OpenTelemetry\Sdk\InstrumentationLibrary $il */
             $il = $span->getInstrumentationLibrary();
             $ilKey = sprintf('%s@%s', $il->getName(), $il->getVersion()??'');
@@ -189,6 +190,10 @@ class SpanConverter
                 $ils[$ilKey] = new InstrumentationLibrary(['name' => $il->getName(), 'version' => $il->getVersion()??'']);
             }
             $convertedSpans[$ilKey][] = $this->as_otlp_span($span);
+        }
+
+        if ($isSpansEmpty == true) {
+            return new Proto\Trace\V1\ResourceSpans();
         }
 
         $ilSpans = [];

--- a/contrib/OtlpHttp/SpanConverter.php
+++ b/contrib/OtlpHttp/SpanConverter.php
@@ -174,11 +174,12 @@ class SpanConverter
 
     public function as_otlp_resource_span(iterable $spans): ResourceSpans
     {
-        // TODO: Should return an empty ResourceSpans when $spans is empty
-        // At the minute it returns an semi populated ResourceSpan
+        $isSpansEmpty = true; //Waiting for the loop to prove otherwise
 
         $ils = $convertedSpans = [];
         foreach ($spans as $span) {
+            $isSpansEmpty = false;
+
             /** @var \OpenTelemetry\Sdk\InstrumentationLibrary $il */
             $il = $span->getInstrumentationLibrary();
             $ilKey = sprintf('%s@%s', $il->getName(), $il->getVersion()??'');
@@ -187,6 +188,10 @@ class SpanConverter
                 $ils[$ilKey] = new InstrumentationLibrary(['name' => $il->getName(), 'version' => $il->getVersion()??'']);
             }
             $convertedSpans[$ilKey][] = $this->as_otlp_span($span);
+        }
+
+        if ($isSpansEmpty == true) {
+            return new Proto\Trace\V1\ResourceSpans();
         }
 
         $ilSpans = [];

--- a/tests/Contrib/Unit/OTLPGrpcSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcSpanConverterTest.php
@@ -264,4 +264,13 @@ class OTLPGrpcSpanConverterTest extends TestCase
 
         $this->assertEquals($expected, $otlpspan);
     }
+
+    public function testOtlpNoSpans() 
+    {
+        $spans = [];
+
+        $otlpspan = (new SpanConverter())->as_otlp_resource_span($spans);
+
+        $this->assertEquals(new ResourceSpans(), $otlpspan);
+    }
 }

--- a/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
@@ -252,4 +252,13 @@ class OTLPHttpSpanConverterTest extends TestCase
 
         $this->assertEquals($expected, $otlpspan);
     }
+
+    public function testOtlpNoSpans() 
+    {
+        $spans = [];
+
+        $otlpspan = (new SpanConverter())->as_otlp_resource_span($spans);
+
+        $this->assertEquals(new ResourceSpans(), $otlpspan);
+    }
 }


### PR DESCRIPTION
Fixes the instances of [issue #327 ](https://github.com/open-telemetry/opentelemetry-php/issues/327) that I was able to notice.

I don't really have a sense for how this fits in overall yet, so I'm not sure what else I need to take into consideration.

Also I couldn't figure out the "idiomatic PHP" way to tell if an iterable was empty or not, hence this solution.