### PR TITLE
Optimize base PHP Dockerfile

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+PHP_USER=php

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage.clover
 tests/coverage
 .php-cs-fixer.cache
 !tests/coverage/html/.gitkeep
+.env
 
 # IntelliJ IDEA
 .idea

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,12 @@
 version: '3.7'
 services:
   php:
-    image: ghcr.io/open-telemetry/opentelemetry-php/opentelemetry-php-base:latest
+    build:
+        context: .
+        dockerfile: docker/Dockerfile
     volumes:
     - ./:/usr/src/myapp
+    user: "${PHP_USER}:root"
   zipkin:
     image: openzipkin/zipkin-slim
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,7 @@
 version: '3.7'
 services:
   php:
-    build:
-        context: .
-        dockerfile: docker/Dockerfile
+    image: ghcr.io/open-telemetry/opentelemetry-php/opentelemetry-php-base:latest
     volumes:
     - ./:/usr/src/myapp
     user: "${PHP_USER}:root"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,10 @@
-FROM php:7.4-cli-alpine
+
+FROM php:7.4-cli-alpine as php_build
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/install-php-extensions; \
-    apk add --no-cache bash git binutils; \
+    apk add --update binutils; \
     install-php-extensions \
         ast-1.0.14 \
         xdebug \
@@ -14,10 +15,20 @@ RUN chmod +x /usr/local/bin/install-php-extensions; \
     ; \
     # strip debug symbols from extensions to reduce size
     strip --strip-debug /usr/local/lib/php/extensions/no-debug-non-zts-20190902/grpc.so; \
-    strip --strip-debug /usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so; \
-    rm /usr/local/bin/install-php-extensions; \
-    apk del --no-cache binutils
+    strip --strip-debug /usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so;
 
-USER guest
+FROM php_build
 
 WORKDIR /usr/src/myapp
+
+RUN   apk add --no-cache bash git; \
+      chmod +x -R /usr/local/lib/php/extensions/no-debug-non-zts-20190902; \
+      addgroup -g "1000" -S php; \
+      adduser --system \
+        --gecos "" \
+        --ingroup "php" \
+        --uid "1000" \
+        "php";
+
+USER php
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,23 @@
-FROM php:8-buster
+FROM php:7.4-cli-alpine
 
-RUN apt-get -y update && apt-get -y install git zip && \
-    curl -sS https://getcomposer.org/installer | php && \
-    mv composer.phar /usr/local/bin/composer && \
-    chmod +x /usr/local/bin/composer && \
-    pecl install ast-1.0.14 xdebug && \
-    docker-php-ext-enable ast xdebug && \
-    # The pcntl extension is used for speeding up `make phan`
-    docker-php-ext-install pcntl
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-# install GRPC
-RUN apt install -y --no-install-recommends zlib1g-dev && \
-    pecl install grpc && \
-    docker-php-ext-enable grpc
+RUN chmod +x /usr/local/bin/install-php-extensions; \
+    apk add --no-cache bash git binutils; \
+    install-php-extensions \
+        ast-1.0.14 \
+        xdebug \
+        zip \
+        pcntl \
+        grpc \
+        @composer \
+    ; \
+    # strip debug symbols from extensions to reduce size
+    strip --strip-debug /usr/local/lib/php/extensions/no-debug-non-zts-20190902/grpc.so; \
+    strip --strip-debug /usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so; \
+    rm /usr/local/bin/install-php-extensions; \
+    apk del --no-cache binutils
+
+USER guest
 
 WORKDIR /usr/src/myapp


### PR DESCRIPTION
This PR reduces the size of the base php image from 627mb to 129mb, and the containers are now run by non privileged user (cotainers were writing as root on local file-system. Some security focused K8S distributions like OpenShift/OKD don't allow privileged users to run containers). Also the PHP version is now 7.4 (instead of 8.0) to ensure compatibility with minimum supported PHP version.

- Uses Alpine (instead of Debain) as base image with smaller footprint
- Uses docker-php-extension-installer
- Strips debug symboly from grpc and xdebug extensions
- Uses a single RUN command to reduce layer size
- ~~Runs containers as alpines standard user "guest"~~

Changes to fix issues mentioned by @brettmc :

The image creates a system user ("php"), which is used to run the container per default. However "root" is still the default
user in docker-compose, but the user can be set to "php/guest" by env var "PHP_USER". I added a `.env.dist` file, which can be copied to `.env` (which is ignored by git) to provide the user for docker-compose. This should solve the issues, the `composer.lock` have been written by root, and the container can still be run as a non privileged user.
