### PR TITLE
Bugfix/batch processor

### DIFF
--- a/examples/BatchExporting.php
+++ b/examples/BatchExporting.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+
+$delayMillis = 3000;
+
+echo 'Starting ConsoleSpanExporter with BatchSpanProcessor' . PHP_EOL;
+echo sprintf('Sending batches every %dms and on shutdown', $delayMillis).PHP_EOL;
+
+$tracerProvider =  new TracerProvider(
+    new BatchSpanProcessor(
+        new ConsoleSpanExporter(),
+        OpenTelemetry\SDK\Trace\SystemClock::getDefault(),
+        2048, //max spans to queue before sending to exporter
+        $delayMillis, //batch delay milliseconds
+    )
+);
+
+$tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
+
+$rootSpan = $tracer->spanBuilder('root')->startSpan();
+$rootSpan->activate();
+
+//3 spans should be sent at 3 seconds
+for ($i=1;$i<=4;$i++) {
+    $span = $tracer->spanBuilder('span-'.$i)->startSpan();
+    sleep(1);
+    $span->end();
+}
+//4th span and root span should be sent on shutdown
+$rootSpan->end();
+sleep(1);

--- a/examples/BatchExporting.php
+++ b/examples/BatchExporting.php
@@ -3,14 +3,14 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
-use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 
 $delayMillis = 3000;
 
 echo 'Starting ConsoleSpanExporter with BatchSpanProcessor' . PHP_EOL;
-echo sprintf('Sending batches every %dms and on shutdown', $delayMillis).PHP_EOL;
+echo sprintf('Sending batches every %dms and on shutdown', $delayMillis) . PHP_EOL;
 
 $tracerProvider =  new TracerProvider(
     new BatchSpanProcessor(
@@ -28,7 +28,7 @@ $rootSpan->activate();
 
 //3 spans should be sent at 3 seconds
 for ($i=1;$i<=4;$i++) {
-    $span = $tracer->spanBuilder('span-'.$i)->startSpan();
+    $span = $tracer->spanBuilder('span-' . $i)->startSpan();
     sleep(1);
     $span->end();
 }

--- a/src/API/Trace/ClockInterface.php
+++ b/src/API/Trace/ClockInterface.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\API\Trace;
 interface ClockInterface
 {
     public const NANOS_PER_SECOND = 1000000000;
-    public const NANOS_PER_MILLI  = 1000000;
+    public const NANOS_PER_MILLISECOND = 1000000;
 
     /**
      * Returns the current epoch wall-clock timestamp in nanoseconds.

--- a/src/API/Trace/ClockInterface.php
+++ b/src/API/Trace/ClockInterface.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\API\Trace;
 interface ClockInterface
 {
     public const NANOS_PER_SECOND = 1000000000;
+    public const NANOS_PER_MILLI  = 1000000;
 
     /**
      * Returns the current epoch wall-clock timestamp in nanoseconds.

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -102,7 +102,7 @@ class BatchSpanProcessor implements SpanProcessorInterface
         }
 
         if (null !== $this->exporter) {
-            return $this->forceFlush() && $this->exporter->shutdown();
+            $this->forceFlush() && $this->exporter->shutdown();
         }
         $this->running = false;
 

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -88,6 +88,7 @@ class BatchSpanProcessor implements SpanProcessorInterface
             $this->exporter->export($this->queue);
             $this->queue = [];
             $this->lastExportTimestamp = $this->clock->nanoTime();
+            $this->exporter->forceFlush();
         }
 
         return true;
@@ -100,10 +101,10 @@ class BatchSpanProcessor implements SpanProcessorInterface
             return true;
         }
 
-        $this->running = false;
         if (null !== $this->exporter) {
             return $this->forceFlush() && $this->exporter->shutdown();
         }
+        $this->running = false;
 
         return true;
     }
@@ -129,6 +130,6 @@ class BatchSpanProcessor implements SpanProcessorInterface
             return false;
         }
 
-        return $this->scheduledDelayMillis < ($now - $this->lastExportTimestamp);
+        return ($this->scheduledDelayMillis * API\ClockInterface::NANOS_PER_MILLI) < ($now - $this->lastExportTimestamp);
     }
 }

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -130,6 +130,6 @@ class BatchSpanProcessor implements SpanProcessorInterface
             return false;
         }
 
-        return ($this->scheduledDelayMillis * API\ClockInterface::NANOS_PER_MILLI) < ($now - $this->lastExportTimestamp);
+        return ($this->scheduledDelayMillis * API\ClockInterface::NANOS_PER_MILLISECOND) < ($now - $this->lastExportTimestamp);
     }
 }


### PR DESCRIPTION
The spec for `SpanProcessor::shutdown()` says 'MUST include the effects of `ForceFlush`', so implement that logic and add a test (also updated a couple of other tests to add a new expectation on forceFlush)
The spec for `SpanProcessor::forceFlush()` also says that built-in span processors MUST call `forceFlush()` on the exporter.
Bugfix: `SpanInterface::scheduledDelayMillis` clearly accepts milliseconds, but time checking arithmetic uses nanoseconds. Adding a constant to convert between the two, and unit tests.