### PR TITLE
Make gRPC PHP extension optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.4 || ^8.0",
-        "ext-grpc": "*",
         "ext-json": "*",
         "google/protobuf": "^v3.3.0",
         "grpc/grpc": "^1.30",
@@ -52,6 +51,7 @@
         }
     },
     "require-dev": {
+        "ext-grpc": "*",
         "assertwell/phpunit-global-state": "^0.2",
         "composer/xdebug-handler": "^2.0",
         "dg/bypass-finals": "^1.3",
@@ -74,5 +74,8 @@
         "psalm/psalm": "^4.0",
         "qossmic/deptrac-shim": "^0.16.0",
         "symfony/http-client": "^5.2"
+    },
+    "suggest": {
+        "ext-grpc": "To use the OTLP GRPC Exporter"
     }
 }


### PR DESCRIPTION
closes: https://github.com/open-telemetry/opentelemetry-php/issues/482

As discussed at the meeting, this PR will remove the hard dependecy on the PHP gRPC extension and move it to be a dev requirement. Additionally a "suggest" section is added to composer.json with information, when the ext-grpc is needed.


The gRPC extension may be a hard dependency of a separate Contrib package in the future, if packages are published individually.

The documentation of this change will be addressed in https://github.com/open-telemetry/opentelemetry-php/issues/481, as this depdendency hasn't been documentated before anyway.

