### PR TITLE
de-duplicating resources from multiple spans

### DIFF
--- a/src/Contrib/OtlpGrpc/SpanConverter.php
+++ b/src/Contrib/OtlpGrpc/SpanConverter.php
@@ -170,11 +170,11 @@ class SpanConverter
         $attrs = [];
         foreach ($spans as $span) {
             foreach ($span->getResource()->getAttributes() as $k => $v) {
-                $attrs[] = $this->as_otlp_key_value($k, $v->getValue());
+                $attrs[$k] = $this->as_otlp_key_value($k, $v->getValue());
             }
         }
 
-        return $attrs;
+        return array_values($attrs);
     }
 
     public function as_otlp_resource_span(iterable $spans): ResourceSpans

--- a/src/Contrib/OtlpHttp/SpanConverter.php
+++ b/src/Contrib/OtlpHttp/SpanConverter.php
@@ -168,11 +168,11 @@ class SpanConverter
         $attrs = [];
         foreach ($spans as $span) {
             foreach ($span->getResource()->getAttributes() as $k => $v) {
-                $attrs[] = $this->as_otlp_key_value($k, $v->getValue());
+                $attrs[$k] = $this->as_otlp_key_value($k, $v->getValue());
             }
         }
 
-        return $attrs;
+        return array_values($attrs);
     }
 
     public function as_otlp_resource_span(iterable $spans): ResourceSpans

--- a/tests/Contrib/Unit/OTLPGrpcSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcSpanConverterTest.php
@@ -16,6 +16,7 @@ use Opentelemetry\Proto\Trace\V1\ResourceSpans;
 use OpenTelemetry\SDK\InstrumentationLibrary;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\Attributes;
+use OpenTelemetry\SDK\Trace\Span;
 use OpenTelemetry\SDK\Trace\StatusData;
 use OpenTelemetry\Tests\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
@@ -228,6 +229,21 @@ class OTLPGrpcSpanConverterTest extends TestCase
         $otlpspan = (new SpanConverter())->as_otlp_resource_span([$sdk]);
 
         $this->assertEquals($expected, $otlpspan);
+    }
+
+    /**
+     * @covers OpenTelemetry\Contrib\OtlpGrpc\SpanConverter::as_otlp_resource_attributes
+     */
+    public function testResourcesFromMultipleSpansAreNotDuplicated()
+    {
+        $span = $this->createMock(Span::class);
+        $resource = $this->createMock(ResourceInfo::class);
+        $attributes = new Attributes(['foo' => 'foo', 'bar' => 'bar']);
+        $span->method('getResource')->willReturn($resource);
+        $resource->method('getAttributes')->willReturn($attributes);
+        $converter = new SpanConverter();
+        $result = $converter->as_otlp_resource_attributes([$span, $span, $span]);
+        $this->assertCount(2, $result);
     }
 
     public function testOtlpNoSpans()

--- a/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpSpanConverterTest.php
@@ -244,6 +244,21 @@ class OTLPHttpSpanConverterTest extends TestCase
         $this->assertEquals($expected, $otlpspan);
     }
 
+    /**
+     * @covers OpenTelemetry\Contrib\OtlpHttp\SpanConverter::as_otlp_resource_attributes
+     */
+    public function testResourcesFromMultipleSpansAreNotDuplicated()
+    {
+        $span = $this->createMock(Span::class);
+        $resource = $this->createMock(ResourceInfo::class);
+        $attributes = new Attributes(['foo' => 'foo', 'bar' => 'bar']);
+        $span->method('getResource')->willReturn($resource);
+        $resource->method('getAttributes')->willReturn($attributes);
+        $converter = new SpanConverter();
+        $result = $converter->as_otlp_resource_attributes([$span, $span, $span]);
+        $this->assertCount(2, $result);
+    }
+
     public function testOtlpNoSpans()
     {
         $spans = [];


### PR DESCRIPTION
OTLP span exporters, when combined with BatchProcessor, were duplicating all resources once for each span. Since resources are identical for each span, it seemed safe enough to just pick one value for each key. Added tests (more duplicated code to be cleaned up later!)