### PR TITLE
Add Logger SpanExporter, Logger ExporterDecorator and other logging related components.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^2.0@RC",
         "mockery/mockery": "^1.4",
+        "monolog/monolog": "^2.3",
         "nyholm/psr7": "^1.4",
         "phan/phan": "^5.0",
         "phpstan/phpstan": "^0.12.50",

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,15 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.4 || ^8.0",
-        "ext-json": "*",
         "ext-grpc": "*",
-        "promphp/prometheus_client_php": "^2.2.1",
-        "grpc/grpc": "^1.30",
+        "ext-json": "*",
         "google/protobuf": "^v3.3.0",
+        "grpc/grpc": "^1.30",
+        "nyholm/dsn": "^2.0.0",
+        "promphp/prometheus_client_php": "^2.2.1",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "nyholm/dsn": "^2.0.0"
+        "psr/log": "^3.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^2.0@RC",
+        "mikey179/vfsstream": "^1.6",
         "mockery/mockery": "^1.4",
         "monolog/monolog": "^2.3",
         "nyholm/psr7": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "promphp/prometheus_client_php": "^2.2.1",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "psr/log": "^3.0"
+        "psr/log": "^1.1"
     },
     "config": {
         "sort-packages": true

--- a/examples/AirGappedTraceDebugging.php
+++ b/examples/AirGappedTraceDebugging.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * If you want/need to test or debug the creation of traces and spans without an instance of an exporter/collector,
+ * you can use the LoggerExporter to send the span data to a Logger of your choice. The LoggerExporter can work
+ * with any Logger implementing the PSR3 standard, for example Monolog, however for this example we use the
+ * SimplePsrFileLogger, the library ships with.
+ *
+ * Note that the spans are logged in the order they are closed, so in this example the root span will be the last log entry
+ */
+
+use OpenTelemetry\SDK\Logs\SimplePsrFileLogger;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Trace\SpanExporter\LoggerExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+
+/**
+ * Create the log directory
+ */
+$logDir = __DIR__ . '/../var/log';
+$logFile = $logDir . '/otel.log';
+if (!is_dir($logDir) && !mkdir($logDir, 0744, true) && !is_dir($logDir)) {
+    throw new \RuntimeException(sprintf('Directory "%s" was not created', $logDir));
+}
+/**
+ * Create the LoggerExporter
+ */
+$exporter = new LoggerExporter(
+    'Logger Example',
+    new SimplePsrFileLogger($logFile)
+);
+/**
+ * If you want to have all spans in one log entry, remove the next line
+ */
+$exporter->setGranularity(LoggerExporter::GRANULARITY_SPAN);
+/**
+ * Create the Tracer
+ */
+$tracerProvider = new TracerProvider(
+    new SimpleSpanProcessor($exporter),
+    new AlwaysOnSampler()
+);
+$tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
+/**
+ * Create some tracing data
+ */
+echo 'Start Logging ...' . PHP_EOL;
+$rootSpan = $tracer->spanBuilder('root')->startSpan();
+$rootSpan->activate();
+
+$spans = [];
+
+for ($i = 0; $i < 5; $i++) {
+    usleep(200000);
+
+    $span = $tracer->spanBuilder('log.span' . ($i + 1))->startSpan();
+
+    usleep(20000);
+
+    $span->addEvent('something_happened' . ($i + 1));
+
+    usleep(20000);
+
+    $spans[] = $span;
+}
+
+$spans = array_reverse($spans);
+foreach ($spans as $span) {
+    usleep(200000);
+    $span->end();
+}
+
+$rootSpan->end();
+echo 'Finished!' . PHP_EOL;

--- a/examples/GettingStarted.php
+++ b/examples/GettingStarted.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
-use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
+use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 

--- a/examples/LoggingOfSpanData.php
+++ b/examples/LoggingOfSpanData.php
@@ -15,7 +15,6 @@ require __DIR__ . '/../vendor/autoload.php';
  * will be the last log entry
  */
 
-
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
 use OpenTelemetry\Contrib\Jaeger\Exporter as JaegerExporter;
@@ -34,7 +33,6 @@ $logFile = $logDir . '/otel.log';
 if (!is_dir($logDir) && !mkdir($logDir, 0744, true) && !is_dir($logDir)) {
     throw new \RuntimeException(sprintf('Directory "%s" was not created', $logDir));
 }
-
 
 /**
  * Create the Exporter.

--- a/examples/LoggingOfSpanData.php
+++ b/examples/LoggingOfSpanData.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * If you want to observe or debug the span data, which is sent to an exporter/collector,
+ * you can use the LoggerDecorator to send the span data to a Logger of your choice.
+ * The LoggerDecorator can decorate any instance of a SpanExporter. It can work with any
+ * Logger implementing the PSR3 standard, for example Monolog, however for this example we
+ * use the SimplePsrFileLogger, the library ships with.
+ *
+ * Note that the spans are logged in the order they are closed, so in this example the root span
+ * will be the last log entry
+ */
+
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\HttpFactory;
+use OpenTelemetry\Contrib\Jaeger\Exporter as JaegerExporter;
+use OpenTelemetry\SDK\Logs\SimplePsrFileLogger;
+use OpenTelemetry\SDK\Trace\AbstractClock;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Trace\SpanExporter\LoggerDecorator;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+
+/**
+ * Create the log directory
+ */
+$logDir = __DIR__ . '/../var/log';
+$logFile = $logDir . '/otel.log';
+if (!is_dir($logDir) && !mkdir($logDir, 0744, true) && !is_dir($logDir)) {
+    throw new \RuntimeException(sprintf('Directory "%s" was not created', $logDir));
+}
+
+
+/**
+ * Create the Exporter.
+ */
+$exporterEndpoint = 'http://jaeger:9412/api/v2/spans';
+/**
+ * If you want to simulate a connection error, uncomment the next line
+ */
+//$exporterEndpoint = 'http://example.com:9412/api/v2/spans';
+$exporter = new JaegerExporter(
+    'alwaysOnJaegerExample',
+    'http://jaeger:9412/api/v2/spans',
+    new Client(),
+    new HttpFactory(),
+    new HttpFactory()
+);
+/**
+ * Decorate the Exporter
+ */
+$decorator = new LoggerDecorator(
+    $exporter,
+    new SimplePsrFileLogger($logFile)
+);
+/**
+ * Create the Tracer
+ */
+$tracerProvider = new TracerProvider(
+    new BatchSpanProcessor($decorator, AbstractClock::getDefault()),
+    new AlwaysOnSampler()
+);
+$tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
+/**
+ * Create some tracing data
+ */
+echo 'Start Logging ...' . PHP_EOL;
+$rootSpan = $tracer->spanBuilder('root')->startSpan();
+$rootSpan->activate();
+
+$spans = [];
+
+for ($i = 0; $i < 5; $i++) {
+    usleep(200000);
+
+    $span = $tracer->spanBuilder('log.span' . ($i + 1))->startSpan();
+
+    usleep(20000);
+
+    $span->addEvent('something_happened' . ($i + 1));
+
+    usleep(20000);
+
+    $spans[] = $span;
+}
+
+$spans = array_reverse($spans);
+foreach ($spans as $span) {
+    usleep(200000);
+    $span->end();
+}
+
+$rootSpan->end();
+echo 'Finished!' . PHP_EOL;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,6 +34,8 @@
         <ini name="display_errors" value="On" />
         <ini name="display_startup_errors" value="On" />
         <ini name="error_reporting" value="E_ALL" />
+        <ini name="assert.active" value="True" />
+        <ini name="assert.exception" value="True" />
     </php>
 
     <testsuites>

--- a/src/SDK/Logs/PsrSeverityMapperInterface.php
+++ b/src/SDK/Logs/PsrSeverityMapperInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Logs;
+
+use Psr\Log\LogLevel as PsrLogLevel;
+
+interface PsrSeverityMapperInterface
+{
+    /**
+     * Severity code according to rfc5424 (Syslog Protocol)
+     * @see : https://datatracker.ietf.org/doc/html/rfc5424#page-10
+     */
+    public const RFC_CODE = [
+        // Detailed debug information.
+        PsrLogLevel::DEBUG => 7,
+        // Interesting events. Examples: User logs in, SQL logs.
+        PsrLogLevel::INFO => 6,
+        // Normal but significant events.
+        PsrLogLevel::NOTICE => 5,
+        // Exceptional occurrences that are not errors. Examples: Use of deprecated APIs, poor use of an API,
+        // undesirable things that are not necessarily wrong.
+        PsrLogLevel::WARNING => 4,
+        // Runtime errors that do not require immediate action but should typically be logged and monitored.
+        PsrLogLevel::ERROR => 3,
+        // Critical conditions. Example: Application component unavailable, unexpected exception.
+        PsrLogLevel::CRITICAL => 2,
+        // Action must be taken immediately. Example: Entire website down, database unavailable, etc.
+        // This should trigger the alerts and wake you up.
+        PsrLogLevel::ALERT => 1,
+        // Emergency: system is unusable.
+        PsrLogLevel::EMERGENCY => 0,
+    ];
+
+    /**
+     * Mappig of OpenTelemetry SeverityNumber to PsrLogLevel.
+     * @see: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/logs/data-model.md#field-severitynumber
+     */
+    public const SEVERITY_NUMBER = [
+        PsrLogLevel::DEBUG => 5,
+        PsrLogLevel::INFO => 9,
+        PsrLogLevel::NOTICE => 10,
+        PsrLogLevel::WARNING => 13,
+        PsrLogLevel::ERROR => 17,
+        PsrLogLevel::CRITICAL => 18,
+        PsrLogLevel::ALERT => 21,
+        PsrLogLevel::EMERGENCY => 22,
+    ];
+}

--- a/src/SDK/Logs/SimplePsrFileLogger.php
+++ b/src/SDK/Logs/SimplePsrFileLogger.php
@@ -15,16 +15,21 @@ class SimplePsrFileLogger implements LoggerInterface
 {
     use LoggerTrait;
 
+    private const DEFAULT_LOGGER_NAME = 'otel';
+
     private static ?array $logLevels = null;
 
     private string $filename;
 
+    private string $loggerName ;
+
     /**
      * @param string $filename
      */
-    public function __construct(string $filename)
+    public function __construct(string $filename, string $loggerName = self::DEFAULT_LOGGER_NAME)
     {
         $this->filename = $filename;
+        $this->loggerName = $loggerName;
     }
 
     /**
@@ -61,8 +66,9 @@ class SimplePsrFileLogger implements LoggerInterface
         }
 
         return sprintf(
-            '[%s] %s: %s %s%s',
+            '[%s] %s %s: %s %s%s',
             date(DATE_RFC3339_EXTENDED),
+            $this->loggerName,
             $level,
             $message,
             $encodedContext,

--- a/src/SDK/Logs/SimplePsrFileLogger.php
+++ b/src/SDK/Logs/SimplePsrFileLogger.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Logs;
+
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+use Psr\Log\LogLevel;
+use ReflectionClass;
+use Throwable;
+
+class SimplePsrFileLogger implements LoggerInterface
+{
+    use LoggerTrait;
+
+    private static ?array $logLevels = null;
+
+    private string $filename;
+
+    /**
+     * @param string $filename
+     */
+    public function __construct(string $filename)
+    {
+        $this->filename = $filename;
+    }
+
+    /**
+     * @param string $level
+     * @param string $message
+     * @param array $context
+     * @psalm-suppress MoreSpecificImplementedParamType
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        $level = strtolower($level);
+
+        if (!in_array($level, self::getLogLevels(), true)) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid Log level: "%s"', $level)
+            );
+        }
+
+        file_put_contents($this->filename, $this->formatLog((string) $level, (string) $message, $context), FILE_APPEND);
+    }
+
+    /**
+     * @param string $level
+     * @param string $message
+     * @param array $context
+     * @return string
+     */
+    private function formatLog(string $level, string $message, array $context = []): string
+    {
+        try {
+            $encodedContext = json_encode($context, JSON_THROW_ON_ERROR);
+        } catch (Throwable $t) {
+            $encodedContext = sprintf('(Could not encode context: %s)', $t->getMessage());
+        }
+
+        return sprintf(
+            '[%s] %s: %s %s',
+            date(DATE_RFC3339_EXTENDED),
+            $level,
+            $message,
+            $encodedContext
+        );
+    }
+
+    /**
+     * @return array
+     */
+    private static function getLogLevels(): array
+    {
+        return self::$logLevels ?? self::$logLevels = (new ReflectionClass(LogLevel::class))->getConstants();
+    }
+}

--- a/src/SDK/Logs/SimplePsrFileLogger.php
+++ b/src/SDK/Logs/SimplePsrFileLogger.php
@@ -61,11 +61,12 @@ class SimplePsrFileLogger implements LoggerInterface
         }
 
         return sprintf(
-            '[%s] %s: %s %s',
+            '[%s] %s: %s %s%s',
             date(DATE_RFC3339_EXTENDED),
             $level,
             $message,
-            $encodedContext
+            $encodedContext,
+            PHP_EOL
         );
     }
 

--- a/src/SDK/Resource/ResourceInfo.php
+++ b/src/SDK/Resource/ResourceInfo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Resource;
 
+use OpenTelemetry\API\Trace\AttributesInterface;
 use OpenTelemetry\SDK\Trace\Attributes;
 
 /**
@@ -15,14 +16,14 @@ use OpenTelemetry\SDK\Trace\Attributes;
  */
 class ResourceInfo
 {
-    private $attributes;
+    private AttributesInterface $attributes;
 
-    private function __construct(Attributes $attributes)
+    private function __construct(AttributesInterface $attributes)
     {
         $this->attributes = $attributes;
     }
 
-    public static function create(Attributes $attributes): self
+    public static function create(AttributesInterface $attributes): self
     {
         $resource = self::merge(self::defaultResource(), new ResourceInfo(clone $attributes));
         /*
@@ -77,7 +78,7 @@ class ResourceInfo
         return new ResourceInfo(new Attributes());
     }
 
-    public function getAttributes(): Attributes
+    public function getAttributes(): AttributesInterface
     {
         return $this->attributes;
     }

--- a/src/SDK/Trace/Behavior/LoggerAwareTrait.php
+++ b/src/SDK/Trace/Behavior/LoggerAwareTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\Behavior;
+
+use Psr\Log\LoggerAwareTrait as PsrTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
+
+trait LoggerAwareTrait
+{
+    use PsrTrait;
+
+    private string $defaultLogLevel = LogLevel::INFO;
+
+    /**
+     * @param string $logLevel
+     */
+    public function setDefaultLogLevel(string $logLevel): void
+    {
+        $this->defaultLogLevel = $logLevel;
+    }
+
+    /**
+     * @param string $message
+     * @param array $context
+     * @param string|null $level
+     */
+    protected function log(string $message, array $context = [], ?string $level = null): void
+    {
+        $this->getLogger()->log(
+            $level ?? $this->defaultLogLevel,
+            $message,
+            $context
+        );
+    }
+
+    protected function getLogger(): LoggerInterface
+    {
+        return $this->logger instanceof LoggerInterface ? $this->logger : $this->logger = new NullLogger();
+    }
+}

--- a/src/SDK/Trace/Behavior/SpanExporterDecoratorTrait.php
+++ b/src/SDK/Trace/Behavior/SpanExporterDecoratorTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\Behavior;
+
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+
+trait SpanExporterDecoratorTrait
+{
+    protected SpanExporterInterface $decorated;
+
+    /**
+     * @param iterable<SpanDataInterface> $spans
+     * @return int
+     * @psalm-return SpanExporterInterface::STATUS_*
+     */
+    public function export(iterable $spans): int
+    {
+        $response = $this->decorated->export(
+            $this->beforeExport($spans)
+        );
+        $this->afterExport($spans, $response);
+
+        return $response;
+    }
+
+    abstract protected function beforeExport(iterable $spans): iterable;
+
+    abstract protected function afterExport(iterable $spans, int $exporterResponse): void;
+
+    public function shutdown(): bool
+    {
+        return $this->decorated->shutdown();
+    }
+
+    public function forceFlush(): bool
+    {
+        return $this->decorated->forceFlush();
+    }
+
+    public function setDecorated(SpanExporterInterface $decorated): void
+    {
+        $this->decorated = $decorated;
+    }
+}

--- a/src/SDK/Trace/Behavior/SpanExporterTrait.php
+++ b/src/SDK/Trace/Behavior/SpanExporterTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\Behavior;
+
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+
+trait SpanExporterTrait
+{
+    private ?SpanConverterInterface $converter = null;
+    private bool $running = true;
+
+    /** @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#shutdown-2 */
+    public function shutdown(): bool
+    {
+        $this->running = false;
+
+        return true;
+    }
+
+    /** @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#forceflush-2 */
+    public function forceFlush(): bool
+    {
+        return true;
+    }
+
+    abstract public static function fromConnectionString(string $endpointUrl, string $name, string $args);
+
+    /**
+     * @param iterable<SpanDataInterface> $spans Batch of spans to export
+     *
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#exportbatch
+     *
+     * @psalm-return SpanExporterInterface::STATUS_*
+     */
+    abstract public function export(iterable $spans): int;
+}

--- a/src/SDK/Trace/Behavior/UsesSpanConverterTrait.php
+++ b/src/SDK/Trace/Behavior/UsesSpanConverterTrait.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\Behavior;
+
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use OpenTelemetry\SDK\Trace\SpanExporter\NullSpanConverter;
+
+trait UsesSpanConverterTrait
+{
+    private ?SpanConverterInterface $converter = null;
+
+    /**
+     * @param SpanConverterInterface $converter
+     */
+    protected function setSpanConverter(SpanConverterInterface $converter): void
+    {
+        $this->converter = $converter;
+    }
+
+    public function getSpanConverter(): SpanConverterInterface
+    {
+        if (null === $this->converter) {
+            $this->converter = new NullSpanConverter();
+        }
+
+        return $this->converter;
+    }
+
+    /**
+     * @param SpanDataInterface $span
+     * @return array
+     * @psalm-suppress PossiblyNullReference
+     */
+    protected function convertContext(SpanDataInterface $span): array
+    {
+        return $this->getSpanConverter()->convert($span);
+    }
+
+    /**
+     * @param iterable $spans
+     * @return array
+     */
+    protected function convertAggregateContext(iterable $spans): array
+    {
+        $aggregate = [];
+        foreach ($spans as $span) {
+            $aggregate[] = $this->convertContext($span);
+        }
+
+        return $aggregate;
+    }
+}

--- a/src/SDK/Trace/Event.php
+++ b/src/SDK/Trace/Event.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
-use OpenTelemetry\API\Trace as API;
 use function count;
+use OpenTelemetry\API\Trace as API;
 
 final class Event implements API\EventInterface
 {

--- a/src/SDK/Trace/Event.php
+++ b/src/SDK/Trace/Event.php
@@ -4,22 +4,20 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
-use function count;
 use OpenTelemetry\API\Trace as API;
+use function count;
 
 final class Event implements API\EventInterface
 {
     private string $name;
     private int $timestamp;
     private API\AttributesInterface $attributes;
-    private int $totalAttributeCount;
 
     public function __construct(string $name, int $timestamp, API\AttributesInterface $attributes = null)
     {
         $this->name = $name;
         $this->timestamp = $timestamp;
         $this->attributes = $attributes ?? new Attributes();
-        $this->totalAttributeCount = count($this->attributes);
     }
 
     public function getAttributes(): API\AttributesInterface
@@ -39,11 +37,11 @@ final class Event implements API\EventInterface
 
     public function getTotalAttributeCount(): int
     {
-        return $this->totalAttributeCount;
+        return count($this->attributes);
     }
 
     public function getDroppedAttributesCount(): int
     {
-        return $this->totalAttributeCount - count($this->attributes);
+        return $this->attributes->getDroppedAttributesCount();
     }
 }

--- a/src/SDK/Trace/ImmutableSpan.php
+++ b/src/SDK/Trace/ImmutableSpan.php
@@ -28,7 +28,7 @@ final class ImmutableSpan implements SpanDataInterface
     private API\AttributesInterface $attributes;
     private int $totalAttributeCount;
     private int $totalRecordedEvents;
-    private StatusData $status;
+    private StatusDataInterface $status;
     private int $endEpochNanos;
     private bool $hasEnded;
 
@@ -48,7 +48,7 @@ final class ImmutableSpan implements SpanDataInterface
         API\AttributesInterface $attributes,
         int $totalAttributeCount,
         int $totalRecordedEvents,
-        StatusData $status,
+        StatusDataInterface $status,
         int $encEpochNanos,
         bool $hasEnded
     ) {
@@ -151,7 +151,7 @@ final class ImmutableSpan implements SpanDataInterface
         return max(0, $this->span->getTotalRecordedLinks() - count($this->links));
     }
 
-    public function getStatus(): StatusData
+    public function getStatus(): StatusDataInterface
     {
         return $this->status;
     }

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -21,6 +21,86 @@ use Throwable;
 
 final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
 {
+
+    /** @readonly */
+    private API\SpanContextInterface $context;
+
+    /** @readonly */
+    private API\SpanContextInterface $parentSpanContext;
+
+    /** @readonly */
+    private SpanLimits $spanLimits;
+
+    /** @readonly */
+    private SpanProcessorInterface $spanProcessor;
+
+    /**
+     * @readonly
+     *
+     * @var list<API\LinkInterface>
+     */
+    private array $links;
+
+    /** @readonly */
+    private int $totalRecordedLinks;
+
+    /** @readonly */
+    private int $kind;
+
+    /** @readonly */
+    private ResourceInfo $resource;
+
+    /** @readonly */
+    private InstrumentationLibrary $instrumentationLibrary;
+
+    /** @readonly */
+    private int $startEpochNanos;
+
+    /** @var non-empty-string */
+    private string $name;
+
+    /** @var list<API\EventInterface> */
+    private array $events = [];
+
+    private ?API\AttributesInterface $attributes;
+    private int $totalRecordedEvents = 0;
+    private StatusDataInterface $status;
+    private int $endEpochNanos = 0;
+    private bool $hasEnded = false;
+
+    /**
+     * @param non-empty-string $name
+     * @param list<API\LinkInterface> $links
+     */
+    private function __construct(
+        string $name,
+        API\SpanContextInterface $context,
+        InstrumentationLibrary $instrumentationLibrary,
+        int $kind,
+        API\SpanContextInterface $parentSpanContext,
+        SpanLimits $spanLimits,
+        SpanProcessorInterface $spanProcessor,
+        ResourceInfo $resource,
+        ?API\AttributesInterface $attributes,
+        array $links,
+        int $totalRecordedLinks,
+        int $startEpochNanos
+    ) {
+        $this->context = $context;
+        $this->instrumentationLibrary = $instrumentationLibrary;
+        $this->parentSpanContext = $parentSpanContext;
+        $this->links = $links;
+        $this->totalRecordedLinks = $totalRecordedLinks;
+        $this->name = $name;
+        $this->kind = $kind;
+        $this->spanProcessor = $spanProcessor;
+        $this->resource = $resource;
+        $this->startEpochNanos = $startEpochNanos;
+        $this->attributes = Attributes::withLimits($attributes ?? new Attributes(), $spanLimits->getAttributeLimits());
+        $this->status = StatusData::unset();
+        $this->spanLimits = $spanLimits;
+    }
+
     /**
      * This method _MUST_ not be used directly.
      * End users should use a {@see API\TracerInterface} in order to create spans.
@@ -130,85 +210,6 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
         }
 
         return $result;
-    }
-
-    /** @readonly */
-    private API\SpanContextInterface $context;
-
-    /** @readonly */
-    private API\SpanContextInterface $parentSpanContext;
-
-    /** @readonly */
-    private SpanLimits $spanLimits;
-
-    /** @readonly */
-    private SpanProcessorInterface $spanProcessor;
-
-    /**
-     * @readonly
-     *
-     * @var list<API\LinkInterface>
-     */
-    private array $links;
-
-    /** @readonly */
-    private int $totalRecordedLinks;
-
-    /** @readonly */
-    private int $kind;
-
-    /** @readonly */
-    private ResourceInfo $resource;
-
-    /** @readonly */
-    private InstrumentationLibrary $instrumentationLibrary;
-
-    /** @readonly */
-    private int $startEpochNanos;
-
-    /** @var non-empty-string */
-    private string $name;
-
-    /** @var list<API\EventInterface> */
-    private array $events = [];
-
-    private ?API\AttributesInterface $attributes;
-    private int $totalRecordedEvents = 0;
-    private StatusData $status;
-    private int $endEpochNanos = 0;
-    private bool $hasEnded = false;
-
-    /**
-     * @param non-empty-string $name
-     * @param list<API\LinkInterface> $links
-     */
-    private function __construct(
-        string $name,
-        API\SpanContextInterface $context,
-        InstrumentationLibrary $instrumentationLibrary,
-        int $kind,
-        API\SpanContextInterface $parentSpanContext,
-        SpanLimits $spanLimits,
-        SpanProcessorInterface $spanProcessor,
-        ResourceInfo $resource,
-        ?API\AttributesInterface $attributes,
-        array $links,
-        int $totalRecordedLinks,
-        int $startEpochNanos
-    ) {
-        $this->context = $context;
-        $this->instrumentationLibrary = $instrumentationLibrary;
-        $this->parentSpanContext = $parentSpanContext;
-        $this->links = $links;
-        $this->totalRecordedLinks = $totalRecordedLinks;
-        $this->name = $name;
-        $this->kind = $kind;
-        $this->spanProcessor = $spanProcessor;
-        $this->resource = $resource;
-        $this->startEpochNanos = $startEpochNanos;
-        $this->attributes = Attributes::withLimits($attributes ?? new Attributes(), $spanLimits->getAttributeLimits());
-        $this->status = StatusData::unset();
-        $this->spanLimits = $spanLimits;
     }
 
     /** @inheritDoc */

--- a/src/SDK/Trace/SpanConverterInterface.php
+++ b/src/SDK/Trace/SpanConverterInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace;
+
+interface SpanConverterInterface
+{
+    public function convert(SpanDataInterface $span): array;
+}

--- a/src/SDK/Trace/SpanDataInterface.php
+++ b/src/SDK/Trace/SpanDataInterface.php
@@ -22,7 +22,7 @@ interface SpanDataInterface
     public function getTraceId(): string;
     public function getSpanId(): string;
     public function getParentSpanId(): string;
-    public function getStatus(): StatusData;
+    public function getStatus(): StatusDataInterface;
     public function getStartEpochNanos(): int;
     public function getAttributes(): API\AttributesInterface;
 

--- a/src/SDK/Trace/SpanExporter/AbstractDecorator.php
+++ b/src/SDK/Trace/SpanExporter/AbstractDecorator.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\SpanExporter;
+
+use OpenTelemetry\SDK\Trace\Behavior\SpanExporterDecoratorTrait;
+
+abstract class AbstractDecorator
+{
+    use SpanExporterDecoratorTrait;
+}

--- a/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php
+++ b/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Trace\SpanProcessor;
+namespace OpenTelemetry\SDK\Trace\SpanExporter;
 
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\SDK\Trace;

--- a/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php
+++ b/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php
@@ -4,137 +4,42 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace\SpanExporter;
 
-use OpenTelemetry\API\Trace\SpanKind;
-use OpenTelemetry\SDK\Trace;
-use ReflectionClass;
+use OpenTelemetry\SDK\Trace\Behavior\SpanExporterTrait;
+use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+use Throwable;
 
-class ConsoleSpanExporter implements Trace\SpanExporterInterface
+class ConsoleSpanExporter implements SpanExporterInterface
 {
-    private $running = true;
+    use SpanExporterTrait;
+    use UsesSpanConverterTrait;
+
+    public function __construct(?SpanConverterInterface $converter = null)
+    {
+        $this->setSpanConverter($converter ?? new FriendlySpanConverter());
+    }
 
     /** @inheritDoc */
     public function export(iterable $spans): int
     {
-        foreach ($spans as $span) {
-            print(json_encode($this->friendlySpan($span), JSON_PRETTY_PRINT) . PHP_EOL);
+        try {
+            foreach ($spans as $span) {
+                print(json_encode(
+                    $this->getSpanConverter()->convert($span),
+                    JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT
+                ) . PHP_EOL
+                );
+            }
+        } catch (Throwable $t) {
+            return SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE;
         }
 
-        return Trace\SpanExporterInterface::STATUS_SUCCESS;
-    }
-
-    /** @inheritDoc */
-    public function shutdown(): bool
-    {
-        $this->running = false;
-
-        return true;
-    }
-
-    /** @inheritDoc */
-    public function forceFlush(): bool
-    {
-        return true;
+        return SpanExporterInterface::STATUS_SUCCESS;
     }
 
     public static function fromConnectionString(string $endpointUrl = null, string $name = null, $args = null)
     {
-        return false;
-    }
-
-    /**
-     * @param iterable<\OpenTelemetry\API\Trace\EventInterface> $events
-     * @return array
-     */
-    private function friendlyEvents(iterable $events)
-    {
-        $tmp = [];
-
-        foreach ($events as $event) {
-            array_push($tmp, [
-                'name' => $event->getName(),
-                'timestamp' => $event->getEpochNanos(),
-                'attributes' => $this->friendlyAttributes($event->getAttributes()),
-            ]);
-        }
-
-        return $tmp;
-    }
-
-    /**
-     * @param \OpenTelemetry\API\Trace\AttributesInterface $attributes
-     * @return array
-     */
-    private function friendlyAttributes(\OpenTelemetry\API\Trace\AttributesInterface $attributes)
-    {
-        $tmp = [];
-
-        foreach ($attributes as $attribute) {
-            $tmp[$attribute->getKey()] = $attribute->getValue();
-        }
-
-        return $tmp;
-    }
-
-    /**
-     * Translates SpanKind from it's integer representation to a more human friendly string.
-     *
-     * @param int $kind
-     * @return string
-     */
-    private function friendlyKind(int $kind)
-    {
-        $spanKinds = (new ReflectionClass(SpanKind::class))->getConstants();
-
-        $kindSpans = array_flip($spanKinds);
-
-        return $kindSpans[$kind];
-    }
-
-    /**
-     * @param \OpenTelemetry\SDK\Resource\ResourceInfo $resource
-     * @return array
-     */
-    private function friendlyResource(\OpenTelemetry\SDK\Resource\ResourceInfo $resource): array
-    {
-        $tmp = [];
-
-        foreach ($resource->getAttributes()->getIterator() as $attribute) {
-            $tmp[$attribute->getKey()] = $attribute->getValue();
-        }
-
-        return $tmp;
-    }
-
-    /**
-     * friendlySpan does the heavy lifting converting a span into an array
-     *
-     * @param Trace\SpanDataInterface $span
-     * @return array
-     */
-    private function friendlySpan(Trace\SpanDataInterface $span)
-    {
-        $parent_span = $span->getParentContext();
-
-        $parent_span_id = $parent_span->isValid() ? $parent_span->getSpanId() : null;
-
-        return [
-            'name' => $span->getName(),
-            'context' => [
-                'trace_id' => $span->getContext()->getTraceId(),
-                'span_id' => $span->getContext()->getSpanId(),
-                'trace_state' => $span->getContext()->getTraceState(),
-            ],
-            'resource' => $this->friendlyResource($span->getResource()),
-            'parent_span_id' => $parent_span_id ? $parent_span_id : '',
-            'kind' => $this->friendlyKind($span->getKind()),
-            'start' => $span->getStartEpochNanos(),
-            'end' => $span->getEndEpochNanos(),
-            'attributes' => $this->friendlyAttributes($span->getAttributes()),
-            'status' => [
-                'code' => $span->getStatus()->getCode(),
-                'description' => $span->getStatus()->getDescription(),
-            ],
-            'events' => $this->friendlyEvents($span->getEvents()),
-        ];
+        return new self();
     }
 }

--- a/src/SDK/Trace/SpanExporter/FriendlySpanConverter.php
+++ b/src/SDK/Trace/SpanExporter/FriendlySpanConverter.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\SpanExporter;
+
+use OpenTelemetry\API\Trace\AttributesInterface;
+use OpenTelemetry\API\Trace\EventInterface;
+use OpenTelemetry\API\Trace\LinkInterface;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use OpenTelemetry\SDK\Trace\StatusDataInterface;
+use ReflectionClass;
+
+class FriendlySpanConverter implements SpanConverterInterface
+{
+    private const NAME_ATTR = 'name';
+    private const CONTEXT_ATTR = 'context';
+    private const TRACE_ID_ATTR = 'trace_id';
+    private const SPAN_ID_ATTR = 'span_id';
+    private const TRACE_STATE_ATTR = 'trace_state';
+    private const RESOURCE_ATTR = 'resource';
+    private const PARENT_SPAN_ATTR = 'parent_span_id';
+    private const KIND_ATTR = 'kind';
+    private const START_ATTR = 'start';
+    private const END_ATTR = 'end';
+    private const ATTRIBUTES_ATTR = 'attributes';
+    private const STATUS_ATTR = 'status';
+    private const CODE_ATTR = 'code';
+    private const DESCRIPTION_ATTR = 'description';
+    private const EVENTS_ATTR = 'events';
+    private const TIMESTAMP_ATTR = 'timestamp';
+    private const LINKS_ATTR = 'links';
+
+    /**
+     * friendlySpan does the heavy lifting converting a span into an array
+     *
+     * @param SpanDataInterface $span
+     * @return array
+     */
+    public function convert(SpanDataInterface $span): array
+    {
+        return [
+            self::NAME_ATTR => $span->getName(),
+            self::CONTEXT_ATTR => $this->convertContext($span->getContext()),
+            self::RESOURCE_ATTR => $this->convertResource($span->getResource()),
+            self::PARENT_SPAN_ATTR => $this->covertParentContext($span->getParentContext()),
+            self::KIND_ATTR => $this->convertKind($span->getKind()),
+            self::START_ATTR => $span->getStartEpochNanos(),
+            self::END_ATTR => $span->getEndEpochNanos(),
+            self::ATTRIBUTES_ATTR => $this->convertAttributes($span->getAttributes()),
+            self::STATUS_ATTR => $this->covertStatus($span->getStatus()),
+            self::EVENTS_ATTR => $this->convertEvents($span->getEvents()),
+            self::LINKS_ATTR => $this->convertLinks($span->getLinks()),
+        ];
+    }
+
+    /**
+     * @param SpanContextInterface $context
+     * @return array
+     */
+    private function convertContext(SpanContextInterface $context): array
+    {
+        return [
+            self::TRACE_ID_ATTR => $context->getTraceId(),
+            self::SPAN_ID_ATTR => $context->getSpanId(),
+            self::TRACE_STATE_ATTR => (string) $context->getTraceState(),
+        ];
+    }
+
+    /**
+     * @param ResourceInfo $resource
+     * @return array
+     */
+    private function convertResource(ResourceInfo $resource): array
+    {
+        $tmp = [];
+
+        foreach ($resource->getAttributes() as $attribute) {
+            $tmp[$attribute->getKey()] = $attribute->getValue();
+        }
+
+        return $tmp;
+    }
+
+    /**
+     * @param SpanContextInterface $context
+     * @return string
+     */
+    private function covertParentContext(SpanContextInterface $context): string
+    {
+        return $context->isValid() ? $context->getSpanId() : '';
+    }
+
+    /**
+     * Translates SpanKind from its integer representation to a more human friendly string.
+     *
+     * @param int $kind
+     * @return string
+     */
+    private function convertKind(int $kind): string
+    {
+        return  array_flip(
+            (new ReflectionClass(SpanKind::class))
+                ->getConstants()
+        )[$kind];
+    }
+
+    /**
+     * @param AttributesInterface $attributes
+     * @return array
+     */
+    private function convertAttributes(AttributesInterface $attributes): array
+    {
+        $tmp = [];
+
+        foreach ($attributes as $attribute) {
+            $tmp[$attribute->getKey()] = $attribute->getValue();
+        }
+
+        return $tmp;
+    }
+
+    /**
+     * @param StatusDataInterface $status
+     * @return array
+     */
+    private function covertStatus(StatusDataInterface $status): array
+    {
+        return [
+            self::CODE_ATTR => $status->getCode(),
+            self::DESCRIPTION_ATTR => $status->getDescription(),
+        ];
+    }
+
+    /**
+     * @param array<EventInterface> $events
+     * @return array
+     */
+    private function convertEvents(array $events): array
+    {
+        $result = [];
+
+        foreach ($events as $event) {
+            $result[] = [
+                self::NAME_ATTR => $event->getName(),
+                self::TIMESTAMP_ATTR => $event->getEpochNanos(),
+                self::ATTRIBUTES_ATTR => $this->convertAttributes($event->getAttributes()),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<LinkInterface> $links
+     * @return array
+     */
+    private function convertLinks(array $links): array
+    {
+        $result = [];
+
+        foreach ($links as $link) {
+            $result[] = [
+                self::CONTEXT_ATTR => $this->convertContext($link->getSpanContext()),
+                self::ATTRIBUTES_ATTR => $this->convertAttributes($link->getAttributes()),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/SDK/Trace/SpanExporter/LoggerDecorator.php
+++ b/src/SDK/Trace/SpanExporter/LoggerDecorator.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\SpanExporter;
+
+use OpenTelemetry\SDK\Trace\Behavior\LoggerAwareTrait;
+use OpenTelemetry\SDK\Trace\Behavior\SpanExporterDecoratorTrait;
+use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+class LoggerDecorator implements SpanExporterInterface, LoggerAwareInterface
+{
+    use SpanExporterDecoratorTrait;
+    use UsesSpanConverterTrait;
+    use LoggerAwareTrait;
+
+    private const RESPONSE_MAPPING = [
+        SpanExporterInterface::STATUS_SUCCESS =>  LogLevel::INFO,
+        SpanExporterInterface::STATUS_FAILED_RETRYABLE =>  LogLevel::ERROR,
+        SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE =>  LogLevel::ALERT,
+    ];
+
+    private const MESSAGE_MAPPING = [
+        SpanExporterInterface::STATUS_SUCCESS =>  'Status Success',
+        SpanExporterInterface::STATUS_FAILED_RETRYABLE =>  'Status Failed Retryable',
+        SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE =>  'Status Failed Not Retryable',
+    ];
+
+    public function __construct(
+        SpanExporterInterface $decorated,
+        ?LoggerInterface $logger = null,
+        ?SpanConverterInterface $converter = null
+    ) {
+        $this->setDecorated($decorated);
+        $this->setLogger($logger ?? new NullLogger());
+        $this->setSpanConverter($converter ?? new FriendlySpanConverter());
+    }
+
+    public static function fromConnectionString(string $endpointUrl, string $name, string $args): void
+    {
+        throw new RuntimeException(
+            sprintf('%s cannot be instantiated via %s', __CLASS__, __METHOD__)
+        );
+    }
+
+    protected function beforeExport(iterable $spans): iterable
+    {
+        return $spans;
+    }
+
+    /**
+     * @param iterable $spans
+     * @param int $exporterResponse
+     */
+    protected function afterExport(iterable $spans, int $exporterResponse): void
+    {
+        $this->log(
+            self::MESSAGE_MAPPING[$exporterResponse],
+            $this->convertAggregateContext($spans),
+            self::RESPONSE_MAPPING[$exporterResponse]
+        );
+    }
+}

--- a/src/SDK/Trace/SpanExporter/LoggerExporter.php
+++ b/src/SDK/Trace/SpanExporter/LoggerExporter.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\SpanExporter;
+
+use OpenTelemetry\SDK\Logs\SimplePsrFileLogger;
+use OpenTelemetry\SDK\Trace\Behavior\LoggerAwareTrait;
+use OpenTelemetry\SDK\Trace\Behavior\SpanExporterTrait;
+use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
+use Throwable;
+
+class LoggerExporter implements SpanExporterInterface, LoggerAwareInterface
+{
+    use SpanExporterTrait;
+    use UsesSpanConverterTrait;
+    use LoggerAwareTrait;
+
+    public const GRANULARITY_AGGREGATE = 1;
+    public const GRANULARITY_SPAN = 2;
+    public const DEFAULT_LOG_LEVEL = LogLevel::DEBUG;
+
+    private string $serviceName;
+    private string $logLevel = self::DEFAULT_LOG_LEVEL;
+    private int $granularity = self::GRANULARITY_AGGREGATE;
+
+    /**
+     * @param string $serviceName
+     * @param LoggerInterface|null $logger
+     * @param string|null $defaultLogLevel
+     * @param SpanConverterInterface|null $converter
+     * @param int $granularity
+     */
+    public function __construct(
+        string $serviceName,
+        ?LoggerInterface $logger = null,
+        ?string $defaultLogLevel = LogLevel::DEBUG,
+        ?SpanConverterInterface $converter = null,
+        int $granularity = 1
+    ) {
+        $this->setServiceName($serviceName);
+        $this->setLogger($logger ?? new NullLogger());
+        $this->setDefaultLogLevel($defaultLogLevel ?? LogLevel::DEBUG);
+        $this->setSpanConverter($converter ?? new FriendlySpanConverter());
+        $this->setGranularity($granularity);
+    }
+
+    /** @inheritDoc */
+    public function export(iterable $spans): int
+    {
+        if ($this->running === false) {
+            return SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE;
+        }
+
+        if (!empty($spans)) {
+            try {
+                $this->doLog($spans);
+            } catch (Throwable $t) {
+                return SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE;
+            }
+        }
+
+        return SpanExporterInterface::STATUS_SUCCESS;
+    }
+
+    /**
+     * @param string $endpointUrl
+     * @param string $name
+     * @param string $args
+     * @return LoggerExporter
+     */
+    public static function fromConnectionString(string $endpointUrl, string $name, string $args): self
+    {
+        return new self(
+            $name,
+            new SimplePsrFileLogger($endpointUrl),
+            $args
+        );
+    }
+
+    /**
+     * @param string $serviceName
+     */
+    private function setServiceName(string $serviceName): void
+    {
+        $this->serviceName = $serviceName;
+    }
+
+    /**
+     * @param int $granularity
+     */
+    private function setGranularity(int $granularity): void
+    {
+        $this->granularity = $granularity === self::GRANULARITY_SPAN
+            ? self::GRANULARITY_SPAN
+            : self::GRANULARITY_AGGREGATE;
+    }
+
+    /**
+     * @param iterable $spans
+     */
+    private function doLog(iterable $spans): void
+    {
+        if ($this->granularity === self::GRANULARITY_AGGREGATE) {
+            $this->log($this->serviceName, $this->convertAggregateContext($spans));
+
+            return;
+        }
+
+        foreach ($spans as $span) {
+            $this->log($this->serviceName, $this->convertContext($span));
+        }
+    }
+}

--- a/src/SDK/Trace/SpanExporter/LoggerExporter.php
+++ b/src/SDK/Trace/SpanExporter/LoggerExporter.php
@@ -95,7 +95,7 @@ class LoggerExporter implements SpanExporterInterface, LoggerAwareInterface
     /**
      * @param int $granularity
      */
-    private function setGranularity(int $granularity): void
+    public function setGranularity(int $granularity): void
     {
         $this->granularity = $granularity === self::GRANULARITY_SPAN
             ? self::GRANULARITY_SPAN

--- a/src/SDK/Trace/SpanExporter/NullSpanConverter.php
+++ b/src/SDK/Trace/SpanExporter/NullSpanConverter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\SpanExporter;
+
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+
+class NullSpanConverter implements SpanConverterInterface
+{
+    public function convert(SpanDataInterface $span): array
+    {
+        return [];
+    }
+}

--- a/src/SDK/Trace/SpanProcessor/MultiSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/MultiSpanProcessor.php
@@ -18,8 +18,6 @@ final class MultiSpanProcessor implements SpanProcessorInterface
     /** @var list<SpanProcessorInterface> */
     private array $processors = [];
 
-    private bool $running = true;
-
     public function __construct(SpanProcessorInterface ...$spanProcessors)
     {
         foreach ($spanProcessors as $processor) {
@@ -57,10 +55,6 @@ final class MultiSpanProcessor implements SpanProcessorInterface
     /** @inheritDoc */
     public function shutdown(): bool
     {
-        if (!$this->running) {
-            return true;
-        }
-
         $result = true;
 
         foreach ($this->processors as $processor) {

--- a/src/SDK/Trace/StatusData.php
+++ b/src/SDK/Trace/StatusData.php
@@ -6,11 +6,22 @@ namespace OpenTelemetry\SDK\Trace;
 
 use OpenTelemetry\API\Trace as API;
 
-final class StatusData
+final class StatusData implements StatusDataInterface
 {
     private static ?self $ok = null;
     private static ?self $unset = null;
     private static ?self $error = null;
+    private string $code;
+    private string $description;
+
+    /** @psalm-param API\StatusCode::STATUS_* $code */
+    public function __construct(
+        string $code,
+        string $description
+    ) {
+        $this->code = $code;
+        $this->description = $description;
+    }
 
     /** @psalm-param API\StatusCode::STATUS_* $code */
     public static function create(string $code, ?string $description = null): self
@@ -59,18 +70,6 @@ final class StatusData
         }
 
         return self::$unset;
-    }
-
-    private string $code;
-    private string $description;
-
-    /** @psalm-param API\StatusCode::STATUS_* $code */
-    public function __construct(
-        string $code,
-        string $description
-    ) {
-        $this->code = $code;
-        $this->description = $description;
     }
 
     public function getCode(): string

--- a/src/SDK/Trace/StatusDataInterface.php
+++ b/src/SDK/Trace/StatusDataInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace;
+
+interface StatusDataInterface
+{
+    public static function ok(): self;
+
+    public static function error(): self;
+
+    public static function unset(): self;
+
+    public function getCode(): string;
+
+    public function getDescription(): string;
+}

--- a/tests/API/Unit/Trace/NonRecordingSpanTest.php
+++ b/tests/API/Unit/Trace/NonRecordingSpanTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\API\Unit\Trace;
+
+use Exception;
+use OpenTelemetry\API\Trace\AttributesInterface;
+use OpenTelemetry\API\Trace\NonRecordingSpan;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use PHPUnit\Framework\TestCase;
+
+class NonRecordingSpanTest extends TestCase
+{
+    private ?SpanContextInterface $context = null;
+
+    public function testGetContext(): void
+    {
+        $span = $this->createNonRecordingSpan();
+
+        $this->assertSame(
+            $this->context,
+            $span->getContext()
+        );
+    }
+
+    public function testIsRecording(): void
+    {
+        $this->assertFalse(
+            $this->createNonRecordingSpan()->isRecording()
+        );
+    }
+
+    public function testSetAttribute(): void
+    {
+        $this->assertInstanceOf(
+            NonRecordingSpan::class,
+            $this->createNonRecordingSpan()->setAttribute('foo', 'bar')
+        );
+    }
+
+    public function testSetAttributes(): void
+    {
+        $this->assertInstanceOf(
+            NonRecordingSpan::class,
+            $this->createNonRecordingSpan()->setAttributes(
+                $this->createMock(AttributesInterface::class)
+            )
+        );
+    }
+
+    public function testAddEvent(): void
+    {
+        $this->assertInstanceOf(
+            NonRecordingSpan::class,
+            $this->createNonRecordingSpan()->addEvent('foo')
+        );
+    }
+
+    public function testRecordException(): void
+    {
+        $this->assertInstanceOf(
+            NonRecordingSpan::class,
+            $this->createNonRecordingSpan()->recordException(
+                new Exception()
+            )
+        );
+    }
+
+    public function testUpdateName(): void
+    {
+        $this->assertInstanceOf(
+            NonRecordingSpan::class,
+            $this->createNonRecordingSpan()->updateName('foo')
+        );
+    }
+
+    public function testSetStatus(): void
+    {
+        $this->assertInstanceOf(
+            NonRecordingSpan::class,
+            $this->createNonRecordingSpan()->setStatus('Ok')
+        );
+    }
+
+    public function testEnd(): void
+    {
+        $this->assertNull(
+            // @phpstan-ignore-next-line
+            $this->createNonRecordingSpan()->end()
+        );
+    }
+
+    private function createNonRecordingSpan(): NonRecordingSpan
+    {
+        return new NonRecordingSpan(
+            $this->getSpanContextInterfaceMock()
+        );
+    }
+
+    private function getSpanContextInterfaceMock(): SpanContextInterface
+    {
+        return $this->context ?? $this->context = $this->createMock(SpanContextInterface::class);
+    }
+}

--- a/tests/SDK/Unit/Logs/SimplePsrFileLoggerTest.php
+++ b/tests/SDK/Unit/Logs/SimplePsrFileLoggerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Logs;
+
+use OpenTelemetry\SDK\Logs\SimplePsrFileLogger;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel;
+
+class SimplePsrFileLoggerTest extends TestCase
+{
+    private const ROOT_DIR = 'var';
+    private const LOG_FILE = 'test.log';
+    private const LOG_PATH = self::ROOT_DIR . '/' . self::LOG_FILE;
+    private const LOG_LEVELS = [
+        LogLevel::EMERGENCY,
+        LogLevel::ALERT,
+        LogLevel::CRITICAL,
+        LogLevel::ERROR,
+        LogLevel::WARNING,
+        LogLevel::NOTICE,
+        LogLevel::INFO,
+        LogLevel::DEBUG,
+    ];
+
+    private SimplePsrFileLogger $logger;
+    private vfsStreamDirectory $root;
+
+    public function setUp(): void
+    {
+        $this->root = vfsStream::setup(self::ROOT_DIR);
+        $this->logger = new SimplePsrFileLogger(
+            vfsStream::url(self::LOG_PATH)
+        );
+    }
+
+    /**
+     * @dataProvider logLevelProvider
+     */
+    public function testLog(string $logLevel): void
+    {
+        $this->assertFalse($this->root->hasChild(self::LOG_FILE));
+
+        $this->logger->log($logLevel, 'foo', ['bar']);
+        $this->logger->{$logLevel}('foz', ['baz']);
+
+        $this->assertTrue($this->root->hasChild(self::LOG_FILE));
+    }
+
+    public function logLevelProvider(): array
+    {
+        $result = [];
+
+        foreach (self::LOG_LEVELS as $level) {
+            $result[] = [$level];
+        }
+
+        return $result;
+    }
+
+    public function testLogInvalidLogLevel(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->logger->log('foo', 'foo', ['bar']);
+    }
+
+    public function testLogInvalidJson(): void
+    {
+        $this->assertFalse($this->root->hasChild(self::LOG_FILE));
+
+        $resource = fopen('php://stdin', 'rb');
+
+        $this->logger->log('info', 'foo', [1 => $resource]);
+
+        $this->assertTrue($this->root->hasChild(self::LOG_FILE));
+
+        fclose($resource);
+    }
+}

--- a/tests/SDK/Unit/Trace/Behavior/UsesSpanConverterTraitTest.php
+++ b/tests/SDK/Unit/Trace/Behavior/UsesSpanConverterTraitTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace\Behavior;
+
+use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanExporter\NullSpanConverter;
+use PHPUnit\Framework\TestCase;
+
+class UsesSpanConverterTraitTest extends TestCase
+{
+    public function testAccessors(): void
+    {
+        $instance = $this->createInstance();
+        $converter = $this->createSpanConverterInterfaceMock();
+
+        $instance->doSetSpanConverter($converter);
+
+        $this->assertSame(
+            $converter,
+            $instance->getSpanConverter()
+        );
+    }
+
+    public function testFallbackConverter(): void
+    {
+        $this->assertInstanceOf(
+            NullSpanConverter::class,
+            $this->createInstance()->getSpanConverter()
+        );
+    }
+
+    private function createInstance(): object
+    {
+        return new class() {
+            use UsesSpanConverterTrait;
+            public function doSetSpanConverter(SpanConverterInterface $converter): void
+            {
+                $this->setSpanConverter($converter);
+            }
+        };
+    }
+
+    private function createSpanConverterInterfaceMock(): SpanConverterInterface
+    {
+        return $this->createMock(SpanConverterInterface::class);
+    }
+}

--- a/tests/SDK/Unit/Trace/EventTest.php
+++ b/tests/SDK/Unit/Trace/EventTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace;
+
+use OpenTelemetry\API\Trace\AttributesInterface;
+use OpenTelemetry\SDK\Trace\Event;
+use OpenTelemetry\Tests\SDK\Util\TestClock;
+use PHPUnit\Framework\TestCase;
+
+class EventTest extends TestCase
+{
+    private const EVENT_NAME = 'test-event';
+    private const ATTR_CONT = 2;
+    private const DROPPED_ATTR_CONT = 1;
+
+    private ?AttributesInterface $attributes = null;
+
+    public function testGetName(): void
+    {
+        $this->assertSame(
+            self::EVENT_NAME,
+            $this->createEvent()->getName()
+        );
+    }
+
+    public function testGetAttributes(): void
+    {
+        $this->assertSame(
+            $this->getAttributesInterfaceMock(),
+            $this->createEvent()->getAttributes()
+        );
+    }
+
+    public function testGetEpochNanos(): void
+    {
+        $this->assertSame(
+            $this->getClock()->now(),
+            $this->createEvent()->getEpochNanos()
+        );
+    }
+
+    public function testGetTotalAttributeCount(): void
+    {
+        $this->assertSame(
+            self::ATTR_CONT,
+            $this->createEvent()->getTotalAttributeCount()
+        );
+    }
+
+    public function testGetDroppedAttributesCount(): void
+    {
+        $this->assertSame(
+            self::DROPPED_ATTR_CONT,
+            $this->createEvent()->getDroppedAttributesCount()
+        );
+    }
+
+    private function createEvent(): Event
+    {
+        return new Event(
+            self::EVENT_NAME,
+            $this->getClock()->now(),
+            $this->getAttributesInterfaceMock()
+        );
+    }
+    private function getClock(): TestClock
+    {
+        return new TestClock();
+    }
+
+    private function getAttributesInterfaceMock(): AttributesInterface
+    {
+        if ($this->attributes instanceof AttributesInterface) {
+            return $this->attributes;
+        }
+
+        $this->attributes = $this->createMock(AttributesInterface::class);
+
+        $this->attributes->method('count')
+            ->willReturn(self::ATTR_CONT);
+
+        $this->attributes->method('getDroppedAttributesCount')
+            ->willReturn(self::DROPPED_ATTR_CONT);
+
+        return $this->attributes;
+    }
+}

--- a/tests/SDK/Unit/Trace/NoopSpanBuilderTest.php
+++ b/tests/SDK/Unit/Trace/NoopSpanBuilderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace;
+
+use OpenTelemetry\API\Trace\AttributesInterface;
+use OpenTelemetry\API\Trace\NonRecordingSpan;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Trace\NoopSpanBuilder;
+use OpenTelemetry\Tests\SDK\Util\TestClock;
+use PHPUnit\Framework\TestCase;
+
+class NoopSpanBuilderTest extends TestCase
+{
+    public function testGetInstance(): void
+    {
+        $this->assertSame(
+            NoopSpanBuilder::getInstance(),
+            NoopSpanBuilder::getInstance()
+        );
+    }
+
+    public function testSetParent(): void
+    {
+        $this->assertInstanceOf(
+            NoopSpanBuilder::class,
+            (new NoopSpanBuilder())->setParent(
+            // @todo: Create a interface for Context to allow it to be mocked
+                new Context()
+            )
+        );
+    }
+
+    public function testSetNoParent(): void
+    {
+        $this->assertInstanceOf(
+            NoopSpanBuilder::class,
+            (new NoopSpanBuilder())->setNoParent()
+        );
+    }
+
+    public function testAddLink(): void
+    {
+        $this->assertInstanceOf(
+            NoopSpanBuilder::class,
+            (new NoopSpanBuilder())->addLink(
+                $this->createMock(SpanContextInterface::class)
+            )
+        );
+    }
+
+    public function testSetAttribute(): void
+    {
+        $this->assertInstanceOf(
+            NoopSpanBuilder::class,
+            (new NoopSpanBuilder())->setAttribute('foo', 'bar')
+        );
+    }
+
+    public function testSetAttributes(): void
+    {
+        $this->assertInstanceOf(
+            NoopSpanBuilder::class,
+            (new NoopSpanBuilder())->setAttributes(
+                $this->createMock(AttributesInterface::class)
+            )
+        );
+    }
+
+    public function testSetStartTimestamp(): void
+    {
+        $this->assertInstanceOf(
+            NoopSpanBuilder::class,
+            (new NoopSpanBuilder())->setStartTimestamp(
+                (new TestClock())->now()
+            )
+        );
+    }
+
+    public function testSetSpanKind(): void
+    {
+        $this->assertInstanceOf(
+            NoopSpanBuilder::class,
+            (new NoopSpanBuilder())->setSpanKind(1)
+        );
+    }
+
+    public function testStartSpan(): void
+    {
+        $this->assertInstanceOf(
+            NonRecordingSpan::class,
+            (new NoopSpanBuilder())->startSpan()
+        );
+    }
+}

--- a/tests/SDK/Unit/Trace/SpanExporter/AbstractLoggerAwareTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/AbstractLoggerAwareTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanExporter;
+
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+abstract class AbstractLoggerAwareTest extends TestCase
+{
+
+    /**
+     * @var LoggerInterface|null
+     */
+    protected ?LoggerInterface $logger;
+
+    /**
+     * @return LoggerInterface|MockObject
+     * @psalm-suppress MismatchingDocblockReturnType
+     */
+    protected function getLoggerInterfaceMock(): LoggerInterface
+    {
+        // @phpstan-ignore-next-line
+        return $this->logger ?? $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    protected function createSpanConverterInterfaceMock(): SpanConverterInterface
+    {
+        $mock = $this->createMock(SpanConverterInterface::class);
+        $mock->method('convert')->willReturn([]);
+
+        return $mock;
+    }
+
+    protected function createSpanMocks(): array
+    {
+        return [
+            $this->createMock(SpanDataInterface::class),
+            $this->createMock(SpanDataInterface::class),
+        ];
+    }
+}

--- a/tests/SDK/Unit/Trace/SpanExporter/ConsoleSpanExporterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/ConsoleSpanExporterTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanProcessor;
+namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanExporter;
 
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\InstrumentationLibrary;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\Attributes;
 use OpenTelemetry\SDK\Trace\SpanContext;
-use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
+use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\StatusData;
 use OpenTelemetry\Tests\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;

--- a/tests/SDK/Unit/Trace/SpanExporter/ConsoleSpanExporterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/ConsoleSpanExporterTest.php
@@ -4,92 +4,120 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanExporter;
 
-use OpenTelemetry\API\Trace\StatusCode;
-use OpenTelemetry\SDK\InstrumentationLibrary;
-use OpenTelemetry\SDK\Resource\ResourceInfo;
-use OpenTelemetry\SDK\Trace\Attributes;
-use OpenTelemetry\SDK\Trace\SpanContext;
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
 use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
-use OpenTelemetry\SDK\Trace\StatusData;
-use OpenTelemetry\Tests\SDK\Util\SpanData;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use PHPUnit\Framework\TestCase;
 
 class ConsoleSpanExporterTest extends TestCase
 {
-    public function testConsoleExporterWorks()
+    private const TEST_DATA = [
+        'name' => 'my.service',
+        'parent_span_id' => '1000000000000000',
+        'kind' => 'KIND_INTERNAL',
+        'start' => 1505855794194009601,
+        'end' => 1505855799465726528,
+        'context' => [
+            'trace_id' => '00000000000000000000000000000000',
+            'span_id' => '0000000000000000',
+            'trace_state' => 'foz=baz,foo=bar',
+        ],
+        'resource' => [
+            'telemetry.sdk.name' => 'opentelemetry',
+            'telemetry.sdk.language' => 'php',
+            'telemetry.sdk.version' => 'dev',
+        ],
+        'attributes' => [
+            'fruit' => 'apple',
+        ],
+        'status' => [
+            'code' => 'Error',
+            'description' => 'status_description',
+        ],
+        'events' => [[
+            'name' => 'validators.list',
+            'timestamp' => 1505855799433901068,
+            'attributes' => [
+                'job' => 'stage.updateTime',
+            ],
+        ],],
+    ];
+
+    public function testExportSuccess(): void
     {
-        $span = (new SpanData())
-        ->setName('my.service')
-        ->setParentContext(
-            SpanContext::create(
-                '10000000000000000000000000000000',
-                '1000000000000000'
-            )
-        )
-        ->setStatus(
-            new StatusData(
-                StatusCode::STATUS_ERROR,
-                'status_description'
-            )
-        )
-        ->setInstrumentationLibrary(new InstrumentationLibrary(
-            'instrumentation_library_name',
-            'instrumentation_library_version'
-        ))
-        ->addAttribute('fruit', 'apple')
-        ->setResource(ResourceInfo::defaultResource())
-        ->addEvent('validators.list', new Attributes(['job' => 'stage.updateTime']), 1505855799433901068)
-        ->setHasEnded(true);
+        $converter = $this->createMock(SpanConverterInterface::class);
+        $converter->expects($this->once())
+            ->method('convert')
+            ->willReturn(self::TEST_DATA);
 
-        $exp = new ConsoleSpanExporter();
-        $exp->export([$span]);
+        ob_start();
 
-        $expected = <<<EOF
-        {
-            "name": "my.service",
-            "context": {
-                "trace_id": "00000000000000000000000000000000",
-                "span_id": "0000000000000000",
-                "trace_state": null
-            },
-            "resource": {
-                "telemetry.sdk.name": "opentelemetry",
-                "telemetry.sdk.language": "php",
-                "telemetry.sdk.version": "dev"
-            },
-            "parent_span_id": "1000000000000000",
-            "kind": "KIND_INTERNAL",
-            "start": 1505855794194009601,
-            "end": 1505855799465726528,
-            "attributes": {
-                "fruit": "apple"
-            },
-            "status": {
-                "code": "Error",
-                "description": "status_description"
-            },
-            "events": [
-                {
-                    "name": "validators.list",
-                    "timestamp": 1505855799433901068,
-                    "attributes": {
-                        "job": "stage.updateTime"
-                    }
-                }
-            ]
-        }
+        $this->assertSame(
+            SpanExporterInterface::STATUS_SUCCESS,
+            (new ConsoleSpanExporter($converter))->export([
+                $this->createMock(SpanDataInterface::class),
+            ])
+        );
 
-        EOF;
-
-        $this->expectOutputString($expected);
+        ob_end_clean();
     }
 
-    public function test_shutdown(): void
+    public function testExportFailed(): void
+    {
+        $resource = fopen('php://stdin', 'rb');
+        $converter = $this->createMock(SpanConverterInterface::class);
+        $converter->expects($this->once())
+            ->method('convert')
+            ->willReturn([$resource]);
+
+        ob_start();
+
+        $this->assertSame(
+            SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE,
+            (new ConsoleSpanExporter($converter))->export([
+                $this->createMock(SpanDataInterface::class),
+            ])
+        );
+
+        ob_end_clean();
+        fclose($resource);
+    }
+
+    public function testExportOutput(): void
+    {
+        try {
+            $expected = json_encode(self::TEST_DATA, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT) . PHP_EOL;
+        } catch (\Throwable $t) {
+            $this->fail($t->getMessage());
+        }
+
+        $converter = $this->createMock(SpanConverterInterface::class);
+        $converter->expects($this->once())
+            ->method('convert')
+            ->willReturn(self::TEST_DATA);
+
+        $this->expectOutputString($expected);
+
+        (new ConsoleSpanExporter($converter))->export([
+            $this->createMock(SpanDataInterface::class),
+        ]);
+    }
+
+    public function testFromConnectionString(): void
+    {
+        $this->assertInstanceOf(
+            ConsoleSpanExporter::class,
+            ConsoleSpanExporter::fromConnectionString()
+        );
+    }
+
+    public function testShutdown(): void
     {
         $this->assertTrue((new ConsoleSpanExporter())->shutdown());
     }
 
-    public function test_forceFlush(): void
+    public function testForceFlush(): void
     {
         $this->assertTrue((new ConsoleSpanExporter())->forceFlush());
     }

--- a/tests/SDK/Unit/Trace/SpanExporter/FriendlySpanConverterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/FriendlySpanConverterTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanExporter;
+
+use ArrayIterator;
+use OpenTelemetry\API\Trace\AttributeInterface;
+use OpenTelemetry\API\Trace\AttributesInterface;
+use OpenTelemetry\API\Trace\AttributesIteratorInterface;
+use OpenTelemetry\API\Trace\EventInterface;
+use OpenTelemetry\API\Trace\LinkInterface;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\TraceStateInterface;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Trace\Attribute;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use OpenTelemetry\SDK\Trace\SpanExporter\FriendlySpanConverter;
+use OpenTelemetry\SDK\Trace\StatusDataInterface;
+use PHPUnit\Framework\TestCase;
+
+//use DG\BypassFinals;
+
+class FriendlySpanConverterTest extends TestCase
+{
+    private const TEST_DATA = [
+        'name' => 'my.service',
+        'parent_span_id' => '1000000000000000',
+        'kind' => 'KIND_INTERNAL',
+        'start' => 1505855794194009601,
+        'end' => 1505855799465726528,
+        'context' => [
+            'trace_id' => '00000000000000000000000000000000',
+            'span_id' => '0000000000000000',
+            'trace_state' => 'foz=baz,foo=bar',
+        ],
+        'resource' => [
+            'telemetry.sdk.name' => 'opentelemetry',
+            'telemetry.sdk.language' => 'php',
+            'telemetry.sdk.version' => 'dev',
+        ],
+        'attributes' => [
+            'fruit' => 'apple',
+        ],
+        'status' => [
+            'code' => 'Error',
+            'description' => 'status_description',
+        ],
+        'events' => [[
+            'name' => 'validators.list',
+            'timestamp' => 1505855799433901068,
+            'attributes' => [
+                'job' => 'stage.updateTime',
+            ],
+        ],[
+            'name' => 'user.created',
+            'timestamp' => 1505855799433901555,
+            'attributes' => [
+                'name' => 'John Doe',
+            ],
+        ],],
+        'links' => [[
+            'context' => [
+                'trace_id' => '20000000000000000000000000000000',
+                'span_id' => '2000000000000000',
+                'trace_state' => 'foo=baz,foz=bar',
+            ],
+            'attributes' => [
+                'foo' => 'bar',
+            ], ],[
+            'context' => [
+                'trace_id' => '20000000000000000000000000000000',
+                'span_id' => '3000000000000000',
+                'trace_state' => 'baz=foz,bar=foo',
+            ],
+            'attributes' => [
+                'foz' => 'baz',
+            ], ],
+        ],
+    ];
+
+    public function testConvert(): void
+    {
+        $this->assertEquals(
+            self::TEST_DATA,
+            (new FriendlySpanConverter())->convert(
+                $this->createSpanDataInterfaceMock()
+            )
+        );
+    }
+
+    private function createSpanDataInterfaceMock(): SpanDataInterface
+    {
+        $mock = $this->getMockBuilder(SpanDataInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock->method('getName')
+            ->willReturn(self::TEST_DATA['name']);
+
+        $mock->method('getContext')
+            ->willReturn(
+                $this->createSpanContextMock(
+                    self::TEST_DATA['context']['span_id'],
+                    self::TEST_DATA['context']['trace_id'],
+                    self::TEST_DATA['context']['trace_state'],
+                )
+            );
+
+        $mock->method('getParentContext')
+            ->willReturn(
+                $this->createSpanContextMock(
+                    self::TEST_DATA['parent_span_id'],
+                )
+            );
+
+        $mock->method('getResource')
+            ->willReturn(
+                $this->createResourceInfoMock()
+            );
+
+        $mock->method('getKind')
+            ->willReturn(SpanKind::KIND_INTERNAL);
+
+        $mock->method('getStartEpochNanos')
+            ->willReturn(self::TEST_DATA['start']);
+
+        $mock->method('getEndEpochNanos')
+            ->willReturn(self::TEST_DATA['end']);
+
+        $mock->method('getAttributes')
+            ->willReturn($this->createAttributesInterfaceMock(self::TEST_DATA['attributes']));
+
+        $mock->method('getStatus')
+            ->willReturn($this->createStatusDataMock());
+
+        $events = [];
+        foreach (self::TEST_DATA['events'] as $event) {
+            $events[] = $this->createEventInterfaceMock(
+                $event['name'],
+                $event['timestamp'],
+                $this->createAttributesInterfaceMock(
+                    $event['attributes']
+                )
+            );
+        }
+        $mock->method('getEvents')->willReturn($events);
+
+        $links = [];
+        foreach (self::TEST_DATA['links'] as $link) {
+            $links[] = $this->createLinkInterfaceMock(
+                $this->createSpanContextMock(
+                    $link['context']['span_id'],
+                    $link['context']['trace_id'],
+                    $link['context']['trace_state']
+                ),
+                $this->createAttributesInterfaceMock($link['attributes'])
+            );
+        }
+        $mock->method('getLinks')->willReturn($links);
+
+        return $mock;
+    }
+
+    private function createSpanContextMock(string $spanId, string $traceId = '0', string $traceState = null): SpanContextInterface
+    {
+        $mock = $this->createMock(SpanContextInterface::class);
+
+        $mock->method('getSpanId')
+            ->willReturn($spanId);
+
+        $mock->method('getTraceId')
+            ->willReturn($traceId);
+
+        $mock->method('getTraceState')
+            ->willReturn(
+                $traceState === null ? null : $this->createTraceStateInterfaceMock($traceState)
+            );
+
+        $mock->method('isValid')
+            ->willReturn(true);
+
+        return $mock;
+    }
+
+    private function createTraceStateInterfaceMock(string $traceState): TraceStateInterface
+    {
+        $mock = $this->createMock(TraceStateInterface::class);
+
+        $mock->method('__toString')
+            ->willReturn($traceState);
+
+        return $mock;
+    }
+
+    private function createResourceInfoMock(): ResourceInfo
+    {
+        $mock = $this->getMockBuilder(ResourceInfo::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock->method('getAttributes')
+            ->willReturn($this->createAttributesInterfaceMock(self::TEST_DATA['resource']));
+
+        return $mock;
+    }
+
+    private function createStatusDataMock(): StatusDataInterface
+    {
+        $mock = $this->createMock(StatusDataInterface::class);
+
+        $mock->method('getCode')
+            ->willReturn(self::TEST_DATA['status']['code']);
+
+        $mock->method('getDescription')
+            ->willReturn(self::TEST_DATA['status']['description']);
+
+        return $mock;
+    }
+
+    private function createAttributesInterfaceMock(array $items): AttributesInterface
+    {
+        $mock = $this->createMock(AttributesInterface::class);
+
+        $attributes = [];
+        foreach ($items as $key => $value) {
+            $attributes[$key] = $this->createAttributeMock($key, $value);
+        }
+        $mock->method('getIterator')
+        ->willReturn(
+            $this->createAttributesIterator($attributes)
+        );
+
+        return $mock;
+    }
+
+    private function createAttributeMock(string $key, $value): Attribute
+    {
+        $mock = $this->getMockBuilder(Attribute::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock->method('getKey')
+            ->willReturn($key);
+
+        $mock->method('getValue')
+            ->willReturn($value);
+
+        return $mock;
+    }
+
+    public function createEventInterfaceMock(string $name, int $timestamp, AttributesInterface $attributes): EventInterface
+    {
+        $mock = $this->createMock(EventInterface::class);
+
+        $mock->method('getName')->willReturn($name);
+        $mock->method('getEpochNanos')->willReturn($timestamp);
+        $mock->method('getAttributes')->willReturn($attributes);
+
+        return $mock;
+    }
+
+    public function createLinkInterfaceMock(SpanContextInterface $context, AttributesInterface $attributes): LinkInterface
+    {
+        $mock = $this->createMock(LinkInterface::class);
+
+        $mock->method('getSpanContext')->willReturn($context);
+        $mock->method('getAttributes')->willReturn($attributes);
+
+        return $mock;
+    }
+
+    public function createAttributesIterator(array $items): AttributesIteratorInterface
+    {
+        return new class($items) implements AttributesIteratorInterface {
+            private ArrayIterator $iterator;
+            public function __construct($attributes)
+            {
+                $this->iterator = new ArrayIterator($attributes);
+            }
+
+            public function key(): string
+            {
+                return (string) $this->iterator->key();
+            }
+
+            public function current(): AttributeInterface
+            {
+                return $this->iterator->current();
+            }
+
+            public function rewind(): void
+            {
+                $this->iterator->rewind();
+            }
+
+            public function valid(): bool
+            {
+                return $this->iterator->valid();
+            }
+
+            public function next(): void
+            {
+                $this->iterator->next();
+            }
+        };
+    }
+}

--- a/tests/SDK/Unit/Trace/SpanExporter/LoggerDecoratorTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/LoggerDecoratorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanExporter;
+
+use OpenTelemetry\SDK\Trace\SpanExporter\LoggerDecorator;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LogLevel;
+use RuntimeException;
+
+class LoggerDecoratorTest extends AbstractLoggerAwareTest
+{
+    /**
+     * @var SpanExporterInterface|null
+     */
+    private ?SpanExporterInterface $decorated;
+
+    public function testFromConnectionString(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        LoggerDecorator::fromConnectionString('foo', 'bar', 'baz');
+    }
+
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod
+     */
+    public function testShutDown(): void
+    {
+        $this->getSpanExporterInterfaceMock()
+            ->expects($this->once())
+            ->method('shutdown')
+            ->willReturn(true);
+
+        $this->assertTrue(
+            $this->createLoggerDecorator()->shutdown()
+        );
+    }
+
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod
+     */
+    public function testForceFlush(): void
+    {
+        $this->getSpanExporterInterfaceMock()
+            ->expects($this->once())
+            ->method('forceFlush')
+            ->willReturn(true);
+
+        $this->assertTrue(
+            $this->createLoggerDecorator()->forceFlush()
+        );
+    }
+
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    public function testExportSuccess(): void
+    {
+        $this->getSpanExporterInterfaceMock()
+            ->expects($this->once())
+            ->method('export')
+            ->willReturn(SpanExporterInterface::STATUS_SUCCESS);
+
+        $this->getLoggerInterfaceMock()
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::INFO);
+
+        $this->createLoggerDecorator()
+            ->export(
+                $this->createSpanMocks()
+            );
+    }
+
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    public function testExportFailedRetryable(): void
+    {
+        $this->getSpanExporterInterfaceMock()
+            ->expects($this->once())
+            ->method('export')
+            ->willReturn(SpanExporterInterface::STATUS_FAILED_RETRYABLE);
+
+        $this->getLoggerInterfaceMock()
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::ERROR);
+
+        $this->createLoggerDecorator()
+            ->export(
+                $this->createSpanMocks()
+            );
+    }
+
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    public function testExportFailedNotRetryable(): void
+    {
+        $this->getSpanExporterInterfaceMock()
+            ->expects($this->once())
+            ->method('export')
+            ->willReturn(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE);
+
+        $this->getLoggerInterfaceMock()
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::ALERT);
+
+        $this->createLoggerDecorator()
+            ->export(
+                $this->createSpanMocks()
+            );
+    }
+
+    /**
+     * @return LoggerDecorator
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    private function createLoggerDecorator(): LoggerDecorator
+    {
+        return new LoggerDecorator(
+            $this->getSpanExporterInterfaceMock(),
+            $this->getLoggerInterfaceMock(),
+            $this->createSpanConverterInterfaceMock()
+        );
+    }
+
+    /**
+     * @return SpanExporterInterface|MockObject
+     * @psalm-suppress MismatchingDocblockReturnType
+     */
+    private function getSpanExporterInterfaceMock(): SpanExporterInterface
+    {
+        // @phpstan-ignore-next-line
+        return $this->decorated ?? $this->decorated = $this->createMock(SpanExporterInterface::class);
+    }
+}

--- a/tests/SDK/Unit/Trace/SpanExporter/LoggerExporterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/LoggerExporterTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanExporter;
+
+use Exception;
+use OpenTelemetry\SDK\Trace\SpanExporter\LoggerExporter;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+
+class LoggerExporterTest extends AbstractLoggerAwareTest
+{
+    private const SERVICE_NAME = 'LoggerExporterTest';
+    private const LOG_LEVEL = 'debug';
+    private const LOG_FILE = 'debug.log';
+
+    public function testFromConnectionString(): void
+    {
+        /** @noinspection UnnecessaryAssertionInspection */
+        $this->assertInstanceOf(
+            LoggerExporter::class,
+            LoggerExporter::fromConnectionString(
+                self::LOG_FILE,
+                self::SERVICE_NAME,
+                self::LOG_LEVEL
+            )
+        );
+    }
+
+    public function testShutDown(): void
+    {
+        $this->assertTrue(
+            $this->createLoggerExporter()->shutdown()
+        );
+    }
+
+    public function testForceFlush(): void
+    {
+        $this->assertTrue(
+            $this->createLoggerExporter()->forceFlush()
+        );
+    }
+
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    public function testExportGranularityAggregate(): void
+    {
+        $this->getLoggerInterfaceMock()
+            ->expects($this->once())
+            ->method('log');
+
+        $this->assertSame(
+            SpanExporterInterface::STATUS_SUCCESS,
+            $this->createLoggerExporter(LoggerExporter::GRANULARITY_AGGREGATE)
+                ->export(
+                    $this->createSpanMocks()
+                )
+        );
+    }
+
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    public function testExportGranularitySpan(): void
+    {
+        $spans = $this->createSpanMocks();
+
+        $this->getLoggerInterfaceMock()
+            ->expects($this->exactly(count($spans)))
+            ->method('log');
+
+        $this->assertSame(
+            SpanExporterInterface::STATUS_SUCCESS,
+            $this->createLoggerExporter(LoggerExporter::GRANULARITY_SPAN)
+                ->export($spans)
+        );
+    }
+
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    public function testLoggerThrowsException(): void
+    {
+        $this->getLoggerInterfaceMock()
+            ->method('log')
+            ->willThrowException(new Exception());
+
+        $this->assertSame(
+            SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE,
+            $this->createLoggerExporter()
+                ->export(
+                    $this->createSpanMocks()
+                )
+        );
+    }
+
+    /**
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    public function testExportNotRunning(): void
+    {
+        $exporter = $this->createLoggerExporter();
+        $exporter->shutdown();
+
+        $this->assertSame(
+            SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE,
+            $exporter->export(
+                $this->createSpanMocks()
+            )
+        );
+    }
+
+    /**
+     * @psalm-suppress PossiblyInvalidArgument
+     */
+    private function createLoggerExporter(int $granularity = 1): LoggerExporter
+    {
+        return new LoggerExporter(
+            self::SERVICE_NAME,
+            $this->getLoggerInterfaceMock(),
+            self::LOG_LEVEL,
+            $this->createSpanConverterInterfaceMock(),
+            $granularity
+        );
+    }
+}

--- a/tests/SDK/Unit/Trace/SpanExporter/NullSpanConverterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/NullSpanConverterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanExporter;
+
+use OpenTelemetry\SDK\Trace\SpanConverterInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use OpenTelemetry\SDK\Trace\SpanExporter\NullSpanConverter;
+use PHPUnit\Framework\TestCase;
+
+class NullSpanConverterTest extends TestCase
+{
+    public function testImplementsSpanConverterInterface(): void
+    {
+        $this->assertInstanceOf(
+            SpanConverterInterface::class,
+            new NullSpanConverter()
+        );
+    }
+
+    public function testConvert(): void
+    {
+        $this->assertSame(
+            [],
+            (new NullSpanConverter())->convert(
+                $this->createMock(SpanDataInterface::class)
+            )
+        );
+    }
+}

--- a/tests/SDK/Unit/Trace/SpanProcessor/MultiSpanProcessorTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessor/MultiSpanProcessorTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\SDK\Unit\Trace\SpanProcessor;
+
+use Monolog\Test\TestCase;
+use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
+use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
+use OpenTelemetry\SDK\Trace\SpanProcessor\MultiSpanProcessor;
+use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MultiSpanProcessorTest extends TestCase
+{
+    private array $spanProcessors = [];
+
+    public function testGetSpanProcessors(): void
+    {
+        $this->assertEquals(
+            $this->getSpanProcessors(),
+            $this->createMultiSpanProcessor()->getSpanProcessors()
+        );
+    }
+
+    public function testAddSpanProcessor(): void
+    {
+        $multiProcessor = $this->createMultiSpanProcessor();
+        $processor = $this->createMock(SpanProcessorInterface::class);
+        $multiProcessor->addSpanProcessor($processor);
+        $processors = array_merge(
+            [$this->createMock(SpanProcessorInterface::class)],
+            $this->getSpanProcessors()
+        );
+
+        $this->assertEquals(
+            $processors,
+            $multiProcessor->getSpanProcessors()
+        );
+    }
+
+    public function testOnStart(): void
+    {
+        /** @var MockObject $processor */
+        foreach ($this->getSpanProcessors() as $processor) {
+            $processor->expects($this->once())
+                ->method('onStart');
+        }
+
+        $this->createMultiSpanProcessor()
+            ->onStart(
+                $this->createMock(ReadWriteSpanInterface::class)
+            );
+    }
+
+    public function testOnEnd(): void
+    {
+        /** @var MockObject $processor */
+        foreach ($this->getSpanProcessors() as $processor) {
+            $processor->expects($this->once())
+                ->method('onEnd');
+        }
+
+        $this->createMultiSpanProcessor()
+            ->onEnd(
+                $this->createMock(ReadableSpanInterface::class)
+            );
+    }
+
+    public function testShutdown(): void
+    {
+        /** @var MockObject $processor */
+        foreach ($this->getSpanProcessors() as $processor) {
+            $processor->expects($this->once())
+                ->method('shutdown')
+                ->willReturn(true);
+        }
+
+        $this->assertTrue(
+            $this->createMultiSpanProcessor()
+                ->shutdown()
+        );
+    }
+
+    public function testShutdownOneFailed(): void
+    {
+        /** @var MockObject $processor */
+        foreach ($this->getSpanProcessors() as $i => $processor) {
+            $processor->expects($this->once())
+                ->method('shutdown')
+                ->willReturn(!(bool) $i);
+        }
+
+        $this->assertFalse(
+            $this->createMultiSpanProcessor()
+                ->shutdown()
+        );
+    }
+
+    public function testForceFlush(): void
+    {
+        /** @var MockObject $processor */
+        foreach ($this->getSpanProcessors() as $processor) {
+            $processor->expects($this->once())
+                ->method('forceFlush')
+                ->willReturn(true);
+        }
+
+        $this->assertTrue(
+            $this->createMultiSpanProcessor()
+                ->forceFlush()
+        );
+    }
+
+    public function testForceFlushOneFailed(): void
+    {
+        /** @var MockObject $processor */
+        foreach ($this->getSpanProcessors() as $i => $processor) {
+            $processor->expects($this->once())
+                ->method('forceFlush')
+                ->willReturn(!(bool) $i);
+        }
+
+        $this->assertFalse(
+            $this->createMultiSpanProcessor()
+                ->forceFlush()
+        );
+    }
+
+    private function createMultiSpanProcessor(): MultiSpanProcessor
+    {
+        return new MultiSpanProcessor(
+            $this->getSpanProcessors()[0],
+            $this->getSpanProcessors()[1]
+        );
+    }
+
+    private function getSpanProcessors(): array
+    {
+        return !empty($this->spanProcessors)
+            ? $this->spanProcessors
+            : $this->spanProcessors = [
+                $this->createMock(SpanProcessorInterface::class),
+                $this->createMock(SpanProcessorInterface::class),
+            ];
+    }
+}


### PR DESCRIPTION
This PR adds observabilty to the library itself by introducing several logging related components. Logging functionality is based on the [PSR-3: Logger standard](https://www.php-fig.org/psr/psr-3/) and a basic mapping between PSR3 and [OpenTelemetry SeverityNumbers](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/logs/data-model.md#field-severitynumber) is added, too (PSR uses [rfc5424 ](https://datatracker.ietf.org/doc/html/rfc5424#page-10) log levels. )

Only the PSR3 interface library is added as a production dependency, so Developers can use a PSR3 implementation of their liking, however the popular choice [Monolog ](https://github.com/Seldaek/monolog)is added as a dev dependency, and a very simple PSR3 implementation is provided, too. 

This PR doesn't take care of log enrichment with trace data, etc. according to the spec, but can be a base for future development.

Furthermore, according to the [specs on error handling](https://github.com/open-telemetry/opentelemetry-specification/blob/b46bcab5fb709381f1fd52096a19541370c7d1b3/specification/error-handling.md#basic-error-handling-principles) "OpenTelemetry implementations MUST NOT throw unhandled exceptions at run time." So components of this PR can help avoid leaking exceptions from the library in the future, while still proving feedback for developers via logs. This can be done by implemeting the PSR "LoggerAware" interface by using a trait. Many frameworks automatically inject a logger instance in classes implementing said interface.

- Adds PSR3 and Monolog libaries (prod / dev)
- Adds VfsStream as dev library to allow mocking of the file system in tests.
- Adds a SpanConverter interface to allow logging of SpanData in different formats.
- Adds a Noop SpanConverter class to avoid runtime errors.
- Extracts friendly JSON converter from ConsoleExporter into dedicated SpanConverter class for reusability.
- Adds a LoggerSpanExporter for debugging/testing purposes which uses the friendly JSON converter as a default.
- Adds an abstract SpanExporterDecorator, which can be extended to enhance/filter Span data or report on it.
- Adds a LoggerDecorator which reports Span data to a given Logger.
- Adds a simple PSR file logger (while a file can be a lot of things in PHP)
- Adds Mapping between PSR and OTEL log/severity levels.
- Adds examples for the usage of LoggerExporter and LoggerDecorator 