### PR TITLE
Add Deptrac as a dependency testing/linting tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ tests/coverage
 # W3C Test Service build artifacts
 tests/TraceContext/W3CTestService/test_app
 tests/TraceContext/W3CTestService/trace-context
+
+# deptrac cache
+/.deptrac.cache

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ bash:
 	$(DC_RUN_PHP) bash
 style:
 	$(DC_RUN_PHP) php ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --using-cache=no -vvv
+deptrac:
+	$(DC_RUN_PHP) vendor/bin/deptrac --formatter=table
 w3c-test-service:
 	@docker-compose -f docker-compose.w3cTraceContext.yaml run --rm php ./tests/TraceContext/W3CTestService/symfony-setup
 FORCE:

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "psalm/plugin-mockery": "^0.9.0",
         "psalm/plugin-phpunit": "^0.13.0",
         "psalm/psalm": "^4.0",
+        "qossmic/deptrac-shim": "^0.16.0",
         "symfony/http-client": "^5.2"
     }
 }

--- a/depfile.yaml
+++ b/depfile.yaml
@@ -1,0 +1,48 @@
+#baseline: depfile.baseline.yml
+paths:
+    - ./src
+exclude_files:
+    - '#.*test.*#'
+layers:
+    -
+        name: API
+        collectors:
+            -
+                type: className
+                regex: OpenTelemetry\\API\\*
+    -
+        name: SDK
+        collectors:
+            -
+                type: className
+                regex: OpenTelemetry\\SDK\\*
+    -
+        name: Context
+        collectors:
+            -
+                type: className
+                regex: OpenTelemetry\\Context\\*
+    -
+        name: Contrib
+        collectors:
+            -
+                type: className
+                regex: OpenTelemetry\\Contrib\\*
+    -
+        name: Proto
+        collectors:
+            -
+                type: className
+                regex: OpenTelemetry\\Proto\\*
+ruleset:
+    Contrib:
+        - API
+        - SDK
+        - Context
+        - Proto
+    Context: ~
+    SDK:
+        - API
+        - Context
+    API:
+        - Context


### PR DESCRIPTION
This PR adds [Deptrac ](https://github.com/qossmic/deptrac) as a tool to test and lint the dependency direction of (sub) packages.
 see: https://github.com/open-telemetry/opentelemetry-php/issues/464


- Adds qossmic/deptrac-shim as a composer dev dependency
- Adds a basic dependency configuration (for now ignoring 3rd party dependencies)
- Adds a make target to execute the deptrac command in the test container ("make deptrac")

Once the issues in https://github.com/open-telemetry/opentelemetry-php/issues/464 are fixed, the deptrac command could become part of the CI pipeline (or even before, since issues can be ignored  in the config)