### PR TITLE
adding new maintainers to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @bobstrecansky @beniamin @zsistla
+* @bobstrecansky @zsistla @tidal @brettmc


### PR DESCRIPTION
As discussed at SIG meeting, adding two new code owners who have recently been approved as maintainers (brettmc, tidal), and removing one code owner who has not been heard from in some time (beniamin)