### PR TITLE
Add AttributeLimits, SpanLimits and dropped event/links counting

### DIFF
--- a/api/Trace/Attributes.php
+++ b/api/Trace/Attributes.php
@@ -16,4 +16,6 @@ interface Attributes extends \IteratorAggregate, \Countable
 
     public function count(): int;
     public function getIterator(): AttributesIterator;
+
+    public function getDroppedAttributesCount(): int;
 }

--- a/contrib/OtlpGrpc/SpanConverter.php
+++ b/contrib/OtlpGrpc/SpanConverter.php
@@ -97,6 +97,9 @@ class SpanConverter
             'end_time_unix_nano' => $end_timestamp,
             'kind' => $this->as_otlp_span_kind($span->getSpanKind()),
             'trace_state' => (string) $span->getContext()->getTraceState(),
+            'dropped_attributes_count' => $span->getAttributes()->getDroppedAttributesCount(),
+            'dropped_events_count' => $span->getDroppedEventsCount(),
+            'dropped_links_count' => $span->getDroppedLinksCount(),
         ];
 
         foreach ($span->getEvents() as $event) {
@@ -113,6 +116,7 @@ class SpanConverter
                 'time_unix_nano' => $event->getTimestamp(),
                 'name' => $event->getName(),
                 'attributes' => $attrs,
+                'dropped_attributes_count' => $event->getAttributes()->getDroppedAttributesCount(),
             ]);
         }
 
@@ -131,6 +135,7 @@ class SpanConverter
                 'span_id' => hex2bin($link->getSpanContext()->getSpanId()),
                 'trace_state' => (string) $link->getSpanContext()->getTraceState(),
                 'attributes' => $attrs,
+                'dropped_attributes_count' => $link->getAttributes()->getDroppedAttributesCount(),
             ]);
         }
 

--- a/contrib/OtlpHttp/SpanConverter.php
+++ b/contrib/OtlpHttp/SpanConverter.php
@@ -95,6 +95,9 @@ class SpanConverter
             'end_time_unix_nano' => $end_timestamp,
             'kind' => $this->as_otlp_span_kind($span->getSpanKind()),
             'trace_state' => (string) $span->getContext()->getTraceState(),
+            'dropped_attributes_count' => $span->getAttributes()->getDroppedAttributesCount(),
+            'dropped_events_count' => $span->getDroppedEventsCount(),
+            'dropped_links_count' => $span->getDroppedLinksCount(),
         ];
 
         foreach ($span->getEvents() as $event) {
@@ -111,6 +114,7 @@ class SpanConverter
                 'time_unix_nano' => $event->getTimestamp(),
                 'name' => $event->getName(),
                 'attributes' => $attrs,
+                'dropped_attributes_count' => $event->getAttributes()->getDroppedAttributesCount(),
             ]);
         }
 
@@ -129,6 +133,7 @@ class SpanConverter
                 'span_id' => hex2bin($link->getSpanContext()->getSpanId()),
                 'trace_state' => (string) $link->getSpanContext()->getTraceState(),
                 'attributes' => $attrs,
+                'dropped_attributes_count' => $link->getAttributes()->getDroppedAttributesCount(),
             ]);
         }
 

--- a/sdk/Internal/StringUtil.php
+++ b/sdk/Internal/StringUtil.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Internal;
+
+class StringUtil
+{
+    public static function substr(string $value, int $offset, int $length): string
+    {
+        if (function_exists('mb_substr')) {
+            return \mb_substr($value, $offset, $length);
+        }
+
+        return \substr($value, $offset, $length);
+    }
+
+    public static function strlen(string $value): int
+    {
+        if (function_exists('mb_strlen')) {
+            return \mb_strlen($value);
+        }
+
+        return \strlen($value);
+    }
+}

--- a/sdk/Trace/AttributeLimits.php
+++ b/sdk/Trace/AttributeLimits.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+class AttributeLimits
+{
+    private const DEFAULT_COUNT_LIMIT = 128;
+
+    private const DEFAULT_VALUE_LENGTH_LIMIT = PHP_INT_MAX;
+
+    private $attributeCountLimit;
+
+    private $attributeValueLengthLimit;
+
+    public function __construct(
+        int $attributeCountLimit = self::DEFAULT_COUNT_LIMIT,
+        int $attributeValueLengthLimit = self::DEFAULT_VALUE_LENGTH_LIMIT
+    ) {
+        $this->attributeCountLimit = $attributeCountLimit;
+        $this->attributeValueLengthLimit = $attributeValueLengthLimit;
+    }
+
+    /** @return int Maximum allowed attribute count */
+    public function getAttributeCountLimit(): int
+    {
+        return $this->attributeCountLimit;
+    }
+
+    /** @return int Maximum allowed attribute value length */
+    public function getAttributeValueLengthLimit(): int
+    {
+        return $this->attributeValueLengthLimit;
+    }
+}

--- a/sdk/Trace/Attributes.php
+++ b/sdk/Trace/Attributes.php
@@ -4,27 +4,66 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace;
 
+use OpenTelemetry\Sdk\Internal\StringUtil;
 use OpenTelemetry\Trace as API;
 
 class Attributes implements API\Attributes
 {
     private $attributes = [];
 
-    public function __construct(iterable $attributes = [])
+    /** @var AttributeLimits */
+    private $attributeLimits;
+
+    /** @var int Counts for attributes dropped due to collection limits */
+    private $droppedAttributeCount = 0;
+
+    /** @return Attributes Returns a new instance of Attributes with the limits applied */
+    public static function withLimits(API\Attributes $attributes, AttributeLimits $attributeLimits): Attributes
     {
+        return new self($attributes->getIterator(), $attributeLimits);
+    }
+
+    public function __construct(iterable $attributes = [], AttributeLimits $attributeLimits = null)
+    {
+        $this->attributeLimits = $attributeLimits ?? new AttributeLimits();
         foreach ($attributes as $key => $attribute) {
-            $this->setAttribute($key, $attribute);
+            $attributeKey = $attribute instanceof Attribute ? $attribute->getKey() : (string) $key;
+            $attributeValue = $attribute instanceof Attribute ? $attribute->getValue() : $attribute;
+            $this->setAttribute($attributeKey, $attributeValue);
         }
     }
 
     public function setAttribute(string $name, $value): API\Attributes
     {
-        if (isset($value)) {
-            $this->attributes[$name] = new Attribute($name, $value);
-        } else {
-            // todo: does this warn?
+        // unset the attribute when null value is passed
+        if (null === $value) {
             unset($this->attributes[$name]);
+
+            return $this;
         }
+
+        // drop attribute when limit is reached
+        if (!isset($this->attributes[$name]) && $this->count() >= $this->attributeLimits->getAttributeCountLimit()) {
+            $this->droppedAttributeCount++;
+
+            return $this;
+        }
+
+        if (is_string($value)) {
+            $limitedValue = StringUtil::substr($value, 0, $this->attributeLimits->getAttributeValueLengthLimit());
+        } elseif (is_array($value)) {
+            $limitedValue = array_map(function ($arrayValue) {
+                if (is_string($arrayValue)) {
+                    return StringUtil::substr($arrayValue, 0, $this->attributeLimits->getAttributeValueLengthLimit());
+                }
+
+                return $arrayValue;
+            }, $value);
+        } else {
+            $limitedValue = $value;
+        }
+
+        $this->attributes[$name] = new Attribute($name, $limitedValue);
 
         return $this;
     }
@@ -50,7 +89,7 @@ class Attributes implements API\Attributes
 
             public function key(): string
             {
-                return $this->inner->key();
+                return (string) $this->inner->key();
             }
 
             public function current(): API\Attribute
@@ -73,5 +112,10 @@ class Attributes implements API\Attributes
                 $this->inner->next();
             }
         };
+    }
+
+    public function getDroppedAttributesCount(): int
+    {
+        return $this->droppedAttributeCount;
     }
 }

--- a/sdk/Trace/NoopSpan.php
+++ b/sdk/Trace/NoopSpan.php
@@ -101,9 +101,19 @@ class NoopSpan implements ReadWriteSpan
         return $this->links;
     }
 
+    public function getDroppedLinksCount(): int
+    {
+        return 0;
+    }
+
     public function getEvents(): API\Events
     {
         return $this->events;
+    }
+
+    public function getDroppedEventsCount(): int
+    {
+        return 0;
     }
 
     public function getStatus(): API\SpanStatus

--- a/sdk/Trace/ReadableSpan.php
+++ b/sdk/Trace/ReadableSpan.php
@@ -27,7 +27,11 @@ interface ReadableSpan
 
     public function getLinks(): API\Links;
 
+    public function getDroppedLinksCount(): int;
+
     public function getEvents(): API\Events;
+
+    public function getDroppedEventsCount(): int;
 
     public function getStatus(): API\SpanStatus;
 

--- a/sdk/Trace/SpanLimits.php
+++ b/sdk/Trace/SpanLimits.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+final class SpanLimits
+{
+    /** @var AttributeLimits */
+    private $attributeLimits;
+
+    private $eventCountLimit;
+
+    private $linkCountLimit;
+
+    private $attributePerEventCountLimit;
+
+    private $attributePerLinkCountLimit;
+
+    public function getAttributeLimits(): AttributeLimits
+    {
+        return $this->attributeLimits;
+    }
+
+    /** @return int Maximum allowed span event count */
+    public function getEventCountLimit(): int
+    {
+        return $this->eventCountLimit;
+    }
+
+    /** @return int Maximum allowed span link count */
+    public function getLinkCountLimit(): int
+    {
+        return $this->linkCountLimit;
+    }
+
+    /** @return int Maximum allowed attribute per span event count */
+    public function getAttributePerEventCountLimit(): int
+    {
+        return $this->attributePerEventCountLimit;
+    }
+
+    /** @return int Maximum allowed attribute per span link count */
+    public function getAttributePerLinkCountLimit(): int
+    {
+        return $this->attributePerLinkCountLimit;
+    }
+
+    /**
+     * @internal Use {@see SpanLimitsBuilder} to create {@see SpanLimits} instance.
+     */
+    public function __construct(
+        int $attributeCountLimit,
+        int $attributeValueLengthLimit,
+        int $eventCountLimit,
+        int $linkCountLimit,
+        int $attributePerEventCountLimit,
+        int $attributePerLinkCountLimit
+    ) {
+        $this->attributeLimits = new AttributeLimits($attributeCountLimit, $attributeValueLengthLimit);
+        $this->eventCountLimit = $eventCountLimit;
+        $this->linkCountLimit = $linkCountLimit;
+        $this->attributePerEventCountLimit = $attributePerEventCountLimit;
+        $this->attributePerLinkCountLimit = $attributePerLinkCountLimit;
+    }
+}

--- a/sdk/Trace/SpanLimitsBuilder.php
+++ b/sdk/Trace/SpanLimitsBuilder.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+class SpanLimitsBuilder
+{
+    /** @var int Maximum allowed attribute count per record */
+    private $attributeCountLimit = 128;
+
+    /** @var int Maximum allowed attribute value length */
+    private $attributeValueLengthLimit = PHP_INT_MAX;
+
+    /** @var int Maximum allowed span event count */
+    private $eventCountLimit = 128;
+
+    /** @var int Maximum allowed span link count */
+    private $linkCountLimit = 128;
+
+    /** @var int Maximum allowed attribute per span event count */
+    private $attributePerEventCountLimit = 128;
+
+    /** @var int Maximum allowed attribute per span link count */
+    private $attributePerLinkCountLimit = 128;
+
+    /**
+     * @param int $attributeCountLimit Maximum allowed attribute count per record
+     */
+    public function setAttributeCountLimit(int $attributeCountLimit): SpanLimitsBuilder
+    {
+        $this->attributeCountLimit = $attributeCountLimit;
+
+        return $this;
+    }
+
+    /**
+     * @param int $attributeValueLengthLimit Maximum allowed attribute value length
+     */
+    public function setAttributeValueLengthLimit(int $attributeValueLengthLimit): SpanLimitsBuilder
+    {
+        $this->attributeValueLengthLimit = $attributeValueLengthLimit;
+
+        return $this;
+    }
+
+    /**
+     * @param int $eventCountLimit Maximum allowed span event count
+     */
+    public function setEventCountLimit(int $eventCountLimit): SpanLimitsBuilder
+    {
+        $this->eventCountLimit = $eventCountLimit;
+
+        return $this;
+    }
+
+    /**
+     * @param int $linkCountLimit Maximum allowed span link count
+     */
+    public function setLinkCountLimit(int $linkCountLimit): SpanLimitsBuilder
+    {
+        $this->linkCountLimit = $linkCountLimit;
+
+        return $this;
+    }
+
+    /**
+     * @param int $attributePerEventCountLimit Maximum allowed attribute per span event count
+     */
+    public function setAttributePerEventCountLimit(int $attributePerEventCountLimit): SpanLimitsBuilder
+    {
+        $this->attributePerEventCountLimit = $attributePerEventCountLimit;
+
+        return $this;
+    }
+
+    /**
+     * @param int $attributePerLinkCountLimit Maximum allowed attribute per span link count
+     */
+    public function setAttributePerLinkCountLimit(int $attributePerLinkCountLimit): SpanLimitsBuilder
+    {
+        $this->attributePerLinkCountLimit = $attributePerLinkCountLimit;
+
+        return $this;
+    }
+
+    public function build(): SpanLimits
+    {
+        return new SpanLimits(
+            $this->attributeCountLimit,
+            $this->attributeValueLengthLimit,
+            $this->eventCountLimit,
+            $this->linkCountLimit,
+            $this->attributePerEventCountLimit,
+            $this->attributePerLinkCountLimit
+        );
+    }
+}

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -93,14 +93,11 @@ class Tracer implements API\Tracer
             $spanKind,
             $attributes,
             $links,
-            $this->provider->getSpanProcessor()
+            $this->provider->getSpanProcessor(),
+            $this->provider->getSpanLimits()
         );
 
         $span->setInstrumentationLibrary($this->instrumentationLibrary);
-
-        if ($links) {
-            $span->setLinks($links);
-        }
 
         $this->provider->getSpanProcessor()->onStart($span, $parentContext ?? Context::getCurrent());
 

--- a/sdk/Trace/TracerProvider.php
+++ b/sdk/Trace/TracerProvider.php
@@ -38,12 +38,18 @@ final class TracerProvider implements API\TracerProvider
      */
     private $sampler;
 
-    public function __construct(?ResourceInfo $resource = null, ?Sampler $sampler = null, ?IdGenerator $idGenerator = null)
+    /**
+     * @var SpanLimits $spanLimits
+     */
+    private $spanLimits;
+
+    public function __construct(?ResourceInfo $resource = null, ?Sampler $sampler = null, ?IdGenerator $idGenerator = null, ?SpanLimits $spanLimits = null)
     {
         $this->spanProcessors = new SpanMultiProcessor();
         $this->resource = $resource ?? ResourceInfo::emptyResource();
         $this->sampler = $sampler ?? new ParentBased(new AlwaysOnSampler());
         $this->idGenerator = $idGenerator ?? new RandomIdGenerator();
+        $this->spanLimits = $spanLimits ?? (new SpanLimitsBuilder())->build();
 
         register_shutdown_function([$this, 'shutdown']);
     }
@@ -100,5 +106,13 @@ final class TracerProvider implements API\TracerProvider
     public function getIdGenerator(): IdGenerator
     {
         return $this->idGenerator;
+    }
+
+    /**
+     * @internal
+     */
+    public function getSpanLimits(): SpanLimits
+    {
+        return $this->spanLimits;
     }
 }

--- a/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
@@ -16,8 +16,9 @@ use OpenTelemetry\Sdk\Trace\Clock;
 use OpenTelemetry\Sdk\Trace\Link;
 use OpenTelemetry\Sdk\Trace\Links;
 use OpenTelemetry\Sdk\Trace\Span;
-
 use OpenTelemetry\Sdk\Trace\SpanContext;
+
+use OpenTelemetry\Sdk\Trace\SpanLimitsBuilder;
 use OpenTelemetry\Sdk\Trace\SpanStatus;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
 
@@ -260,5 +261,55 @@ class OTLPHttpSpanConverterTest extends TestCase
         $otlpspan = (new SpanConverter())->as_otlp_resource_span($spans);
 
         $this->assertEquals(new ResourceSpans(), $otlpspan);
+    }
+
+    public function testOtlpDroppedAttributes()
+    {
+        $spanLimits = (new SpanLimitsBuilder())->setAttributeCountLimit(2)->build();
+        $span = new Span('tags.test', SpanContext::generate(), null, null, SpanKind::KIND_INTERNAL, null, null, null, $spanLimits);
+
+        $span->setAttribute('attr-1', '1');
+        $span->setAttribute('attr-2', '2');
+        $span->setAttribute('attr-3', '3');
+
+        $converter = new \OpenTelemetry\Contrib\OtlpGrpc\SpanConverter();
+        $convertedSpan = $converter->as_otlp_span($span);
+
+        $this->assertCount(2, $convertedSpan->getAttributes());
+        $this->assertEquals(1, $convertedSpan->getDroppedAttributesCount());
+    }
+
+    public function testOtlpDroppedEvents()
+    {
+        $spanLimits = (new SpanLimitsBuilder())->setEventCountLimit(2)->build();
+        $span = new Span('tags.test', SpanContext::generate(), null, null, SpanKind::KIND_INTERNAL, null, null, null, $spanLimits);
+
+        $span->addEvent('event-1', Clock::get()->timestamp());
+        $span->addEvent('event-2', Clock::get()->timestamp());
+        $span->addEvent('event-3', Clock::get()->timestamp());
+
+        $converter = new SpanConverter();
+        $convertedSpan = $converter->as_otlp_span($span);
+
+        $this->assertCount(2, $convertedSpan->getEvents());
+        $this->assertEquals(1, $convertedSpan->getDroppedEventsCount());
+    }
+
+    public function testOtlpDroppedLinks()
+    {
+        $spanLimits = (new SpanLimitsBuilder())->setLinkCountLimit(2)->build();
+        $links = new Links([
+            new Link(SpanContext::generate()),
+            new Link(SpanContext::generate()),
+            new Link(SpanContext::generate()),
+        ]);
+
+        $span = new Span('tags.test', SpanContext::generate(), null, null, SpanKind::KIND_INTERNAL, null, $links, null, $spanLimits);
+
+        $converter = new SpanConverter();
+        $convertedSpan = $converter->as_otlp_span($span);
+
+        $this->assertCount(2, $convertedSpan->getLinks());
+        $this->assertEquals(1, $convertedSpan->getDroppedLinksCount());
     }
 }

--- a/tests/Sdk/Integration/SpanLimitsTest.php
+++ b/tests/Sdk/Integration/SpanLimitsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Integration\Trace;
+
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Link;
+use OpenTelemetry\Sdk\Trace\Links;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\SpanLimits;
+use OpenTelemetry\Sdk\Trace\SpanLimitsBuilder;
+use OpenTelemetry\Sdk\Trace\Tracer;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace\SpanKind;
+use PHPUnit\Framework\TestCase;
+
+class SpanLimitsTest extends TestCase
+{
+    public function testSpanAttributeLimits()
+    {
+        $spanLimits = (new SpanLimitsBuilder())
+            ->setAttributeCountLimit(3)
+            ->build();
+
+        $span = $this->getTracerSpanWithLimits($spanLimits)->startSpan('test.spanlimits');
+        for ($i = 0; $i < 4; $i++) {
+            $span->setAttribute('attr' . $i, $i);
+        }
+
+        $this->assertCount(3, $span->getAttributes());
+        $this->assertEquals(1, $span->getAttributes()->getDroppedAttributesCount());
+    }
+
+    public function testSpanEventLimits()
+    {
+        $spanLimits = (new SpanLimitsBuilder())
+            ->setEventCountLimit(3)
+            ->setAttributePerEventCountLimit(2)
+            ->build();
+
+        $span = $this->getTracerSpanWithLimits($spanLimits)->startSpan('test.spanlimits');
+        for ($i = 0; $i < 4; $i++) {
+            $span->addEvent('event' . $i, 0, new Attributes(['a1' => 1, 'a2' => 2, 'a3' => 3]));
+        }
+
+        $this->assertCount(3, $span->getEvents());
+        $this->assertEquals(1, $span->getDroppedEventsCount(), 'Should be dropped exactly one event');
+
+        foreach ($span->getEvents() as $event) {
+            $this->assertCount(2, $event->getAttributes());
+            $this->assertEquals(1, $event->getAttributes()->getDroppedAttributesCount(), 'Should be dropped exactly one attribute');
+        }
+    }
+
+    public function testSpanLinksLimits()
+    {
+        $spanLimits = (new SpanLimitsBuilder())
+            ->setLinkCountLimit(3)
+            ->setAttributePerLinkCountLimit(2)
+            ->build();
+
+        $links = new Links();
+        for ($i = 0; $i < 4; $i++) {
+            $links->addLink(new Link(SpanContext::getInvalid(), new Attributes(['a1' => 1, 'a2' => 2, 'a3' => 3])));
+        }
+
+        $span = $this->getTracerSpanWithLimits($spanLimits)->startSpan('test.spanlimits', null, SpanKind::KIND_INTERNAL, null, $links);
+
+        $this->assertCount(3, $span->getLinks());
+        $this->assertEquals(1, $span->getDroppedLinksCount(), 'Should be dropped exactly one link');
+
+        foreach ($span->getLinks() as $link) {
+            $this->assertCount(2, $link->getAttributes());
+            $this->assertEquals(1, $link->getAttributes()->getDroppedAttributesCount(), 'Should be dropped exactly one attribute');
+        }
+    }
+
+    private function getTracerSpanWithLimits(SpanLimits $spanLimits): Tracer
+    {
+        $tracerProvider = new TracerProvider(null, null, null, $spanLimits);
+
+        return $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+    }
+}

--- a/tests/Sdk/Unit/Trace/AttributesTest.php
+++ b/tests/Sdk/Unit/Trace/AttributesTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
+
+use OpenTelemetry\Sdk\Trace\AttributeLimits;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use PHPUnit\Framework\TestCase;
+
+class AttributesTest extends TestCase
+{
+    public function testAttributeLimitsCompare()
+    {
+        $attrLimits1 = new AttributeLimits(10, 20);
+        $attrLimits2 = new AttributeLimits(10, 20);
+        $attrLimits3 = new AttributeLimits(20, 30);
+
+        $this->assertTrue($attrLimits1 == $attrLimits2);
+        $this->assertTrue($attrLimits1 != $attrLimits3);
+    }
+
+    /** @test Test numeric attribute key is not cast to integer value */
+    public function testNumericAttributeName()
+    {
+        $attributes = new Attributes(['1' => '2']);
+        $this->assertCount(1, $attributes);
+        foreach ($attributes as $attribute) {
+            $this->assertTrue(is_string($attribute->getKey()));
+            $this->assertTrue(is_string($attribute->getValue()));
+        }
+    }
+
+    /**
+     * @psalm-suppress PossiblyNullReference
+     */
+    public function testAttributeLimits()
+    {
+        $boolValue = true;
+        $intValue = 42;
+        $floatValue = 3.14;
+        $shortStringValue = '0123';
+        $longStringValue = '0123456789abcdefghijklmnopqrstuvwxyz';
+        $longStringTrimmed = '0123456789abcdef';
+
+        $attributeLimits = new AttributeLimits(6, 16);
+        $attributes = new Attributes([
+            'bool' => $boolValue,
+            'int' => $intValue,
+            'float' => $floatValue,
+            'short_string' => $shortStringValue,
+            'long_string' => $longStringValue,
+            'array' => [
+                $shortStringValue,
+                $longStringValue,
+            ],
+            'ignored_key' => 'ignored_value',
+        ], $attributeLimits);
+
+        $this->assertEquals($boolValue, $attributes->getAttribute('bool')->getValue());
+        $this->assertEquals($intValue, $attributes->getAttribute('int')->getValue());
+        $this->assertEquals($floatValue, $attributes->getAttribute('float')->getValue());
+        $this->assertEquals($shortStringValue, $attributes->getAttribute('short_string')->getValue());
+        $this->assertEquals($longStringTrimmed, $attributes->getAttribute('long_string')->getValue());
+        $this->assertEquals([$shortStringValue, $longStringTrimmed], $attributes->getAttribute('array')->getValue());
+
+        $this->assertEquals(6, $attributes->count());
+        $this->assertNull($attributes->getAttribute('ignored_key'));
+    }
+
+    /**
+     * @psalm-suppress PossiblyNullReference
+     */
+    public function testApplyLimits()
+    {
+        $attributes = new Attributes([
+            'short' => '123',
+            'long' => '1234567890',
+            'dropped' => true,
+        ]);
+        $limitedAttributes = Attributes::withLimits($attributes, new AttributeLimits(2, 5));
+        $this->assertCount(2, $limitedAttributes);
+        $this->assertEquals('123', $limitedAttributes->getAttribute('short')->getValue());
+        $this->assertEquals('12345', $limitedAttributes->getAttribute('long')->getValue());
+        $this->assertNull($limitedAttributes->getAttribute('dropped'));
+    }
+}

--- a/tests/Sdk/Unit/Trace/SpanOptionsTest.php
+++ b/tests/Sdk/Unit/Trace/SpanOptionsTest.php
@@ -84,7 +84,7 @@ class SpanOptionsTest extends TestCase
         $web = $spanOptions->toActiveSpan();
 
         // Check that span attributes are the ones passed in to spanOptions
-        $this->assertSame($attributes, $web->getAttributes());
+        $this->assertEquals($attributes, $web->getAttributes());
     }
 
     /**

--- a/tests/Sdk/Unit/Trace/TracerTest.php
+++ b/tests/Sdk/Unit/Trace/TracerTest.php
@@ -167,7 +167,7 @@ class TracerTest extends TestCase
         $links = new Links();
         $span = $tracer->startSpan('test.span', null, API\SpanKind::KIND_INTERNAL, null, $links);
 
-        $this->assertSame($links, $span->getLinks());
+        $this->assertEquals($links, $span->getLinks());
     }
 
     /**


### PR DESCRIPTION
This PR adds support for [Span Limits](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-limits) and common [Attribute Limits](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attribute-limits).

The `Span` class counts attributes, events and links dropped due to limits. These counters are exported via OTLP.

Fixed: Numeric attribute key is interpreted as an integer value which breaks string-key type checks on reading from Attributes.