### PR TITLE
Add semantic conventions for Resource and Trace attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,6 @@ deptrac:
 	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/deptrac --formatter=table
 w3c-test-service:
 	@docker-compose -f docker-compose.w3cTraceContext.yaml run --rm php ./tests/TraceContext/W3CTestService/symfony-setup
+semconv:
+	./script/semantic-conventions/semconv.sh
 FORCE:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ From your bash compatible shell in the root of this directory.  This wil create 
 directory of the
 repository.
 
+
+## Semantic Conventions Generation
+A generated semantic convention files are committed to the repository in the `/src/SemConv` directory. These files
+get updated when new version of [opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification)
+released.
+
+```bash
+SEMCONV_VERSION=1.8.0 make semconv
+```
+
+Run it from you bash compatible shell in the root of this repository.
+
 ## Styling
 We use [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) for our code linting and standards fixer.  The associated configuration for this standards fixer can be found in the root of the repository [here](https://github.com/open-telemetry/opentelemetry-php/blob/master/.php_cs)
 

--- a/examples/SpanResources.php
+++ b/examples/SpanResources.php
@@ -3,25 +3,25 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
-use OpenTelemetry\SDK\Resource\ResourceConstants;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\Attributes;
 use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\SemConv\ResourceAttributes;
 
 echo 'Starting ConsoleSpanExporter' . PHP_EOL;
 
 $resource = ResourceInfo::create(new Attributes([
     //@see https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions
-    ResourceConstants::SERVICE_NAMESPACE => 'foo',
-    ResourceConstants::SERVICE_NAME => 'bar',
-    ResourceConstants::SERVICE_INSTANCE_ID => 1,
-    ResourceConstants::SERVICE_VERSION => '0.1',
-    ResourceConstants::HOST_HOSTNAME => \gethostname(),
-    ResourceConstants::DEPLOYMENT_ENVIRONMENT => 'development',
-    ResourceConstants::HOST_ARCH => strtolower(php_uname('m')),
-    ResourceConstants::HOST_TYPE => strtolower(php_uname('s')),
+    ResourceAttributes::SERVICE_NAMESPACE => 'foo',
+    ResourceAttributes::SERVICE_NAME => 'bar',
+    ResourceAttributes::SERVICE_INSTANCE_ID => 1,
+    ResourceAttributes::SERVICE_VERSION => '0.1',
+    ResourceAttributes::HOST_NAME => \gethostname(),
+    ResourceAttributes::DEPLOYMENT_ENVIRONMENT => 'development',
+    ResourceAttributes::HOST_ARCH => strtolower(php_uname('m')),
+    ResourceAttributes::HOST_TYPE => strtolower(php_uname('s')),
 ]));
 
 $tracerProvider =  new TracerProvider(

--- a/script/semantic-conventions/semconv.sh
+++ b/script/semantic-conventions/semconv.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.8.0
+SEMCONV_VERSION=${SEMCONV_VERSION:=1.8.0}
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.8.0
@@ -42,7 +42,8 @@ docker run --rm \
   --template /templates/Attributes.php.j2 \
   --output "/output/TraceAttributes.php" \
   -Dnamespace="OpenTelemetry\\SemConv" \
-  -Dclass="Trace"
+  -Dclass="Trace" \
+  -DschemaUrl=$SCHEMA_URL
 
 docker run --rm \
   -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/trace:/source \
@@ -54,7 +55,8 @@ docker run --rm \
   --template /templates/AttributeValues.php.j2 \
   --output "/output/TraceAttributeValues.php" \
   -Dnamespace="OpenTelemetry\\SemConv" \
-  -Dclass="Trace"
+  -Dclass="Trace" \
+  -DschemaUrl=$SCHEMA_URL
 
 
 # Resource
@@ -68,7 +70,8 @@ docker run --rm \
   --template /templates/Attributes.php.j2 \
   --output "/output/ResourceAttributes.php" \
   -Dnamespace="OpenTelemetry\\SemConv" \
-  -Dclass="Resource"
+  -Dclass="Resource" \
+  -DschemaUrl=$SCHEMA_URL
 
 docker run --rm \
   -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/resource:/source \
@@ -80,4 +83,5 @@ docker run --rm \
   --template /templates/AttributeValues.php.j2 \
   --output "/output/ResourceAttributeValues.php" \
   -Dnamespace="OpenTelemetry\\SemConv" \
-  -Dclass="Resource"
+  -Dclass="Resource" \
+  -DschemaUrl=$SCHEMA_URL

--- a/script/semantic-conventions/semconv.sh
+++ b/script/semantic-conventions/semconv.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# This script generates PHP code for semantic conventions
+#
+# Supported semantic conventions:
+#  - Trace
+#  - Resource
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="${SCRIPT_DIR}/../../"
+
+# freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
+SEMCONV_VERSION=1.8.0
+SPEC_VERSION=v$SEMCONV_VERSION
+SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
+GENERATOR_VERSION=0.8.0
+
+cd ${SCRIPT_DIR}
+
+rm -rf opentelemetry-specification || true
+mkdir opentelemetry-specification
+cd opentelemetry-specification
+
+git init
+git remote add origin https://github.com/open-telemetry/opentelemetry-specification.git
+git fetch origin "$SPEC_VERSION"
+git reset --hard FETCH_HEAD
+
+cd ${SCRIPT_DIR}
+
+rm -rf ${ROOT_DIR}/src/SemConv || true
+mkdir -p ${ROOT_DIR}/src/SemConv
+
+# Trace
+docker run --rm \
+  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/trace:/source \
+  -v ${SCRIPT_DIR}/templates:/templates \
+  -v ${ROOT_DIR}/src/SemConv:/output \
+  -u ${UID} \
+  otel/semconvgen:$GENERATOR_VERSION \
+  -f /source code \
+  --template /templates/Attributes.php.j2 \
+  --output "/output/TraceAttributes.php" \
+  -Dnamespace="OpenTelemetry\\SemConv" \
+  -Dclass="Trace"
+
+docker run --rm \
+  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/trace:/source \
+  -v ${SCRIPT_DIR}/templates:/templates \
+  -v ${ROOT_DIR}/src/SemConv:/output \
+  -u ${UID} \
+  otel/semconvgen:$GENERATOR_VERSION \
+  -f /source code \
+  --template /templates/AttributeValues.php.j2 \
+  --output "/output/TraceAttributeValues.php" \
+  -Dnamespace="OpenTelemetry\\SemConv" \
+  -Dclass="Trace"
+
+
+# Resource
+docker run --rm \
+  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/resource:/source \
+  -v ${SCRIPT_DIR}/templates:/templates \
+  -v ${ROOT_DIR}/src/SemConv:/output \
+  -u ${UID} \
+  otel/semconvgen:$GENERATOR_VERSION \
+  -f /source code \
+  --template /templates/Attributes.php.j2 \
+  --output "/output/ResourceAttributes.php" \
+  -Dnamespace="OpenTelemetry\\SemConv" \
+  -Dclass="Resource"
+
+docker run --rm \
+  -v ${SCRIPT_DIR}/opentelemetry-specification/semantic_conventions/resource:/source \
+  -v ${SCRIPT_DIR}/templates:/templates \
+  -v ${ROOT_DIR}/src/SemConv:/output \
+  -u ${UID} \
+  otel/semconvgen:$GENERATOR_VERSION \
+  -f /source code \
+  --template /templates/AttributeValues.php.j2 \
+  --output "/output/ResourceAttributeValues.php" \
+  -Dnamespace="OpenTelemetry\\SemConv" \
+  -Dclass="Resource"

--- a/script/semantic-conventions/templates/AttributeValues.php.j2
+++ b/script/semantic-conventions/templates/AttributeValues.php.j2
@@ -8,6 +8,11 @@ namespace {{ namespace }};
 
 class {{ class }}AttributeValues
 {
+    /**
+     * The URL of the OpenTelemetry schema for these keys and values.
+     */
+    public const SCHEMA_URL = '{{schemaUrl}}';
+
 {%- for attribute in attributes | unique(attribute="fqn") %}
 {%- if attribute.attr_type.members %}
 {%- for member in attribute.attr_type.members %}

--- a/script/semantic-conventions/templates/AttributeValues.php.j2
+++ b/script/semantic-conventions/templates/AttributeValues.php.j2
@@ -1,0 +1,30 @@
+<?php
+
+// DO NOT EDIT, this is an Auto-generated file from script/semantic-convention{{template}}
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+class {{ class }}AttributeValues
+{
+{%- for attribute in attributes | unique(attribute="fqn") %}
+{%- if attribute.attr_type.members %}
+{%- for member in attribute.attr_type.members %}
+    {%- if member.brief %}
+    /**
+     * @see {{ class }}Attributes::{{ attribute.fqn | to_const_name }} {% filter escape %}{{member.brief | to_doc_brief}}{% endfilter %}
+     {%- if member.note %}
+     *
+     * {{ member.note | render_markdown(code="<code>{0}</code>", paragraph="{0}") | regex_replace(pattern="\n", replace="\n     * ") }}
+     {%- endif %}
+     */
+    {%- endif %}
+    public const {{ attribute.fqn | to_const_name }}_{{ member.member_id | to_const_name }} = '{{ member.value }}';
+{% if not loop.last %}{# blank line #}{% endif %}
+{%- endfor -%}
+{%- endif -%}
+{% if not loop.last %}{# blank line #}{% endif %}
+{%- endfor -%}
+}
+{# blank line #}

--- a/script/semantic-conventions/templates/Attributes.php.j2
+++ b/script/semantic-conventions/templates/Attributes.php.j2
@@ -8,7 +8,11 @@ namespace {{ namespace }};
 
 class {{ class }}Attributes
 {
-{%- for attribute in attributes | unique(attribute="fqn") %}
+    /**
+     * The URL of the OpenTelemetry schema for these keys and values.
+     */
+    public const SCHEMA_URL = '{{schemaUrl}}';
+{% for attribute in attributes | unique(attribute="fqn") %}
     /**
      * {{ attribute.brief | render_markdown(code="`{0}`", paragraph="{0}", link="{1}") | to_doc_brief | regex_replace(pattern="\n", replace="\n     * ") }}.
      {%- if attribute.note %}

--- a/script/semantic-conventions/templates/Attributes.php.j2
+++ b/script/semantic-conventions/templates/Attributes.php.j2
@@ -1,0 +1,32 @@
+<?php
+
+// DO NOT EDIT, this is an Auto-generated file from script/semantic-convention{{template}}
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+class {{ class }}Attributes
+{
+{%- for attribute in attributes | unique(attribute="fqn") %}
+    /**
+     * {{ attribute.brief | render_markdown(code="`{0}`", paragraph="{0}", link="{1}") | to_doc_brief | regex_replace(pattern="\n", replace="\n     * ") }}.
+     {%- if attribute.note %}
+     *
+     * {{ attribute.note | render_markdown(code="`{0}`", paragraph="{0}", link="{1}") | trim("\n")| regex_replace(pattern="\n", replace="\n     * ") }}
+     {%- endif %}
+     {%- if attribute.examples or attribute.deprecated %}
+     *
+     {%- if attribute.deprecated %}
+     * @deprecated {{ attribute.deprecated | render_markdown(code="`{0}`", paragraph="{0}", link="{{@link {0} {1}}}") | regex_replace(pattern="\n", replace="\n    * ") }}
+     {%- endif %}
+     {%- for example in attribute.examples if example %}
+     * @example {{ example }}
+     {%- endfor %}
+     {%- endif %}
+     */
+    public const {{ attribute.fqn | to_const_name }} = '{{ attribute.fqn }}';
+{% if not loop.last %}{# blank line #}{% endif %}
+{%- endfor -%}
+}
+{# blank line #}

--- a/src/SDK/Resource/ResourceConstants.php
+++ b/src/SDK/Resource/ResourceConstants.php
@@ -11,6 +11,7 @@ namespace OpenTelemetry\SDK\Resource;
  * marked as Required in this document).
  *
  * @link https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions
+ * @deprecated Use {@see \OpenTelemetry\SemConv\ResourceAttributes} instead.
  */
 class ResourceConstants
 {

--- a/src/SDK/Resource/ResourceInfo.php
+++ b/src/SDK/Resource/ResourceInfo.php
@@ -71,7 +71,6 @@ class ResourceInfo
     {
         return new ResourceInfo(new Attributes(
             [
-                ResourceAttributes::SERVICE_NAME => 'unknown',
                 ResourceAttributes::TELEMETRY_SDK_NAME => 'opentelemetry',
                 ResourceAttributes::TELEMETRY_SDK_LANGUAGE => 'php',
                 ResourceAttributes::TELEMETRY_SDK_VERSION => 'dev',

--- a/src/SDK/Resource/ResourceInfo.php
+++ b/src/SDK/Resource/ResourceInfo.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\SDK\Resource;
 
 use OpenTelemetry\API\Trace\AttributesInterface;
 use OpenTelemetry\SDK\Trace\Attributes;
+use OpenTelemetry\SemConv\ResourceAttributes;
 
 /**
  * A Resource is an immutable representation of the entity producing telemetry. For example, a process producing telemetry
@@ -70,9 +71,10 @@ class ResourceInfo
     {
         return new ResourceInfo(new Attributes(
             [
-                ResourceConstants::TELEMETRY_SDK_NAME => 'opentelemetry',
-                ResourceConstants::TELEMETRY_SDK_LANGUAGE => 'php',
-                ResourceConstants::TELEMETRY_SDK_VERSION => 'dev',
+                ResourceAttributes::SERVICE_NAME => 'unknown',
+                ResourceAttributes::TELEMETRY_SDK_NAME => 'opentelemetry',
+                ResourceAttributes::TELEMETRY_SDK_LANGUAGE => 'php',
+                ResourceAttributes::TELEMETRY_SDK_VERSION => 'dev',
             ]
         ));
     }
@@ -84,7 +86,7 @@ class ResourceInfo
     public static function environmentResource(): self
     {
         $attributes = [
-            ResourceConstants::SERVICE_NAME => 'unknown_service',
+            ResourceAttributes::SERVICE_NAME => 'unknown_service',
         ];
         $string = getenv('OTEL_RESOURCE_ATTRIBUTES');
         if ($string && false !== strpos($string, '=')) {
@@ -96,7 +98,7 @@ class ResourceInfo
         //@see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration
         $serviceName = getenv('OTEL_SERVICE_NAME');
         if ($serviceName) {
-            $attributes[ResourceConstants::SERVICE_NAME] = $serviceName;
+            $attributes[ResourceAttributes::SERVICE_NAME] = $serviceName;
         }
 
         return new ResourceInfo(new Attributes($attributes));

--- a/src/SemConv/ResourceAttributeValues.php
+++ b/src/SemConv/ResourceAttributeValues.php
@@ -9,6 +9,10 @@ namespace OpenTelemetry\SemConv;
 class ResourceAttributeValues
 {
     /**
+     * The URL of the OpenTelemetry schema for these keys and values.
+     */
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.8.0';
+    /**
      * @see ResourceAttributes::CLOUD_PROVIDER Alibaba Cloud
      */
     public const CLOUD_PROVIDER_ALIBABA_CLOUD = 'alibaba_cloud';

--- a/src/SemConv/ResourceAttributeValues.php
+++ b/src/SemConv/ResourceAttributeValues.php
@@ -1,0 +1,300 @@
+<?php
+
+// DO NOT EDIT, this is an Auto-generated file from script/semantic-convention/templates/AttributeValues.php.j2
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SemConv;
+
+class ResourceAttributeValues
+{
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Alibaba Cloud
+     */
+    public const CLOUD_PROVIDER_ALIBABA_CLOUD = 'alibaba_cloud';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Amazon Web Services
+     */
+    public const CLOUD_PROVIDER_AWS = 'aws';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Microsoft Azure
+     */
+    public const CLOUD_PROVIDER_AZURE = 'azure';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Google Cloud Platform
+     */
+    public const CLOUD_PROVIDER_GCP = 'gcp';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Tencent Cloud
+     */
+    public const CLOUD_PROVIDER_TENCENT_CLOUD = 'tencent_cloud';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Alibaba Cloud Elastic Compute Service
+     */
+    public const CLOUD_PLATFORM_ALIBABA_CLOUD_ECS = 'alibaba_cloud_ecs';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Alibaba Cloud Function Compute
+     */
+    public const CLOUD_PLATFORM_ALIBABA_CLOUD_FC = 'alibaba_cloud_fc';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Elastic Compute Cloud
+     */
+    public const CLOUD_PLATFORM_AWS_EC2 = 'aws_ec2';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Elastic Container Service
+     */
+    public const CLOUD_PLATFORM_AWS_ECS = 'aws_ecs';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Elastic Kubernetes Service
+     */
+    public const CLOUD_PLATFORM_AWS_EKS = 'aws_eks';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Lambda
+     */
+    public const CLOUD_PLATFORM_AWS_LAMBDA = 'aws_lambda';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Elastic Beanstalk
+     */
+    public const CLOUD_PLATFORM_AWS_ELASTIC_BEANSTALK = 'aws_elastic_beanstalk';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS App Runner
+     */
+    public const CLOUD_PLATFORM_AWS_APP_RUNNER = 'aws_app_runner';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Virtual Machines
+     */
+    public const CLOUD_PLATFORM_AZURE_VM = 'azure_vm';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Container Instances
+     */
+    public const CLOUD_PLATFORM_AZURE_CONTAINER_INSTANCES = 'azure_container_instances';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Kubernetes Service
+     */
+    public const CLOUD_PLATFORM_AZURE_AKS = 'azure_aks';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Functions
+     */
+    public const CLOUD_PLATFORM_AZURE_FUNCTIONS = 'azure_functions';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure App Service
+     */
+    public const CLOUD_PLATFORM_AZURE_APP_SERVICE = 'azure_app_service';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud Compute Engine (GCE)
+     */
+    public const CLOUD_PLATFORM_GCP_COMPUTE_ENGINE = 'gcp_compute_engine';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud Run
+     */
+    public const CLOUD_PLATFORM_GCP_CLOUD_RUN = 'gcp_cloud_run';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud Kubernetes Engine (GKE)
+     */
+    public const CLOUD_PLATFORM_GCP_KUBERNETES_ENGINE = 'gcp_kubernetes_engine';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud Functions (GCF)
+     */
+    public const CLOUD_PLATFORM_GCP_CLOUD_FUNCTIONS = 'gcp_cloud_functions';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud App Engine (GAE)
+     */
+    public const CLOUD_PLATFORM_GCP_APP_ENGINE = 'gcp_app_engine';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Tencent Cloud Cloud Virtual Machine (CVM)
+     */
+    public const CLOUD_PLATFORM_TENCENT_CLOUD_CVM = 'tencent_cloud_cvm';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Tencent Cloud Elastic Kubernetes Service (EKS)
+     */
+    public const CLOUD_PLATFORM_TENCENT_CLOUD_EKS = 'tencent_cloud_eks';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Tencent Cloud Serverless Cloud Function (SCF)
+     */
+    public const CLOUD_PLATFORM_TENCENT_CLOUD_SCF = 'tencent_cloud_scf';
+
+    /**
+     * @see ResourceAttributes::AWS_ECS_LAUNCHTYPE ec2
+     */
+    public const AWS_ECS_LAUNCHTYPE_EC2 = 'ec2';
+
+    /**
+     * @see ResourceAttributes::AWS_ECS_LAUNCHTYPE fargate
+     */
+    public const AWS_ECS_LAUNCHTYPE_FARGATE = 'fargate';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH AMD64
+     */
+    public const HOST_ARCH_AMD64 = 'amd64';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH ARM32
+     */
+    public const HOST_ARCH_ARM32 = 'arm32';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH ARM64
+     */
+    public const HOST_ARCH_ARM64 = 'arm64';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH Itanium
+     */
+    public const HOST_ARCH_IA64 = 'ia64';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH 32-bit PowerPC
+     */
+    public const HOST_ARCH_PPC32 = 'ppc32';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH 64-bit PowerPC
+     */
+    public const HOST_ARCH_PPC64 = 'ppc64';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH IBM z/Architecture
+     */
+    public const HOST_ARCH_S390X = 's390x';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH 32-bit x86
+     */
+    public const HOST_ARCH_X86 = 'x86';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE Microsoft Windows
+     */
+    public const OS_TYPE_WINDOWS = 'windows';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE Linux
+     */
+    public const OS_TYPE_LINUX = 'linux';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE Apple Darwin
+     */
+    public const OS_TYPE_DARWIN = 'darwin';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE FreeBSD
+     */
+    public const OS_TYPE_FREEBSD = 'freebsd';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE NetBSD
+     */
+    public const OS_TYPE_NETBSD = 'netbsd';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE OpenBSD
+     */
+    public const OS_TYPE_OPENBSD = 'openbsd';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE DragonFly BSD
+     */
+    public const OS_TYPE_DRAGONFLYBSD = 'dragonflybsd';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE HP-UX (Hewlett Packard Unix)
+     */
+    public const OS_TYPE_HPUX = 'hpux';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE AIX (Advanced Interactive eXecutive)
+     */
+    public const OS_TYPE_AIX = 'aix';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE Oracle Solaris
+     */
+    public const OS_TYPE_SOLARIS = 'solaris';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE IBM z/OS
+     */
+    public const OS_TYPE_Z_OS = 'z_os';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE cpp
+     */
+    public const TELEMETRY_SDK_LANGUAGE_CPP = 'cpp';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE dotnet
+     */
+    public const TELEMETRY_SDK_LANGUAGE_DOTNET = 'dotnet';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE erlang
+     */
+    public const TELEMETRY_SDK_LANGUAGE_ERLANG = 'erlang';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE go
+     */
+    public const TELEMETRY_SDK_LANGUAGE_GO = 'go';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE java
+     */
+    public const TELEMETRY_SDK_LANGUAGE_JAVA = 'java';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE nodejs
+     */
+    public const TELEMETRY_SDK_LANGUAGE_NODEJS = 'nodejs';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE php
+     */
+    public const TELEMETRY_SDK_LANGUAGE_PHP = 'php';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE python
+     */
+    public const TELEMETRY_SDK_LANGUAGE_PYTHON = 'python';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE ruby
+     */
+    public const TELEMETRY_SDK_LANGUAGE_RUBY = 'ruby';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE webjs
+     */
+    public const TELEMETRY_SDK_LANGUAGE_WEBJS = 'webjs';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE swift
+     */
+    public const TELEMETRY_SDK_LANGUAGE_SWIFT = 'swift';
+}

--- a/src/SemConv/ResourceAttributes.php
+++ b/src/SemConv/ResourceAttributes.php
@@ -9,6 +9,11 @@ namespace OpenTelemetry\SemConv;
 class ResourceAttributes
 {
     /**
+     * The URL of the OpenTelemetry schema for these keys and values.
+     */
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.8.0';
+
+    /**
      * Name of the cloud provider.
      */
     public const CLOUD_PROVIDER = 'cloud.provider';

--- a/src/SemConv/ResourceAttributes.php
+++ b/src/SemConv/ResourceAttributes.php
@@ -1,0 +1,645 @@
+<?php
+
+// DO NOT EDIT, this is an Auto-generated file from script/semantic-convention/templates/Attributes.php.j2
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SemConv;
+
+class ResourceAttributes
+{
+    /**
+     * Name of the cloud provider.
+     */
+    public const CLOUD_PROVIDER = 'cloud.provider';
+
+    /**
+     * The cloud account ID the resource is assigned to.
+     *
+     * @example 111111111111
+     * @example opentelemetry
+     */
+    public const CLOUD_ACCOUNT_ID = 'cloud.account.id';
+
+    /**
+     * The geographical region the resource is running.
+     *
+     * Refer to your provider's docs to see the available regions, for example Alibaba Cloud regions, AWS regions, Azure regions, Google Cloud regions, or Tencent Cloud regions.
+     *
+     * @example us-central1
+     * @example us-east-1
+     */
+    public const CLOUD_REGION = 'cloud.region';
+
+    /**
+     * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
+     *
+     * Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
+     *
+     * @example us-east-1c
+     */
+    public const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
+
+    /**
+     * The cloud platform in use.
+     *
+     * The prefix of the service SHOULD match the one specified in `cloud.provider`.
+     */
+    public const CLOUD_PLATFORM = 'cloud.platform';
+
+    /**
+     * The Amazon Resource Name (ARN) of an ECS container instance.
+     *
+     * @example arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9
+     */
+    public const AWS_ECS_CONTAINER_ARN = 'aws.ecs.container.arn';
+
+    /**
+     * The ARN of an ECS cluster.
+     *
+     * @example arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
+     */
+    public const AWS_ECS_CLUSTER_ARN = 'aws.ecs.cluster.arn';
+
+    /**
+     * The launch type for an ECS task.
+     */
+    public const AWS_ECS_LAUNCHTYPE = 'aws.ecs.launchtype';
+
+    /**
+     * The ARN of an ECS task definition.
+     *
+     * @example arn:aws:ecs:us-west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b
+     */
+    public const AWS_ECS_TASK_ARN = 'aws.ecs.task.arn';
+
+    /**
+     * The task definition family this task definition is a member of.
+     *
+     * @example opentelemetry-family
+     */
+    public const AWS_ECS_TASK_FAMILY = 'aws.ecs.task.family';
+
+    /**
+     * The revision for this task definition.
+     *
+     * @example 8
+     * @example 26
+     */
+    public const AWS_ECS_TASK_REVISION = 'aws.ecs.task.revision';
+
+    /**
+     * The ARN of an EKS cluster.
+     *
+     * @example arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
+     */
+    public const AWS_EKS_CLUSTER_ARN = 'aws.eks.cluster.arn';
+
+    /**
+     * The name(s) of the AWS log group(s) an application is writing to.
+     *
+     * Multiple log groups must be supported for cases like multi-container applications, where a single application has sidecar containers, and each write to their own log group.
+     *
+     * @example /aws/lambda/my-function
+     * @example opentelemetry-service
+     */
+    public const AWS_LOG_GROUP_NAMES = 'aws.log.group.names';
+
+    /**
+     * The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+     *
+     * See the log group ARN format documentation.
+     *
+     * @example arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*
+     */
+    public const AWS_LOG_GROUP_ARNS = 'aws.log.group.arns';
+
+    /**
+     * The name(s) of the AWS log stream(s) an application is writing to.
+     *
+     * @example logs/main/10838bed-421f-43ef-870a-f43feacbbb5b
+     */
+    public const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
+
+    /**
+     * The ARN(s) of the AWS log stream(s).
+     *
+     * See the log stream ARN format documentation. One log group can contain several log streams, so these ARNs necessarily identify both a log group and a log stream.
+     *
+     * @example arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b
+     */
+    public const AWS_LOG_STREAM_ARNS = 'aws.log.stream.arns';
+
+    /**
+     * Container name used by container runtime.
+     *
+     * @example opentelemetry-autoconf
+     */
+    public const CONTAINER_NAME = 'container.name';
+
+    /**
+     * Container ID. Usually a UUID, as for example used to identify Docker containers. The UUID might be abbreviated.
+     *
+     * @example a3bf90e006b2
+     */
+    public const CONTAINER_ID = 'container.id';
+
+    /**
+     * The container runtime managing this container.
+     *
+     * @example docker
+     * @example containerd
+     * @example rkt
+     */
+    public const CONTAINER_RUNTIME = 'container.runtime';
+
+    /**
+     * Name of the image the container was built on.
+     *
+     * @example gcr.io/opentelemetry/operator
+     */
+    public const CONTAINER_IMAGE_NAME = 'container.image.name';
+
+    /**
+     * Container image tag.
+     *
+     * @example 0.1
+     */
+    public const CONTAINER_IMAGE_TAG = 'container.image.tag';
+
+    /**
+     * Name of the deployment environment (aka deployment tier).
+     *
+     * @example staging
+     * @example production
+     */
+    public const DEPLOYMENT_ENVIRONMENT = 'deployment.environment';
+
+    /**
+     * A unique identifier representing the device.
+     *
+     * The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the vendor identifier. On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found here on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+     *
+     * @example 2ab2916d-a51f-4ac8-80ee-45ac31a28092
+     */
+    public const DEVICE_ID = 'device.id';
+
+    /**
+     * The model identifier for the device.
+     *
+     * It's recommended this value represents a machine readable version of the model identifier rather than the market or consumer-friendly name of the device.
+     *
+     * @example iPhone3,4
+     * @example SM-G920F
+     */
+    public const DEVICE_MODEL_IDENTIFIER = 'device.model.identifier';
+
+    /**
+     * The marketing name for the device model.
+     *
+     * It's recommended this value represents a human readable version of the device model rather than a machine readable alternative.
+     *
+     * @example iPhone 6s Plus
+     * @example Samsung Galaxy S6
+     */
+    public const DEVICE_MODEL_NAME = 'device.model.name';
+
+    /**
+     * The name of the single function that this runtime instance executes.
+     *
+     * This is the name of the function as configured/deployed on the FaaS platform and is usually different from the name of the callback function (which may be stored in the `code.namespace`/`code.function` span attributes).
+     *
+     * @example my-function
+     */
+    public const FAAS_NAME = 'faas.name';
+
+    /**
+     * The unique ID of the single function that this runtime instance executes.
+     *
+     * Depending on the cloud provider, use:<ul>
+     * <li><strong>AWS Lambda:</strong> The function ARN.</li>
+     * </ul>
+     * Take care not to use the &quot;invoked ARN&quot; directly but replace any
+     * alias suffix with the resolved function version, as the same runtime instance may be invokable with multiple
+     * different aliases.<ul>
+     * <li><strong>GCP:</strong> The URI of the resource</li>
+     * <li><strong>Azure:</strong> The Fully Qualified Resource ID.</li>
+     * </ul>
+     * On some providers, it may not be possible to determine the full ID at startup,
+     * which is why this field cannot be made required. For example, on AWS the account ID
+     * part of the ARN is not available without calling another AWS API
+     * which may be deemed too slow for a short-running lambda function.
+     * As an alternative, consider setting `faas.id` as a span attribute instead.
+     *
+     * @example arn:aws:lambda:us-west-2:123456789012:function:my-function
+     */
+    public const FAAS_ID = 'faas.id';
+
+    /**
+     * The immutable version of the function being executed.
+     *
+     * Depending on the cloud provider and platform, use:<ul>
+     * <li><strong>AWS Lambda:</strong> The function version
+     * (an integer represented as a decimal string).</li>
+     * <li><strong>Google Cloud Run:</strong> The revision
+     * (i.e., the function name plus the revision suffix).</li>
+     * <li><strong>Google Cloud Functions:</strong> The value of the
+     * `K_REVISION` environment variable.</li>
+     * <li><strong>Azure Functions:</strong> Not applicable. Do not set this attribute.</li>
+     * </ul>
+     *
+     * @example 26
+     * @example pinkfroid-00002
+     */
+    public const FAAS_VERSION = 'faas.version';
+
+    /**
+     * The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version.
+     *
+     * <ul>
+     * <li><strong>AWS Lambda:</strong> Use the (full) log stream name.</li>
+     * </ul>
+     *
+     * @example 2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de
+     */
+    public const FAAS_INSTANCE = 'faas.instance';
+
+    /**
+     * The amount of memory available to the serverless function in MiB.
+     *
+     * It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
+     *
+     * @example 128
+     */
+    public const FAAS_MAX_MEMORY = 'faas.max_memory';
+
+    /**
+     * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider.
+     *
+     * @example opentelemetry-test
+     */
+    public const HOST_ID = 'host.id';
+
+    /**
+     * Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
+     *
+     * @example opentelemetry-test
+     */
+    public const HOST_NAME = 'host.name';
+
+    /**
+     * Type of host. For Cloud, this must be the machine type.
+     *
+     * @example n1-standard-1
+     */
+    public const HOST_TYPE = 'host.type';
+
+    /**
+     * The CPU architecture the host system is running on.
+     */
+    public const HOST_ARCH = 'host.arch';
+
+    /**
+     * Name of the VM image or OS install the host was instantiated from.
+     *
+     * @example infra-ami-eks-worker-node-7d4ec78312
+     * @example CentOS-8-x86_64-1905
+     */
+    public const HOST_IMAGE_NAME = 'host.image.name';
+
+    /**
+     * VM image ID. For Cloud, this value is from the provider.
+     *
+     * @example ami-07b06b442921831e5
+     */
+    public const HOST_IMAGE_ID = 'host.image.id';
+
+    /**
+     * The version string of the VM image as defined in Version Attributes.
+     *
+     * @example 0.1
+     */
+    public const HOST_IMAGE_VERSION = 'host.image.version';
+
+    /**
+     * The name of the cluster.
+     *
+     * @example opentelemetry-cluster
+     */
+    public const K8S_CLUSTER_NAME = 'k8s.cluster.name';
+
+    /**
+     * The name of the Node.
+     *
+     * @example node-1
+     */
+    public const K8S_NODE_NAME = 'k8s.node.name';
+
+    /**
+     * The UID of the Node.
+     *
+     * @example 1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2
+     */
+    public const K8S_NODE_UID = 'k8s.node.uid';
+
+    /**
+     * The name of the namespace that the pod is running in.
+     *
+     * @example default
+     */
+    public const K8S_NAMESPACE_NAME = 'k8s.namespace.name';
+
+    /**
+     * The UID of the Pod.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_POD_UID = 'k8s.pod.uid';
+
+    /**
+     * The name of the Pod.
+     *
+     * @example opentelemetry-pod-autoconf
+     */
+    public const K8S_POD_NAME = 'k8s.pod.name';
+
+    /**
+     * The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`).
+     *
+     * @example redis
+     */
+    public const K8S_CONTAINER_NAME = 'k8s.container.name';
+
+    /**
+     * Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec.
+     *
+     * @example 2
+     */
+    public const K8S_CONTAINER_RESTART_COUNT = 'k8s.container.restart_count';
+
+    /**
+     * The UID of the ReplicaSet.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_REPLICASET_UID = 'k8s.replicaset.uid';
+
+    /**
+     * The name of the ReplicaSet.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_REPLICASET_NAME = 'k8s.replicaset.name';
+
+    /**
+     * The UID of the Deployment.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_DEPLOYMENT_UID = 'k8s.deployment.uid';
+
+    /**
+     * The name of the Deployment.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_DEPLOYMENT_NAME = 'k8s.deployment.name';
+
+    /**
+     * The UID of the StatefulSet.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_STATEFULSET_UID = 'k8s.statefulset.uid';
+
+    /**
+     * The name of the StatefulSet.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_STATEFULSET_NAME = 'k8s.statefulset.name';
+
+    /**
+     * The UID of the DaemonSet.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_DAEMONSET_UID = 'k8s.daemonset.uid';
+
+    /**
+     * The name of the DaemonSet.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_DAEMONSET_NAME = 'k8s.daemonset.name';
+
+    /**
+     * The UID of the Job.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_JOB_UID = 'k8s.job.uid';
+
+    /**
+     * The name of the Job.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_JOB_NAME = 'k8s.job.name';
+
+    /**
+     * The UID of the CronJob.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_CRONJOB_UID = 'k8s.cronjob.uid';
+
+    /**
+     * The name of the CronJob.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_CRONJOB_NAME = 'k8s.cronjob.name';
+
+    /**
+     * The operating system type.
+     */
+    public const OS_TYPE = 'os.type';
+
+    /**
+     * Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands.
+     *
+     * @example Microsoft Windows [Version 10.0.18363.778]
+     * @example Ubuntu 18.04.1 LTS
+     */
+    public const OS_DESCRIPTION = 'os.description';
+
+    /**
+     * Human readable operating system name.
+     *
+     * @example iOS
+     * @example Android
+     * @example Ubuntu
+     */
+    public const OS_NAME = 'os.name';
+
+    /**
+     * The version string of the operating system as defined in Version Attributes.
+     *
+     * @example 14.2.1
+     * @example 18.04.1
+     */
+    public const OS_VERSION = 'os.version';
+
+    /**
+     * Process identifier (PID).
+     *
+     * @example 1234
+     */
+    public const PROCESS_PID = 'process.pid';
+
+    /**
+     * The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
+     *
+     * @example otelcol
+     */
+    public const PROCESS_EXECUTABLE_NAME = 'process.executable.name';
+
+    /**
+     * The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`.
+     *
+     * @example /usr/bin/cmd/otelcol
+     */
+    public const PROCESS_EXECUTABLE_PATH = 'process.executable.path';
+
+    /**
+     * The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
+     *
+     * @example cmd/otelcol
+     */
+    public const PROCESS_COMMAND = 'process.command';
+
+    /**
+     * The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead.
+     *
+     * @example C:\cmd\otecol --config="my directory\config.yaml"
+     */
+    public const PROCESS_COMMAND_LINE = 'process.command_line';
+
+    /**
+     * All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`.
+     *
+     * @example cmd/otecol
+     * @example --config=config.yaml
+     */
+    public const PROCESS_COMMAND_ARGS = 'process.command_args';
+
+    /**
+     * The username of the user that owns the process.
+     *
+     * @example root
+     */
+    public const PROCESS_OWNER = 'process.owner';
+
+    /**
+     * The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler.
+     *
+     * @example OpenJDK Runtime Environment
+     */
+    public const PROCESS_RUNTIME_NAME = 'process.runtime.name';
+
+    /**
+     * The version of the runtime of this process, as returned by the runtime without modification.
+     *
+     * @example 14.0.2
+     */
+    public const PROCESS_RUNTIME_VERSION = 'process.runtime.version';
+
+    /**
+     * An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
+     *
+     * @example Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0
+     */
+    public const PROCESS_RUNTIME_DESCRIPTION = 'process.runtime.description';
+
+    /**
+     * Logical name of the service.
+     *
+     * MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with `process.executable.name`, e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+     *
+     * @example shoppingcart
+     */
+    public const SERVICE_NAME = 'service.name';
+
+    /**
+     * A namespace for `service.name`.
+     *
+     * A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+     *
+     * @example Shop
+     */
+    public const SERVICE_NAMESPACE = 'service.namespace';
+
+    /**
+     * The string ID of the service instance.
+     *
+     * MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
+     *
+     * @example 627cc493-f310-47de-96bd-71410b7dec09
+     */
+    public const SERVICE_INSTANCE_ID = 'service.instance.id';
+
+    /**
+     * The version string of the service API or implementation.
+     *
+     * @example 2.0.0
+     */
+    public const SERVICE_VERSION = 'service.version';
+
+    /**
+     * The name of the telemetry SDK as defined above.
+     *
+     * @example opentelemetry
+     */
+    public const TELEMETRY_SDK_NAME = 'telemetry.sdk.name';
+
+    /**
+     * The language of the telemetry SDK.
+     */
+    public const TELEMETRY_SDK_LANGUAGE = 'telemetry.sdk.language';
+
+    /**
+     * The version string of the telemetry SDK.
+     *
+     * @example 1.2.3
+     */
+    public const TELEMETRY_SDK_VERSION = 'telemetry.sdk.version';
+
+    /**
+     * The version string of the auto instrumentation agent, if used.
+     *
+     * @example 1.2.3
+     */
+    public const TELEMETRY_AUTO_VERSION = 'telemetry.auto.version';
+
+    /**
+     * The name of the web engine.
+     *
+     * @example WildFly
+     */
+    public const WEBENGINE_NAME = 'webengine.name';
+
+    /**
+     * The version of the web engine.
+     *
+     * @example 21.0.0
+     */
+    public const WEBENGINE_VERSION = 'webengine.version';
+
+    /**
+     * Additional description of the web engine (e.g. detailed version and edition information).
+     *
+     * @example WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final
+     */
+    public const WEBENGINE_DESCRIPTION = 'webengine.description';
+}

--- a/src/SemConv/TraceAttributeValues.php
+++ b/src/SemConv/TraceAttributeValues.php
@@ -9,6 +9,10 @@ namespace OpenTelemetry\SemConv;
 class TraceAttributeValues
 {
     /**
+     * The URL of the OpenTelemetry schema for these keys and values.
+     */
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.8.0';
+    /**
      * @see TraceAttributes::DB_SYSTEM Some other SQL database. Fallback only. See notes
      */
     public const DB_SYSTEM_OTHER_SQL = 'other_sql';

--- a/src/SemConv/TraceAttributeValues.php
+++ b/src/SemConv/TraceAttributeValues.php
@@ -1,0 +1,702 @@
+<?php
+
+// DO NOT EDIT, this is an Auto-generated file from script/semantic-convention/templates/AttributeValues.php.j2
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SemConv;
+
+class TraceAttributeValues
+{
+    /**
+     * @see TraceAttributes::DB_SYSTEM Some other SQL database. Fallback only. See notes
+     */
+    public const DB_SYSTEM_OTHER_SQL = 'other_sql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Microsoft SQL Server
+     */
+    public const DB_SYSTEM_MSSQL = 'mssql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM MySQL
+     */
+    public const DB_SYSTEM_MYSQL = 'mysql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Oracle Database
+     */
+    public const DB_SYSTEM_ORACLE = 'oracle';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM IBM Db2
+     */
+    public const DB_SYSTEM_DB2 = 'db2';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM PostgreSQL
+     */
+    public const DB_SYSTEM_POSTGRESQL = 'postgresql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Amazon Redshift
+     */
+    public const DB_SYSTEM_REDSHIFT = 'redshift';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache Hive
+     */
+    public const DB_SYSTEM_HIVE = 'hive';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Cloudscape
+     */
+    public const DB_SYSTEM_CLOUDSCAPE = 'cloudscape';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM HyperSQL DataBase
+     */
+    public const DB_SYSTEM_HSQLDB = 'hsqldb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Progress Database
+     */
+    public const DB_SYSTEM_PROGRESS = 'progress';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM SAP MaxDB
+     */
+    public const DB_SYSTEM_MAXDB = 'maxdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM SAP HANA
+     */
+    public const DB_SYSTEM_HANADB = 'hanadb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Ingres
+     */
+    public const DB_SYSTEM_INGRES = 'ingres';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM FirstSQL
+     */
+    public const DB_SYSTEM_FIRSTSQL = 'firstsql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM EnterpriseDB
+     */
+    public const DB_SYSTEM_EDB = 'edb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM InterSystems Caché
+     */
+    public const DB_SYSTEM_CACHE = 'cache';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Adabas (Adaptable Database System)
+     */
+    public const DB_SYSTEM_ADABAS = 'adabas';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Firebird
+     */
+    public const DB_SYSTEM_FIREBIRD = 'firebird';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache Derby
+     */
+    public const DB_SYSTEM_DERBY = 'derby';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM FileMaker
+     */
+    public const DB_SYSTEM_FILEMAKER = 'filemaker';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Informix
+     */
+    public const DB_SYSTEM_INFORMIX = 'informix';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM InstantDB
+     */
+    public const DB_SYSTEM_INSTANTDB = 'instantdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM InterBase
+     */
+    public const DB_SYSTEM_INTERBASE = 'interbase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM MariaDB
+     */
+    public const DB_SYSTEM_MARIADB = 'mariadb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Netezza
+     */
+    public const DB_SYSTEM_NETEZZA = 'netezza';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Pervasive PSQL
+     */
+    public const DB_SYSTEM_PERVASIVE = 'pervasive';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM PointBase
+     */
+    public const DB_SYSTEM_POINTBASE = 'pointbase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM SQLite
+     */
+    public const DB_SYSTEM_SQLITE = 'sqlite';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Sybase
+     */
+    public const DB_SYSTEM_SYBASE = 'sybase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Teradata
+     */
+    public const DB_SYSTEM_TERADATA = 'teradata';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Vertica
+     */
+    public const DB_SYSTEM_VERTICA = 'vertica';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM H2
+     */
+    public const DB_SYSTEM_H2 = 'h2';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM ColdFusion IMQ
+     */
+    public const DB_SYSTEM_COLDFUSION = 'coldfusion';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache Cassandra
+     */
+    public const DB_SYSTEM_CASSANDRA = 'cassandra';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache HBase
+     */
+    public const DB_SYSTEM_HBASE = 'hbase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM MongoDB
+     */
+    public const DB_SYSTEM_MONGODB = 'mongodb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Redis
+     */
+    public const DB_SYSTEM_REDIS = 'redis';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Couchbase
+     */
+    public const DB_SYSTEM_COUCHBASE = 'couchbase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM CouchDB
+     */
+    public const DB_SYSTEM_COUCHDB = 'couchdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Microsoft Azure Cosmos DB
+     */
+    public const DB_SYSTEM_COSMOSDB = 'cosmosdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Amazon DynamoDB
+     */
+    public const DB_SYSTEM_DYNAMODB = 'dynamodb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Neo4j
+     */
+    public const DB_SYSTEM_NEO4J = 'neo4j';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache Geode
+     */
+    public const DB_SYSTEM_GEODE = 'geode';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Elasticsearch
+     */
+    public const DB_SYSTEM_ELASTICSEARCH = 'elasticsearch';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Memcached
+     */
+    public const DB_SYSTEM_MEMCACHED = 'memcached';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM CockroachDB
+     */
+    public const DB_SYSTEM_COCKROACHDB = 'cockroachdb';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT ip_tcp
+     */
+    public const NET_TRANSPORT_IP_TCP = 'ip_tcp';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT ip_udp
+     */
+    public const NET_TRANSPORT_IP_UDP = 'ip_udp';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT Another IP-based protocol
+     */
+    public const NET_TRANSPORT_IP = 'ip';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT Unix Domain socket. See below
+     */
+    public const NET_TRANSPORT_UNIX = 'unix';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT Named or anonymous pipe. See note below
+     */
+    public const NET_TRANSPORT_PIPE = 'pipe';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT In-process communication
+     *
+     * Signals that there is only in-process communication not using a &quot;real&quot; network protocol in cases where network attributes would normally be expected. Usually all other network attributes can be left out in that case.
+     */
+    public const NET_TRANSPORT_INPROC = 'inproc';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT Something else (non IP-based)
+     */
+    public const NET_TRANSPORT_OTHER = 'other';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL all
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_ALL = 'all';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL each_quorum
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_EACH_QUORUM = 'each_quorum';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL quorum
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_QUORUM = 'quorum';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL local_quorum
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_LOCAL_QUORUM = 'local_quorum';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL one
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_ONE = 'one';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL two
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_TWO = 'two';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL three
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_THREE = 'three';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL local_one
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_LOCAL_ONE = 'local_one';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL any
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_ANY = 'any';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL serial
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_SERIAL = 'serial';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL local_serial
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_LOCAL_SERIAL = 'local_serial';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER A response to some data source operation such as a database or filesystem read/write
+     */
+    public const FAAS_TRIGGER_DATASOURCE = 'datasource';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER To provide an answer to an inbound HTTP request
+     */
+    public const FAAS_TRIGGER_HTTP = 'http';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER A function is set to be executed when messages are sent to a messaging system
+     */
+    public const FAAS_TRIGGER_PUBSUB = 'pubsub';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER A function is scheduled to be executed regularly
+     */
+    public const FAAS_TRIGGER_TIMER = 'timer';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER If none of the others apply
+     */
+    public const FAAS_TRIGGER_OTHER = 'other';
+
+    /**
+     * @see TraceAttributes::FAAS_DOCUMENT_OPERATION When a new object is created
+     */
+    public const FAAS_DOCUMENT_OPERATION_INSERT = 'insert';
+
+    /**
+     * @see TraceAttributes::FAAS_DOCUMENT_OPERATION When an object is modified
+     */
+    public const FAAS_DOCUMENT_OPERATION_EDIT = 'edit';
+
+    /**
+     * @see TraceAttributes::FAAS_DOCUMENT_OPERATION When an object is deleted
+     */
+    public const FAAS_DOCUMENT_OPERATION_DELETE = 'delete';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR HTTP 1.0
+     */
+    public const HTTP_FLAVOR_HTTP_1_0 = '1.0';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR HTTP 1.1
+     */
+    public const HTTP_FLAVOR_HTTP_1_1 = '1.1';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR HTTP 2
+     */
+    public const HTTP_FLAVOR_HTTP_2_0 = '2.0';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR SPDY protocol
+     */
+    public const HTTP_FLAVOR_SPDY = 'SPDY';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR QUIC protocol
+     */
+    public const HTTP_FLAVOR_QUIC = 'QUIC';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_TYPE wifi
+     */
+    public const NET_HOST_CONNECTION_TYPE_WIFI = 'wifi';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_TYPE wired
+     */
+    public const NET_HOST_CONNECTION_TYPE_WIRED = 'wired';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_TYPE cell
+     */
+    public const NET_HOST_CONNECTION_TYPE_CELL = 'cell';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_TYPE unavailable
+     */
+    public const NET_HOST_CONNECTION_TYPE_UNAVAILABLE = 'unavailable';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_TYPE unknown
+     */
+    public const NET_HOST_CONNECTION_TYPE_UNKNOWN = 'unknown';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE GPRS
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_GPRS = 'gprs';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE EDGE
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_EDGE = 'edge';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE UMTS
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_UMTS = 'umts';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE CDMA
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_CDMA = 'cdma';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE EVDO Rel. 0
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_EVDO_0 = 'evdo_0';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE EVDO Rev. A
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_EVDO_A = 'evdo_a';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE CDMA2000 1XRTT
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_CDMA2000_1XRTT = 'cdma2000_1xrtt';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE HSDPA
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_HSDPA = 'hsdpa';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE HSUPA
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_HSUPA = 'hsupa';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE HSPA
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_HSPA = 'hspa';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE IDEN
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_IDEN = 'iden';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE EVDO Rev. B
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_EVDO_B = 'evdo_b';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE LTE
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_LTE = 'lte';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE EHRPD
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_EHRPD = 'ehrpd';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE HSPAP
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_HSPAP = 'hspap';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE GSM
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_GSM = 'gsm';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE TD-SCDMA
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_TD_SCDMA = 'td_scdma';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE IWLAN
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_IWLAN = 'iwlan';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE 5G NR (New Radio)
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_NR = 'nr';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE 5G NRNSA (New Radio Non-Standalone)
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_NRNSA = 'nrnsa';
+
+    /**
+     * @see TraceAttributes::NET_HOST_CONNECTION_SUBTYPE LTE CA
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE_LTE_CA = 'lte_ca';
+
+    /**
+     * @see TraceAttributes::MESSAGING_DESTINATION_KIND A message sent to a queue
+     */
+    public const MESSAGING_DESTINATION_KIND_QUEUE = 'queue';
+
+    /**
+     * @see TraceAttributes::MESSAGING_DESTINATION_KIND A message sent to a topic
+     */
+    public const MESSAGING_DESTINATION_KIND_TOPIC = 'topic';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Alibaba Cloud
+     */
+    public const FAAS_INVOKED_PROVIDER_ALIBABA_CLOUD = 'alibaba_cloud';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Amazon Web Services
+     */
+    public const FAAS_INVOKED_PROVIDER_AWS = 'aws';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Microsoft Azure
+     */
+    public const FAAS_INVOKED_PROVIDER_AZURE = 'azure';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Google Cloud Platform
+     */
+    public const FAAS_INVOKED_PROVIDER_GCP = 'gcp';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Tencent Cloud
+     */
+    public const FAAS_INVOKED_PROVIDER_TENCENT_CLOUD = 'tencent_cloud';
+
+    /**
+     * @see TraceAttributes::MESSAGING_OPERATION receive
+     */
+    public const MESSAGING_OPERATION_RECEIVE = 'receive';
+
+    /**
+     * @see TraceAttributes::MESSAGING_OPERATION process
+     */
+    public const MESSAGING_OPERATION_PROCESS = 'process';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_MESSAGE_TYPE Normal message
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE_NORMAL = 'normal';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_MESSAGE_TYPE FIFO message
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE_FIFO = 'fifo';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_MESSAGE_TYPE Delay message
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE_DELAY = 'delay';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_MESSAGE_TYPE Transaction message
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE_TRANSACTION = 'transaction';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_CONSUMPTION_MODEL Clustering consumption model
+     */
+    public const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL_CLUSTERING = 'clustering';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_CONSUMPTION_MODEL Broadcasting consumption model
+     */
+    public const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL_BROADCASTING = 'broadcasting';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE OK
+     */
+    public const RPC_GRPC_STATUS_CODE_OK = '0';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE CANCELLED
+     */
+    public const RPC_GRPC_STATUS_CODE_CANCELLED = '1';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNKNOWN
+     */
+    public const RPC_GRPC_STATUS_CODE_UNKNOWN = '2';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE INVALID_ARGUMENT
+     */
+    public const RPC_GRPC_STATUS_CODE_INVALID_ARGUMENT = '3';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE DEADLINE_EXCEEDED
+     */
+    public const RPC_GRPC_STATUS_CODE_DEADLINE_EXCEEDED = '4';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE NOT_FOUND
+     */
+    public const RPC_GRPC_STATUS_CODE_NOT_FOUND = '5';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE ALREADY_EXISTS
+     */
+    public const RPC_GRPC_STATUS_CODE_ALREADY_EXISTS = '6';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE PERMISSION_DENIED
+     */
+    public const RPC_GRPC_STATUS_CODE_PERMISSION_DENIED = '7';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE RESOURCE_EXHAUSTED
+     */
+    public const RPC_GRPC_STATUS_CODE_RESOURCE_EXHAUSTED = '8';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE FAILED_PRECONDITION
+     */
+    public const RPC_GRPC_STATUS_CODE_FAILED_PRECONDITION = '9';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE ABORTED
+     */
+    public const RPC_GRPC_STATUS_CODE_ABORTED = '10';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE OUT_OF_RANGE
+     */
+    public const RPC_GRPC_STATUS_CODE_OUT_OF_RANGE = '11';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNIMPLEMENTED
+     */
+    public const RPC_GRPC_STATUS_CODE_UNIMPLEMENTED = '12';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE INTERNAL
+     */
+    public const RPC_GRPC_STATUS_CODE_INTERNAL = '13';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNAVAILABLE
+     */
+    public const RPC_GRPC_STATUS_CODE_UNAVAILABLE = '14';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE DATA_LOSS
+     */
+    public const RPC_GRPC_STATUS_CODE_DATA_LOSS = '15';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNAUTHENTICATED
+     */
+    public const RPC_GRPC_STATUS_CODE_UNAUTHENTICATED = '16';
+
+    /**
+     * @see TraceAttributes::MESSAGE_TYPE sent
+     */
+    public const MESSAGE_TYPE_SENT = 'SENT';
+
+    /**
+     * @see TraceAttributes::MESSAGE_TYPE received
+     */
+    public const MESSAGE_TYPE_RECEIVED = 'RECEIVED';
+}

--- a/src/SemConv/TraceAttributes.php
+++ b/src/SemConv/TraceAttributes.php
@@ -1,0 +1,1002 @@
+<?php
+
+// DO NOT EDIT, this is an Auto-generated file from script/semantic-convention/templates/Attributes.php.j2
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SemConv;
+
+class TraceAttributes
+{
+    /**
+     * The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
+     *
+     * This may be different from `faas.id` if an alias is involved.
+     *
+     * @example arn:aws:lambda:us-east-1:123456:function:myfunction:myalias
+     */
+    public const AWS_LAMBDA_INVOKED_ARN = 'aws.lambda.invoked_arn';
+
+    /**
+     * An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
+     */
+    public const DB_SYSTEM = 'db.system';
+
+    /**
+     * The connection string used to connect to the database. It is recommended to remove embedded credentials.
+     *
+     * @example Server=(localdb)\v11.0;Integrated Security=true;
+     */
+    public const DB_CONNECTION_STRING = 'db.connection_string';
+
+    /**
+     * Username for accessing the database.
+     *
+     * @example readonly_user
+     * @example reporting_user
+     */
+    public const DB_USER = 'db.user';
+
+    /**
+     * The fully-qualified class name of the Java Database Connectivity (JDBC) driver used to connect.
+     *
+     * @example org.postgresql.Driver
+     * @example com.microsoft.sqlserver.jdbc.SQLServerDriver
+     */
+    public const DB_JDBC_DRIVER_CLASSNAME = 'db.jdbc.driver_classname';
+
+    /**
+     * This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails).
+     *
+     * In some SQL databases, the database name to be used is called &quot;schema name&quot;. In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name).
+     *
+     * @example customers
+     * @example main
+     */
+    public const DB_NAME = 'db.name';
+
+    /**
+     * The database statement being executed.
+     *
+     * The value may be sanitized to exclude sensitive information.
+     *
+     * @example SELECT * FROM wuser_table
+     * @example SET mykey "WuValue"
+     */
+    public const DB_STATEMENT = 'db.statement';
+
+    /**
+     * The name of the operation being executed, e.g. the MongoDB command name such as `findAndModify`, or the SQL keyword.
+     *
+     * When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+     *
+     * @example findAndModify
+     * @example HMSET
+     * @example SELECT
+     */
+    public const DB_OPERATION = 'db.operation';
+
+    /**
+     * Remote hostname or similar, see note below.
+     *
+     * @example example.com
+     */
+    public const NET_PEER_NAME = 'net.peer.name';
+
+    /**
+     * Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6).
+     *
+     * @example 127.0.0.1
+     */
+    public const NET_PEER_IP = 'net.peer.ip';
+
+    /**
+     * Remote port number.
+     *
+     * @example 80
+     * @example 8080
+     * @example 443
+     */
+    public const NET_PEER_PORT = 'net.peer.port';
+
+    /**
+     * Transport protocol used. See note below.
+     */
+    public const NET_TRANSPORT = 'net.transport';
+
+    /**
+     * The Microsoft SQL Server instance name connecting to. This name is used to determine the port of a named instance.
+     *
+     * If setting a `db.mssql.instance_name`, `net.peer.port` is no longer required (but still recommended if non-standard).
+     *
+     * @example MSSQLSERVER
+     */
+    public const DB_MSSQL_INSTANCE_NAME = 'db.mssql.instance_name';
+
+    /**
+     * The fetch size used for paging, i.e. how many rows will be returned at once.
+     *
+     * @example 5000
+     */
+    public const DB_CASSANDRA_PAGE_SIZE = 'db.cassandra.page_size';
+
+    /**
+     * The consistency level of the query. Based on consistency values from CQL.
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL = 'db.cassandra.consistency_level';
+
+    /**
+     * The name of the primary table that the operation is acting upon, including the keyspace name (if applicable).
+     *
+     * This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+     *
+     * @example mytable
+     */
+    public const DB_CASSANDRA_TABLE = 'db.cassandra.table';
+
+    /**
+     * Whether or not the query is idempotent.
+     */
+    public const DB_CASSANDRA_IDEMPOTENCE = 'db.cassandra.idempotence';
+
+    /**
+     * The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
+     *
+     * @example 2
+     */
+    public const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = 'db.cassandra.speculative_execution_count';
+
+    /**
+     * The ID of the coordinating node for a query.
+     *
+     * @example be13faa2-8574-4d71-926d-27f16cf8a7af
+     */
+    public const DB_CASSANDRA_COORDINATOR_ID = 'db.cassandra.coordinator.id';
+
+    /**
+     * The data center of the coordinating node for a query.
+     *
+     * @example us-west-2
+     */
+    public const DB_CASSANDRA_COORDINATOR_DC = 'db.cassandra.coordinator.dc';
+
+    /**
+     * The index of the database being accessed as used in the `SELECT` command, provided as an integer. To be used instead of the generic `db.name` attribute.
+     *
+     * @example 1
+     * @example 15
+     */
+    public const DB_REDIS_DATABASE_INDEX = 'db.redis.database_index';
+
+    /**
+     * The collection being accessed within the database stated in `db.name`.
+     *
+     * @example customers
+     * @example products
+     */
+    public const DB_MONGODB_COLLECTION = 'db.mongodb.collection';
+
+    /**
+     * The name of the primary table that the operation is acting upon, including the database name (if applicable).
+     *
+     * It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+     *
+     * @example public.users
+     * @example customers
+     */
+    public const DB_SQL_TABLE = 'db.sql.table';
+
+    /**
+     * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+     *
+     * @example java.net.ConnectException
+     * @example OSError
+     */
+    public const EXCEPTION_TYPE = 'exception.type';
+
+    /**
+     * The exception message.
+     *
+     * @example Division by zero
+     * @example Can't convert 'int' object to str implicitly
+     */
+    public const EXCEPTION_MESSAGE = 'exception.message';
+
+    /**
+     * A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
+     *
+     * @example Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
+     */
+    public const EXCEPTION_STACKTRACE = 'exception.stacktrace';
+
+    /**
+     * SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.
+     *
+     * An exception is considered to have escaped (or left) the scope of a span,
+     * if that span is ended while the exception is still logically &quot;in flight&quot;.
+     * This may be actually &quot;in flight&quot; in some languages (e.g. if the exception
+     * is passed to a Context manager's `__exit__` method in Python) but will
+     * usually be caught at the point of recording the exception in most languages.It is usually not possible to determine at the point where an exception is thrown
+     * whether it will escape the scope of a span.
+     * However, it is trivial to know that an exception
+     * will escape, if one checks for an active exception just before ending the span,
+     * as done in the example above.It follows that an exception may still escape the scope of the span
+     * even if the `exception.escaped` attribute was not set or set to false,
+     * since the event might have been recorded at a time where it was not
+     * clear whether the exception will escape.
+     */
+    public const EXCEPTION_ESCAPED = 'exception.escaped';
+
+    /**
+     * Type of the trigger which caused this function execution.
+     *
+     * For the server/consumer span on the incoming side,
+     * `faas.trigger` MUST be set.Clients invoking FaaS instances usually cannot set `faas.trigger`,
+     * since they would typically need to look in the payload to determine
+     * the event type. If clients set it, it should be the same as the
+     * trigger that corresponding incoming would have (i.e., this has
+     * nothing to do with the underlying transport used to make the API
+     * call to invoke the lambda, which is often HTTP).
+     */
+    public const FAAS_TRIGGER = 'faas.trigger';
+
+    /**
+     * The execution ID of the current function execution.
+     *
+     * @example af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+     */
+    public const FAAS_EXECUTION = 'faas.execution';
+
+    /**
+     * The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
+     *
+     * @example myBucketName
+     * @example myDbName
+     */
+    public const FAAS_DOCUMENT_COLLECTION = 'faas.document.collection';
+
+    /**
+     * Describes the type of the operation that was performed on the data.
+     */
+    public const FAAS_DOCUMENT_OPERATION = 'faas.document.operation';
+
+    /**
+     * A string containing the time when the data was accessed in the ISO 8601 format expressed in UTC.
+     *
+     * @example 2020-01-23T13:47:06Z
+     */
+    public const FAAS_DOCUMENT_TIME = 'faas.document.time';
+
+    /**
+     * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
+     *
+     * @example myFile.txt
+     * @example myTableName
+     */
+    public const FAAS_DOCUMENT_NAME = 'faas.document.name';
+
+    /**
+     * HTTP request method.
+     *
+     * @example GET
+     * @example POST
+     * @example HEAD
+     */
+    public const HTTP_METHOD = 'http.method';
+
+    /**
+     * Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+     *
+     * `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`.
+     *
+     * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
+     */
+    public const HTTP_URL = 'http.url';
+
+    /**
+     * The full request target as passed in a HTTP request line or equivalent.
+     *
+     * @example /path/12314/?q=ddds#123
+     */
+    public const HTTP_TARGET = 'http.target';
+
+    /**
+     * The value of the HTTP host header. An empty Host header should also be reported, see note.
+     *
+     * When the header is present but empty the attribute SHOULD be set to the empty string. Note that this is a valid situation that is expected in certain cases, according the aforementioned section of RFC 7230. When the header is not set the attribute MUST NOT be set.
+     *
+     * @example www.example.org
+     */
+    public const HTTP_HOST = 'http.host';
+
+    /**
+     * The URI scheme identifying the used protocol.
+     *
+     * @example http
+     * @example https
+     */
+    public const HTTP_SCHEME = 'http.scheme';
+
+    /**
+     * HTTP response status code.
+     *
+     * @example 200
+     */
+    public const HTTP_STATUS_CODE = 'http.status_code';
+
+    /**
+     * Kind of HTTP protocol used.
+     *
+     * If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+     */
+    public const HTTP_FLAVOR = 'http.flavor';
+
+    /**
+     * Value of the HTTP User-Agent header sent by the client.
+     *
+     * @example CERN-LineMode/2.15 libwww/2.17b3
+     */
+    public const HTTP_USER_AGENT = 'http.user_agent';
+
+    /**
+     * The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
+     *
+     * @example 3495
+     */
+    public const HTTP_REQUEST_CONTENT_LENGTH = 'http.request_content_length';
+
+    /**
+     * The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used.
+     *
+     * @example 5493
+     */
+    public const HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = 'http.request_content_length_uncompressed';
+
+    /**
+     * The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
+     *
+     * @example 3495
+     */
+    public const HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length';
+
+    /**
+     * The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used.
+     *
+     * @example 5493
+     */
+    public const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = 'http.response_content_length_uncompressed';
+
+    /**
+     * The primary server name of the matched virtual host. This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `net.host.name` should be used instead).
+     *
+     * `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. open-telemetry/opentelemetry-python/pull/148). It is thus preferred to supply the raw data that is available.
+     *
+     * @example example.com
+     */
+    public const HTTP_SERVER_NAME = 'http.server_name';
+
+    /**
+     * The matched route (path template).
+     *
+     * @example /users/:userID?
+     */
+    public const HTTP_ROUTE = 'http.route';
+
+    /**
+     * The IP address of the original client behind all proxies, if known (e.g. from X-Forwarded-For).
+     *
+     * This is not necessarily the same as `net.peer.ip`, which would
+     * identify the network-level peer, which may be a proxy.This attribute should be set when a source of information different
+     * from the one used for `net.peer.ip`, is available even if that other
+     * source just confirms the same value as `net.peer.ip`.
+     * Rationale: For `net.peer.ip`, one typically does not know if it
+     * comes from a proxy, reverse proxy, or the actual client. Setting
+     * `http.client_ip` when it's the same as `net.peer.ip` means that
+     * one is at least somewhat confident that the address is not that of
+     * the closest proxy.
+     *
+     * @example 83.164.160.102
+     */
+    public const HTTP_CLIENT_IP = 'http.client_ip';
+
+    /**
+     * Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
+     *
+     * @example 192.168.0.1
+     */
+    public const NET_HOST_IP = 'net.host.ip';
+
+    /**
+     * Like `net.peer.port` but for the host port.
+     *
+     * @example 35555
+     */
+    public const NET_HOST_PORT = 'net.host.port';
+
+    /**
+     * Local hostname or similar, see note below.
+     *
+     * @example localhost
+     */
+    public const NET_HOST_NAME = 'net.host.name';
+
+    /**
+     * The internet connection type currently being used by the host.
+     *
+     * @example wifi
+     */
+    public const NET_HOST_CONNECTION_TYPE = 'net.host.connection.type';
+
+    /**
+     * This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
+     *
+     * @example LTE
+     */
+    public const NET_HOST_CONNECTION_SUBTYPE = 'net.host.connection.subtype';
+
+    /**
+     * The name of the mobile carrier.
+     *
+     * @example sprint
+     */
+    public const NET_HOST_CARRIER_NAME = 'net.host.carrier.name';
+
+    /**
+     * The mobile carrier country code.
+     *
+     * @example 310
+     */
+    public const NET_HOST_CARRIER_MCC = 'net.host.carrier.mcc';
+
+    /**
+     * The mobile carrier network code.
+     *
+     * @example 001
+     */
+    public const NET_HOST_CARRIER_MNC = 'net.host.carrier.mnc';
+
+    /**
+     * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
+     *
+     * @example DE
+     */
+    public const NET_HOST_CARRIER_ICC = 'net.host.carrier.icc';
+
+    /**
+     * A string identifying the messaging system.
+     *
+     * @example kafka
+     * @example rabbitmq
+     * @example rocketmq
+     * @example activemq
+     * @example AmazonSQS
+     */
+    public const MESSAGING_SYSTEM = 'messaging.system';
+
+    /**
+     * The message destination name. This might be equal to the span name but is required nevertheless.
+     *
+     * @example MyQueue
+     * @example MyTopic
+     */
+    public const MESSAGING_DESTINATION = 'messaging.destination';
+
+    /**
+     * The kind of message destination.
+     */
+    public const MESSAGING_DESTINATION_KIND = 'messaging.destination_kind';
+
+    /**
+     * A boolean that is true if the message destination is temporary.
+     */
+    public const MESSAGING_TEMP_DESTINATION = 'messaging.temp_destination';
+
+    /**
+     * The name of the transport protocol.
+     *
+     * @example AMQP
+     * @example MQTT
+     */
+    public const MESSAGING_PROTOCOL = 'messaging.protocol';
+
+    /**
+     * The version of the transport protocol.
+     *
+     * @example 0.9.1
+     */
+    public const MESSAGING_PROTOCOL_VERSION = 'messaging.protocol_version';
+
+    /**
+     * Connection string.
+     *
+     * @example tibjmsnaming://localhost:7222
+     * @example https://queue.amazonaws.com/80398EXAMPLE/MyQueue
+     */
+    public const MESSAGING_URL = 'messaging.url';
+
+    /**
+     * A value used by the messaging system as an identifier for the message, represented as a string.
+     *
+     * @example 452a7c7c7c7048c2f887f61572b18fc2
+     */
+    public const MESSAGING_MESSAGE_ID = 'messaging.message_id';
+
+    /**
+     * The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called &quot;Correlation ID&quot;.
+     *
+     * @example MyConversationId
+     */
+    public const MESSAGING_CONVERSATION_ID = 'messaging.conversation_id';
+
+    /**
+     * The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
+     *
+     * @example 2738
+     */
+    public const MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES = 'messaging.message_payload_size_bytes';
+
+    /**
+     * The compressed size of the message payload in bytes.
+     *
+     * @example 2048
+     */
+    public const MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES = 'messaging.message_payload_compressed_size_bytes';
+
+    /**
+     * A string containing the function invocation time in the ISO 8601 format expressed in UTC.
+     *
+     * @example 2020-01-23T13:47:06Z
+     */
+    public const FAAS_TIME = 'faas.time';
+
+    /**
+     * A string containing the schedule period as Cron Expression.
+     *
+     * @example 0/5 * * * ? *
+     */
+    public const FAAS_CRON = 'faas.cron';
+
+    /**
+     * A boolean that is true if the serverless function is executed for the first time (aka cold-start).
+     */
+    public const FAAS_COLDSTART = 'faas.coldstart';
+
+    /**
+     * The name of the invoked function.
+     *
+     * SHOULD be equal to the `faas.name` resource attribute of the invoked function.
+     *
+     * @example my-function
+     */
+    public const FAAS_INVOKED_NAME = 'faas.invoked_name';
+
+    /**
+     * The cloud provider of the invoked function.
+     *
+     * SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
+     */
+    public const FAAS_INVOKED_PROVIDER = 'faas.invoked_provider';
+
+    /**
+     * The cloud region of the invoked function.
+     *
+     * SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
+     *
+     * @example eu-central-1
+     */
+    public const FAAS_INVOKED_REGION = 'faas.invoked_region';
+
+    /**
+     * The `service.name` of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
+     *
+     * @example AuthTokenCache
+     */
+    public const PEER_SERVICE = 'peer.service';
+
+    /**
+     * Username or client_id extracted from the access token or Authorization header in the inbound request from outside the system.
+     *
+     * @example username
+     */
+    public const ENDUSER_ID = 'enduser.id';
+
+    /**
+     * Actual/assumed role the client is making the request under extracted from token or application security context.
+     *
+     * @example admin
+     */
+    public const ENDUSER_ROLE = 'enduser.role';
+
+    /**
+     * Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
+     *
+     * @example read:message, write:files
+     */
+    public const ENDUSER_SCOPE = 'enduser.scope';
+
+    /**
+     * Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
+     *
+     * @example 42
+     */
+    public const THREAD_ID = 'thread.id';
+
+    /**
+     * Current thread name.
+     *
+     * @example main
+     */
+    public const THREAD_NAME = 'thread.name';
+
+    /**
+     * The method or function name, or equivalent (usually rightmost part of the code unit's name).
+     *
+     * @example serveRequest
+     */
+    public const CODE_FUNCTION = 'code.function';
+
+    /**
+     * The &quot;namespace&quot; within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit.
+     *
+     * @example com.example.MyHttpService
+     */
+    public const CODE_NAMESPACE = 'code.namespace';
+
+    /**
+     * The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
+     *
+     * @example /usr/local/MyApplication/content_root/app/index.php
+     */
+    public const CODE_FILEPATH = 'code.filepath';
+
+    /**
+     * The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
+     *
+     * @example 42
+     */
+    public const CODE_LINENO = 'code.lineno';
+
+    /**
+     * The value `aws-api`.
+     *
+     * @example aws-api
+     */
+    public const RPC_SYSTEM = 'rpc.system';
+
+    /**
+     * The name of the service to which a request is made, as returned by the AWS SDK.
+     *
+     * This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
+     *
+     * @example DynamoDB
+     * @example S3
+     */
+    public const RPC_SERVICE = 'rpc.service';
+
+    /**
+     * The name of the operation corresponding to the request, as returned by the AWS SDK.
+     *
+     * This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
+     *
+     * @example GetItem
+     * @example PutItem
+     */
+    public const RPC_METHOD = 'rpc.method';
+
+    /**
+     * The keys in the `RequestItems` object field.
+     *
+     * @example Users
+     * @example Cats
+     */
+    public const AWS_DYNAMODB_TABLE_NAMES = 'aws.dynamodb.table_names';
+
+    /**
+     * The JSON-serialized value of each item in the `ConsumedCapacity` response field.
+     *
+     * @example { "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }
+     */
+    public const AWS_DYNAMODB_CONSUMED_CAPACITY = 'aws.dynamodb.consumed_capacity';
+
+    /**
+     * The JSON-serialized value of the `ItemCollectionMetrics` response field.
+     *
+     * @example { "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }
+     */
+    public const AWS_DYNAMODB_ITEM_COLLECTION_METRICS = 'aws.dynamodb.item_collection_metrics';
+
+    /**
+     * The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
+     *
+     * @example 1.0
+     * @example 2.0
+     */
+    public const AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = 'aws.dynamodb.provisioned_read_capacity';
+
+    /**
+     * The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
+     *
+     * @example 1.0
+     * @example 2.0
+     */
+    public const AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = 'aws.dynamodb.provisioned_write_capacity';
+
+    /**
+     * The value of the `ConsistentRead` request parameter.
+     */
+    public const AWS_DYNAMODB_CONSISTENT_READ = 'aws.dynamodb.consistent_read';
+
+    /**
+     * The value of the `ProjectionExpression` request parameter.
+     *
+     * @example Title
+     * @example Title, Price, Color
+     * @example Title, Description, RelatedItems, ProductReviews
+     */
+    public const AWS_DYNAMODB_PROJECTION = 'aws.dynamodb.projection';
+
+    /**
+     * The value of the `Limit` request parameter.
+     *
+     * @example 10
+     */
+    public const AWS_DYNAMODB_LIMIT = 'aws.dynamodb.limit';
+
+    /**
+     * The value of the `AttributesToGet` request parameter.
+     *
+     * @example lives
+     * @example id
+     */
+    public const AWS_DYNAMODB_ATTRIBUTES_TO_GET = 'aws.dynamodb.attributes_to_get';
+
+    /**
+     * The value of the `IndexName` request parameter.
+     *
+     * @example name_to_group
+     */
+    public const AWS_DYNAMODB_INDEX_NAME = 'aws.dynamodb.index_name';
+
+    /**
+     * The value of the `Select` request parameter.
+     *
+     * @example ALL_ATTRIBUTES
+     * @example COUNT
+     */
+    public const AWS_DYNAMODB_SELECT = 'aws.dynamodb.select';
+
+    /**
+     * The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
+     *
+     * @example { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }
+     */
+    public const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = 'aws.dynamodb.global_secondary_indexes';
+
+    /**
+     * The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.
+     *
+     * @example { "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }
+     */
+    public const AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = 'aws.dynamodb.local_secondary_indexes';
+
+    /**
+     * The value of the `ExclusiveStartTableName` request parameter.
+     *
+     * @example Users
+     * @example CatsTable
+     */
+    public const AWS_DYNAMODB_EXCLUSIVE_START_TABLE = 'aws.dynamodb.exclusive_start_table';
+
+    /**
+     * The the number of items in the `TableNames` response parameter.
+     *
+     * @example 20
+     */
+    public const AWS_DYNAMODB_TABLE_COUNT = 'aws.dynamodb.table_count';
+
+    /**
+     * The value of the `ScanIndexForward` request parameter.
+     */
+    public const AWS_DYNAMODB_SCAN_FORWARD = 'aws.dynamodb.scan_forward';
+
+    /**
+     * The value of the `Segment` request parameter.
+     *
+     * @example 10
+     */
+    public const AWS_DYNAMODB_SEGMENT = 'aws.dynamodb.segment';
+
+    /**
+     * The value of the `TotalSegments` request parameter.
+     *
+     * @example 100
+     */
+    public const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
+
+    /**
+     * The value of the `Count` response parameter.
+     *
+     * @example 10
+     */
+    public const AWS_DYNAMODB_COUNT = 'aws.dynamodb.count';
+
+    /**
+     * The value of the `ScannedCount` response parameter.
+     *
+     * @example 50
+     */
+    public const AWS_DYNAMODB_SCANNED_COUNT = 'aws.dynamodb.scanned_count';
+
+    /**
+     * The JSON-serialized value of each item in the `AttributeDefinitions` request field.
+     *
+     * @example { "AttributeName": "string", "AttributeType": "string" }
+     */
+    public const AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS = 'aws.dynamodb.attribute_definitions';
+
+    /**
+     * The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates` request field.
+     *
+     * @example { "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }
+     */
+    public const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = 'aws.dynamodb.global_secondary_index_updates';
+
+    /**
+     * A string identifying the kind of message consumption as defined in the Operation names section above. If the operation is &quot;send&quot;, this attribute MUST NOT be set, since the operation can be inferred from the span kind in that case.
+     */
+    public const MESSAGING_OPERATION = 'messaging.operation';
+
+    /**
+     * The identifier for the consumer receiving a message. For Kafka, set it to `{messaging.kafka.consumer_group} - {messaging.kafka.client_id}`, if both are present, or only `messaging.kafka.consumer_group`. For brokers, such as RabbitMQ and Artemis, set it to the `client_id` of the client consuming the message.
+     *
+     * @example mygroup - client-6
+     */
+    public const MESSAGING_CONSUMER_ID = 'messaging.consumer_id';
+
+    /**
+     * RabbitMQ message routing key.
+     *
+     * @example myKey
+     */
+    public const MESSAGING_RABBITMQ_ROUTING_KEY = 'messaging.rabbitmq.routing_key';
+
+    /**
+     * Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message_id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set.
+     *
+     * If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
+     *
+     * @example myKey
+     */
+    public const MESSAGING_KAFKA_MESSAGE_KEY = 'messaging.kafka.message_key';
+
+    /**
+     * Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
+     *
+     * @example my-group
+     */
+    public const MESSAGING_KAFKA_CONSUMER_GROUP = 'messaging.kafka.consumer_group';
+
+    /**
+     * Client Id for the Consumer or Producer that is handling the message.
+     *
+     * @example client-5
+     */
+    public const MESSAGING_KAFKA_CLIENT_ID = 'messaging.kafka.client_id';
+
+    /**
+     * Partition the message is sent to.
+     *
+     * @example 2
+     */
+    public const MESSAGING_KAFKA_PARTITION = 'messaging.kafka.partition';
+
+    /**
+     * A boolean that is true if the message is a tombstone.
+     */
+    public const MESSAGING_KAFKA_TOMBSTONE = 'messaging.kafka.tombstone';
+
+    /**
+     * Namespace of RocketMQ resources, resources in different namespaces are individual.
+     *
+     * @example myNamespace
+     */
+    public const MESSAGING_ROCKETMQ_NAMESPACE = 'messaging.rocketmq.namespace';
+
+    /**
+     * Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind.
+     *
+     * @example myConsumerGroup
+     */
+    public const MESSAGING_ROCKETMQ_CLIENT_GROUP = 'messaging.rocketmq.client_group';
+
+    /**
+     * The unique identifier for each client.
+     *
+     * @example myhost@8742@s8083jm
+     */
+    public const MESSAGING_ROCKETMQ_CLIENT_ID = 'messaging.rocketmq.client_id';
+
+    /**
+     * Type of message.
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE = 'messaging.rocketmq.message_type';
+
+    /**
+     * The secondary classifier of message besides topic.
+     *
+     * @example tagA
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TAG = 'messaging.rocketmq.message_tag';
+
+    /**
+     * Key(s) of message, another way to mark message besides message id.
+     *
+     * @example keyA
+     * @example keyB
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_KEYS = 'messaging.rocketmq.message_keys';
+
+    /**
+     * Model of message consumption. This only applies to consumer spans.
+     */
+    public const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL = 'messaging.rocketmq.consumption_model';
+
+    /**
+     * The numeric status code of the gRPC request.
+     */
+    public const RPC_GRPC_STATUS_CODE = 'rpc.grpc.status_code';
+
+    /**
+     * Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 does not specify this, the value can be omitted.
+     *
+     * @example 2.0
+     * @example 1.0
+     */
+    public const RPC_JSONRPC_VERSION = 'rpc.jsonrpc.version';
+
+    /**
+     * `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification.
+     *
+     * @example 10
+     * @example request-7
+     */
+    public const RPC_JSONRPC_REQUEST_ID = 'rpc.jsonrpc.request_id';
+
+    /**
+     * `error.code` property of response if it is an error response.
+     *
+     * @example -32700
+     * @example 100
+     */
+    public const RPC_JSONRPC_ERROR_CODE = 'rpc.jsonrpc.error_code';
+
+    /**
+     * `error.message` property of response if it is an error response.
+     *
+     * @example Parse error
+     * @example User already exists
+     */
+    public const RPC_JSONRPC_ERROR_MESSAGE = 'rpc.jsonrpc.error_message';
+
+    /**
+     * Whether this is a received or sent message.
+     */
+    public const MESSAGE_TYPE = 'message.type';
+
+    /**
+     * MUST be calculated as two different counters starting from `1` one for sent messages and one for received message.
+     *
+     * This way we guarantee that the values will be consistent between different implementations.
+     */
+    public const MESSAGE_ID = 'message.id';
+
+    /**
+     * Compressed size of the message in bytes.
+     */
+    public const MESSAGE_COMPRESSED_SIZE = 'message.compressed_size';
+
+    /**
+     * Uncompressed size of the message in bytes.
+     */
+    public const MESSAGE_UNCOMPRESSED_SIZE = 'message.uncompressed_size';
+}

--- a/src/SemConv/TraceAttributes.php
+++ b/src/SemConv/TraceAttributes.php
@@ -9,6 +9,11 @@ namespace OpenTelemetry\SemConv;
 class TraceAttributes
 {
     /**
+     * The URL of the OpenTelemetry schema for these keys and values.
+     */
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.8.0';
+
+    /**
      * The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
      *
      * This may be different from `faas.id` if an alias is involved.

--- a/tests/SDK/Unit/Resource/ResourceTest.php
+++ b/tests/SDK/Unit/Resource/ResourceTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\SDK\Unit\Resource;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
-use OpenTelemetry\SDK\Resource\ResourceConstants;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\Attribute;
 use OpenTelemetry\SDK\Trace\Attributes;
+use OpenTelemetry\SemConv\ResourceAttributes;
 use PHPUnit\Framework\TestCase;
 
 class ResourceTest extends TestCase
@@ -35,16 +35,16 @@ class ResourceTest extends TestCase
         /** @var Attribute $name */
         $name = $resource->getAttributes()->getAttribute('name');
         /** @var Attribute $sdkname */
-        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceAttributes::TELEMETRY_SDK_NAME);
         /** @var Attribute $sdklanguage */
-        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceAttributes::TELEMETRY_SDK_LANGUAGE);
         /** @var Attribute $sdkversion */
-        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceAttributes::TELEMETRY_SDK_VERSION);
 
-        $attributes->setAttribute(ResourceConstants::TELEMETRY_SDK_NAME, 'opentelemetry');
-        $attributes->setAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE, 'php');
-        $attributes->setAttribute(ResourceConstants::TELEMETRY_SDK_VERSION, 'dev');
-        $attributes->setAttribute(ResourceConstants::SERVICE_NAME, 'unknown_service');
+        $attributes->setAttribute(ResourceAttributes::TELEMETRY_SDK_NAME, 'opentelemetry');
+        $attributes->setAttribute(ResourceAttributes::TELEMETRY_SDK_LANGUAGE, 'php');
+        $attributes->setAttribute(ResourceAttributes::TELEMETRY_SDK_VERSION, 'dev');
+        $attributes->setAttribute(ResourceAttributes::SERVICE_NAME, 'unknown_service');
 
         $this->assertEquals($attributes, $resource->getAttributes());
         $this->assertSame('opentelemetry', $sdkname->getValue());
@@ -60,19 +60,19 @@ class ResourceTest extends TestCase
     {
         $attributes = new Attributes(
             [
-                ResourceConstants::TELEMETRY_SDK_NAME => 'opentelemetry',
-                ResourceConstants::TELEMETRY_SDK_LANGUAGE => 'php',
-                ResourceConstants::TELEMETRY_SDK_VERSION => 'dev',
-                ResourceConstants::SERVICE_NAME => 'unknown_service',
+                ResourceAttributes::TELEMETRY_SDK_NAME => 'opentelemetry',
+                ResourceAttributes::TELEMETRY_SDK_LANGUAGE => 'php',
+                ResourceAttributes::TELEMETRY_SDK_VERSION => 'dev',
+                ResourceAttributes::SERVICE_NAME => 'unknown_service',
             ]
         );
         $resource = ResourceInfo::create(new Attributes());
         /** @var Attribute $sdkname */
-        $sdkname = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_NAME);
+        $sdkname = $resource->getAttributes()->getAttribute(ResourceAttributes::TELEMETRY_SDK_NAME);
         /** @var Attribute $sdklanguage */
-        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_LANGUAGE);
+        $sdklanguage = $resource->getAttributes()->getAttribute(ResourceAttributes::TELEMETRY_SDK_LANGUAGE);
         /** @var Attribute $sdkversion */
-        $sdkversion = $resource->getAttributes()->getAttribute(ResourceConstants::TELEMETRY_SDK_VERSION);
+        $sdkversion = $resource->getAttributes()->getAttribute(ResourceAttributes::TELEMETRY_SDK_VERSION);
 
         $this->assertEquals($attributes, $resource->getAttributes());
         $this->assertEquals('opentelemetry', $sdkname->getValue());


### PR DESCRIPTION
This PR adds semantic conventions for Resource and Trace attributes.

Fixes #376.

As spec [says](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#semantic-conventions), semconv is a candidate for the separated package. So generated classes are in their own namespace `\OpenTelemetry\SemConv`.

There is a script to generate PHP classes from yaml semantic conventions files, (usage `SEMCONV_VERSION=1.8.0 make semconv`).

Deprected class `\OpenTelemetry\SDK\Resource\ResourceConstants`.