### PR TITLE
Add make target to create HTML code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vendor/
 coverage.clover
 tests/coverage
 .php-cs-fixer.cache
+!tests/coverage/html/.gitkeep
 
 # IntelliJ IDEA
 .idea

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ update:
 	$(DC_RUN_PHP) composer update
 test:
 	$(DC_RUN_PHP) php ./vendor/bin/phpunit --colors=always --coverage-text --testdox --coverage-clover coverage.clover
+test-coverage:
+	$(DC_RUN_PHP) php ./vendor/bin/phpunit --colors=always --testdox --coverage-html=tests/coverage/html
 phan:
 	$(DC_RUN_PHP) env PHAN_DISABLE_XDEBUG_WARN=1 php ./vendor/bin/phan
 psalm:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ update:
 test:
 	$(DC_RUN_PHP) php ./vendor/bin/phpunit --colors=always --coverage-text --testdox --coverage-clover coverage.clover
 test-coverage:
-	$(DC_RUN_PHP) php ./vendor/bin/phpunit --colors=always --testdox --coverage-html=tests/coverage/html
+	docker-compose run -e XDEBUG_MODE=coverage --rm php php ./vendor/bin/phpunit --colors=always --testdox --coverage-html=tests/coverage/html
 phan:
 	$(DC_RUN_PHP) env PHAN_DISABLE_XDEBUG_WARN=1 php ./vendor/bin/phan
 psalm:


### PR DESCRIPTION
This PR adds a make target to create the PHPunit HTML code coverage report

See [conversation](https://github.com/open-telemetry/opentelemetry-php/pull/474/files/9d64efe0a7530bdd9b67e4247dd17a497e0e9546#r750225346).