### PR TITLE
docs/updated examples

### DIFF
--- a/examples/ConcurrentSpans.php
+++ b/examples/ConcurrentSpans.php
@@ -25,7 +25,7 @@ try {
     $childSpan->activate();
     $spans = [];
     for ($i=1; $i<=4; $i++) {
-        $spans[] = $tracer->spanBuilder('GET example.com/:id')
+        $spans[] = $tracer->spanBuilder('http-' . $i)
             //@see https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/v1.6.1/trace.go#L834
             ->setAttribute('http.method', 'GET')
             ->setAttribute('http.url', 'example.com/' . $i)

--- a/examples/ConcurrentSpans.php
+++ b/examples/ConcurrentSpans.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+
+echo 'Starting ConsoleSpanExporter' . PHP_EOL;
+
+$tracerProvider =  new TracerProvider(
+    new SimpleSpanProcessor(
+        new ConsoleSpanExporter()
+    )
+);
+
+$tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
+
+$rootSpan = $tracer->spanBuilder('root')->startSpan();
+$rootSpan->activate();
+try {
+    $childSpan = $tracer->spanBuilder('child-span')->startSpan();
+    $childSpan->activate();
+    $spans = [];
+    for ($i=1; $i<=4; $i++) {
+        $spans[] = $tracer->spanBuilder('GET example.com/:id')
+            //@see https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/v1.6.1/trace.go#L834
+            ->setAttribute('http.method', 'GET')
+            ->setAttribute('http.url', 'example.com/'.$i)
+            ->setAttribute('http.status_code', 200)
+            ->setAttribute('http.response_content_length', 1024)
+            ->startSpan();
+    }
+    foreach ($spans as $span) {
+        usleep((int)(0.3 * 1e6));
+        $span->end();
+    }
+} finally {
+    $childSpan->end();
+}
+
+$rootSpan->end();

--- a/examples/ConcurrentSpans.php
+++ b/examples/ConcurrentSpans.php
@@ -19,6 +19,7 @@ $tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
 
 $rootSpan = $tracer->spanBuilder('root')->startSpan();
 $rootSpan->activate();
+
 try {
     $childSpan = $tracer->spanBuilder('child-span')->startSpan();
     $childSpan->activate();
@@ -27,13 +28,13 @@ try {
         $spans[] = $tracer->spanBuilder('GET example.com/:id')
             //@see https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/v1.6.1/trace.go#L834
             ->setAttribute('http.method', 'GET')
-            ->setAttribute('http.url', 'example.com/'.$i)
+            ->setAttribute('http.url', 'example.com/' . $i)
             ->setAttribute('http.status_code', 200)
             ->setAttribute('http.response_content_length', 1024)
             ->startSpan();
     }
     foreach ($spans as $span) {
-        usleep((int)(0.3 * 1e6));
+        usleep((int) (0.3 * 1e6));
         $span->end();
     }
 } finally {

--- a/examples/SpanResources.php
+++ b/examples/SpanResources.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Resource\ResourceConstants;
+use OpenTelemetry\SDK\Trace\Attributes;
+use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+
+echo 'Starting ConsoleSpanExporter' . PHP_EOL;
+
+$resource = ResourceInfo::create(new Attributes([
+    //@see https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions
+    ResourceConstants::SERVICE_NAMESPACE => 'foo',
+    ResourceConstants::SERVICE_NAME => 'bar',
+    ResourceConstants::SERVICE_INSTANCE_ID => 1,
+    ResourceConstants::SERVICE_VERSION => '0.1',
+    ResourceConstants::HOST_HOSTNAME => \gethostname(),
+    'deployment.environment' => 'development',
+    'host.arch' => strtolower(php_uname('m')),
+    'host.type' => strtolower(php_uname('s')),
+]));
+
+$tracerProvider =  new TracerProvider(
+    new SimpleSpanProcessor(
+        new ConsoleSpanExporter()
+    ),
+    null,
+    $resource
+);
+
+$tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
+
+$rootSpan = $tracer->spanBuilder('root')->startSpan();
+$rootSpan->activate();
+
+$rootSpan->end();

--- a/examples/SpanResources.php
+++ b/examples/SpanResources.php
@@ -19,9 +19,9 @@ $resource = ResourceInfo::create(new Attributes([
     ResourceConstants::SERVICE_INSTANCE_ID => 1,
     ResourceConstants::SERVICE_VERSION => '0.1',
     ResourceConstants::HOST_HOSTNAME => \gethostname(),
-    'deployment.environment' => 'development',
-    'host.arch' => strtolower(php_uname('m')),
-    'host.type' => strtolower(php_uname('s')),
+    ResourceConstants::DEPLOYMENT_ENVIRONMENT => 'development',
+    ResourceConstants::HOST_ARCH => strtolower(php_uname('m')),
+    ResourceConstants::HOST_TYPE => strtolower(php_uname('s')),
 ]));
 
 $tracerProvider =  new TracerProvider(

--- a/examples/SpanResources.php
+++ b/examples/SpanResources.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
-use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Resource\ResourceConstants;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\Attributes;
 use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;

--- a/src/SDK/Resource/ResourceConstants.php
+++ b/src/SDK/Resource/ResourceConstants.php
@@ -34,6 +34,7 @@ class ResourceConstants
      */
     public const CONTAINER_NAME = 'container.name';
     public const CONTAINER_ID = 'container.id';
+    public const CONTAINER_RUNTIME = 'container.runtime';
     public const CONTAINER_IMAGE_NAME = 'container.image.name';
     public const CONTAINER_IMAGE_TAG = 'container.image.tag';
 
@@ -44,6 +45,7 @@ class ResourceConstants
     public const FAAS_ID = 'faas.id'; // required
     public const FAAS_VERSION = 'faas.version';
     public const FAAS_INSTANCE = 'faas.instance';
+    public const FAAS_MAX_MEMORY = 'faas.max_memory';
 
     /**
      * Kubernetes
@@ -63,6 +65,7 @@ class ResourceConstants
     public const HOST_IMAGE_NAME = 'host.image.name';
     public const HOST_IMAGE_ID = 'host.image.id';
     public const HOST_IMAGE_VERSION = 'host.image.version';
+    public const HOST_ARCH = 'host.arch';
 
     /**
      * Cloud
@@ -70,6 +73,12 @@ class ResourceConstants
     public const CLOUD_PROVIDER = 'cloud.provider';
     public const CLOUD_ACCOUNT_ID = 'cloud.account.id';
     public const CLOUD_REGION = 'cloud.region';
-    public const CLOUD_ZONE = 'cloud.zone';
+    public const CLOUD_ZONE = 'cloud.zone'; //@deprecated
+    public const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
     public const CLOUD_PLATFORM = 'cloud.platform';
+
+    /**
+     * Deployment
+     */
+    public const DEPLOYMENT_ENVIRONMENT = 'deployment.environment';
 }

--- a/src/SDK/Trace/SpanProcessor/ConsoleSpanExporter.php
+++ b/src/SDK/Trace/SpanProcessor/ConsoleSpanExporter.php
@@ -94,6 +94,21 @@ class ConsoleSpanExporter implements Trace\SpanExporterInterface
     }
 
     /**
+     * @param \OpenTelemetry\SDK\Resource\ResourceInfo $resource
+     * @return array
+     */
+    private function friendlyResource(\OpenTelemetry\SDK\Resource\ResourceInfo $resource): array
+    {
+        $tmp = [];
+
+        foreach ($resource->getAttributes()->getIterator() as $attribute) {
+            $tmp[$attribute->getKey()] = $attribute->getValue();
+        }
+
+        return $tmp;
+    }
+
+    /**
      * friendlySpan does the heavy lifting converting a span into an array
      *
      * @param Trace\SpanDataInterface $span
@@ -106,6 +121,7 @@ class ConsoleSpanExporter implements Trace\SpanExporterInterface
         $parent_span_id = $parent_span->isValid() ? $parent_span->getSpanId() : null;
 
         $foo = $span->getEvents();
+        var_dump($span->getResource()->getAttributes());
 
         return [
             'name' => $span->getName(),
@@ -114,6 +130,7 @@ class ConsoleSpanExporter implements Trace\SpanExporterInterface
                 'span_id' => $span->getContext()->getSpanId(),
                 'trace_state' => $span->getContext()->getTraceState(),
             ],
+            'resource' => $this->friendlyResource($span->getResource()),
             'parent_span_id' => $parent_span_id ? $parent_span_id : '',
             'kind' => $this->friendlyKind($span->getKind()),
             'start' => $span->getStartEpochNanos(),

--- a/src/SDK/Trace/SpanProcessor/ConsoleSpanExporter.php
+++ b/src/SDK/Trace/SpanProcessor/ConsoleSpanExporter.php
@@ -69,10 +69,7 @@ class ConsoleSpanExporter implements Trace\SpanExporterInterface
         $tmp = [];
 
         foreach ($attributes as $attribute) {
-            array_push($tmp, [
-                'key' => $attribute->getKey(),
-                'value' => $attribute->getValue(),
-            ]);
+            $tmp[$attribute->getKey()] = $attribute->getValue();
         }
 
         return $tmp;
@@ -119,9 +116,6 @@ class ConsoleSpanExporter implements Trace\SpanExporterInterface
         $parent_span = $span->getParentContext();
 
         $parent_span_id = $parent_span->isValid() ? $parent_span->getSpanId() : null;
-
-        $foo = $span->getEvents();
-        var_dump($span->getResource()->getAttributes());
 
         return [
             'name' => $span->getName(),

--- a/tests/SDK/Unit/Trace/SpanProcessor/ConsoleSpanExporterTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessor/ConsoleSpanExporterTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanProcessor;
 
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\InstrumentationLibrary;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\Attributes;
 use OpenTelemetry\SDK\Trace\SpanContext;
 use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
@@ -36,6 +37,7 @@ class ConsoleSpanExporterTest extends TestCase
             'instrumentation_library_version'
         ))
         ->addAttribute('fruit', 'apple')
+        ->setResource(ResourceInfo::defaultResource())
         ->addEvent('validators.list', new Attributes(['job' => 'stage.updateTime']), 1505855799433901068)
         ->setHasEnded(true);
 
@@ -50,16 +52,18 @@ class ConsoleSpanExporterTest extends TestCase
                 "span_id": "0000000000000000",
                 "trace_state": null
             },
+            "resource": {
+                "telemetry.sdk.name": "opentelemetry",
+                "telemetry.sdk.language": "php",
+                "telemetry.sdk.version": "dev"
+            },
             "parent_span_id": "1000000000000000",
             "kind": "KIND_INTERNAL",
             "start": 1505855794194009601,
             "end": 1505855799465726528,
-            "attributes": [
-                {
-                    "key": "fruit",
-                    "value": "apple"
-                }
-            ],
+            "attributes": {
+                "fruit": "apple"
+            },
             "status": {
                 "code": "Error",
                 "description": "status_description"
@@ -68,12 +72,9 @@ class ConsoleSpanExporterTest extends TestCase
                 {
                     "name": "validators.list",
                     "timestamp": 1505855799433901068,
-                    "attributes": [
-                        {
-                            "key": "job",
-                            "value": "stage.updateTime"
-                        }
-                    ]
+                    "attributes": {
+                        "job": "stage.updateTime"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Adding some current examples which illustrate some features not contained in other examples (resources, http attributes), which partially addresses https://github.com/open-telemetry/opentelemetry-php/issues/426;
Adding more resource constants per the opentelemetry-collector spec.
Updating ConsoleExporter to output span resources, and compacting span attributes.