### PR TITLE
Add sockets extension to dev container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN chmod +x /usr/local/bin/install-php-extensions; \
         zip \
         pcntl \
         grpc \
+        sockets \
         @composer \
     ; \
     # strip debug symbols from extensions to reduce size


### PR DESCRIPTION
(I didn't try building this locally fwiw)

Adds the sockets extension to the dev container so socket-related functions (e.g. socket_create) work ok