### PR TITLE
Finish Off Zipkin Spec Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "ext-json": "*",
         "google/protobuf": "^v3.3.0",
         "grpc/grpc": "^1.30",
-        "mlocati/ip-lib": "^1.17",
         "nyholm/dsn": "^2.0.0",
         "promphp/prometheus_client_php": "^2.2.1",
         "psr/http-client-implementation": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,12 @@
         "google/protobuf": "^v3.3.0",
         "grpc/grpc": "^1.30",
         "nyholm/dsn": "^2.0.0",
+        "php-http/async-client-implementation": "^1.0",
+        "php-http/discovery": "^1.14",
         "promphp/prometheus_client_php": "^2.2.1",
-        "psr/http-client-implementation": "^1.0",
-        "psr/http-factory-implementation": "^1.0"
+        "psr/http-factory-implementation": "^1.0",
+        "psr/log": "^1.1",
+        "symfony/polyfill-mbstring": "^1.23"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,15 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.4 || ^8.0",
-        "ext-json": "*",
         "ext-grpc": "*",
-        "promphp/prometheus_client_php": "^2.2.1",
-        "grpc/grpc": "^1.30",
+        "ext-json": "*",
         "google/protobuf": "^v3.3.0",
+        "grpc/grpc": "^1.30",
+        "mlocati/ip-lib": "^1.17",
+        "nyholm/dsn": "^2.0.0",
+        "promphp/prometheus_client_php": "^2.2.1",
         "psr/http-client-implementation": "^1.0",
-        "psr/http-factory-implementation": "^1.0",
-        "nyholm/dsn": "^2.0.0"
+        "psr/http-factory-implementation": "^1.0"
     },
     "config": {
         "sort-packages": true

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -184,53 +184,12 @@ class SpanConverter
         //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
         switch($preferredAttr->getKey()) {
             case "net.peer.ip":
-                $ipString = $preferredAttr->getValue();
-
-                if (filter_var($ipString, FILTER_VALIDATE_IP)) {
-
-                    $remoteEndpointArr = [
-                        //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
-                        'serviceName' => "unknown"
-                    ];
-
-                    if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
-                        //Key casing/value units loosely inferred from Go comments around here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127
-                        $remoteEndpointArr["ipv4"] = ip2long($ipString);
-                    }
-
-                    if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
-                        //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
-                            //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
-                            //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
-                            $remoteEndpointArr["ipv6"] = inet_pton($ipString);
-                        //}
-                        //TODO - does the else case need handling here?
-                    }
-
-                    //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
-                    $remoteEndpointArr["port"] = 0;
-                    foreach ($span->getAttributes() as $attr) {
-                        if ($attr->getKey() === "net.peer.port") {
-                            //TODO - take care of the cases where this isn't a string
-                            $portVal = $attr->getValue();
-                            $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
-
-                            $remoteEndpointArr["port"] = $portInt;
-
-                            break;
-                        }
-                    }
-
-                    return $remoteEndpointArr;
-                }
-                break;
+                return SpanConverter::getRemoteEndpointDataFromIpAddressAndPort($preferredAttr, $span);
             default:
                 return [
                     'serviceName' => $preferredAttr->getValue(),
                 ];
         }
-
-        return null; //Determine if this is safe to remove
     }
 
     private static function findRemoteEndpointPreferredAttribute(SpanDataInterface $span): ?Attribute {
@@ -249,5 +208,49 @@ class SpanConverter
         }
 
         return $preferredAttr;
+    }
+
+    private static function getRemoteEndpointDataFromIpAddressAndPort(Attribute $preferredAttr, SpanDataInterface $span): ?array { //TODO - switch the span out for just the list of attributes
+        $ipString = $preferredAttr->getValue();
+
+        if (filter_var($ipString, FILTER_VALIDATE_IP)) {
+
+            $remoteEndpointArr = [
+                //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
+                'serviceName' => "unknown"
+            ];
+
+            if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
+                //Key casing/value units loosely inferred from Go comments around here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127
+                $remoteEndpointArr["ipv4"] = ip2long($ipString);
+            }
+
+            if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
+                //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
+                    //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
+                    //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
+                    $remoteEndpointArr["ipv6"] = inet_pton($ipString);
+                //}
+                //TODO - does the else case need handling here?
+            }
+
+            //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
+            $remoteEndpointArr["port"] = 0;
+            foreach ($span->getAttributes() as $attr) {
+                if ($attr->getKey() === "net.peer.port") {
+                    //TODO - take care of the cases where this isn't a string
+                    $portVal = $attr->getValue();
+                    $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
+
+                    $remoteEndpointArr["port"] = $portInt;
+
+                    break;
+                }
+            }
+
+            return $remoteEndpointArr;
+        }
+
+        return null;
     }
 }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -147,7 +147,7 @@ class SpanConverter
     }
 
     private static function toAnnotation(EventInterface $event): array {
-        $value = $event->getName();
+        
 
         if (count($event->getAttributes()) > 0) {
             $attributesArray = [];
@@ -161,6 +161,9 @@ class SpanConverter
 
                 $value = "\"{$eventName}\": {$attributesAsJson}";
             }
+        } else {
+            $eventName = $event->getName();
+            $value = "\"{$eventName}\"";
         }
 
         $annotation = [

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -227,12 +227,7 @@ class SpanConverter
         }
 
         if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
-            //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
-                //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
-                //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
-                $remoteEndpointArr["ipv6"] = inet_pton($ipString);
-            //}
-            //TODO - does the else case need handling here?
+            $remoteEndpointArr["ipv6"] = inet_pton($ipString);
         }
 
         $remoteEndpointArr["port"] = $portNumber ?? 0;

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -19,6 +19,16 @@ class SpanConverter
     const KEY_INSTRUMENTATION_LIBRARY_NAME = 'otel.library.name';
     const KEY_INSTRUMENTATION_LIBRARY_VERSION = 'otel.library.version';
 
+    const REMOTE_ENDPOINT_PREFERRED_ATTRIBUTE_TO_RANK_MAP = [
+        "peer.service" => 1,
+        "net.peer.name" => 2,
+        "net.peer.ip" => 3,
+        "peer.hostname" => 4,
+        "peer.address" => 5,
+        "http.host" => 6,
+        "db.name" => 7
+    ];
+
     /**
      * @var string
      */
@@ -224,22 +234,12 @@ class SpanConverter
     }
 
     private static function findRemoteEndpointPreferredAttribute(SpanDataInterface $span): ?Attribute {
-        $attributeToRankMap = [
-            "peer.service" => 1,
-            "net.peer.name" => 2,
-            "net.peer.ip" => 3,
-            "peer.hostname" => 4,
-            "peer.address" => 5,
-            "http.host" => 6,
-            "db.name" => 7
-        ];
-
         $preferredAttrRank = null;
         $preferredAttr = null;
 
         foreach ($span->getAttributes() as $attr) {
-            if (array_key_exists($attr->getKey(), $attributeToRankMap)) {
-                $attrRank = $attributeToRankMap[$attr->getKey()];
+            if (array_key_exists($attr->getKey(), SpanConverter::REMOTE_ENDPOINT_PREFERRED_ATTRIBUTE_TO_RANK_MAP)) {
+                $attrRank = SpanConverter::REMOTE_ENDPOINT_PREFERRED_ATTRIBUTE_TO_RANK_MAP[$attr->getKey()];
 
                 if (($preferredAttrRank === null) || ($attrRank <= $preferredAttrRank)) {
                     $preferredAttr = $attr;

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -21,13 +21,13 @@ class SpanConverter
     const KEY_INSTRUMENTATION_LIBRARY_VERSION = 'otel.library.version';
 
     const REMOTE_ENDPOINT_PREFERRED_ATTRIBUTE_TO_RANK_MAP = [
-        "peer.service" => 1,
-        "net.peer.name" => 2,
-        "net.peer.ip" => 3,
-        "peer.hostname" => 4,
-        "peer.address" => 5,
-        "http.host" => 6,
-        "db.name" => 7
+        'peer.service' => 1,
+        'net.peer.name' => 2,
+        'net.peer.ip' => 3,
+        'peer.hostname' => 4,
+        'peer.address' => 5,
+        'http.host' => 6,
+        'db.name' => 7,
     ];
 
     /**
@@ -114,11 +114,10 @@ class SpanConverter
             $row['annotations'][] = SpanConverter::toAnnotation($event);
         }
 
-        if (($span->getKind() === SpanKind::KIND_CLIENT) || ($span->getKind() === SpanKind::KIND_PRODUCER))
-        {
+        if (($span->getKind() === SpanKind::KIND_CLIENT) || ($span->getKind() === SpanKind::KIND_PRODUCER)) {
             $remoteEndpointData = SpanConverter::toRemoteEndpoint($span);
             if ($remoteEndpointData != null) {
-                $row["remoteEndpoint"] = $remoteEndpointData;
+                $row['remoteEndpoint'] = $remoteEndpointData;
             }
         }
 
@@ -147,7 +146,8 @@ class SpanConverter
         return null;
     }
 
-    private static function toAnnotation(EventInterface $event): array {
+    private static function toAnnotation(EventInterface $event): array
+    {
         $eventName = $event->getName();
         $attributesAsJson = SpanConverter::convertEventAttributesToJson($event);
 
@@ -161,7 +161,8 @@ class SpanConverter
         return $annotation;
     }
 
-    private static function convertEventAttributesToJson(EventInterface $event): ?string {
+    private static function convertEventAttributesToJson(EventInterface $event): ?string
+    {
         if (count($event->getAttributes()) === 0) {
             return null;
         }
@@ -179,7 +180,8 @@ class SpanConverter
         return $attributesAsJson;
     }
 
-    private static function toRemoteEndpoint(SpanDataInterface $span): ?array {
+    private static function toRemoteEndpoint(SpanDataInterface $span): ?array
+    {
         $preferredAttr = SpanConverter::findRemoteEndpointPreferredAttribute($span);
 
         if ($preferredAttr === null) {
@@ -190,10 +192,10 @@ class SpanConverter
             return null;
         }
 
-        switch($preferredAttr->getKey()) {
-            case "net.peer.ip":
+        switch ($preferredAttr->getKey()) {
+            case 'net.peer.ip':
                 return SpanConverter::getRemoteEndpointDataFromIpAddressAndPort(
-                    $preferredAttr, 
+                    $preferredAttr,
                     SpanConverter::getPortNumberFromSpanAttributes($span)
                 );
             default:
@@ -203,7 +205,8 @@ class SpanConverter
         }
     }
 
-    private static function findRemoteEndpointPreferredAttribute(SpanDataInterface $span): ?AttributeInterface {
+    private static function findRemoteEndpointPreferredAttribute(SpanDataInterface $span): ?AttributeInterface
+    {
         $preferredAttrRank = null;
         $preferredAttr = null;
 
@@ -221,7 +224,8 @@ class SpanConverter
         return $preferredAttr;
     }
 
-    private static function getRemoteEndpointDataFromIpAddressAndPort(AttributeInterface $preferredAttr, ?int $portNumber): ?array {
+    private static function getRemoteEndpointDataFromIpAddressAndPort(AttributeInterface $preferredAttr, ?int $portNumber): ?array
+    {
         $ipString = $preferredAttr->getValue();
 
         if (!is_string($ipString)) {
@@ -233,29 +237,30 @@ class SpanConverter
         }
 
         $remoteEndpointArr = [
-            'serviceName' => "unknown"
+            'serviceName' => 'unknown',
         ];
 
-        if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
-            $remoteEndpointArr["ipv4"] = ip2long($ipString);
+        if (filter_var($ipString, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            $remoteEndpointArr['ipv4'] = ip2long($ipString);
         }
 
-        if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
-            $remoteEndpointArr["ipv6"] = inet_pton($ipString);
+        if (filter_var($ipString, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            $remoteEndpointArr['ipv6'] = inet_pton($ipString);
         }
 
-        $remoteEndpointArr["port"] = $portNumber ?? 0;
+        $remoteEndpointArr['port'] = $portNumber ?? 0;
 
         return $remoteEndpointArr;
     }
 
-    private static function getPortNumberFromSpanAttributes(SpanDataInterface $span): ?int {
+    private static function getPortNumberFromSpanAttributes(SpanDataInterface $span): ?int
+    {
         foreach ($span->getAttributes() as $attr) {
-            if ($attr->getKey() === "net.peer.port") {
+            if ($attr->getKey() === 'net.peer.port') {
                 $portVal = $attr->getValue();
-                $portInt = intval($portVal);
+                $portInt = (int) $portVal;
 
-                if (($portInt > 0) && ($portInt < pow(2,16))) {
+                if (($portInt > 0) && ($portInt < pow(2, 16))) {
                     return $portInt;
                 }
             }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -153,7 +153,7 @@ class SpanConverter
         $eventName = $event->getName();
         $attributesAsJson = SpanConverter::convertEventAttributesToJson($event);
 
-        $value = ($attributesAsJson !== null) ? "\"{$eventName}\": {$attributesAsJson}" : "\"{$eventName}\"";
+        $value = ($attributesAsJson !== null) ? sprintf('"%s": %s', $eventName, $attributesAsJson) : sprintf('"%s"', $eventName);
 
         $annotation = [
             'timestamp' => AbstractClock::nanosToMicro($event->getEpochNanos()),

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Zipkin;
 
 use function max;
+
+use OpenTelemetry\API\Trace\AttributeInterface;
 use OpenTelemetry\API\Trace\EventInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\Trace\AbstractClock;
-use OpenTelemetry\SDK\Trace\Attribute;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
 
 class SpanConverter
@@ -202,7 +203,7 @@ class SpanConverter
         }
     }
 
-    private static function findRemoteEndpointPreferredAttribute(SpanDataInterface $span): ?Attribute {
+    private static function findRemoteEndpointPreferredAttribute(SpanDataInterface $span): ?AttributeInterface {
         $preferredAttrRank = null;
         $preferredAttr = null;
 
@@ -220,7 +221,7 @@ class SpanConverter
         return $preferredAttr;
     }
 
-    private static function getRemoteEndpointDataFromIpAddressAndPort(Attribute $preferredAttr, ?int $portNumber): ?array {
+    private static function getRemoteEndpointDataFromIpAddressAndPort(AttributeInterface $preferredAttr, ?int $portNumber): ?array {
         $ipString = $preferredAttr->getValue();
 
         if (!is_string($ipString)) {

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -213,44 +213,43 @@ class SpanConverter
     private static function getRemoteEndpointDataFromIpAddressAndPort(Attribute $preferredAttr, SpanDataInterface $span): ?array { //TODO - switch the span out for just the list of attributes
         $ipString = $preferredAttr->getValue();
 
-        if (filter_var($ipString, FILTER_VALIDATE_IP)) {
-
-            $remoteEndpointArr = [
-                //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
-                'serviceName' => "unknown"
-            ];
-
-            if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
-                //Key casing/value units loosely inferred from Go comments around here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127
-                $remoteEndpointArr["ipv4"] = ip2long($ipString);
-            }
-
-            if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
-                //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
-                    //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
-                    //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
-                    $remoteEndpointArr["ipv6"] = inet_pton($ipString);
-                //}
-                //TODO - does the else case need handling here?
-            }
-
-            //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
-            $remoteEndpointArr["port"] = 0;
-            foreach ($span->getAttributes() as $attr) {
-                if ($attr->getKey() === "net.peer.port") {
-                    //TODO - take care of the cases where this isn't a string
-                    $portVal = $attr->getValue();
-                    $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
-
-                    $remoteEndpointArr["port"] = $portInt;
-
-                    break;
-                }
-            }
-
-            return $remoteEndpointArr;
+        if (!filter_var($ipString, FILTER_VALIDATE_IP)) {
+            return null;
         }
 
-        return null;
+        $remoteEndpointArr = [
+            //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
+            'serviceName' => "unknown"
+        ];
+
+        if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
+            //Key casing/value units loosely inferred from Go comments around here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127
+            $remoteEndpointArr["ipv4"] = ip2long($ipString);
+        }
+
+        if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
+            //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
+                //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
+                //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
+                $remoteEndpointArr["ipv6"] = inet_pton($ipString);
+            //}
+            //TODO - does the else case need handling here?
+        }
+
+        //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
+        $remoteEndpointArr["port"] = 0;
+        foreach ($span->getAttributes() as $attr) {
+            if ($attr->getKey() === "net.peer.port") {
+                //TODO - take care of the cases where this isn't a string
+                $portVal = $attr->getValue();
+                $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
+
+                $remoteEndpointArr["port"] = $portInt;
+
+                break;
+            }
+        }
+
+        return $remoteEndpointArr;
     }
 }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -118,7 +118,7 @@ class SpanConverter
 
         if (($span->getKind() === SpanKind::KIND_CLIENT) || ($span->getKind() === SpanKind::KIND_PRODUCER)) {
             $remoteEndpointData = SpanConverter::toRemoteEndpoint($span);
-            if ($remoteEndpointData != null) {
+            if ($remoteEndpointData !== null) {
                 $row['remoteEndpoint'] = $remoteEndpointData;
             }
         }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -30,6 +30,8 @@ class SpanConverter
         'db.name' => 7,
     ];
 
+    const NET_PEER_IP_KEY = 'net.peer.ip';
+
     /**
      * @var string
      */
@@ -193,7 +195,7 @@ class SpanConverter
         }
 
         switch ($preferredAttr->getKey()) {
-            case 'net.peer.ip':
+            case SpanConverter::NET_PEER_IP_KEY:
                 return SpanConverter::getRemoteEndpointDataFromIpAddressAndPort(
                     $preferredAttr,
                     SpanConverter::getPortNumberFromSpanAttributes($span)

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -176,12 +176,13 @@ class SpanConverter
             return null;
         }
 
+        //GO doesn't check if the value is a string here, but it seems like it should based on the comment here - https://github.com/open-telemetry/opentelemetry-go/blob/4ba964bae77d9d32b4bb0167ed5533a0c05dcdf9/attribute/value.go#L200
+        if (!is_string($preferredAttr->getValue())) {
+            return null;
+        }
+
         //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
         if ($preferredAttr->getKey() === "net.peer.ip") {
-
-            //GO doesn't check if the value is a string here, but it seems like it should based on the comment here - https://github.com/open-telemetry/opentelemetry-go/blob/4ba964bae77d9d32b4bb0167ed5533a0c05dcdf9/attribute/value.go#L200
-
-            if (is_string($preferredAttr->getValue())) {
                 $ipString = $preferredAttr->getValue();
 
                 if (filter_var($ipString, FILTER_VALIDATE_IP)) {
@@ -221,14 +222,10 @@ class SpanConverter
 
                     return $remoteEndpointArr;
                 }
-            }
-            
         } else {
-            if (is_string($preferredAttr->getValue())) {
-                return [
-                    'serviceName' => $preferredAttr->getValue(),
-                ];
-            }
+            return [
+                'serviceName' => $preferredAttr->getValue(),
+            ];
         }
 
         return null;

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -98,10 +98,6 @@ class SpanConverter
         }
 
         foreach ($span->getEvents() as $event) {
-            if (!array_key_exists('annotations', $row)) {
-                $row['annotations'] = [];
-            }
-
             $value = $event->getName();
 
             if (count($event->getAttributes()) > 0) {

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -184,7 +184,10 @@ class SpanConverter
         //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
         switch($preferredAttr->getKey()) {
             case "net.peer.ip":
-                return SpanConverter::getRemoteEndpointDataFromIpAddressAndPort($preferredAttr, $span);
+                return SpanConverter::getRemoteEndpointDataFromIpAddressAndPort(
+                    $preferredAttr, 
+                    SpanConverter::getPortNumberFromSpanAttributes($span)
+                );
             default:
                 return [
                     'serviceName' => $preferredAttr->getValue(),
@@ -210,7 +213,7 @@ class SpanConverter
         return $preferredAttr;
     }
 
-    private static function getRemoteEndpointDataFromIpAddressAndPort(Attribute $preferredAttr, SpanDataInterface $span): ?array { //TODO - switch the span out for just the list of attributes
+    private static function getRemoteEndpointDataFromIpAddressAndPort(Attribute $preferredAttr, ?int $portNumber): ?array {
         $ipString = $preferredAttr->getValue();
 
         if (!filter_var($ipString, FILTER_VALIDATE_IP)) {
@@ -236,7 +239,7 @@ class SpanConverter
             //TODO - does the else case need handling here?
         }
 
-        $remoteEndpointArr["port"] = SpanConverter::getPortNumberFromSpanAttributes($span) ?? 0;
+        $remoteEndpointArr["port"] = $portNumber ?? 0;
 
         return $remoteEndpointArr;
     }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -223,6 +223,10 @@ class SpanConverter
     private static function getRemoteEndpointDataFromIpAddressAndPort(Attribute $preferredAttr, ?int $portNumber): ?array {
         $ipString = $preferredAttr->getValue();
 
+        if (!is_string($ipString)) {
+            return null;
+        }
+
         if (!filter_var($ipString, FILTER_VALIDATE_IP)) {
             return null;
         }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -157,7 +157,9 @@ class SpanConverter
             
             $attributesAsJson = json_encode($attributesArray);
             if (($attributesAsJson !== false) && (strlen($attributesAsJson) > 0)) {
-                $value = '"' . $event->getName() . '"' . ': ' . $attributesAsJson; //TODO - clean this up and make sure it's spec compliant
+                $eventName = $event->getName();
+
+                $value = "\"{$eventName}\": {$attributesAsJson}";
             }
         }
 

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -101,9 +101,24 @@ class SpanConverter
             if (!array_key_exists('annotations', $row)) {
                 $row['annotations'] = [];
             }
+
+            $value = $event->getName();
+
+            if (count($event->getAttributes()) > 0) {
+                $attributesArray = [];
+                foreach ($event->getAttributes() as $attr) {
+                    $attributesArray[$attr->getKey()] = $attr->getValue();
+                }
+                
+                $attributesAsJson = json_encode($attributesArray);
+                if (($attributesAsJson !== false) && (strlen($attributesAsJson) > 0)) {
+                    $value = '"' . $event->getName() . '"' . ': ' . $attributesAsJson;
+                }
+            }
+
             $row['annotations'][] = [
                 'timestamp' => AbstractClock::nanosToMicro($event->getEpochNanos()),
-                'value' => $event->getName(),
+                'value' => $value,
             ];
         }
 

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -172,61 +172,62 @@ class SpanConverter
     private static function toRemoteEndpoint(SpanDataInterface $span): ?array {
         $preferredAttr = SpanConverter::findRemoteEndpointPreferredAttribute($span);
 
-        if ($preferredAttr !== null) {
+        if ($preferredAttr === null) {
+            return null;
+        }
 
-            //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
-            if ($preferredAttr->getKey() === "net.peer.ip") {
+        //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
+        if ($preferredAttr->getKey() === "net.peer.ip") {
 
-                //GO doesn't check if the value is a string here, but it seems like it should based on the comment here - https://github.com/open-telemetry/opentelemetry-go/blob/4ba964bae77d9d32b4bb0167ed5533a0c05dcdf9/attribute/value.go#L200
+            //GO doesn't check if the value is a string here, but it seems like it should based on the comment here - https://github.com/open-telemetry/opentelemetry-go/blob/4ba964bae77d9d32b4bb0167ed5533a0c05dcdf9/attribute/value.go#L200
 
-                if (is_string($preferredAttr->getValue())) {
-                    $ipString = $preferredAttr->getValue();
+            if (is_string($preferredAttr->getValue())) {
+                $ipString = $preferredAttr->getValue();
 
-                    if (filter_var($ipString, FILTER_VALIDATE_IP)) {
+                if (filter_var($ipString, FILTER_VALIDATE_IP)) {
 
-                        $remoteEndpointArr = [
-                            //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
-                            'serviceName' => "unknown"
-                        ];
-
-                        if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
-                            //Key casing/value units loosely inferred from Go comments around here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127
-                            $remoteEndpointArr["ipv4"] = ip2long($ipString);
-                        }
-
-                        if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
-                            //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
-                                //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
-                                //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
-                                $remoteEndpointArr["ipv6"] = inet_pton($ipString);
-                            //}
-                            //TODO - does the else case need handling here?
-                        }
-
-                        //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
-                        $remoteEndpointArr["port"] = 0;
-                        foreach ($span->getAttributes() as $attr) {
-                            if ($attr->getKey() === "net.peer.port") {
-                                //TODO - take care of the cases where this isn't a string
-                                $portVal = $attr->getValue();
-                                $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
-
-                                $remoteEndpointArr["port"] = $portInt;
-
-                                break;
-                            }
-                        }
-
-                        return $remoteEndpointArr;
-                    }
-                }
-                
-            } else {
-                if (is_string($preferredAttr->getValue())) {
-                    return [
-                        'serviceName' => $preferredAttr->getValue(),
+                    $remoteEndpointArr = [
+                        //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
+                        'serviceName' => "unknown"
                     ];
+
+                    if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
+                        //Key casing/value units loosely inferred from Go comments around here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127
+                        $remoteEndpointArr["ipv4"] = ip2long($ipString);
+                    }
+
+                    if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
+                        //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
+                            //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
+                            //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
+                            $remoteEndpointArr["ipv6"] = inet_pton($ipString);
+                        //}
+                        //TODO - does the else case need handling here?
+                    }
+
+                    //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
+                    $remoteEndpointArr["port"] = 0;
+                    foreach ($span->getAttributes() as $attr) {
+                        if ($attr->getKey() === "net.peer.port") {
+                            //TODO - take care of the cases where this isn't a string
+                            $portVal = $attr->getValue();
+                            $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
+
+                            $remoteEndpointArr["port"] = $portInt;
+
+                            break;
+                        }
+                    }
+
+                    return $remoteEndpointArr;
                 }
+            }
+            
+        } else {
+            if (is_string($preferredAttr->getValue())) {
+                return [
+                    'serviceName' => $preferredAttr->getValue(),
+                ];
             }
         }
 

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -104,86 +104,9 @@ class SpanConverter
 
         if (($span->getKind() === SpanKind::KIND_CLIENT) || ($span->getKind() === SpanKind::KIND_PRODUCER))
         {
-            $attributeToRankMap = [
-                "peer.service" => 1,
-                "net.peer.name" => 2,
-                "net.peer.ip" => 3,
-                "peer.hostname" => 4,
-                "peer.address" => 5,
-                "http.host" => 6,
-                "db.name" => 7
-            ];
-    
-            $preferredAttrRank = null;
-            $preferredAttr = null;
-
-            foreach ($span->getAttributes() as $attr) {
-                if (array_key_exists($attr->getKey(), $attributeToRankMap)) {
-                    $attrRank = $attributeToRankMap[$attr->getKey()];
-
-                    if (($preferredAttrRank === null) || ($attrRank <= $preferredAttrRank)) {
-                        $preferredAttr = $attr;
-                        $preferredAttrRank = $attrRank;
-                    }
-                }
-            }
-
-            if ($preferredAttr !== null) {
-
-                //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
-                if ($preferredAttr->getKey() === "net.peer.ip") {
-
-                    //GO doesn't check if the value is a string here, but it seems like it should based on the comment here - https://github.com/open-telemetry/opentelemetry-go/blob/4ba964bae77d9d32b4bb0167ed5533a0c05dcdf9/attribute/value.go#L200
-
-                    if (is_string($preferredAttr->getValue())) {
-                        $ipString = $preferredAttr->getValue();
-
-                        if (filter_var($ipString, FILTER_VALIDATE_IP)) {
-
-                            $remoteEndpointArr = [
-                                //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
-                                'serviceName' => "unknown"
-                            ];
-
-                            if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
-                                //Key casing/value units loosely inferred from Go comments around here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127
-                                $remoteEndpointArr["ipv4"] = ip2long($ipString);
-                            }
-
-                            if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
-                                //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
-                                    //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
-                                    //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
-                                    $remoteEndpointArr["ipv6"] = inet_pton($ipString);
-                                //}
-                                //TODO - does the else case need handling here?
-                            }
-
-                            //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
-                            $remoteEndpointArr["port"] = 0;
-                            foreach ($span->getAttributes() as $attr) {
-                                if ($attr->getKey() === "net.peer.port") {
-                                    //TODO - take care of the cases where this isn't a string
-                                    $portVal = $attr->getValue();
-                                    $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
-
-                                    $remoteEndpointArr["port"] = $portInt;
-
-                                    break;
-                                }
-                            }
-
-                            $row['remoteEndpoint'] = $remoteEndpointArr;
-                        }
-                    }
-                    
-                } else {
-                    if (is_string($preferredAttr->getValue())) {
-                        $row['remoteEndpoint'] = [
-                            'serviceName' => $preferredAttr->getValue(),
-                        ];
-                    }
-                }
+            $remoteEndpointData = SpanConverter::toRemoteEndpoint($span);
+            if ($remoteEndpointData != null) {
+                $row["remoteEndpoint"] = $remoteEndpointData;
             }
         }
 
@@ -233,5 +156,91 @@ class SpanConverter
         ];
 
         return $annotation;
+    }
+
+    private static function toRemoteEndpoint(SpanDataInterface $span): ?array {
+        $attributeToRankMap = [
+            "peer.service" => 1,
+            "net.peer.name" => 2,
+            "net.peer.ip" => 3,
+            "peer.hostname" => 4,
+            "peer.address" => 5,
+            "http.host" => 6,
+            "db.name" => 7
+        ];
+
+        $preferredAttrRank = null;
+        $preferredAttr = null;
+
+        foreach ($span->getAttributes() as $attr) {
+            if (array_key_exists($attr->getKey(), $attributeToRankMap)) {
+                $attrRank = $attributeToRankMap[$attr->getKey()];
+
+                if (($preferredAttrRank === null) || ($attrRank <= $preferredAttrRank)) {
+                    $preferredAttr = $attr;
+                    $preferredAttrRank = $attrRank;
+                }
+            }
+        }
+
+        if ($preferredAttr !== null) {
+
+            //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
+            if ($preferredAttr->getKey() === "net.peer.ip") {
+
+                //GO doesn't check if the value is a string here, but it seems like it should based on the comment here - https://github.com/open-telemetry/opentelemetry-go/blob/4ba964bae77d9d32b4bb0167ed5533a0c05dcdf9/attribute/value.go#L200
+
+                if (is_string($preferredAttr->getValue())) {
+                    $ipString = $preferredAttr->getValue();
+
+                    if (filter_var($ipString, FILTER_VALIDATE_IP)) {
+
+                        $remoteEndpointArr = [
+                            //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
+                            'serviceName' => "unknown"
+                        ];
+
+                        if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
+                            //Key casing/value units loosely inferred from Go comments around here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127
+                            $remoteEndpointArr["ipv4"] = ip2long($ipString);
+                        }
+
+                        if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
+                            //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
+                                //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
+                                //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
+                                $remoteEndpointArr["ipv6"] = inet_pton($ipString);
+                            //}
+                            //TODO - does the else case need handling here?
+                        }
+
+                        //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
+                        $remoteEndpointArr["port"] = 0;
+                        foreach ($span->getAttributes() as $attr) {
+                            if ($attr->getKey() === "net.peer.port") {
+                                //TODO - take care of the cases where this isn't a string
+                                $portVal = $attr->getValue();
+                                $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
+
+                                $remoteEndpointArr["port"] = $portInt;
+
+                                break;
+                            }
+                        }
+
+                        return $remoteEndpointArr;
+                    }
+                }
+                
+            } else {
+                if (is_string($preferredAttr->getValue())) {
+                    return [
+                        'serviceName' => $preferredAttr->getValue(),
+                    ];
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -182,7 +182,8 @@ class SpanConverter
         }
 
         //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
-        if ($preferredAttr->getKey() === "net.peer.ip") {
+        switch($preferredAttr->getKey()) {
+            case "net.peer.ip":
                 $ipString = $preferredAttr->getValue();
 
                 if (filter_var($ipString, FILTER_VALIDATE_IP)) {
@@ -222,13 +223,14 @@ class SpanConverter
 
                     return $remoteEndpointArr;
                 }
-        } else {
-            return [
-                'serviceName' => $preferredAttr->getValue(),
-            ];
+                break;
+            default:
+                return [
+                    'serviceName' => $preferredAttr->getValue(),
+                ];
         }
 
-        return null;
+        return null; //Determine if this is safe to remove
     }
 
     private static function findRemoteEndpointPreferredAttribute(SpanDataInterface $span): ?Attribute {

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Zipkin;
 
 use function max;
+//TODO - fix this namespace to not pull from OpenTelemetry, but the dependency instead
+use IPLib;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\Trace\AbstractClock;
@@ -152,10 +154,24 @@ class SpanConverter
             if ($preferredAttr !== null) {
                 
                 //TODO - incorporate the ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
-                
-                $row['remoteEndpoint'] = [
-                    'serviceName' => $preferredAttr->getValue(),
-                ];
+                if ($preferredAttr->getKey() === "net.peer.ip") {
+
+                    //GO doesn't check if the value is a string here, but it seems like it should based on the comment here - https://github.com/open-telemetry/opentelemetry-go/blob/4ba964bae77d9d32b4bb0167ed5533a0c05dcdf9/attribute/value.go#L200
+
+                    if (is_string($preferredAttr->getValue())) {
+                        $ipString = $preferredAttr->getValue();
+
+                        //TODO - figure out how this needs to be adjusted
+                        $ipObj = \IPLib\Factory::parseAddressString($ipString);
+                    }
+                    
+                } else {
+                    if (is_string($preferredAttr->getValue())) {
+                        $row['remoteEndpoint'] = [
+                            'serviceName' => $preferredAttr->getValue(),
+                        ];
+                    }
+                }
             }
         }
 

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -159,6 +159,7 @@ class SpanConverter
                         $ipString = $preferredAttr->getValue();
 
                         if (filter_var($ipString, FILTER_VALIDATE_IP)) {
+
                             $remoteEndpointArr = [
                                 //Not in the Go code but mentioned in a comment here - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125
                                 'serviceName' => "unknown"
@@ -170,11 +171,11 @@ class SpanConverter
                             }
 
                             if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
-                                if (defined('AF_INET6')) {
+                                //if (defined('AF_INET6')) { //TODO - figure out why this was never getting dropped into during the tests
                                     //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
                                     //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
                                     $remoteEndpointArr["ipv6"] = inet_pton($ipString);
-                                }
+                                //}
                                 //TODO - does the else case need handling here?
                             }
 

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -236,20 +236,23 @@ class SpanConverter
             //TODO - does the else case need handling here?
         }
 
+        $remoteEndpointArr["port"] = SpanConverter::getPortNumberFromSpanAttributes($span) ?? 0;
+
+        return $remoteEndpointArr;
+    }
+
+    private static function getPortNumberFromSpanAttributes(SpanDataInterface $span): ?int {
         //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122
-        $remoteEndpointArr["port"] = 0;
         foreach ($span->getAttributes() as $attr) {
             if ($attr->getKey() === "net.peer.port") {
                 //TODO - take care of the cases where this isn't a string
                 $portVal = $attr->getValue();
                 $portInt = intval($portVal); //TODO - find out if Go's setting of 16 for bit size is implicitly the case here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292
 
-                $remoteEndpointArr["port"] = $portInt;
-
-                break;
+                return $portInt;
             }
         }
 
-        return $remoteEndpointArr;
+        return null;
     }
 }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -142,7 +142,7 @@ class SpanConverter
                 if (array_key_exists($attr->getKey(), $attributeToRankMap)) {
                     $attrRank = $attributeToRankMap[$attr->getKey()];
 
-                    if (($preferredAttrRank === null) || ($preferredAttrRank <= $attrRank)) {
+                    if (($preferredAttrRank === null) || ($attrRank <= $preferredAttrRank)) {
                         $preferredAttr = $attr;
                         $preferredAttrRank = $attrRank;
                     }

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -128,7 +128,6 @@ class SpanConverter
                 "peer.service" => 1,
                 "net.peer.name" => 2,
                 "net.peer.ip" => 3,
-                "net.peer.port" => 3,
                 "peer.hostname" => 4,
                 "peer.address" => 5,
                 "http.host" => 6,
@@ -150,7 +149,7 @@ class SpanConverter
             }
 
             if ($preferredAttr !== null) {
-                
+
                 //ip address handling from the spec, like is done here - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L264-L271
                 if ($preferredAttr->getKey() === "net.peer.ip") {
 

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -171,8 +171,12 @@ class SpanConverter
                             }
 
                             if (filter_var($ipString, FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)) {
-                                //BEWARE: This might not work (how so?) when ipv6 has been disabled for PHP
-                                $remoteEndpointArr["ipv6"] = inet_pton($ipString);
+                                if (defined('AF_INET6')) {
+                                    //This won't work (oddly) if ipv6 has been disabled for PHP and the server it's running on
+                                    //Where this idea came from - https://www.php.net/manual/en/function.inet-pton.php#104917
+                                    $remoteEndpointArr["ipv6"] = inet_pton($ipString);
+                                }
+                                //TODO - does the else case need handling here?
                             }
 
                             //Go comment (but not code...), mentions port = 0 should be the default - https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -212,7 +212,7 @@ class SpanConverter
         return null;
     }
 
-    private static function toAnnotation(EventInterface $event) {
+    private static function toAnnotation(EventInterface $event): array {
         $value = $event->getName();
 
         if (count($event->getAttributes()) > 0) {

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -202,6 +202,22 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
+    public function shouldUseOTELIpv6CorrectlyForZipkinRemoteEndpoint()
+    {
+        $span = (new SpanData())
+            ->addAttribute('net.peer.ip', '2001:0db8:0100:f101:0210:a4ff:fee3:9566') // 'ffff:ffff:ffff:ffff:0fff:a4ff:fee3:9566') //TODO - figure out why the left-most '0' here can't be switched to an 'f'
+            ->setKind(SpanKind::KIND_PRODUCER);
+
+        $converter = new SpanConverter('unused');
+        $row = $converter->convert($span);
+
+        //TODO - figure out the right way to get this test working
+        $this->assertSame($row['remoteEndpoint']['ipv6'], b'0xffffffffffffffff0fffa4fffee39566');
+    }
+
+    /**
+     * @test
+     */
     public function tagsAreCoercedCorrectlyToStrings()
     {
         $listOfStrings = ['string-1', 'string-2'];

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -71,7 +71,7 @@ class ZipkinSpanConverterTest extends TestCase
 
         $this->assertCount(1, $row['annotations']);
         [$annotation] = $row['annotations'];
-        $this->assertSame('validators.list', $annotation['value']);
+        $this->assertSame('"validators.list": {"job":"stage.updateTime"}', $annotation['value']);
         $this->assertSame(1505855799433901, $annotation['timestamp']);
     }
 

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -211,7 +211,7 @@ class ZipkinSpanConverterTest extends TestCase
         $converter = new SpanConverter('unused');
         $row = $converter->convert($span);
 
-        $this->assertEquals('00000000000000000000000000000001', bin2hex($row['remoteEndpoint']['ipv6'])); //Couldn't figure out how to do a direct assertion against binary data
+        $this->assertSame('00000000000000000000000000000001', bin2hex($row['remoteEndpoint']['ipv6'])); //Couldn't figure out how to do a direct assertion against binary data
     }
 
     /**

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -193,7 +193,7 @@ class ZipkinSpanConverterTest extends TestCase
         $row = $converter->convert($span);
 
         [$annotation] = $row['annotations'];
-        $this->assertSame("\"event.name\"", $annotation['value']);
+        $this->assertSame('"event.name"', $annotation['value']);
     }
 
     /**
@@ -210,7 +210,7 @@ class ZipkinSpanConverterTest extends TestCase
         $row = $converter->convert($span);
 
         $this->assertSame('unknown', $row['remoteEndpoint']['serviceName']);
-        $this->assertSame(pow(2,32)-1, $row['remoteEndpoint']['ipv4']);
+        $this->assertSame(pow(2, 32)-1, $row['remoteEndpoint']['ipv4']);
         $this->assertSame(80, $row['remoteEndpoint']['port']);
     }
 

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -205,14 +205,13 @@ class ZipkinSpanConverterTest extends TestCase
     public function shouldUseOTELIpv6CorrectlyForZipkinRemoteEndpoint()
     {
         $span = (new SpanData())
-            ->addAttribute('net.peer.ip', '2001:0db8:0100:f101:0210:a4ff:fee3:9566') // 'ffff:ffff:ffff:ffff:0fff:a4ff:fee3:9566') //TODO - figure out why the left-most '0' here can't be switched to an 'f'
+            ->addAttribute('net.peer.ip', '::1')
             ->setKind(SpanKind::KIND_PRODUCER);
 
         $converter = new SpanConverter('unused');
         $row = $converter->convert($span);
 
-        //TODO - figure out the right way to get this test working
-        $this->assertSame(b'0xffffffffffffffff0fffa4fffee39566', $row['remoteEndpoint']['ipv6']);
+        $this->assertEquals('00000000000000000000000000000001', bin2hex($row['remoteEndpoint']['ipv6'])); //Couldn't figure out how to do a direct assertion against binary data
     }
 
     /**

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -193,7 +193,7 @@ class ZipkinSpanConverterTest extends TestCase
         $row = $converter->convert($span);
 
         [$annotation] = $row['annotations'];
-        $this->assertSame('event.name', $annotation['value']);
+        $this->assertSame("\"event.name\"", $annotation['value']);
     }
 
     /**

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -184,6 +184,24 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
+    public function shouldUseOTELIpv4AndPortCorrectlyForZipkinRemoteEndpoint()
+    {
+        $span = (new SpanData())
+            ->addAttribute('net.peer.ip', '255.255.255.255')
+            ->addAttribute('net.peer.port', '80')
+            ->setKind(SpanKind::KIND_PRODUCER);
+
+        $converter = new SpanConverter('unused');
+        $row = $converter->convert($span);
+
+        $this->assertSame($row['remoteEndpoint']['serviceName'], 'unknown');
+        $this->assertSame($row['remoteEndpoint']['ipv4'], pow(2,32)-1);
+        $this->assertSame($row['remoteEndpoint']['port'], 80);
+    }
+
+    /**
+     * @test
+     */
     public function tagsAreCoercedCorrectlyToStrings()
     {
         $listOfStrings = ['string-1', 'string-2'];

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -15,6 +15,9 @@ use OpenTelemetry\SDK\Trace\StatusData;
 use OpenTelemetry\Tests\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers SpanConverter
+ */
 class ZipkinSpanConverterTest extends TestCase
 {
     /**

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -24,6 +24,7 @@ class ZipkinSpanConverterTest extends TestCase
     {
         $span = (new SpanData())
             ->setName('guard.validate')
+            ->setKind(SpanKind::KIND_CLIENT)
             ->setParentContext(
                 SpanContext::create(
                     '10000000000000000000000000000000',
@@ -41,6 +42,8 @@ class ZipkinSpanConverterTest extends TestCase
                 'instrumentation_library_version'
             ))
             ->addAttribute('service', 'guard')
+            ->addAttribute('net.peer.name', 'authorizationservice.com')
+            ->addAttribute('peer.service', 'AuthService')
             ->addEvent('validators.list', new Attributes(['job' => 'stage.updateTime']), 1505855799433901068)
             ->setHasEnded(true);
 
@@ -57,7 +60,7 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertSame(1505855794194009, $row['timestamp']);
         $this->assertSame(5271717, $row['duration']);
 
-        $this->assertCount(3, $row['tags']);
+        $this->assertCount(5, $row['tags']);
 
         $this->assertSame('Error', $row['tags']['otel.status_code']);
         $this->assertSame('status_description', $row['tags']['error']);
@@ -73,6 +76,8 @@ class ZipkinSpanConverterTest extends TestCase
         [$annotation] = $row['annotations'];
         $this->assertSame('"validators.list": {"job":"stage.updateTime"}', $annotation['value']);
         $this->assertSame(1505855799433901, $annotation['timestamp']);
+
+        $this->assertSame('AuthService', $row['remoteEndpoint']['serviceName']);
     }
 
     /**

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -184,6 +184,21 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
+    public function shouldConvertAnEventWithoutAttributesToAnAnnotationWithOnlyItsName()
+    {
+        $span = (new SpanData())
+            ->addEvent('event.name', new Attributes());
+
+        $converter = new SpanConverter('test.name');
+        $row = $converter->convert($span);
+
+        [$annotation] = $row['annotations'];
+        $this->assertSame('event.name', $annotation['value']);
+    }
+
+    /**
+     * @test
+     */
     public function shouldUseOTELIpv4AndPortCorrectlyForZipkinRemoteEndpoint()
     {
         $span = (new SpanData())

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -194,9 +194,9 @@ class ZipkinSpanConverterTest extends TestCase
         $converter = new SpanConverter('unused');
         $row = $converter->convert($span);
 
-        $this->assertSame($row['remoteEndpoint']['serviceName'], 'unknown');
-        $this->assertSame($row['remoteEndpoint']['ipv4'], pow(2,32)-1);
-        $this->assertSame($row['remoteEndpoint']['port'], 80);
+        $this->assertSame('unknown', $row['remoteEndpoint']['serviceName']);
+        $this->assertSame(pow(2,32)-1, $row['remoteEndpoint']['ipv4']);
+        $this->assertSame(80, $row['remoteEndpoint']['port']);
     }
 
     /**
@@ -212,7 +212,7 @@ class ZipkinSpanConverterTest extends TestCase
         $row = $converter->convert($span);
 
         //TODO - figure out the right way to get this test working
-        $this->assertSame($row['remoteEndpoint']['ipv6'], b'0xffffffffffffffff0fffa4fffee39566');
+        $this->assertSame(b'0xffffffffffffffff0fffa4fffee39566', $row['remoteEndpoint']['ipv6']);
     }
 
     /**


### PR DESCRIPTION
Resolves #295 and maybe addresses part of #283 ?

This just covers these 2 parts of [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#opentelemetry-to-zipkin-transformation)

[Remote Endpoint](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#remote-endpoint)
[Event Attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/418016dc4014f0c64acea74881774d34178bf15a/specification/trace/sdk_exporters/zipkin.md#events)

I co-opted Go's code heavily for both sets of changes, as well as the comments in and around them for context (some of which didn't line up with Go's implementation actually)

[Remote Endpoint](https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L238)
[Event Attributes](https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L141)

I haven't done any testing with an actual Zipkin instance (so idk how much of this actually works), but I tried to add unit tests as appropriate. These are the 4 untested lines I noticed in SpanConverter.php

- Line 177 - if json_encode fails on the attributes array
- Line 192 - the preferred attribute ends up not having a string value
- Line 232 - the preferred attribute ends up not having a string value
- Line 236 - if an invalid ip is passed (edited) 

Other notes on things I grappled with along the way:

- Go checks if attribute values are a string in some places, but not others (see [this comment](https://github.com/open-telemetry/opentelemetry-go/blob/4ba964bae77d9d32b4bb0167ed5533a0c05dcdf9/attribute/value.go#L200) that suggests it should always do so)
- Setting 'serviceName' to 'unknown' isn't done in the Go code nor mentioned in the spec, but it is called out in a comment [here](https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L125)
- I couldn't really figure out what the keys of the 'remoteEndpoint' node were supposed to be, nor what their values' units should be, but I loosely inferred them based off of the comments in Go [here](https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L127)
- Not done in code, but a [Go comment](https://github.com/open-telemetry/opentelemetry-go/blob/7ce58f355851d0412e45ceb79d977bc612701b3f/exporters/jaeger/internal/gen-go/zipkincore/zipkincore.go#L122) mentions port = 0 should be the default
- I couldn't figure out a clean way in PHP to limit a port to less than 65536, like Go seems to do [here](https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/zipkin/model.go#L292)
- defined('AF_INET6') seems to be returning something falsy while running the tests, even while inet_pton seems to be working ok, so I wasn't able to use it as a detector for if PHP was compiled with ipv6 support (I'm not really sure what inet_pton will do in that case tbh. Tried googling but couldn't suss it out)
- Other parts of the file use a ```foreach($attributes as $k => $v)``` approach, but I couldn't figure out how that worked in general, with AttributesInterface only extending IteratorAggregate and Countable, and then AttributeInterface only declaring getKey and getValue methods