### PR TITLE
`BatchSpanProcessor` clock fixes

### DIFF
--- a/api/Trace/Clock.php
+++ b/api/Trace/Clock.php
@@ -16,7 +16,7 @@ interface Clock
     public function now(): int;
 
     /**
-     * Returns the current epoch monotonic timestamp in nanoseconds that can only be used to calculate elapsed time.
+     * Returns a high resolution timestamp that should _ONLY_ be used to calculate elapsed time.
      */
     public function nanoTime(): int;
 }

--- a/sdk/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/sdk/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -6,12 +6,12 @@ namespace OpenTelemetry\Sdk\Trace\SpanProcessor;
 
 use InvalidArgumentException;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\Sdk\Trace\Clock;
 use OpenTelemetry\Sdk\Trace\Exporter;
 use OpenTelemetry\Sdk\Trace\ReadableSpan;
 use OpenTelemetry\Sdk\Trace\ReadWriteSpan;
 use OpenTelemetry\Sdk\Trace\SpanData;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
+use OpenTelemetry\Trace as API;
 
 class BatchSpanProcessor implements SpanProcessor
 {
@@ -21,7 +21,7 @@ class BatchSpanProcessor implements SpanProcessor
     private int $exporterTimeoutMillis;
     private int $maxExportBatchSize;
     private ?int $lastExportTimestamp = null;
-    private Clock $clock;
+    private API\Clock $clock;
     private bool $running = true;
 
     /** @var list<SpanData> */
@@ -29,7 +29,7 @@ class BatchSpanProcessor implements SpanProcessor
 
     public function __construct(
         ?Exporter $exporter,
-        Clock $clock,
+        API\Clock $clock,
         int $maxQueueSize = 2048,
         int $scheduledDelayMillis = 5000,
         int $exporterTimeoutMillis = 30000,
@@ -85,7 +85,7 @@ class BatchSpanProcessor implements SpanProcessor
         if (null !== $this->exporter) {
             $this->exporter->export($this->queue);
             $this->queue = [];
-            $this->lastExportTimestamp = $this->clock->now();
+            $this->lastExportTimestamp = $this->clock->nanoTime();
         }
     }
 
@@ -101,7 +101,7 @@ class BatchSpanProcessor implements SpanProcessor
 
     protected function enoughTimeHasPassed(): bool
     {
-        $now = $this->clock->now();
+        $now = $this->clock->nanoTime();
 
         // if lastExport never occurred let it start from now on
         if (null === $this->lastExportTimestamp) {

--- a/sdk/Trace/Test/TestClock.php
+++ b/sdk/Trace/Test/TestClock.php
@@ -8,9 +8,11 @@ use OpenTelemetry\Trace as API;
 
 final class TestClock implements API\Clock
 {
+    public const DEFAULT_START_EPOCH = 1633060331386955008; // Fri Oct 01 2021 03:52:11 UTC
+
     private int $currentEpochNanos;
 
-    public function __construct(int $currentEpochNanos)
+    public function __construct(int $currentEpochNanos = self::DEFAULT_START_EPOCH)
     {
         $this->currentEpochNanos = $currentEpochNanos;
     }

--- a/tests/Sdk/Unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/Sdk/Unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -100,7 +100,6 @@ class BatchSpanProcessorTest extends MockeryTestCase
             );
 
         /** @var Exporter $exporter */
-        /** @var Clock $clock */
         $processor = new BatchSpanProcessor(
             $exporter,
             $this->testClock,
@@ -132,7 +131,6 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $exporter->expects($this->never())->method('export');
 
         /** @var Exporter $exporter */
-        /** @var Clock $clock */
         $processor = new BatchSpanProcessor(
             $exporter,
             $this->testClock,


### PR DESCRIPTION
* Allow `BatchSpanProcessor` to use any `API\Clock`
  * Previously could only use `SDK\Clock` instances
* Clarify and update batch processor to use `nanoTime` since it is calculating elapsed time
* Update unit test to make use of `TestClock`
* Add default timestamp to `TestClock`