### PR TITLE
Publish OpenTelemetry PHP Base Docker Image

### DIFF
--- a/.github/workflows/publish-otel-php-base-docker-image
+++ b/.github/workflows/publish-otel-php-base-docker-image
@@ -1,0 +1,30 @@
+name: publish-otel-php-base-docker-image
+on:
+  push:
+    branches: [ 'main' ]
+  workflow_dispatch:
+jobs:
+  push_to_registry:
+    name: OpenTelemetry PHP base docker image creation
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+
+      - name: check out the repo
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to ghcr.io
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: docker/Dockerfile
+          tags: ghcr.io/open-telemetry/opentelemetry-php/opentelemetry-php-base:latest


### PR DESCRIPTION
Currently, a developer for this project uses a docker base image that includes the gRPC extension.  That takes approximately 15-20 minutes to build, causing developer friction.  This PR creates a github action that builds a new opentelemetry-php base docker image on push.  This will be used as the default standard base Docker image in subsequent PRs.