### PR TITLE
Convert and send zipkin span kind in string format

### DIFF
--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -170,12 +170,12 @@ class SpanConverter implements SpanConverterInterface
         if (count($event->getAttributes()) === 0) {
             return null;
         }
-        
+
         $attributesArray = [];
         foreach ($event->getAttributes() as $attr) {
             $attributesArray[$attr->getKey()] = $attr->getValue();
         }
-        
+
         $attributesAsJson = json_encode($attributesArray);
         if (($attributesAsJson === false) || (strlen($attributesAsJson) === 0)) {
             return null;

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -10,6 +10,7 @@ use OpenTelemetry\API\Trace\AttributeInterface;
 use OpenTelemetry\API\Trace\EventInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Contrib\Zipkin\SpanKind as ZipkinSpanKind;
 use OpenTelemetry\SDK\Trace\AbstractClock;
 use OpenTelemetry\SDK\Trace\SpanConverterInterface;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
@@ -131,17 +132,17 @@ class SpanConverter implements SpanConverterInterface
         return $row;
     }
 
-    private static function toSpanKind(SpanDataInterface $span): ?int
+    private static function toSpanKind(SpanDataInterface $span): ?string
     {
         switch ($span->getKind()) {
           case SpanKind::KIND_SERVER:
-            return SpanKind::KIND_SERVER;
+            return ZipkinSpanKind::KIND_SERVER;
           case SpanKind::KIND_CLIENT:
-            return SpanKind::KIND_CLIENT;
+            return ZipkinSpanKind::KIND_CLIENT;
           case SpanKind::KIND_PRODUCER:
-            return SpanKind::KIND_PRODUCER;
+            return ZipkinSpanKind::KIND_PRODUCER;
           case SpanKind::KIND_CONSUMER:
-            return SpanKind::KIND_CONSUMER;
+            return ZipkinSpanKind::KIND_CONSUMER;
           case SpanKind::KIND_INTERNAL:
             return null;
         }

--- a/src/Contrib/Zipkin/SpanKind.php
+++ b/src/Contrib/Zipkin/SpanKind.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Zipkin;
+
+final class SpanKind
+{
+    public const KIND_SERVER = 'SERVER';
+    public const KIND_CLIENT = 'CLIENT';
+    public const KIND_PRODUCER = 'PRODUCER';
+    public const KIND_CONSUMER = 'CONSUMER';
+
+    public static function getChoices(): array
+    {
+        return [
+            self::KIND_CLIENT,
+            self::KIND_SERVER,
+            self::KIND_PRODUCER,
+            self::KIND_CONSUMER,
+        ];
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Contrib\Zipkin\SpanConverter;
+use OpenTelemetry\Contrib\Zipkin\SpanKind as ZipkinSpanKind;
 use OpenTelemetry\SDK\InstrumentationLibrary;
 use OpenTelemetry\SDK\Trace\Attribute;
 use OpenTelemetry\SDK\Trace\Attributes;
@@ -111,7 +112,7 @@ class ZipkinSpanConverterTest extends TestCase
         $converter = new SpanConverter('unused');
         $row = $converter->convert($span);
 
-        $this->assertSame(SpanKind::KIND_SERVER, $row['kind']);
+        $this->assertSame(ZipkinSpanKind::KIND_SERVER, $row['kind']);
     }
 
     /**
@@ -125,7 +126,7 @@ class ZipkinSpanConverterTest extends TestCase
         $converter = new SpanConverter('unused');
         $row = $converter->convert($span);
 
-        $this->assertSame(SpanKind::KIND_CLIENT, $row['kind']);
+        $this->assertSame(ZipkinSpanKind::KIND_CLIENT, $row['kind']);
     }
 
     /**
@@ -139,7 +140,7 @@ class ZipkinSpanConverterTest extends TestCase
         $converter = new SpanConverter('unused');
         $row = $converter->convert($span);
 
-        $this->assertSame(SpanKind::KIND_PRODUCER, $row['kind']);
+        $this->assertSame(ZipkinSpanKind::KIND_PRODUCER, $row['kind']);
     }
 
     /**
@@ -153,7 +154,7 @@ class ZipkinSpanConverterTest extends TestCase
         $converter = new SpanConverter('unused');
         $row = $converter->convert($span);
 
-        $this->assertSame(SpanKind::KIND_CONSUMER, $row['kind']);
+        $this->assertSame(ZipkinSpanKind::KIND_CONSUMER, $row['kind']);
     }
 
     /**


### PR DESCRIPTION
Zipkin span exporter currently serializes and sends span kind in integer format. However, Zipkin span api endpoint seems to only accept them in strings format (https://zipkin.io/zipkin-api/#/default/post_spans). This results in rejected method calls with status code 400 when using any span kind other that internal. This PR converts spans to required format to fix rejected method calls to Zipkin endpoints.