### PR TITLE
Fix noop SpanContext propagation

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\Context;
 /**
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.1/specification/context/context.md#overview
  */
-final class Context
+class Context
 {
     private static ?ContextStorageInterface $storage = null;
 

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -21,9 +21,6 @@ final class Context
         self::$storage = $storage;
     }
 
-    /**
-     * @internal
-     */
     public static function storage(): ContextStorageInterface
     {
         return self::$storage ??= new ContextStorage(self::getRoot());

--- a/src/Context/ContextStorageInterface.php
+++ b/src/Context/ContextStorageInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Context;
 
-/**
- * @internal
- */
 interface ContextStorageInterface
 {
     public function fork(int $id): void;

--- a/src/SDK/Trace/NoopSpanBuilder.php
+++ b/src/SDK/Trace/NoopSpanBuilder.php
@@ -9,10 +9,18 @@ use OpenTelemetry\API\Trace\SpanBuilderInterface;
 use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextStorageInterface;
 
 final class NoopSpanBuilder implements SpanBuilderInterface
 {
+    private ContextStorageInterface $contextStorage;
+
     private ?Context $parent = null;
+
+    public function __construct(ContextStorageInterface $contextStorage)
+    {
+        $this->contextStorage = $contextStorage;
+    }
 
     public function setParent(Context $parentContext): SpanBuilderInterface
     {
@@ -55,7 +63,7 @@ final class NoopSpanBuilder implements SpanBuilderInterface
 
     public function startSpan(): SpanInterface
     {
-        $span = Span::fromContext($this->parent ?? Context::getCurrent());
+        $span = Span::fromContext($this->parent ?? $this->contextStorage->current());
         if ($span->isRecording()) {
             $span = Span::wrap($span->getContext());
         }

--- a/src/SDK/Trace/NoopTracer.php
+++ b/src/SDK/Trace/NoopTracer.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\SDK\Trace;
 
 use OpenTelemetry\API\Trace\SpanBuilderInterface;
 use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\Context\Context;
 
 final class NoopTracer implements TracerInterface
 {
@@ -22,6 +23,6 @@ final class NoopTracer implements TracerInterface
 
     public function spanBuilder(string $spanName): SpanBuilderInterface
     {
-        return new NoopSpanBuilder();
+        return new NoopSpanBuilder(Context::storage());
     }
 }

--- a/src/SDK/Trace/NoopTracer.php
+++ b/src/SDK/Trace/NoopTracer.php
@@ -22,6 +22,6 @@ final class NoopTracer implements TracerInterface
 
     public function spanBuilder(string $spanName): SpanBuilderInterface
     {
-        return NoopSpanBuilder::getInstance();
+        return new NoopSpanBuilder();
     }
 }

--- a/tests/SDK/Unit/Trace/NoopSpanBuilderTest.php
+++ b/tests/SDK/Unit/Trace/NoopSpanBuilderTest.php
@@ -15,14 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class NoopSpanBuilderTest extends TestCase
 {
-    public function testGetInstance(): void
-    {
-        $this->assertSame(
-            NoopSpanBuilder::getInstance(),
-            NoopSpanBuilder::getInstance()
-        );
-    }
-
     public function testSetParent(): void
     {
         $this->assertInstanceOf(


### PR DESCRIPTION
[Specification - Behavior of the API in the absence of an installed SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk):
> The API MUST create a non-recording Span with the SpanContext that is in the Span in the parent Context (whether explicitly given or implicit current) or, if the parent is a non-recording Span (which it usually always is if no SDK is present), it MAY return the parent Span back from the creation method.