### PR TITLE
Fixing issues around jaeger-exporter by adding the guzzlehttp 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "google/protobuf": "^v3.3.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "nyholm/dsn": "^2.0.0"
+        "nyholm/dsn": "^2.0.0",
+        "guzzlehttp/guzzle": "^7.3",
+        "guzzlehttp/psr7": "^2.1.0"
     },
     "config": {
         "sort-packages": true
@@ -51,8 +53,6 @@
     "require-dev": {
         "composer/xdebug-handler": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "guzzlehttp/guzzle": "^7.3",
-        "guzzlehttp/psr7": "^2.0@RC",
         "mockery/mockery": "^1.4",
         "nyholm/psr7": "^1.4",
         "phan/phan": "^5.0",


### PR DESCRIPTION
This PR fixed issues around jaeger-exporter by adding the guzzlehttp to the required dependencies