### PR TITLE
Add metric aggregation implementation

### DIFF
--- a/docker/prometheus/Dockerfile
+++ b/docker/prometheus/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-alpine
+FROM php:8.1-fpm-alpine
 
 RUN apk update && apk add --no-cache \
     $PHPIZE_DEPS

--- a/src/API/Metrics/Observer.php
+++ b/src/API/Metrics/Observer.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Metrics;
+
+interface Observer {
+
+    public function observe(float|int $amount, iterable $attributes = []): void;
+}

--- a/src/SDK/Metrics/Aggregation.php
+++ b/src/SDK/Metrics/Aggregation.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+use OpenTelemetry\SDK\Metrics\Data\Data;
+use OpenTelemetry\SDK\Metrics\Data\Exemplar;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+
+/**
+ * @template T
+ */
+interface Aggregation {
+
+    /**
+     * @return T
+     */
+    public function initialize(): mixed;
+
+    /**
+     * @param T $summary
+     */
+    public function record(mixed $summary, float|int $value, Attributes $attributes, Context $context, int $timestamp): void;
+
+    /**
+     * @param T $left
+     * @param T $right
+     * @return T
+     */
+    public function merge(mixed $left, mixed $right): mixed;
+
+    /**
+     * @param T $left
+     * @param T $right
+     * @return T
+     */
+    public function diff(mixed $left, mixed $right): mixed;
+
+    /**
+     * @param array<Attributes> $attributes
+     * @param array<T> $summaries
+     * @param array<list<Exemplar>> $exemplars
+     */
+    public function toData(
+        array $attributes,
+        array $summaries,
+        array $exemplars,
+        ?int $startTimestamp,
+        int $timestamp,
+        Temporality $temporality,
+    ): Data;
+}

--- a/src/SDK/Metrics/Aggregation/ExplicitBucketHistogram.php
+++ b/src/SDK/Metrics/Aggregation/ExplicitBucketHistogram.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Aggregation;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+use OpenTelemetry\SDK\Metrics\Aggregation;
+use OpenTelemetry\SDK\Metrics\Data;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+use function array_fill;
+use function count;
+
+/**
+ * @implements Aggregation<ExplicitBucketHistogramSummary>
+ */
+final class ExplicitBucketHistogram implements Aggregation {
+
+    public readonly array $boundaries;
+
+    public function __construct(array $boundaries) {
+        $this->boundaries = $boundaries;
+    }
+
+    public function initialize(): ExplicitBucketHistogramSummary {
+        return new ExplicitBucketHistogramSummary(
+            0,
+            0,
+            array_fill(0, count($this->boundaries) + 1, 0),
+        );
+    }
+
+    /**
+     * @param ExplicitBucketHistogramSummary $summary
+     */
+    public function record(mixed $summary, float|int $value, Attributes $attributes, Context $context, int $timestamp): void {
+        for ($i = 0; $i < count($this->boundaries) && $this->boundaries[$i] < $value; $i++) {}
+        $summary->count++;
+        $summary->sum += $value;
+        $summary->buckets[$i]++;
+    }
+
+    /**
+     * @param ExplicitBucketHistogramSummary $left
+     * @param ExplicitBucketHistogramSummary $right
+     */
+    public function merge(mixed $left, mixed $right): ExplicitBucketHistogramSummary {
+        $count = $left->count + $right->count;
+        $sum = $left->sum + $right->sum;
+        $buckets = [];
+        for ($i = 0; $i < count($this->boundaries) + 1; $i++) {
+            $buckets[$i] = $left->buckets[$i] + $right->buckets[$i];
+        }
+
+        return new ExplicitBucketHistogramSummary(
+            $count,
+            $sum,
+            $buckets,
+        );
+    }
+
+    /**
+     * @param ExplicitBucketHistogramSummary $left
+     * @param ExplicitBucketHistogramSummary $right
+     */
+    public function diff(mixed $left, mixed $right): ExplicitBucketHistogramSummary {
+        $count = -$left->count + $right->count;
+        $sum = -$left->sum + $right->sum;
+        $buckets = [];
+        for ($i = 0; $i < count($this->boundaries) + 1; $i++) {
+            $buckets[$i] = -$left->buckets[$i] + $right->buckets[$i];
+        }
+
+        return new ExplicitBucketHistogramSummary(
+            $count,
+            $sum,
+            $buckets,
+        );
+    }
+
+    /**
+     * @param array<ExplicitBucketHistogramSummary> $summaries
+     */
+    public function toData(
+        array $attributes,
+        array $summaries,
+        array $exemplars,
+        ?int $startTimestamp,
+        int $timestamp,
+        Temporality $temporality,
+    ): Data\Histogram {
+        $dataPoints = [];
+        foreach ($attributes as $key => $dataPointAttributes) {
+            $dataPoints[] = new Data\HistogramDataPoint(
+                $summaries[$key]->count,
+                $summaries[$key]->sum,
+                $summaries[$key]->buckets,
+                $this->boundaries,
+                $dataPointAttributes,
+                $startTimestamp,
+                $timestamp,
+                $exemplars[$key] ?? [],
+            );
+        }
+
+        return new Data\Histogram(
+            $dataPoints,
+            $temporality,
+        );
+    }
+}

--- a/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramSummary.php
+++ b/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramSummary.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Aggregation;
+
+final class ExplicitBucketHistogramSummary {
+
+    public function __construct(
+        public int $count,
+        public float|int $sum,
+        public array $buckets,
+    ) {}
+}

--- a/src/SDK/Metrics/Aggregation/LastValue.php
+++ b/src/SDK/Metrics/Aggregation/LastValue.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Aggregation;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+use OpenTelemetry\SDK\Metrics\Aggregation;
+use OpenTelemetry\SDK\Metrics\Data;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+
+/**
+ * @implements Aggregation<LastValueSummary>
+ */
+final class LastValue implements Aggregation {
+
+    public function initialize(): LastValueSummary {
+        return new LastValueSummary(null, 0);
+    }
+
+    /**
+     * @param LastValueSummary $summary
+     */
+    public function record(mixed $summary, float|int $value, Attributes $attributes, Context $context, int $timestamp): void {
+        $summary->value = $value;
+        $summary->timestamp = $timestamp;
+    }
+
+    /**
+     * @param LastValueSummary $left
+     * @param LastValueSummary $right
+     */
+    public function merge(mixed $left, mixed $right): LastValueSummary {
+        return $right;
+    }
+
+    /**
+     * @param LastValueSummary $left
+     * @param LastValueSummary $right
+     */
+    public function diff(mixed $left, mixed $right): LastValueSummary {
+        return $right;
+    }
+
+    /**
+     * @param array<LastValueSummary> $summaries
+     */
+    public function toData(
+        array $attributes,
+        array $summaries,
+        array $exemplars,
+        ?int $startTimestamp,
+        int $timestamp,
+        Temporality $temporality,
+    ): Data\Gauge {
+        $dataPoints = [];
+        foreach ($attributes as $key => $dataPointAttributes) {
+            if ($summaries[$key]->value === null) {
+                continue;
+            }
+
+            $dataPoints[] = new Data\NumberDataPoint(
+                $summaries[$key]->value,
+                $dataPointAttributes,
+                $startTimestamp,
+                $timestamp,
+                $exemplars[$key] ?? [],
+            );
+        }
+
+        return new Data\Gauge(
+            $dataPoints,
+        );
+    }
+}

--- a/src/SDK/Metrics/Aggregation/LastValueSummary.php
+++ b/src/SDK/Metrics/Aggregation/LastValueSummary.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Aggregation;
+
+final class LastValueSummary {
+
+    public function __construct(
+        public float|int|null $value,
+        public int $timestamp,
+    ) {}
+}

--- a/src/SDK/Metrics/Aggregation/Sum.php
+++ b/src/SDK/Metrics/Aggregation/Sum.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Aggregation;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+use OpenTelemetry\SDK\Metrics\Aggregation;
+use OpenTelemetry\SDK\Metrics\Data;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+
+/**
+ * @implements Aggregation<SumSummary>
+ */
+final class Sum implements Aggregation {
+
+    private bool $monotonic;
+
+    public function __construct(bool $monotonic = false) {
+        $this->monotonic = $monotonic;
+    }
+
+    public function initialize(): SumSummary {
+        return new SumSummary(0);
+    }
+
+    /**
+     * @param SumSummary $summary
+     */
+    public function record(mixed $summary, float|int $value, Attributes $attributes, Context $context, int $timestamp): void {
+        $summary->value += $value;
+    }
+
+    /**
+     * @param SumSummary $left
+     * @param SumSummary $right
+     */
+    public function merge(mixed $left, mixed $right): SumSummary {
+        $sum = $left->value + $right->value;
+
+        return new SumSummary(
+            $sum,
+        );
+    }
+
+    /**
+     * @param SumSummary $left
+     * @param SumSummary $right
+     */
+    public function diff(mixed $left, mixed $right): SumSummary {
+        $sum = -$left->value + $right->value;
+
+        return new SumSummary(
+            $sum,
+        );
+    }
+
+    /**
+     * @param array<SumSummary> $summaries
+     */
+    public function toData(
+        array $attributes,
+        array $summaries,
+        array $exemplars,
+        ?int $startTimestamp,
+        int $timestamp,
+        Temporality $temporality,
+    ): Data\Sum {
+        $dataPoints = [];
+        foreach ($attributes as $key => $dataPointAttributes) {
+            $dataPoints[] = new Data\NumberDataPoint(
+                $summaries[$key]->value,
+                $dataPointAttributes,
+                $startTimestamp,
+                $timestamp,
+                $exemplars[$key] ?? [],
+            );
+        }
+
+        return new Data\Sum(
+            $dataPoints,
+            $temporality,
+            $this->monotonic,
+        );
+    }
+}

--- a/src/SDK/Metrics/Aggregation/SumSummary.php
+++ b/src/SDK/Metrics/Aggregation/SumSummary.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Aggregation;
+
+final class SumSummary {
+
+    public function __construct(
+        public float|int $value,
+    ) {}
+}

--- a/src/SDK/Metrics/AttributeProcessor.php
+++ b/src/SDK/Metrics/AttributeProcessor.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+
+interface AttributeProcessor {
+
+    public function process(Attributes $attributes, Context $context): Attributes;
+}

--- a/src/SDK/Metrics/AttributeProcessor/Identity.php
+++ b/src/SDK/Metrics/AttributeProcessor/Identity.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\AttributeProcessor;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+use OpenTelemetry\SDK\Metrics\AttributeProcessor;
+
+final class Identity implements AttributeProcessor {
+
+    public function process(Attributes $attributes, Context $context): Attributes {
+        return $attributes;
+    }
+}

--- a/src/SDK/Metrics/Data/Data.php
+++ b/src/SDK/Metrics/Data/Data.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+interface Data {
+
+}

--- a/src/SDK/Metrics/Data/Exemplar.php
+++ b/src/SDK/Metrics/Data/Exemplar.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+use OpenTelemetry\SDK\Attributes;
+
+final class Exemplar {
+
+    public function __construct(
+        public readonly float|int $value,
+        public readonly int $timestamp,
+        public readonly Attributes $attributes,
+        public readonly ?string $traceId,
+        public readonly ?string $spanId,
+    ) {}
+}

--- a/src/SDK/Metrics/Data/Gauge.php
+++ b/src/SDK/Metrics/Data/Gauge.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+final class Gauge implements Data {
+
+    /**
+     * @param iterable<NumberDataPoint> $dataPoints
+     */
+    public function __construct(
+        public readonly iterable $dataPoints,
+    ) {}
+}

--- a/src/SDK/Metrics/Data/Histogram.php
+++ b/src/SDK/Metrics/Data/Histogram.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+final class Histogram implements Data {
+
+    /**
+     * @param iterable<HistogramDataPoint> $dataPoints
+     */
+    public function __construct(
+        public readonly iterable $dataPoints,
+        public readonly Temporality $temporality,
+    ) {}
+}

--- a/src/SDK/Metrics/Data/HistogramDataPoint.php
+++ b/src/SDK/Metrics/Data/HistogramDataPoint.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+use OpenTelemetry\SDK\Attributes;
+
+final class HistogramDataPoint {
+
+    public function __construct(
+        public readonly int $count,
+        public readonly float|int $sum,
+        public readonly array $bucketCounts,
+        public readonly array $explicitBounds,
+        public readonly Attributes $attributes,
+        public readonly ?int $startTimestamp,
+        public readonly int $timestamp,
+        public readonly iterable $exemplars = [],
+    ) {}
+}

--- a/src/SDK/Metrics/Data/Metric.php
+++ b/src/SDK/Metrics/Data/Metric.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+use OpenTelemetry\SDK\InstrumentationLibrary;
+use OpenTelemetry\SDK\Resource;
+
+final class Metric {
+
+    public function __construct(
+        public readonly InstrumentationLibrary $instrumentationLibrary,
+        public readonly Resource $resource,
+        public readonly string $name,
+        public readonly ?string $description,
+        public readonly ?string $unit,
+        public readonly Data $data,
+    ) {}
+}

--- a/src/SDK/Metrics/Data/NumberDataPoint.php
+++ b/src/SDK/Metrics/Data/NumberDataPoint.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+use OpenTelemetry\SDK\Attributes;
+
+final class NumberDataPoint {
+
+    public function __construct(
+        public readonly float|int $value,
+        public readonly Attributes $attributes,
+        public readonly ?int $startTimestamp,
+        public readonly int $timestamp,
+        public readonly iterable $exemplars = [],
+    ) {}
+}

--- a/src/SDK/Metrics/Data/Sum.php
+++ b/src/SDK/Metrics/Data/Sum.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+final class Sum implements Data {
+
+    /**
+     * @param iterable<NumberDataPoint> $dataPoints
+     */
+    public function __construct(
+        public readonly iterable $dataPoints,
+        public readonly Temporality $temporality,
+        public readonly bool $monotonic,
+    ) {}
+}

--- a/src/SDK/Metrics/Data/Temporality.php
+++ b/src/SDK/Metrics/Data/Temporality.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Data;
+
+enum Temporality {
+
+    case Delta;
+    case Cumulative;
+}

--- a/src/SDK/Metrics/Exemplar/ExemplarReservoir.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarReservoir.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Exemplar;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+use OpenTelemetry\SDK\Metrics\Data\Exemplar;
+
+interface ExemplarReservoir {
+
+    public function offer(int|string $index, float|int $value, Attributes $attributes, Context $context, int $timestamp): void;
+
+    /**
+     * @param array<Attributes> $dataPointAttributes
+     * @return array<list<Exemplar>>
+     */
+    public function collect(array $dataPointAttributes, ?int $revision = null): array;
+}

--- a/src/SDK/Metrics/Exemplar/NoopReservoir.php
+++ b/src/SDK/Metrics/Exemplar/NoopReservoir.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Exemplar;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+
+final class NoopReservoir implements ExemplarReservoir {
+
+    public function offer(int|string $index, float|int $value, Attributes $attributes, Context $context, int $timestamp): void {
+        // no-op
+    }
+
+    public function collect(array $dataPointAttributes, ?int $revision = null): array {
+        return [];
+    }
+}

--- a/src/SDK/Metrics/MetricWriter.php
+++ b/src/SDK/Metrics/MetricWriter.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics;
+
+use OpenTelemetry\Context;
+
+interface MetricWriter {
+
+    public function record(float|int $value, iterable $attributes = [], Context|false|null $context = null): void;
+}

--- a/src/SDK/Metrics/MetricWriter/MultiStreamWriter.php
+++ b/src/SDK/Metrics/MetricWriter/MultiStreamWriter.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\MetricWriter;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\AttributesFactory;
+use OpenTelemetry\SDK\Clock;
+use OpenTelemetry\SDK\Metrics\MetricWriter;
+use OpenTelemetry\SDK\Metrics\Stream\WritableMetricStream;
+
+final class MultiStreamWriter implements MetricWriter {
+
+    private iterable $streams;
+    private AttributesFactory $attributes;
+    private Clock $clock;
+
+    /**
+     * @param iterable<WritableMetricStream> $streams
+     */
+    public function __construct(iterable $streams, AttributesFactory $attributes, Clock $clock) {
+        $this->streams = $streams;
+        $this->attributes = $attributes;
+        $this->clock = $clock;
+    }
+
+    public function record(float|int $value, iterable $attributes = [], Context|false|null $context = null): void {
+        $attributes = $this->attributes->builder($attributes)->build();
+        $context = $context
+            ?? Context::static::current()
+            ?: Context::static::empty();
+        $timestamp = $this->clock->nanotime();
+
+        foreach ($this->streams as $stream) {
+            $stream->record($value, $attributes, $context, $timestamp);
+        }
+    }
+}

--- a/src/SDK/Metrics/MetricWriter/StreamWriter.php
+++ b/src/SDK/Metrics/MetricWriter/StreamWriter.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\MetricWriter;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\AttributesFactory;
+use OpenTelemetry\SDK\Clock;
+use OpenTelemetry\SDK\Metrics\MetricWriter;
+use OpenTelemetry\SDK\Metrics\Stream\WritableMetricStream;
+
+final class StreamWriter implements MetricWriter {
+
+    private WritableMetricStream $stream;
+    private AttributesFactory $attributes;
+    private Clock $clock;
+
+    public function __construct(WritableMetricStream $stream, AttributesFactory $attributes, Clock $clock) {
+        $this->stream = $stream;
+        $this->attributes = $attributes;
+        $this->clock = $clock;
+    }
+
+    public function record(float|int $value, iterable $attributes = [], Context|false|null $context = null): void {
+        $attributes = $this->attributes->builder($attributes)->build();
+        $context = $context
+            ?? Context::static::current()
+            ?: Context::static::empty();
+        $timestamp = $this->clock->nanotime();
+
+        $this->stream->record($value, $attributes, $context, $timestamp);
+    }
+}

--- a/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use OpenTelemetry\Metrics\Observer;
+use OpenTelemetry\SDK\AttributesFactory;
+use OpenTelemetry\SDK\Metrics\Aggregation;
+use OpenTelemetry\SDK\Metrics\AttributeProcessor;
+use OpenTelemetry\SDK\Metrics\Data\Data;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarReservoir;
+use function array_search;
+use function count;
+
+final class AsynchronousMetricStream implements MetricStream {
+
+    private MetricAggregator $metricAggregator;
+    private AttributesFactory $attributes;
+    private Aggregation $aggregation;
+    private ?ExemplarReservoir $exemplarReservoir;
+    private $instrument;
+
+    private int $startTimestamp;
+
+    /** @var array<int, LastRead|null> */
+    private array $lastReads = [];
+
+    /**
+     * @param callable(Observer): void $instrument
+     */
+    public function __construct(
+        AttributesFactory $attributes,
+        ?AttributeProcessor $attributeProcessor,
+        Aggregation $aggregation,
+        ?ExemplarReservoir $exemplarReservoir,
+        callable $instrument,
+        int $startTimestamp,
+    ) {
+        $this->metricAggregator = new MetricAggregator(
+            $attributeProcessor,
+            $aggregation,
+            $exemplarReservoir,
+        );
+        $this->attributes = $attributes;
+        $this->aggregation = $aggregation;
+        $this->exemplarReservoir = $exemplarReservoir;
+        $this->instrument = $instrument;
+        $this->startTimestamp = $startTimestamp;
+    }
+
+    public function register(Temporality $temporality): int {
+        if ($temporality === Temporality::Cumulative) {
+            return -1;
+        }
+
+        if (($reader = array_search(null, $this->lastReads, true)) === false) {
+            $reader = count($this->lastReads);
+        }
+
+        $this->lastReads[$reader] = new LastRead(new Metric(), $this->startTimestamp);
+
+        return $reader;
+    }
+
+    public function unregister(int $reader): void {
+        if (!isset($this->lastReads[$reader])) {
+            return;
+        }
+
+        $this->lastReads[$reader] = null;
+    }
+
+    public function collect(int $reader, int $timestamp): Data {
+        ($this->instrument)(new AsynchronousMetricStreamObserver($this->metricAggregator, $this->attributes, $timestamp));
+
+        $metric = $this->metricAggregator->collect();
+        $exemplars = $this->exemplarReservoir?->collect($metric->attributes) ?? [];
+
+        if (!$lastRead = $this->lastReads[$reader] ?? null) {
+            $temporality = Temporality::Cumulative;
+            $startTimestamp = $this->startTimestamp;
+        } else {
+            $temporality = Temporality::Delta;
+            $startTimestamp = $lastRead->timestamp;
+
+            $this->diffInto($lastRead->metric, $metric);
+            [$lastRead->metric, $metric] = [$metric, $lastRead->metric];
+            $lastRead->timestamp = $timestamp;
+        }
+
+        $data = $this->aggregation->toData(
+            $metric->attributes,
+            $metric->summaries,
+            $exemplars,
+            $startTimestamp,
+            $timestamp,
+            $temporality,
+        );
+
+        return $data;
+    }
+
+    private function diffInto(Metric $into, Metric $metric): void {
+        $summaries = $metric->summaries;
+        foreach ($metric->summaries as $k => $summary) {
+            if (!isset($into->summaries[$k])) {
+                continue;
+            }
+
+            $summaries[$k] = $this->aggregation->diff($into->summaries[$k], $summary);
+        }
+
+        $into->attributes = $metric->attributes;
+        $into->summaries = $summaries;
+    }
+}

--- a/src/SDK/Metrics/Stream/AsynchronousMetricStreamObserver.php
+++ b/src/SDK/Metrics/Stream/AsynchronousMetricStreamObserver.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\Metrics\Observer;
+use OpenTelemetry\SDK\AttributesFactory;
+
+final class AsynchronousMetricStreamObserver implements Observer {
+
+    private WritableMetricStream $stream;
+    private AttributesFactory $attributes;
+    private int $timestamp;
+
+    public function __construct(WritableMetricStream $stream, AttributesFactory $attributes, int $timestamp) {
+        $this->stream = $stream;
+        $this->attributes = $attributes;
+        $this->timestamp = $timestamp;
+    }
+
+    public function observe(float|int $amount, iterable $attributes = []): void {
+        $this->stream->record($amount, $this->attributes->builder($attributes)->build(), Context::static::empty(), $this->timestamp);
+    }
+}

--- a/src/SDK/Metrics/Stream/Delta.php
+++ b/src/SDK/Metrics/Stream/Delta.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use GMP;
+
+final class Delta {
+
+    public function __construct(
+        public Metric $metric,
+        public int|GMP $readers,
+        public int $timestamp,
+        public ?Delta $prev = null,
+    ) {}
+}

--- a/src/SDK/Metrics/Stream/DeltaStorage.php
+++ b/src/SDK/Metrics/Stream/DeltaStorage.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use GMP;
+use OpenTelemetry\SDK\Metrics\Aggregation;
+
+final class DeltaStorage {
+
+    private Aggregation $aggregation;
+    private Delta $head;
+
+    public function __construct(Aggregation $aggregation) {
+        $this->aggregation = $aggregation;
+        $this->head = new Delta(new Metric(), 0, 0);
+    }
+
+    public function add(Metric $metric, int|GMP $readers, int $timestamp): void {
+        if ($readers == 0) {
+            return;
+        }
+
+        if ($this->head->prev?->readers != $readers) {
+            $this->head->prev = new Delta($metric, $readers, $timestamp, $this->head->prev);
+        } else {
+            $this->mergeInto($this->head->prev->metric, $metric);
+        }
+    }
+
+    public function collect(int $reader, bool $retain = false): ?Delta {
+        $n = null;
+        for ($d = $this->head; $d->prev; $d = $d->prev) {
+            if (($d->prev->readers >> $reader & 1) != 0) {
+                if ($n) {
+                    $n->prev->readers ^= $d->prev->readers;
+                    $this->mergeInto($d->prev->metric, $n->prev->metric);
+                    $this->tryUnlink($n);
+
+                    if ($n->prev === $d->prev) {
+                        continue;
+                    }
+                }
+
+                $n = $d;
+            }
+        }
+
+        $delta = $n?->prev;
+
+        if (!$retain && $n) {
+            $n->prev->readers ^= ($n->prev->readers & 1 | 1) << $reader;
+            $this->tryUnlink($n);
+        }
+
+        return $delta;
+    }
+
+    private function tryUnlink(Delta $n): void {
+        if ($n->prev->readers == 0) {
+            $n->prev = $n->prev->prev;
+            return;
+        }
+
+        for ($c = $n->prev->prev;
+             $c && ($n->prev->readers & $c->readers) == 0;
+             $c = $c->prev) {}
+
+        if ($n->prev->readers == $c?->readers) {
+            $this->mergeInto($c->metric, $n->prev->metric);
+            $n->prev = $n->prev->prev;
+        }
+    }
+
+    private function mergeInto(Metric $into, Metric $metric): void {
+        foreach ($metric->summaries as $k => $summary) {
+            $into->attributes[$k] ??= $metric->attributes[$k];
+            $into->summaries[$k] = isset($into->summaries[$k])
+                ? $this->aggregation->merge($into->summaries[$k], $summary)
+                : $summary;
+        }
+    }
+}

--- a/src/SDK/Metrics/Stream/LastRead.php
+++ b/src/SDK/Metrics/Stream/LastRead.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+final class LastRead {
+
+    public function __construct(
+        public Metric $metric,
+        public int $timestamp,
+    ) {}
+}

--- a/src/SDK/Metrics/Stream/Metric.php
+++ b/src/SDK/Metrics/Stream/Metric.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use OpenTelemetry\SDK\Attributes;
+
+/**
+ * @template T
+ */
+final class Metric {
+
+    /**
+     * @param array<Attributes> $attributes
+     * @param array<T> $summaries
+     */
+    public function __construct(
+        public array $attributes = [],
+        public array $summaries = [],
+    ) {}
+}

--- a/src/SDK/Metrics/Stream/MetricAggregator.php
+++ b/src/SDK/Metrics/Stream/MetricAggregator.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+use OpenTelemetry\SDK\Metrics\Aggregation;
+use OpenTelemetry\SDK\Metrics\AttributeProcessor;
+use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarReservoir;
+use function serialize;
+
+final class MetricAggregator implements WritableMetricStream {
+
+    private ?AttributeProcessor $attributeProcessor;
+    private Aggregation $aggregation;
+    private ?ExemplarReservoir $exemplarReservoir;
+
+    /** @var array<Attributes> */
+    private array $attributes = [];
+    private array $summaries = [];
+
+    public function __construct(
+        ?AttributeProcessor $attributeProcessor,
+        Aggregation $aggregation,
+        ?ExemplarReservoir $exemplarReservoir,
+    ) {
+        $this->attributeProcessor = $attributeProcessor;
+        $this->aggregation = $aggregation;
+        $this->exemplarReservoir = $exemplarReservoir;
+    }
+
+    public function record(float|int $value, Attributes $attributes, Context $context, int $timestamp): void {
+        $filteredAttributes = $this->attributeProcessor?->process($attributes, $context) ?? $attributes;
+        $raw = $filteredAttributes->toArray();
+        $index = $raw ? serialize($raw) : 0;
+        $this->attributes[$index] = $filteredAttributes;
+        $this->aggregation->record(
+            $this->summaries[$index] ??= $this->aggregation->initialize(),
+            $value,
+            $attributes,
+            $context,
+            $timestamp,
+        );
+
+        $this->exemplarReservoir?->offer($index, $value, $attributes, $context, $timestamp);
+    }
+
+    public function collect(): Metric {
+        $metric = new Metric($this->attributes, $this->summaries);
+        $this->attributes = [];
+        $this->summaries = [];
+
+        return $metric;
+    }
+}

--- a/src/SDK/Metrics/Stream/MetricStream.php
+++ b/src/SDK/Metrics/Stream/MetricStream.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use OpenTelemetry\SDK\Metrics\Data\Data;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+
+interface MetricStream {
+
+    public function register(Temporality $temporality): int;
+
+    public function unregister(int $reader): void;
+
+    public function collect(int $reader, int $timestamp): Data;
+}

--- a/src/SDK/Metrics/Stream/SynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/SynchronousMetricStream.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use GMP;
+use OpenTelemetry\SDK\Metrics\Aggregation;
+use OpenTelemetry\SDK\Metrics\AttributeProcessor;
+use OpenTelemetry\SDK\Metrics\Data\Data;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarReservoir;
+use function extension_loaded;
+use function gmp_init;
+use function is_int;
+use function sprintf;
+use function trigger_error;
+use const E_USER_WARNING;
+use const PHP_INT_SIZE;
+
+final class SynchronousMetricStream implements MetricStream {
+
+    private MetricAggregator $metricAggregator;
+    private Aggregation $aggregation;
+    private ?ExemplarReservoir $exemplarReservoir;
+
+    private int $collectionTimestamp;
+
+    private DeltaStorage $delta;
+    private int|GMP $readers = 0;
+    private int|GMP $cumulative = 0;
+
+    public function __construct(
+        ?AttributeProcessor $attributeProcessor,
+        Aggregation $aggregation,
+        ?ExemplarReservoir $exemplarReservoir,
+        int $startTimestamp,
+    ) {
+        $this->metricAggregator = new MetricAggregator(
+            $attributeProcessor,
+            $aggregation,
+            $exemplarReservoir,
+        );
+        $this->aggregation = $aggregation;
+        $this->exemplarReservoir = $exemplarReservoir;
+        $this->collectionTimestamp = $startTimestamp;
+        $this->delta = new DeltaStorage($aggregation);
+    }
+
+    public function writable(): WritableMetricStream {
+        return $this->metricAggregator;
+    }
+
+    public function register(Temporality $temporality): int {
+        $reader = 0;
+        for ($r = $this->readers; ($r & 1) != 0; $r >>= 1, $reader++) {}
+
+        if ($reader === (PHP_INT_SIZE << 3) - 1 && is_int($this->readers)) {
+            if (!extension_loaded('gmp')) {
+                trigger_error(sprintf('GMP extension required to register over %d readers', (PHP_INT_SIZE << 3) - 1), E_USER_WARNING);
+                $reader = PHP_INT_SIZE << 3;
+            } else {
+                $this->readers = gmp_init($this->readers);
+                $this->cumulative = gmp_init($this->cumulative);
+            }
+        }
+
+        $readerMask = ($this->readers & 1 | 1) << $reader;
+        $this->readers ^= $readerMask;
+        if ($temporality === Temporality::Cumulative) {
+            $this->cumulative ^= $readerMask;
+        }
+
+        return $reader;
+    }
+
+    public function unregister(int $reader): void {
+        $readerMask = ($this->readers & 1 | 1) << $reader;
+        if (($this->readers & $readerMask) == 0) {
+            return;
+        }
+
+        $this->delta->collect($reader);
+
+        $this->readers ^= $readerMask;
+        if (($this->cumulative & $readerMask) != 0) {
+            $this->cumulative ^= $readerMask;
+        }
+    }
+
+    public function collect(int $reader, int $timestamp): Data {
+        $this->delta->add(
+            $this->metricAggregator->collect(),
+            $this->readers,
+            $this->collectionTimestamp,
+        );
+        $this->collectionTimestamp = $timestamp;
+
+        $cumulative = ($this->cumulative >> $reader & 1) != 0;
+        $delta = $this->delta->collect($reader, $cumulative) ?? new Delta(new Metric(), 0, $this->collectionTimestamp);
+        $exemplars = $this->exemplarReservoir?->collect($delta->metric->attributes, $delta->timestamp) ?? [];
+
+        $temporality = $cumulative
+            ? Temporality::Cumulative
+            : Temporality::Delta;
+
+        $data = $this->aggregation->toData(
+            $delta->metric->attributes,
+            $delta->metric->summaries,
+            $exemplars,
+            $delta->timestamp,
+            $this->collectionTimestamp,
+            $temporality,
+        );
+
+        return $data;
+    }
+}

--- a/src/SDK/Metrics/Stream/WritableMetricStream.php
+++ b/src/SDK/Metrics/Stream/WritableMetricStream.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use OpenTelemetry\Context;
+use OpenTelemetry\SDK\Attributes;
+
+interface WritableMetricStream {
+
+    public function record(float|int $value, Attributes $attributes, Context $context, int $timestamp): void;
+}

--- a/src/SDK/Metrics/compatibility.php
+++ b/src/SDK/Metrics/compatibility.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * To be removed - added to simplify updates of metrics implementation.
+ */
+/** @noinspection PhpMultipleClassesDeclarationsInOneFile */
+/** @noinspection PhpIllegalPsrClassPathInspection */
+/** @noinspection PhpUnusedParameterInspection */
+
+namespace OpenTelemetry;
+
+use OpenTelemetry\API\Metrics\Observer;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use function class_alias;
+
+// TODO Replace usage with ResourceInfo
+class_alias(ResourceInfo::class, SDK\Resource::class);
+// TODO Replace usage with Observer
+class_alias(Observer::class, Metrics\Observer::class);
+
+// TODO Replace usage with Context\Context
+class Context {
+
+    /** @var class-string|self */
+    public const static = self::class;
+
+    private function __construct(
+        public Context\Context $context,
+    ) {}
+
+    public static function empty(): Context {
+        return new self(Context\Context::getRoot());
+    }
+
+    public static function current(): Context {
+        return new self(Context\Context::getCurrent());
+    }
+}
+
+namespace OpenTelemetry\SDK;
+
+use OpenTelemetry\API\Trace\ClockInterface;
+use function iterator_to_array;
+
+// TODO Replace usage with ClockInterface::now()
+class Clock {
+
+    public function __construct(
+        private ClockInterface $clock,
+    ) {}
+
+    public function nanotime(): int {
+        return $this->clock->now();
+    }
+}
+
+// TODO Add implementation
+class AttributesFactory {
+
+    public function builder(iterable $attributes = []): AttributesBuilder {
+        return new AttributesBuilder(new Attributes($attributes));
+    }
+}
+
+// TODO Split Attributes implementation into mutable builder and readonly attributes
+class AttributesBuilder {
+
+    private Attributes $attributes;
+
+    public function __construct(Attributes $attributes) {
+        $this->attributes = $attributes;
+    }
+
+    public function build(): Attributes {
+        return $this->attributes;
+    }
+}
+
+// TODO Move Attributes out of \Trace namespace
+class Attributes extends Trace\Attributes {
+
+    public function toArray(): array {
+        return iterator_to_array($this);
+    }
+}

--- a/tests/SDK/Unit/Metrics/MetricStreamTest.php
+++ b/tests/SDK/Unit/Metrics/MetricStreamTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\Tests\SDK\Unit\Metrics;
+
+use OpenTelemetry\Metrics\Observer;
+use OpenTelemetry\SDK\AttributesFactory;
+use OpenTelemetry\SDK\Clock;
+use OpenTelemetry\SDK\Metrics\Aggregation\Sum;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
+use OpenTelemetry\SDK\Metrics\MetricWriter\StreamWriter;
+use OpenTelemetry\SDK\Metrics\Stream\AsynchronousMetricStream;
+use OpenTelemetry\SDK\Metrics\Stream\SynchronousMetricStream;
+use OpenTelemetry\SDK\Trace\SystemClock;
+use PHPUnit\Framework\TestCase;
+
+final class MetricStreamTest extends TestCase {
+
+    public function testAsynchronousSingleDataPoint(): void {
+        $s = new AsynchronousMetricStream(new AttributesFactory(), null, new Sum(), null, function(Observer $observer) use (&$m): void {
+            match ($m) {
+                0 => $observer->observe(5),
+                1 => $observer->observe(7),
+                2 => $observer->observe(3),
+            };
+        }, 3);
+
+        $d = $s->register(Temporality::Delta);
+        $c = $s->register(Temporality::Cumulative);
+
+        $m = 0;
+        $md = $s->collect($d, 5);
+        $mc = $s->collect($c, 5);
+        $this->assertSame(3, $md->dataPoints[0]->startTimestamp);
+        $this->assertSame(3, $mc->dataPoints[0]->startTimestamp);
+        $this->assertSame(5, $md->dataPoints[0]->timestamp);
+        $this->assertSame(5, $mc->dataPoints[0]->timestamp);
+        $this->assertSame(5, $md->dataPoints[0]->value);
+        $this->assertSame(5, $mc->dataPoints[0]->value);
+        $this->assertSame(Temporality::Delta, $md->temporality);
+        $this->assertSame(Temporality::Cumulative, $mc->temporality);
+
+        $m = 1;
+        $md = $s->collect($d, 8);
+        $mc = $s->collect($c, 8);
+        $this->assertSame(5, $md->dataPoints[0]->startTimestamp);
+        $this->assertSame(3, $mc->dataPoints[0]->startTimestamp);
+        $this->assertSame(8, $md->dataPoints[0]->timestamp);
+        $this->assertSame(8, $mc->dataPoints[0]->timestamp);
+        $this->assertSame(2, $md->dataPoints[0]->value);
+        $this->assertSame(7, $mc->dataPoints[0]->value);
+        $this->assertSame(Temporality::Delta, $md->temporality);
+        $this->assertSame(Temporality::Cumulative, $mc->temporality);
+
+        $m = 2;
+        $md = $s->collect($d, 12);
+        $mc = $s->collect($c, 12);
+        $this->assertSame(8, $md->dataPoints[0]->startTimestamp);
+        $this->assertSame(3, $mc->dataPoints[0]->startTimestamp);
+        $this->assertSame(12, $md->dataPoints[0]->timestamp);
+        $this->assertSame(12, $mc->dataPoints[0]->timestamp);
+        $this->assertSame(-4, $md->dataPoints[0]->value);
+        $this->assertSame(3, $mc->dataPoints[0]->value);
+        $this->assertSame(Temporality::Delta, $md->temporality);
+        $this->assertSame(Temporality::Cumulative, $mc->temporality);
+    }
+
+    public function testSynchronousSingleDataPoint(): void {
+        $s = new SynchronousMetricStream(null, new Sum(), null, 3);
+        $w = new StreamWriter($s->writable(), new AttributesFactory(), new Clock(SystemClock::getInstance()));
+
+        $d = $s->register(Temporality::Delta);
+        $c = $s->register(Temporality::Cumulative);
+
+        $w->record(5);
+        $md = $s->collect($d, 5);
+        $mc = $s->collect($c, 5);
+        $this->assertSame(3, $md->dataPoints[0]->startTimestamp);
+        $this->assertSame(3, $mc->dataPoints[0]->startTimestamp);
+        $this->assertSame(5, $md->dataPoints[0]->timestamp);
+        $this->assertSame(5, $mc->dataPoints[0]->timestamp);
+        $this->assertSame(5, $md->dataPoints[0]->value);
+        $this->assertSame(5, $mc->dataPoints[0]->value);
+        $this->assertSame(Temporality::Delta, $md->temporality);
+        $this->assertSame(Temporality::Cumulative, $mc->temporality);
+
+        $w->record(2);
+        $md = $s->collect($d, 8);
+        $mc = $s->collect($c, 8);
+        $this->assertSame(5, $md->dataPoints[0]->startTimestamp);
+        $this->assertSame(3, $mc->dataPoints[0]->startTimestamp);
+        $this->assertSame(8, $md->dataPoints[0]->timestamp);
+        $this->assertSame(8, $mc->dataPoints[0]->timestamp);
+        $this->assertSame(2, $md->dataPoints[0]->value);
+        $this->assertSame(7, $mc->dataPoints[0]->value);
+        $this->assertSame(Temporality::Delta, $md->temporality);
+        $this->assertSame(Temporality::Cumulative, $mc->temporality);
+
+        $w->record(-4);
+        $md = $s->collect($d, 12);
+        $mc = $s->collect($c, 12);
+        $this->assertSame(8, $md->dataPoints[0]->startTimestamp);
+        $this->assertSame(3, $mc->dataPoints[0]->startTimestamp);
+        $this->assertSame(12, $md->dataPoints[0]->timestamp);
+        $this->assertSame(12, $mc->dataPoints[0]->timestamp);
+        $this->assertSame(-4, $md->dataPoints[0]->value);
+        $this->assertSame(3, $mc->dataPoints[0]->value);
+        $this->assertSame(Temporality::Delta, $md->temporality);
+        $this->assertSame(Temporality::Cumulative, $mc->temporality);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use DG\BypassFinals;
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/SDK/Metrics/compatibility.php';
 
 BypassFinals::enable();
 


### PR DESCRIPTION
Adds synchronous and asynchronous metric aggregations with support for multiple readers per aggregation.
Intended as internal implementation of meter instruments; on instrument creation: `Meter` would create a `MetricStream` for each registered `View`, `MetricReader`s would register as reader for each `MetricStream`.

Creating this as draft to gather some feedback before I start working on the todos. Are there objections to implementing the metrics SDK this way?

---

TODOs:
- [ ] remove/resolve compatibility.php
- [ ] add PHP7.4 compatibility (currently ^8.1 only)
- [ ] add tests
- [ ] fix cs / psalm / phpstan / phan