### PR TITLE
Add typed properties

### DIFF
--- a/src/API/Baggage/Baggage.php
+++ b/src/API/Baggage/Baggage.php
@@ -44,7 +44,7 @@ final class Baggage implements BaggageInterface
     }
 
     /** @var array<string, Entry> */
-    private $entries;
+    private array $entries;
 
     /** @param array<string, Entry> $entries */
     public function __construct(array $entries = [])

--- a/src/API/Baggage/BaggageBuilder.php
+++ b/src/API/Baggage/BaggageBuilder.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\API\Baggage;
 final class BaggageBuilder implements BaggageBuilderInterface
 {
     /** @var array<string, Entry> */
-    private $entries;
+    private array $entries;
 
     /** @param array<string, Entry> $entries */
     public function __construct(array $entries = [])

--- a/src/API/Baggage/Entry.php
+++ b/src/API/Baggage/Entry.php
@@ -9,8 +9,7 @@ final class Entry
     /** @var mixed */
     private $value;
 
-    /** @var MetadataInterface */
-    private $metadata;
+    private MetadataInterface $metadata;
 
     /**
      * @param mixed $value

--- a/src/API/Trace/AttributesInterface.php
+++ b/src/API/Trace/AttributesInterface.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Trace;
 
-interface AttributesInterface extends \IteratorAggregate, \Countable
+use Countable;
+use IteratorAggregate;
+
+interface AttributesInterface extends IteratorAggregate, Countable
 {
     public function setAttribute(string $name, $value): AttributesInterface;
     public function getAttribute(string $name): ?AttributeInterface;

--- a/src/API/Trace/AttributesIteratorInterface.php
+++ b/src/API/Trace/AttributesIteratorInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Trace;
 
-interface AttributesIteratorInterface extends \Iterator
+use Iterator;
+
+interface AttributesIteratorInterface extends Iterator
 {
     public function key(): string;
     public function current(): AttributeInterface;

--- a/src/API/Trace/SpanContextKey.php
+++ b/src/API/Trace/SpanContextKey.php
@@ -14,8 +14,7 @@ final class SpanContextKey extends ContextKey
 {
     private const KEY_NAME = 'opentelemetry-trace-span-key';
 
-    /** @var ContextKey */
-    private static $instance;
+    private static ?ContextKey $instance = null;
 
     public static function instance(): ContextKey
     {

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -11,8 +11,7 @@ final class Context
 {
     private static ?ContextStorageInterface $storage = null;
 
-    /** @var self|null */
-    private static $root;
+    private static ?\OpenTelemetry\Context\Context $root = null;
 
     /**
      * @internal
@@ -126,18 +125,14 @@ final class Context
         return new self($key, $value, $parent);
     }
 
-    /**
-     * @var ContextKey|null
-     */
-    protected $key;
+    protected ?ContextKey $key;
 
     /**
      * @var mixed|null
      */
     protected $value;
 
-    /** @var self|null */
-    protected $parent;
+    protected ?\OpenTelemetry\Context\Context $parent;
 
     /**
      * This is a general purpose read-only key-value store. Read-only in the sense that adding a new value does not

--- a/src/Context/ContextKey.php
+++ b/src/Context/ContextKey.php
@@ -6,10 +6,7 @@ namespace OpenTelemetry\Context;
 
 class ContextKey
 {
-    /**
-     * @var string|null
-     */
-    private $name;
+    private ?string $name;
 
     public function __construct(?string $name=null)
     {

--- a/src/Context/fiber/zend_observer_fiber.php
+++ b/src/Context/fiber/zend_observer_fiber.php
@@ -13,6 +13,7 @@ namespace OpenTelemetry\Context;
 
 use function define;
 use FFI;
+use FFI\Exception;
 
 if (PHP_VERSION_ID < 80100 || !class_exists(FFI::class)) {
     return false;
@@ -22,10 +23,10 @@ if (PHP_VERSION_ID < 80100 || !class_exists(FFI::class)) {
 return (function (): bool {
     try {
         $fibers = FFI::scope('OTEL_ZEND_OBSERVER_FIBER');
-    } catch (FFI\Exception $e) {
+    } catch (Exception $e) {
         try {
             $fibers = FFI::load(__DIR__ . '/zend_observer_fiber.h');
-        } catch (FFI\Exception $e) {
+        } catch (Exception $e) {
             return false;
         }
 

--- a/src/Contrib/Newrelic/Exporter.php
+++ b/src/Contrib/Newrelic/Exporter.php
@@ -11,6 +11,7 @@ use JsonException;
 use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Behavior\HttpSpanExporterTrait;
 use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -24,7 +25,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * It will send PHP Otel trace data end to end across the internet to a functional backend.
  * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
  */
-class Exporter implements Trace\SpanExporterInterface
+class Exporter implements SpanExporterInterface
 {
     use UsesSpanConverterTrait;
     use HttpSpanExporterTrait;

--- a/src/Contrib/Newrelic/Exporter.php
+++ b/src/Contrib/Newrelic/Exporter.php
@@ -8,7 +8,6 @@ use Exception;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
 use JsonException;
-use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Behavior\HttpSpanExporterTrait;
 use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;

--- a/src/Contrib/Newrelic/SpanConverter.php
+++ b/src/Contrib/Newrelic/SpanConverter.php
@@ -16,10 +16,7 @@ class SpanConverter implements SpanConverterInterface
     const STATUS_CODE_TAG_KEY = 'otel.status_code';
     const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
 
-    /**
-     * @var string
-     */
-    private $serviceName;
+    private string $serviceName;
 
     public function __construct(string $serviceName)
     {

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\OtlpGrpc;
 
 use grpc;
+use Grpc\ChannelCredentials;
 use InvalidArgumentException;
 use Opentelemetry\Proto\Collector\Trace\V1\ExportTraceServiceRequest;
 use Opentelemetry\Proto\Collector\Trace\V1\TraceServiceClient;
 use OpenTelemetry\SDK\EnvironmentVariablesTrait;
-use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Behavior\SpanExporterTrait;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
-class Exporter implements Trace\SpanExporterInterface
+class Exporter implements SpanExporterInterface
 {
     use EnvironmentVariablesTrait;
     use SpanExporterTrait;
@@ -158,7 +159,7 @@ class Exporter implements Trace\SpanExporterInterface
         return $metadata;
     }
 
-    private function getCredentials(): ?\Grpc\ChannelCredentials
+    private function getCredentials(): ?ChannelCredentials
     {
         if (!$this->insecure) {
             return $this->certificateFile !== ''

--- a/src/Contrib/OtlpGrpc/SpanConverter.php
+++ b/src/Contrib/OtlpGrpc/SpanConverter.php
@@ -7,11 +7,11 @@ namespace OpenTelemetry\Contrib\OtlpGrpc;
 use function array_key_exists;
 use function hex2bin;
 use OpenTelemetry\API\Trace as API;
-use Opentelemetry\Proto;
 use Opentelemetry\Proto\Common\V1\AnyValue;
 use Opentelemetry\Proto\Common\V1\ArrayValue;
 use Opentelemetry\Proto\Common\V1\InstrumentationLibrary;
 use Opentelemetry\Proto\Common\V1\KeyValue;
+use Opentelemetry\Proto\Resource\V1\Resource;
 use Opentelemetry\Proto\Trace\V1\InstrumentationLibrarySpans;
 use Opentelemetry\Proto\Trace\V1\ResourceSpans;
 use Opentelemetry\Proto\Trace\V1\Span as CollectorSpan;
@@ -196,7 +196,7 @@ class SpanConverter
         }
 
         if ($isSpansEmpty == true) {
-            return new Proto\Trace\V1\ResourceSpans();
+            return new ResourceSpans();
         }
 
         $ilSpans = [];
@@ -207,8 +207,8 @@ class SpanConverter
             ]);
         }
 
-        return new Proto\Trace\V1\ResourceSpans([
-            'resource' => new Proto\Resource\V1\Resource([
+        return new ResourceSpans([
+            'resource' => new Resource([
                 'attributes' => $this->as_otlp_resource_attributes($spans),
             ]),
             'instrumentation_library_spans' => $ilSpans,

--- a/src/Contrib/OtlpHttp/Exporter.php
+++ b/src/Contrib/OtlpHttp/Exporter.php
@@ -10,15 +10,15 @@ use InvalidArgumentException;
 use Nyholm\Dsn\DsnParser;
 use Opentelemetry\Proto\Collector\Trace\V1\ExportTraceServiceRequest;
 use OpenTelemetry\SDK\EnvironmentVariablesTrait;
-use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Behavior\HttpSpanExporterTrait;
 use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
-class Exporter implements Trace\SpanExporterInterface
+class Exporter implements SpanExporterInterface
 {
     use EnvironmentVariablesTrait;
     use UsesSpanConverterTrait;

--- a/src/Contrib/OtlpHttp/SpanConverter.php
+++ b/src/Contrib/OtlpHttp/SpanConverter.php
@@ -7,11 +7,11 @@ namespace OpenTelemetry\Contrib\OtlpHttp;
 use function array_key_exists;
 use function hex2bin;
 use OpenTelemetry\API\Trace as API;
-use Opentelemetry\Proto;
 use Opentelemetry\Proto\Common\V1\AnyValue;
 use Opentelemetry\Proto\Common\V1\ArrayValue;
 use Opentelemetry\Proto\Common\V1\InstrumentationLibrary;
 use Opentelemetry\Proto\Common\V1\KeyValue;
+use Opentelemetry\Proto\Resource\V1\Resource;
 use Opentelemetry\Proto\Trace\V1\InstrumentationLibrarySpans;
 use Opentelemetry\Proto\Trace\V1\ResourceSpans;
 use Opentelemetry\Proto\Trace\V1\Span as CollectorSpan;
@@ -194,7 +194,7 @@ class SpanConverter
         }
 
         if ($isSpansEmpty == true) {
-            return new Proto\Trace\V1\ResourceSpans();
+            return new ResourceSpans();
         }
 
         $ilSpans = [];
@@ -205,8 +205,8 @@ class SpanConverter
             ]);
         }
 
-        return new Proto\Trace\V1\ResourceSpans([
-            'resource' => new Proto\Resource\V1\Resource([
+        return new ResourceSpans([
+            'resource' => new Resource([
                 'attributes' => $this->as_otlp_resource_attributes($spans),
             ]),
             'instrumentation_library_spans' => $ilSpans,

--- a/src/Contrib/Zipkin/Exporter.php
+++ b/src/Contrib/Zipkin/Exporter.php
@@ -7,9 +7,9 @@ namespace OpenTelemetry\Contrib\Zipkin;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
 use JsonException;
-use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Behavior\HttpSpanExporterTrait;
 use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -19,7 +19,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * Class ZipkinExporter - implements the export interface for data transfer via Zipkin protocol
  * @package OpenTelemetry\Exporter
  */
-class Exporter implements Trace\SpanExporterInterface
+class Exporter implements SpanExporterInterface
 {
     use UsesSpanConverterTrait;
     use HttpSpanExporterTrait;

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -33,10 +33,7 @@ class SpanConverter implements SpanConverterInterface
 
     const NET_PEER_IP_KEY = 'net.peer.ip';
 
-    /**
-     * @var string
-     */
-    private $serviceName;
+    private string $serviceName;
 
     public function __construct(string $serviceName)
     {

--- a/src/Contrib/ZipkinToNewrelic/Exporter.php
+++ b/src/Contrib/ZipkinToNewrelic/Exporter.php
@@ -11,6 +11,7 @@ use JsonException;
 use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Behavior\HttpSpanExporterTrait;
 use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -24,7 +25,7 @@ use Psr\Http\Message\StreamFactoryInterface;
  * It will send PHP Otel trace data end to end across the internet to a functional backend.
  * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
  */
-class Exporter implements Trace\SpanExporterInterface
+class Exporter implements SpanExporterInterface
 {
     use UsesSpanConverterTrait;
     use HttpSpanExporterTrait;

--- a/src/Contrib/ZipkinToNewrelic/Exporter.php
+++ b/src/Contrib/ZipkinToNewrelic/Exporter.php
@@ -8,7 +8,6 @@ use Exception;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
 use JsonException;
-use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Behavior\HttpSpanExporterTrait;
 use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;

--- a/src/Contrib/ZipkinToNewrelic/SpanConverter.php
+++ b/src/Contrib/ZipkinToNewrelic/SpanConverter.php
@@ -13,10 +13,7 @@ class SpanConverter implements SpanConverterInterface
 {
     const STATUS_CODE_TAG_KEY = 'otel.status_code';
     const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
-    /**
-     * @var string
-     */
-    private $serviceName;
+    private string $serviceName;
 
     public function __construct(string $serviceName)
     {

--- a/src/SDK/EnvironmentVariablesTrait.php
+++ b/src/SDK/EnvironmentVariablesTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK;
 
+use InvalidArgumentException;
+
 /**
  * Centralized methods for retrieving environment variables
  */
@@ -19,7 +21,7 @@ trait EnvironmentVariablesTrait
             return $default;
         }
         if (false === \filter_var($value, FILTER_VALIDATE_INT)) {
-            throw new \InvalidArgumentException($key . ' contains non-numeric value');
+            throw new InvalidArgumentException($key . ' contains non-numeric value');
         }
 
         return (int) $value;
@@ -49,7 +51,7 @@ trait EnvironmentVariablesTrait
             case '0':
                 return false;
             default:
-                throw new \InvalidArgumentException($key . ' contains a non-boolean value');
+                throw new InvalidArgumentException($key . ' contains a non-boolean value');
         }
     }
 }

--- a/src/SDK/Metrics/AbstractMetric.php
+++ b/src/SDK/Metrics/AbstractMetric.php
@@ -8,15 +8,9 @@ use OpenTelemetry\API\Metrics as API;
 
 abstract class AbstractMetric implements API\MetricInterface
 {
-    /**
-     * @var string $name
-     */
-    protected $name;
+    protected string $name;
 
-    /**
-     * @var string $description
-     */
-    protected $description;
+    protected string $description;
 
     public function __construct(string $name, string $description = '')
     {

--- a/src/SDK/Metrics/Counter.php
+++ b/src/SDK/Metrics/Counter.php
@@ -11,10 +11,7 @@ class Counter extends AbstractMetric implements API\CounterInterface, API\Labela
 {
     use HasLabelsTrait;
 
-    /**
-     * @var int $value
-     */
-    protected $value = 0;
+    protected int $value = 0;
 
     /**
      * Get $type

--- a/src/SDK/Metrics/Exporters/AbstractExporter.php
+++ b/src/SDK/Metrics/Exporters/AbstractExporter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Metrics\Exporters;
 
 use Exception;
+use InvalidArgumentException;
 use OpenTelemetry\API\Metrics as API;
 use OpenTelemetry\SDK\Metrics\Exceptions\RetryableExportException;
 
@@ -22,7 +23,7 @@ abstract class AbstractExporter implements API\ExporterInterface
         try {
             foreach ($metrics as $metric) {
                 if (! $metric instanceof API\MetricInterface) {
-                    throw new \InvalidArgumentException('Metric must implement ' . API\MetricInterface::class);
+                    throw new InvalidArgumentException('Metric must implement ' . API\MetricInterface::class);
                 }
             }
 

--- a/src/SDK/Metrics/Exporters/PrometheusExporter.php
+++ b/src/SDK/Metrics/Exporters/PrometheusExporter.php
@@ -11,15 +11,9 @@ use Prometheus\CollectorRegistry;
 
 class PrometheusExporter extends AbstractExporter
 {
-    /**
-     * @var CollectorRegistry $registry
-     */
-    protected $registry;
+    protected CollectorRegistry $registry;
 
-    /**
-     * @var string $namespace
-     */
-    protected $namespace;
+    protected string $namespace;
 
     public function __construct(CollectorRegistry $registry, string $namespace = '')
     {

--- a/src/SDK/Metrics/HasLabelsTrait.php
+++ b/src/SDK/Metrics/HasLabelsTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Metrics;
 
+use InvalidArgumentException;
+
 trait HasLabelsTrait
 {
     /**
@@ -26,7 +28,7 @@ trait HasLabelsTrait
     {
         foreach ($labels as $label) {
             if (! is_string($label)) {
-                throw new \InvalidArgumentException('The label is expected to be a string');
+                throw new InvalidArgumentException('The label is expected to be a string');
             }
         }
 

--- a/src/SDK/Metrics/Meter.php
+++ b/src/SDK/Metrics/Meter.php
@@ -8,12 +8,8 @@ use OpenTelemetry\API\Metrics as API;
 
 class Meter implements API\MeterInterface
 {
-    /**
-     * @var string $name
-     * @var string $version
-     */
-    protected $name;
-    protected $version;
+    protected string $name;
+    protected string $version;
 
     public function __construct(string $name, string $version = null)
     {

--- a/src/SDK/Metrics/Providers/MeterProvider.php
+++ b/src/SDK/Metrics/Providers/MeterProvider.php
@@ -9,10 +9,7 @@ use OpenTelemetry\SDK\Metrics\Meter;
 
 class MeterProvider implements API\MeterProviderInterface
 {
-    /**
-     * @var array $meters
-     */
-    protected $meters = [];
+    protected array $meters = [];
 
     /**
      * {@inheritDoc}

--- a/src/SDK/Metrics/UpDownCounter.php
+++ b/src/SDK/Metrics/UpDownCounter.php
@@ -24,10 +24,7 @@ class UpDownCounter extends AbstractMetric implements API\UpDownCounterInterface
 {
     use HasLabelsTrait;
 
-    /**
-     * @var int $value
-     */
-    protected $value = 0;
+    protected int $value = 0;
 
     /**
      * getType

--- a/src/SDK/Metrics/ValueRecorder.php
+++ b/src/SDK/Metrics/ValueRecorder.php
@@ -43,27 +43,18 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
      */
     protected $valueSum = 0;
 
-    /**
-     * @var float $valueMin
-     */
-    protected $valueMin = INF;
+    protected float $valueMin = INF;
 
-    /**
-     * @var float $valueMax
-     */
-    protected $valueMax = -INF;
+    protected float $valueMax = -INF;
 
-    /**
-     * @var int $valueCount
-     */
-    protected $valueCount = 0;
+    protected int $valueCount = 0;
 
     /*
      * Testing floating point values for equality is problematic, due to
      * the way that they are represented internally.  Therefore, force all
      * precision to a predetermined number, and equality can be determined.
      */
-    private $decimalPointPrecision = 10;
+    private int $decimalPointPrecision = 10;
 
     /**
      * getType: get the type of metric instrument

--- a/src/SDK/Trace/Attribute.php
+++ b/src/SDK/Trace/Attribute.php
@@ -8,7 +8,7 @@ use OpenTelemetry\API\Trace as API;
 
 class Attribute implements API\AttributeInterface
 {
-    private $key;
+    private string $key;
     private $value;
 
     public function __construct(string $key, $value)

--- a/src/SDK/Trace/AttributeLimits.php
+++ b/src/SDK/Trace/AttributeLimits.php
@@ -10,9 +10,9 @@ class AttributeLimits
 
     private const DEFAULT_VALUE_LENGTH_LIMIT = PHP_INT_MAX;
 
-    private $attributeCountLimit;
+    private int $attributeCountLimit;
 
-    private $attributeValueLengthLimit;
+    private int $attributeValueLengthLimit;
 
     public function __construct(
         int $attributeCountLimit = self::DEFAULT_COUNT_LIMIT,

--- a/src/SDK/Trace/Attributes.php
+++ b/src/SDK/Trace/Attributes.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
+use ArrayIterator;
 use OpenTelemetry\API\Trace as API;
 
 class Attributes implements API\AttributesInterface
 {
-    private $attributes = [];
+    private array $attributes = [];
 
-    /** @var AttributeLimits */
-    private $attributeLimits;
+    private AttributeLimits $attributeLimits;
 
-    private $totalAddedAttributes = 0;
+    private int $totalAddedAttributes = 0;
 
     /** @return Attributes Returns a new instance of Attributes with the limits applied */
     public static function withLimits(API\AttributesInterface $attributes, AttributeLimits $attributeLimits): Attributes
@@ -91,10 +91,10 @@ class Attributes implements API\AttributesInterface
     public function getIterator(): API\AttributesIteratorInterface
     {
         return new class($this->attributes) implements API\AttributesIteratorInterface {
-            private $inner;
+            private ArrayIterator $inner;
             public function __construct($attributes)
             {
-                $this->inner = new \ArrayIterator($attributes);
+                $this->inner = new ArrayIterator($attributes);
             }
 
             public function key(): string

--- a/src/SDK/Trace/ExporterFactory.php
+++ b/src/SDK/Trace/ExporterFactory.php
@@ -19,8 +19,8 @@ class ExporterFactory
 {
     use EnvironmentVariablesTrait;
 
-    private $name;
-    private $allowedExporters = ['jaeger' => true, 'zipkin' => true, 'newrelic' => true, 'otlp' => true, 'otlpgrpc' => true, 'otlphttp' => true ,'zipkintonewrelic' => true, 'console' => true];
+    private string $name;
+    private array $allowedExporters = ['jaeger' => true, 'zipkin' => true, 'newrelic' => true, 'otlp' => true, 'otlpgrpc' => true, 'otlphttp' => true ,'zipkintonewrelic' => true, 'console' => true];
 
     public function __construct(string $name)
     {

--- a/src/SDK/Trace/RandomIdGenerator.php
+++ b/src/SDK/Trace/RandomIdGenerator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
+use Throwable;
+
 class RandomIdGenerator implements IdGeneratorInterface
 {
     private const TRACE_ID_HEX_LENGTH = 32;
@@ -23,7 +25,7 @@ class RandomIdGenerator implements IdGeneratorInterface
     {
         try {
             return bin2hex(random_bytes(intdiv($hexLength, 2)));
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             return $this->fallbackAlgorithm($hexLength);
         }
     }

--- a/src/SDK/Trace/Sampler/ParentBased.php
+++ b/src/SDK/Trace/Sampler/ParentBased.php
@@ -29,31 +29,15 @@ use OpenTelemetry\SDK\Trace\Span;
  */
 class ParentBased implements SamplerInterface
 {
+    private SamplerInterface $root;
 
-    /**
-     * @var SamplerInterface
-     */
-    private $root;
+    private SamplerInterface $remoteParentSampled;
 
-    /**
-     * @var SamplerInterface
-     */
-    private $remoteParentSampled;
+    private SamplerInterface $remoteParentNotSampled;
 
-    /**
-     * @var SamplerInterface
-     */
-    private $remoteParentNotSampled;
+    private SamplerInterface $localParentSampled;
 
-    /**
-     * @var SamplerInterface
-     */
-    private $localParentSampled;
-
-    /**
-     * @var SamplerInterface
-     */
-    private $localParentNotSampled;
+    private SamplerInterface $localParentNotSampled;
 
     /**
      * ParentBased sampler delegates the sampling decision based on the parent context.

--- a/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -21,10 +21,7 @@ use OpenTelemetry\SDK\Trace\Span;
  */
 class TraceIdRatioBasedSampler implements SamplerInterface
 {
-    /**
-     * @var float
-     */
-    private $probability;
+    private float $probability;
 
     /**
      * TraceIdRatioBasedSampler constructor.

--- a/src/SDK/Trace/SamplerFactory.php
+++ b/src/SDK/Trace/SamplerFactory.php
@@ -6,6 +6,10 @@ namespace OpenTelemetry\SDK\Trace;
 
 use InvalidArgumentException;
 use OpenTelemetry\SDK\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
+use OpenTelemetry\SDK\Trace\Sampler\TraceIdRatioBasedSampler;
 
 class SamplerFactory
 {
@@ -28,17 +32,17 @@ class SamplerFactory
         }
         switch ($name) {
             case 'always_on':
-                return new Sampler\AlwaysOnSampler();
+                return new AlwaysOnSampler();
             case 'always_off':
-                return new Sampler\AlwaysOffSampler();
+                return new AlwaysOffSampler();
             case 'traceidratio':
-                return new Sampler\TraceIdRatioBasedSampler((float) $arg);
+                return new TraceIdRatioBasedSampler((float) $arg);
             case 'parentbased_always_on':
-                return new Sampler\ParentBased(new Sampler\AlwaysOnSampler());
+                return new ParentBased(new AlwaysOnSampler());
             case 'parentbased_always_off':
-                return new Sampler\ParentBased(new Sampler\AlwaysOffSampler());
+                return new ParentBased(new AlwaysOffSampler());
             case 'parentbased_traceidratio':
-                return new Sampler\ParentBased(new Sampler\TraceIdRatioBasedSampler((float) $arg));
+                return new ParentBased(new TraceIdRatioBasedSampler((float) $arg));
             default:
                 throw new InvalidArgumentException('Unknown sampler: ' . $name);
         }

--- a/src/SDK/Trace/SamplingResult.php
+++ b/src/SDK/Trace/SamplingResult.php
@@ -26,17 +26,17 @@ final class SamplingResult
     /**
      * @var int A sampling Decision.
      */
-    private $decision;
+    private int $decision;
 
     /**
      * @var ?API\AttributesInterface A set of span Attributes that will also be added to the Span.
      */
-    private $attributes;
+    private ?API\AttributesInterface $attributes;
 
     /**
      * @var ?API\TraceStateInterface A Tracestate that will be associated with the Span through the new SpanContext.
      */
-    private $traceState;
+    private ?API\TraceStateInterface $traceState;
 
     public function __construct(int $decision, ?API\AttributesInterface $attributes = null, ?API\TraceStateInterface $traceState = null)
     {

--- a/src/SDK/Trace/SpanLimits.php
+++ b/src/SDK/Trace/SpanLimits.php
@@ -13,16 +13,15 @@ final class SpanLimits
     public const DEFAULT_EVENT_ATTRIBUTE_COUNT_LIMIT = 128;
     public const DEFAULT_LINK_ATTRIBUTE_COUNT_LIMIT = 128;
 
-    /** @var AttributeLimits */
-    private $attributeLimits;
+    private AttributeLimits $attributeLimits;
 
-    private $eventCountLimit;
+    private int $eventCountLimit;
 
-    private $linkCountLimit;
+    private int $linkCountLimit;
 
-    private $attributePerEventCountLimit;
+    private int $attributePerEventCountLimit;
 
-    private $attributePerLinkCountLimit;
+    private int $attributePerLinkCountLimit;
 
     public function getAttributeLimits(): AttributeLimits
     {

--- a/src/SDK/Trace/SpanLimitsBuilder.php
+++ b/src/SDK/Trace/SpanLimitsBuilder.php
@@ -11,22 +11,22 @@ class SpanLimitsBuilder
     use EnvironmentVariablesTrait;
 
     /** @var int Maximum allowed attribute count per record */
-    private $attributeCountLimit;
+    private ?int $attributeCountLimit = null;
 
     /** @var int Maximum allowed attribute value length */
-    private $attributeValueLengthLimit;
+    private ?int $attributeValueLengthLimit = null;
 
     /** @var int Maximum allowed span event count */
-    private $eventCountLimit;
+    private ?int $eventCountLimit = null;
 
     /** @var int Maximum allowed span link count */
-    private $linkCountLimit;
+    private ?int $linkCountLimit = null;
 
     /** @var int Maximum allowed attribute per span event count */
-    private $attributePerEventCountLimit;
+    private ?int $attributePerEventCountLimit = null;
 
     /** @var int Maximum allowed attribute per span link count */
-    private $attributePerLinkCountLimit;
+    private ?int $attributePerLinkCountLimit = null;
 
     /**
      * @param int $attributeCountLimit Maximum allowed attribute count per record

--- a/src/SDK/Trace/TraceState.php
+++ b/src/SDK/Trace/TraceState.php
@@ -25,7 +25,7 @@ class TraceState implements API\TraceStateInterface
     /**
      * @var string[]
      */
-    private $traceState = [];
+    private array $traceState = [];
 
     public function __construct(string $rawTracestate = null)
     {

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -19,7 +19,7 @@ final class TracerProvider implements API\TracerProviderInterface
     private static ?API\TracerInterface $defaultTracer = null;
 
     /** @var array<string, API\TracerInterface> */
-    private $tracers;
+    private ?array $tracers = null;
 
     /** @readonly */
     private TracerSharedState $tracerSharedState;


### PR DESCRIPTION
This PR makes all class properties type safe by adding the appropriate type declarations.
It also resolves inline class imports to proper namespace imports.

As discussed this PR uses [rector](https://github.com/rectorphp/rector), however rector and its config
will be added in a later PR. I had to make a few small manual adjustments (because gRPC), which have to 
be turned into code first, so refactoring can run automatically.