### PR TITLE
Allow psr/log ^2.0 and ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php-http/discovery": "^1.14",
         "promphp/prometheus_client_php": "^2.2.1",
         "psr/http-factory-implementation": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "symfony/polyfill-mbstring": "^1.23"
     },
     "config": {

--- a/src/Contrib/composer.json
+++ b/src/Contrib/composer.json
@@ -23,7 +23,7 @@
         "php-http/discovery": "^1.14",
         "promphp/prometheus_client_php": "^2.2.1",
         "psr/http-factory-implementation": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "symfony/polyfill-mbstring": "^1.23"
     },
     "autoload": {

--- a/src/SDK/Logs/SimplePsrFileLogger.php
+++ b/src/SDK/Logs/SimplePsrFileLogger.php
@@ -34,7 +34,7 @@ class SimplePsrFileLogger implements LoggerInterface
 
     /**
      * @param string $level
-     * @param string $message
+     * @param mixed $message
      * @param array $context
      * @psalm-suppress MoreSpecificImplementedParamType
      */

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -20,7 +20,7 @@
         "php-http/async-client-implementation": "^1.0",
         "php-http/discovery": "^1.14",
         "psr/http-factory-implementation": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "symfony/polyfill-mbstring": "^1.23"
     },
     "autoload": {


### PR DESCRIPTION
In PHP >= 8 psr/log versions ^2.0 or ^3.0 are loaded by default (stronger typed than version1).
Allowing these packages to be loaded allows opentelemetry-php to be added without having to downgrade psr/log.

