### PR TITLE
Update OTEL-to-Zipkin Span Converter to be a Little More Spec Compliant

### DIFF
--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -107,6 +107,10 @@ class SpanConverter
             ];
         }
 
+        if (empty($row['tags'])) {
+            unset($row['tags']);
+        }
+
         return $row;
     }
 

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -78,6 +78,23 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
+    public function shouldOmitEmptyKeysFromZipkinSpan()
+    {
+        $span = (new SpanData());
+
+        $converter = new SpanConverter('unused');
+        $row = $converter->convert($span);
+
+        $this->assertArrayNotHasKey('kind', $row);
+        $this->assertArrayNotHasKey('parentId', $row);
+        $this->assertArrayNotHasKey('tags', $row);
+        $this->assertArrayNotHasKey('otel.library.name', $row);
+        $this->assertArrayNotHasKey('otel.library.version', $row);
+    }
+
+    /**
+     * @test
+     */
     public function shouldConvertAnOTELServerSpanToAZipkinServerSpan()
     {
         $span = (new SpanData())


### PR DESCRIPTION
This partially addresses #295, except for the [Remote endpoint](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#remote-endpoint) and [Event attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#events) parts, which I'll be figuring out and creating a separate PR for

The sections of the spec this did touch on are 

[Span Kind](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#spankind)
[Instrumentation Library](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#instrumentationlibrary)
[Status](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#status)
[Request Payload](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#request-payload)

To figure out how to make the changes, I relied lightly on the spec but very heavily on the Java, Python, and JS implementations (mostly Java tbh). Here are their files I drew from

[Java](https://github.com/open-telemetry/opentelemetry-java/blob/6ef3091cfb83946372da0d47d70acdf468c9e6c3/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java#L174)
[Python](https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/opentelemetry-exporter-zipkin-json/src/opentelemetry/exporter/zipkin/encoder/__init__.py)
[JS](https://github.com/t2t2/opentelemetry-js/blob/zipkin-span-status/packages/opentelemetry-exporter-zipkin/src/transform.ts)

The PHP implementation went fairly smoothly. I ran into one thing I wanted to do in the tests but couldn't figure out how to do so in a "short and sweet" manner

- shouldOmitEmptyKeysFromZipkinSpan 
    - I wanted to loop over all nodes of ```$row``` to make sure none were null or an empty array, but saw ```array_walk_recursive``` was only hitting leaf nodes (and skipping the ```tags``` key if it still had an empty array set on it)
    - FWIW I left the test as-is because I thought it could be helpful for documentation's sake