### PR TITLE
Unify test method's coding style

### DIFF
--- a/tests/API/Unit/Baggage/BaggageTest.php
+++ b/tests/API/Unit/Baggage/BaggageTest.php
@@ -81,7 +81,7 @@ class BaggageTest extends TestCase
         $this->assertSame('meta', $entry->getMetadata()->getValue());
     }
 
-    public function test_get_entry_presentNoMetadata(): void
+    public function test_get_entry_present_no_metadata(): void
     {
         /** @var Entry $entry */
         $entry = Baggage::getBuilder()->set('foo', 10)->build()->getEntry('foo');

--- a/tests/API/Unit/Baggage/BaggageTest.php
+++ b/tests/API/Unit/Baggage/BaggageTest.php
@@ -14,14 +14,14 @@ class BaggageTest extends TestCase
 {
     // region contextInteraction
 
-    public function testCurrentEmpty(): void
+    public function test_current_empty(): void
     {
         $scope = Context::getRoot()->activate();
         $this->assertSame(Baggage::getCurrent(), Baggage::getEmpty());
         $scope->detach();
     }
 
-    public function testCurrent(): void
+    public function test_current(): void
     {
         $scope = Context::getRoot()->withContextValue(
             Baggage::getBuilder()->set('foo', 'bar')->build(),
@@ -30,7 +30,7 @@ class BaggageTest extends TestCase
         $scope->detach();
     }
 
-    public function testGetCurrentBaggageDefault(): void
+    public function test_get_current_baggage_default(): void
     {
         $scope = Context::getRoot()->activate();
         $baggage = Baggage::getCurrent();
@@ -38,7 +38,7 @@ class BaggageTest extends TestCase
         $scope->detach();
     }
 
-    public function testGetCurrentBaggageSetsCorrectContext(): void
+    public function test_get_current_baggage_sets_correct_context(): void
     {
         $baggage = Baggage::getEmpty();
         $scope = Context::getRoot()->withContextValue($baggage)->activate();
@@ -46,13 +46,13 @@ class BaggageTest extends TestCase
         $scope->detach();
     }
 
-    public function testBaggageFromContextDefaultContext(): void
+    public function test_baggage_from_context_default_context(): void
     {
         $baggage = Baggage::fromContext(Context::getRoot());
         $this->assertSame($baggage, Baggage::getEmpty());
     }
 
-    public function testGetBaggageExplicitContext(): void
+    public function test_get_baggage_explicit_context(): void
     {
         $baggage = Baggage::getEmpty();
         $context = Context::getRoot()->withContextValue($baggage);
@@ -63,17 +63,17 @@ class BaggageTest extends TestCase
 
     // region functionality
 
-    public function testGetValuePresent(): void
+    public function test_get_value_present(): void
     {
         $this->assertSame(10, Baggage::getBuilder()->set('foo', 10)->build()->getValue('foo'));
     }
 
-    public function testGetValueMissing(): void
+    public function test_get_value_missing(): void
     {
         $this->assertNull(Baggage::getBuilder()->build()->getValue('foo'));
     }
 
-    public function testGetEntryPresent(): void
+    public function test_get_entry_present(): void
     {
         /** @var Entry $entry */
         $entry = Baggage::getBuilder()->set('foo', 10, new Metadata('meta'))->build()->getEntry('foo');
@@ -81,7 +81,7 @@ class BaggageTest extends TestCase
         $this->assertSame('meta', $entry->getMetadata()->getValue());
     }
 
-    public function testGetEntryPresentNoMetadata(): void
+    public function test_get_entry_presentNoMetadata(): void
     {
         /** @var Entry $entry */
         $entry = Baggage::getBuilder()->set('foo', 10)->build()->getEntry('foo');
@@ -89,12 +89,12 @@ class BaggageTest extends TestCase
         $this->assertEmpty($entry->getMetadata()->getValue());
     }
 
-    public function testGetEntryMissing(): void
+    public function test_get_entry_missing(): void
     {
         $this->assertNull(Baggage::getBuilder()->build()->getEntry('foo'));
     }
 
-    public function testToBuilder(): void
+    public function test_to_builder(): void
     {
         $baggage = Baggage::getBuilder()->set('foo', 10)->build();
         $baggage2 = $baggage->toBuilder()->build();
@@ -102,7 +102,7 @@ class BaggageTest extends TestCase
         $this->assertSame(10, $baggage2->getValue('foo'));
     }
 
-    public function testGetAll(): void
+    public function test_get_all(): void
     {
         $baggage = Baggage::getBuilder()
             ->set('foo', 'bar')

--- a/tests/API/Unit/Baggage/Propagation/BaggagePropagatorTest.php
+++ b/tests/API/Unit/Baggage/Propagation/BaggagePropagatorTest.php
@@ -20,7 +20,7 @@ class BaggagePropagatorTest extends TestCase
         );
     }
 
-    public function test_inject_emptyBaggage(): void
+    public function test_inject_empty_baggage(): void
     {
         $carrier = [];
 
@@ -50,7 +50,7 @@ class BaggagePropagatorTest extends TestCase
         );
     }
 
-    public function test_inject_encodesValue(): void
+    public function test_inject_encodes_value(): void
     {
         $carrier = [];
 
@@ -73,7 +73,7 @@ class BaggagePropagatorTest extends TestCase
         );
     }
 
-    public function test_extract_missingHeader(): void
+    public function test_extract_missing_header(): void
     {
         $this->assertEquals(
             Context::getRoot(),

--- a/tests/API/Unit/Trace/NonRecordingSpanTest.php
+++ b/tests/API/Unit/Trace/NonRecordingSpanTest.php
@@ -14,7 +14,7 @@ class NonRecordingSpanTest extends TestCase
 {
     private ?SpanContextInterface $context = null;
 
-    public function testGetContext(): void
+    public function test_get_context(): void
     {
         $span = $this->createNonRecordingSpan();
 
@@ -24,14 +24,14 @@ class NonRecordingSpanTest extends TestCase
         );
     }
 
-    public function testIsRecording(): void
+    public function test_is_recording(): void
     {
         $this->assertFalse(
             $this->createNonRecordingSpan()->isRecording()
         );
     }
 
-    public function testSetAttribute(): void
+    public function test_set_attribute(): void
     {
         $this->assertInstanceOf(
             NonRecordingSpan::class,
@@ -39,7 +39,7 @@ class NonRecordingSpanTest extends TestCase
         );
     }
 
-    public function testSetAttributes(): void
+    public function test_set_attributes(): void
     {
         $this->assertInstanceOf(
             NonRecordingSpan::class,
@@ -49,7 +49,7 @@ class NonRecordingSpanTest extends TestCase
         );
     }
 
-    public function testAddEvent(): void
+    public function test_add_event(): void
     {
         $this->assertInstanceOf(
             NonRecordingSpan::class,
@@ -57,7 +57,7 @@ class NonRecordingSpanTest extends TestCase
         );
     }
 
-    public function testRecordException(): void
+    public function test_record_exception(): void
     {
         $this->assertInstanceOf(
             NonRecordingSpan::class,
@@ -67,7 +67,7 @@ class NonRecordingSpanTest extends TestCase
         );
     }
 
-    public function testUpdateName(): void
+    public function test_update_name(): void
     {
         $this->assertInstanceOf(
             NonRecordingSpan::class,
@@ -75,7 +75,7 @@ class NonRecordingSpanTest extends TestCase
         );
     }
 
-    public function testSetStatus(): void
+    public function test_set_status(): void
     {
         $this->assertInstanceOf(
             NonRecordingSpan::class,
@@ -83,7 +83,7 @@ class NonRecordingSpanTest extends TestCase
         );
     }
 
-    public function testEnd(): void
+    public function test_end(): void
     {
         $this->assertNull(
             // @phpstan-ignore-next-line

--- a/tests/API/Unit/Trace/NoopSpanBuilderTest.php
+++ b/tests/API/Unit/Trace/NoopSpanBuilderTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class NoopSpanBuilderTest extends TestCase
 {
-    public function testSetParent(): void
+    public function test_set_parent(): void
     {
         $contextStorage = $this->createMock(ContextStorageInterface::class);
 
@@ -32,7 +32,7 @@ class NoopSpanBuilderTest extends TestCase
         );
     }
 
-    public function testNoopCreatedSpanUsesProvidedContext(): void
+    public function test_noop_created_span_uses_provided_context(): void
     {
         $spanContext = $this->createMock(SpanContextInterface::class);
 
@@ -52,7 +52,7 @@ class NoopSpanBuilderTest extends TestCase
         $this->assertSame($span->getContext(), $spanContext);
     }
 
-    public function testNoopCreatedSpanUsesCurrentContext(): void
+    public function test_noop_created_span_uses_current_context(): void
     {
         $spanContext = $this->createMock(SpanContextInterface::class);
 
@@ -72,7 +72,7 @@ class NoopSpanBuilderTest extends TestCase
         $this->assertSame($span->getContext(), $spanContext);
     }
 
-    public function testNoopCreatedSpanDoesntUseCurrentContextIfNoParent(): void
+    public function test_noop_created_span_doesnt_use_current_context_if_no_parent(): void
     {
         $spanContext = $this->createMock(SpanContextInterface::class);
 
@@ -94,7 +94,7 @@ class NoopSpanBuilderTest extends TestCase
         $this->assertFalse($span->getContext()->isValid());
     }
 
-    public function testNoopCreatedSpanRemovesIsRecordingFlag(): void
+    public function test_noop_created_span_removes_is_recording_flag(): void
     {
         $span = $this->createMock(SpanInterface::class);
         $span->method('isRecording')->willReturn(true);
@@ -112,7 +112,7 @@ class NoopSpanBuilderTest extends TestCase
         $this->assertFalse($span->isRecording());
     }
 
-    public function testSetNoParent(): void
+    public function test_set_no_parent(): void
     {
         $contextStorage = $this->createMock(ContextStorageInterface::class);
 
@@ -122,7 +122,7 @@ class NoopSpanBuilderTest extends TestCase
         );
     }
 
-    public function testAddLink(): void
+    public function test_add_link(): void
     {
         $contextStorage = $this->createMock(ContextStorageInterface::class);
 
@@ -134,7 +134,7 @@ class NoopSpanBuilderTest extends TestCase
         );
     }
 
-    public function testSetAttribute(): void
+    public function test_set_attribute(): void
     {
         $contextStorage = $this->createMock(ContextStorageInterface::class);
 
@@ -144,7 +144,7 @@ class NoopSpanBuilderTest extends TestCase
         );
     }
 
-    public function testSetAttributes(): void
+    public function test_set_attributes(): void
     {
         $contextStorage = $this->createMock(ContextStorageInterface::class);
 
@@ -154,7 +154,7 @@ class NoopSpanBuilderTest extends TestCase
         );
     }
 
-    public function testSetStartTimestamp(): void
+    public function test_set_start_timestamp(): void
     {
         $contextStorage = $this->createMock(ContextStorageInterface::class);
 
@@ -166,7 +166,7 @@ class NoopSpanBuilderTest extends TestCase
         );
     }
 
-    public function testSetSpanKind(): void
+    public function test_set_span_kind(): void
     {
         $contextStorage = $this->createMock(ContextStorageInterface::class);
 
@@ -176,7 +176,7 @@ class NoopSpanBuilderTest extends TestCase
         );
     }
 
-    public function testStartSpan(): void
+    public function test_start_span(): void
     {
         $contextStorage = $this->createMock(ContextStorageInterface::class);
 

--- a/tests/API/Unit/Trace/Propagation/TraceContextPropagatorTest.php
+++ b/tests/API/Unit/Trace/Propagation/TraceContextPropagatorTest.php
@@ -46,7 +46,7 @@ class TraceContextPropagatorTest extends TestCase
         $this->assertEmpty($carrier);
     }
 
-    public function test_inject_invalidContext(): void
+    public function test_inject_invalid_context(): void
     {
         $carrier = [];
         $this
@@ -66,7 +66,7 @@ class TraceContextPropagatorTest extends TestCase
         $this->assertEmpty($carrier);
     }
 
-    public function test_inject_sampledContext(): void
+    public function test_inject_sampled_context(): void
     {
         $carrier = [];
         $this
@@ -86,7 +86,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_inject_sampledContext_withTraceState(): void
+    public function test_inject_sampled_context_with_trace_state(): void
     {
         $carrier = [];
         $this
@@ -109,7 +109,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_inject_nonSampledContext(): void
+    public function test_inject_non_sampled_context(): void
     {
         $carrier = [];
         $this
@@ -129,7 +129,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_inject_nonSampledContext_withTraceState(): void
+    public function test_inject_non_sampled_context_with_trace_state(): void
     {
         $carrier = [];
         $this
@@ -160,7 +160,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_extract_sampledContext(): void
+    public function test_extract_sampled_context(): void
     {
         $carrier = [
             TraceContextPropagator::TRACEPARENT => self::TRACEPARENT_HEADER_SAMPLED,
@@ -172,7 +172,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_extract_sampledContext_withTraceState(): void
+    public function test_extract_sampled_context_with_trace_state(): void
     {
         $carrier = [
             TraceContextPropagator::TRACEPARENT => self::TRACEPARENT_HEADER_SAMPLED,
@@ -185,7 +185,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_extract_nonSampledContext(): void
+    public function test_extract_non_sampled_context(): void
     {
         $carrier = [
             TraceContextPropagator::TRACEPARENT => self::TRACEPARENT_HEADER_NOT_SAMPLED,
@@ -197,7 +197,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_extract_nonSampledContext_withTraceState(): void
+    public function test_extract_non_sampled_context_with_trace_state(): void
     {
         $carrier = [
             TraceContextPropagator::TRACEPARENT => self::TRACEPARENT_HEADER_NOT_SAMPLED,
@@ -210,7 +210,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_extractAndInject(): void
+    public function test_extract_and_inject(): void
     {
         $traceParent = '00-' . self::TRACE_ID_BASE16 . '-' . self::SPAN_ID_BASE16 . '-01';
         $extractCarrier = [
@@ -222,7 +222,7 @@ class TraceContextPropagatorTest extends TestCase
         $this->assertSame($injectCarrier, $extractCarrier);
     }
 
-    public function test_extract_traceStateWithSpaces(): void
+    public function test_extract_trace_state_with_spaces(): void
     {
         $carrier = [
             TraceContextPropagator::TRACEPARENT => self::TRACEPARENT_HEADER_NOT_SAMPLED,
@@ -235,7 +235,7 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_extract_emptyTraceState(): void
+    public function test_extract_empty_trace_state(): void
     {
         $carrier = [
             TraceContextPropagator::TRACEPARENT => self::TRACEPARENT_HEADER_NOT_SAMPLED,
@@ -248,35 +248,35 @@ class TraceContextPropagatorTest extends TestCase
         );
     }
 
-    public function test_extract_emptyHeader(): void
+    public function test_extract_empty_header(): void
     {
         $this->assertInvalid([
             TraceContextPropagator::TRACEPARENT => '',
         ]);
     }
 
-    public function test_invalidTraceId(): void
+    public function test_invalid_trace_id(): void
     {
         $this->assertInvalid([
             TraceContextPropagator::TRACEPARENT => '00-abcdefghijklmnopabcdefghijklmnop-' . self::SPAN_ID_BASE16 . '-01',
         ]);
     }
 
-    public function test_invalidTraceId_size(): void
+    public function test_invalid_trace_id_size(): void
     {
         $this->assertInvalid([
             TraceContextPropagator::TRACEPARENT => '00-' . self::TRACE_ID_BASE16 . '00-' . self::SPAN_ID_BASE16 . '-01',
         ]);
     }
 
-    public function test_invalidSpanId(): void
+    public function test_invalid_span_id(): void
     {
         $this->assertInvalid([
             TraceContextPropagator::TRACEPARENT => '00-' . self::TRACE_ID_BASE16 . 'abcdefghijklmnop-01',
         ]);
     }
 
-    public function test_invalidSpanId_size(): void
+    public function test_invalid_span_id_size(): void
     {
         $this->assertInvalid([
             TraceContextPropagator::TRACEPARENT => '00-' . self::TRACE_ID_BASE16 . 'abcdefghijklmnop-00-01',

--- a/tests/API/Unit/Trace/SpanContextTest.php
+++ b/tests/API/Unit/Trace/SpanContextTest.php
@@ -29,7 +29,7 @@ class SpanContextTest extends TestCase
 
     // region API
 
-    public function test_isValid(): void
+    public function test_is_valid(): void
     {
         $this->assertFalse(SpanContext::getInvalid()->isValid());
 
@@ -51,31 +51,31 @@ class SpanContextTest extends TestCase
         $this->assertTrue($this->second->isValid());
     }
 
-    public function test_getTraceId(): void
+    public function test_get_trace_id(): void
     {
         $this->assertSame(self::FIRST_TRACE_ID, $this->first->getTraceId());
         $this->assertSame(self::SECOND_TRACE_ID, $this->second->getTraceId());
     }
 
-    public function test_getSpanId(): void
+    public function test_get_span_id(): void
     {
         $this->assertSame(self::FIRST_SPAN_ID, $this->first->getSpanId());
         $this->assertSame(self::SECOND_SPAN_ID, $this->second->getSpanId());
     }
 
-    public function test_getTraceFlags(): void
+    public function test_get_trace_flags(): void
     {
         $this->assertSame(API\SpanContextInterface::TRACE_FLAG_DEFAULT, $this->first->getTraceFlags());
         $this->assertSame(API\SpanContextInterface::TRACE_FLAG_SAMPLED, $this->second->getTraceFlags());
     }
 
-    public function test_getTraceState(): void
+    public function test_get_trace_state(): void
     {
         $this->assertEquals(new TraceState('foo=bar'), $this->first->getTraceState());
         $this->assertEquals(new TraceState('foo=baz'), $this->second->getTraceState());
     }
 
-    public function test_isRemote(): void
+    public function test_is_remote(): void
     {
         $this->assertFalse($this->first->isRemote());
         $this->assertFalse($this->second->isRemote());

--- a/tests/API/Unit/Trace/TraceStateTest.php
+++ b/tests/API/Unit/Trace/TraceStateTest.php
@@ -9,9 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class TraceStateTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_get_tracestate_value(): void
     {
         $tracestate = new TraceState('vendor1=value1');
@@ -19,9 +16,6 @@ class TraceStateTest extends TestCase
         $this->assertSame('value1', $tracestate->get('vendor1'));
     }
 
-    /**
-     * @test
-     */
     public function test_with_tracestate_value(): void
     {
         $tracestate = new TraceState('vendor1=value1');
@@ -52,9 +46,6 @@ class TraceStateTest extends TestCase
         $this->assertSame((string) $tracestate, (string) $tracestateWithInvalidValue);
     }
 
-    /**
-     * @test
-     */
     public function test_without_tracestate_value(): void
     {
         $tracestate = new TraceState('vendor1=value1,vendor2=value2');
@@ -66,9 +57,6 @@ class TraceStateTest extends TestCase
         $this->assertSame('value2', $tracestate->get('vendor2'));
     }
 
-    /**
-     * @test
-     */
     public function test_to_string_tracestate(): void
     {
         $tracestate = new TraceState('vendor1=value1');
@@ -79,9 +67,6 @@ class TraceStateTest extends TestCase
         $this->assertEmpty((string) $emptyTracestate);
     }
 
-    /**
-     * @test
-     */
     public function test_max_tracestate_list_members(): void
     {
         // Build a tracestate with the max 32 values. Ex '0=0,1=1,...,31=31'
@@ -107,9 +92,6 @@ class TraceStateTest extends TestCase
         $this->assertSame(TraceState::MAX_TRACESTATE_LIST_MEMBERS, $truncatedTracestate->getListMemberCount());
     }
 
-    /**
-     * @test
-     */
     public function test_max_tracestate_length(): void
     {
         // Build a vendor key with a length of 256 characters. The max characters allowed.
@@ -133,9 +115,6 @@ class TraceStateTest extends TestCase
         $this->assertSame($rawTraceState, (string) $validTracestate);
     }
 
-    /**
-     * @test
-     */
     public function test_validate_key(): void
     {
         // Valid keys
@@ -178,9 +157,6 @@ class TraceStateTest extends TestCase
         $this->assertNull($tracestate->get($invalidKey));
     }
 
-    /**
-     * @test
-     */
     public function test_validate_value(): void
     {
         // Tests values are within the range of 0x20 to 0x7E characters

--- a/tests/API/Unit/Trace/TraceStateTest.php
+++ b/tests/API/Unit/Trace/TraceStateTest.php
@@ -12,7 +12,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function test_get_tracestate_value()
+    public function test_get_tracestate_value(): void
     {
         $tracestate = new TraceState('vendor1=value1');
 
@@ -22,7 +22,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function test_with_tracestate_value()
+    public function test_with_tracestate_value(): void
     {
         $tracestate = new TraceState('vendor1=value1');
         $tracestateWithNewValue = $tracestate->with('vendor2', 'value2');
@@ -55,7 +55,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function test_without_tracestate_value()
+    public function test_without_tracestate_value(): void
     {
         $tracestate = new TraceState('vendor1=value1,vendor2=value2');
         $tracestateWithoutNewValue = $tracestate->without('vendor1');
@@ -69,7 +69,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function test_to_string_tracestate()
+    public function test_to_string_tracestate(): void
     {
         $tracestate = new TraceState('vendor1=value1');
         $emptyTracestate = new TraceState();
@@ -82,7 +82,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function test_max_tracestate_list_members()
+    public function test_max_tracestate_list_members(): void
     {
         // Build a tracestate with the max 32 values. Ex '0=0,1=1,...,31=31'
         $rawTraceState = range(0, TraceState::MAX_TRACESTATE_LIST_MEMBERS - 1);
@@ -110,7 +110,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function test_max_tracestate_length()
+    public function test_max_tracestate_length(): void
     {
         // Build a vendor key with a length of 256 characters. The max characters allowed.
         $vendorKey = \str_repeat('k', TraceState::MAX_TRACESTATE_LENGTH / 2);
@@ -136,7 +136,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function test_validate_key()
+    public function test_validate_key(): void
     {
         // Valid keys
         $validKeys = 'a-b=1,c*d=2,e/f=3,g_h=4,01@i-j=5';
@@ -181,7 +181,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function test_validate_value()
+    public function test_validate_value(): void
     {
         // Tests values are within the range of 0x20 to 0x7E characters
         $tracestate =   'char1=value' . chr(0x19) . '1'

--- a/tests/API/Unit/Trace/TraceStateTest.php
+++ b/tests/API/Unit/Trace/TraceStateTest.php
@@ -12,7 +12,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testGetTracestateValue()
+    public function test_get_tracestate_value()
     {
         $tracestate = new TraceState('vendor1=value1');
 
@@ -22,7 +22,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testWithTracestateValue()
+    public function test_with_tracestate_value()
     {
         $tracestate = new TraceState('vendor1=value1');
         $tracestateWithNewValue = $tracestate->with('vendor2', 'value2');
@@ -55,7 +55,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testWithoutTracestateValue()
+    public function test_without_tracestate_value()
     {
         $tracestate = new TraceState('vendor1=value1,vendor2=value2');
         $tracestateWithoutNewValue = $tracestate->without('vendor1');
@@ -69,7 +69,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testToStringTracestate()
+    public function test_to_string_tracestate()
     {
         $tracestate = new TraceState('vendor1=value1');
         $emptyTracestate = new TraceState();
@@ -82,7 +82,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testMaxTracestateListMembers()
+    public function test_max_tracestate_list_members()
     {
         // Build a tracestate with the max 32 values. Ex '0=0,1=1,...,31=31'
         $rawTraceState = range(0, TraceState::MAX_TRACESTATE_LIST_MEMBERS - 1);
@@ -110,7 +110,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testMaxTracestateLength()
+    public function test_max_tracestate_length()
     {
         // Build a vendor key with a length of 256 characters. The max characters allowed.
         $vendorKey = \str_repeat('k', TraceState::MAX_TRACESTATE_LENGTH / 2);
@@ -136,7 +136,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testValidateKey()
+    public function test_validate_key()
     {
         // Valid keys
         $validKeys = 'a-b=1,c*d=2,e/f=3,g_h=4,01@i-j=5';
@@ -181,7 +181,7 @@ class TraceStateTest extends TestCase
     /**
      * @test
      */
-    public function testvalidateValue()
+    public function test_validate_value()
     {
         // Tests values are within the range of 0x20 to 0x7E characters
         $tracestate =   'char1=value' . chr(0x19) . '1'

--- a/tests/Context/Unit/ContextKeyTest.php
+++ b/tests/Context/Unit/ContextKeyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ContextKeyTest extends TestCase
 {
-    public function test_name()
+    public function test_name(): void
     {
         $name = 'foo';
 

--- a/tests/Context/Unit/ContextKeyTest.php
+++ b/tests/Context/Unit/ContextKeyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ContextKeyTest extends TestCase
 {
-    public function testName()
+    public function test_name()
     {
         $name = 'foo';
 

--- a/tests/Context/Unit/ContextTest.php
+++ b/tests/Context/Unit/ContextTest.php
@@ -19,9 +19,6 @@ class ContextTest extends TestCase
         $this->assertSame($context, Context::getCurrent());
     }
 
-    /**
-     * @test
-     */
     public function test_ctx_can_store_values_by_key(): void
     {
         $key1 = new ContextKey('key1');
@@ -33,9 +30,6 @@ class ContextTest extends TestCase
         $this->assertSame($ctx->get($key2), 'val2');
     }
 
-    /**
-     * @test
-     */
     public function test_set_does_not_mutate_the_original(): void
     {
         $key1 = new ContextKey();
@@ -51,9 +45,6 @@ class ContextTest extends TestCase
         $this->assertNull($parent->get($key2));
     }
 
-    /**
-     * @test
-     */
     public function test_ctx_key_names_are_not_ids(): void
     {
         $key_name = 'foo';
@@ -67,9 +58,6 @@ class ContextTest extends TestCase
         $this->assertSame($ctx->get($key2), 'val2');
     }
 
-    /**
-     * @test
-     */
     public function test_empty_ctx_keys_are_valid(): void
     {
         $key1 = new ContextKey();
@@ -81,9 +69,6 @@ class ContextTest extends TestCase
         $this->assertSame($ctx->get($key2), 'val2');
     }
 
-    /**
-     * @test
-     */
     public function test_ctx_can_store_scalar_array_null_and_obj(): void
     {
         $scalar_val = 42;
@@ -108,9 +93,6 @@ class ContextTest extends TestCase
         $this->assertSame($ctx->get($obj_key), $obj_val);
     }
 
-    /**
-     * @test
-     */
     public function test_storage_order_doesnt_matter(): void
     {
         $arr = [];
@@ -128,9 +110,6 @@ class ContextTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
     public function test_static_use_of_current_doesnt_interfere_with_other_calls(): void
     {
         $key1 = new ContextKey();
@@ -152,9 +131,6 @@ class ContextTest extends TestCase
         $this->assertNull(Context::getValue($key3));
     }
 
-    /**
-     * @test
-     */
     public function test_reusing_key_overwrites_value(): void
     {
         $key = new ContextKey();
@@ -165,18 +141,12 @@ class ContextTest extends TestCase
         $this->assertSame($ctx->get($key), 'val2');
     }
 
-    /**
-     * @test
-     */
     public function test_ctx_value_not_found_throws(): void
     {
         $ctx = (new Context())->with(new ContextKey('foo'), 'bar');
         $this->assertNull($ctx->get(new ContextKey('baz')));
     }
 
-    /**
-     * @test
-     */
     public function test_attach_and_detach_set_current_ctx(): void
     {
         $key = new ContextKey();
@@ -189,9 +159,6 @@ class ContextTest extends TestCase
         $this->assertSame(Context::getValue($key), '111');
     }
 
-    /**
-     * @test
-     */
     public function test_instance_set_and_static_get_use_same_ctx(): void
     {
         $key = new ContextKey('ofoba');
@@ -204,9 +171,6 @@ class ContextTest extends TestCase
         $this->assertSame(Context::getValue($key, null), $val);
     }
 
-    /**
-     * @test
-     */
     public function test_static_set_and_instance_get_use_same_ctx(): void
     {
         $key1 = new ContextKey();
@@ -221,9 +185,6 @@ class ContextTest extends TestCase
         $this->assertSame($ctx->get($key2), $val2);
     }
 
-    /**
-     * @test
-     */
     public function test_static_without_passed_ctx_uses_current(): void
     {
         $ctx = Context::withValue(new ContextKey(), '111');
@@ -237,9 +198,6 @@ class ContextTest extends TestCase
         $this->assertNotSame($first, $second);
     }
 
-    /**
-     * @test
-     */
     public function test_static_with_passed_ctx_does_not_use_current(): void
     {
         $key1 = new ContextKey();
@@ -250,9 +208,6 @@ class ContextTest extends TestCase
         $this->assertSame($currentCtx, Context::getCurrent());
     }
 
-    /**
-     * @test
-     */
     public function test_storage_switch_switches_context(): void
     {
         $main = new Context();
@@ -285,9 +240,6 @@ class ContextTest extends TestCase
         $scopeMain->detach();
     }
 
-    /**
-     * @test
-     */
     public function test_storage_fork_keeps_forked_root(): void
     {
         $main = new Context();

--- a/tests/Context/Unit/ContextTest.php
+++ b/tests/Context/Unit/ContextTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class ContextTest extends TestCase
 {
-    public function testActivate(): void
+    public function test_activate(): void
     {
         $context = new Context();
 
@@ -22,7 +22,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function ctxCanStoreValuesByKey(): void
+    public function test_ctx_can_store_values_by_key(): void
     {
         $key1 = new ContextKey('key1');
         $key2 = new ContextKey('key2');
@@ -36,7 +36,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function setDoesNotMutateTheOriginal(): void
+    public function test_set_does_not_mutate_the_original(): void
     {
         $key1 = new ContextKey();
         $key2 = new ContextKey();
@@ -54,7 +54,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function ctxKeyNamesAreNotIds(): void
+    public function test_ctx_key_names_are_not_ids(): void
     {
         $key_name = 'foo';
 
@@ -70,7 +70,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function emptyCtxKeysAreValid(): void
+    public function test_empty_ctx_keys_are_valid(): void
     {
         $key1 = new ContextKey();
         $key2 = new ContextKey();
@@ -84,7 +84,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function ctxCanStoreScalarArrayNullAndObj(): void
+    public function test_ctx_can_store_scalar_array_null_and_obj(): void
     {
         $scalar_val = 42;
         $array_val = ['foo', 'bar'];
@@ -111,7 +111,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function storageOrderDoesntMatter(): void
+    public function test_storage_order_doesnt_matter(): void
     {
         $arr = [];
         foreach (range(0, 9) as $i) {
@@ -131,7 +131,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function staticUseOfCurrentDoesntInterfereWithOtherCalls(): void
+    public function test_static_use_of_current_doesnt_interfere_with_other_calls(): void
     {
         $key1 = new ContextKey();
         $key2 = new ContextKey();
@@ -155,7 +155,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function reusingKeyOverwritesValue(): void
+    public function test_reusing_key_overwrites_value(): void
     {
         $key = new ContextKey();
         $ctx = (new Context())->with($key, 'val1');
@@ -168,7 +168,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function ctxValueNotFoundThrows(): void
+    public function test_ctx_value_not_found_throws(): void
     {
         $ctx = (new Context())->with(new ContextKey('foo'), 'bar');
         $this->assertNull($ctx->get(new ContextKey('baz')));
@@ -177,7 +177,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function attachAndDetachSetCurrentCtx(): void
+    public function test_attach_and_detach_set_current_ctx(): void
     {
         $key = new ContextKey();
         Context::attach((new Context())->with($key, '111'));
@@ -192,7 +192,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function instanceSetAndStaticGetUseSameCtx(): void
+    public function test_instance_set_and_static_get_use_same_ctx(): void
     {
         $key = new ContextKey('ofoba');
         $val = 'foobar';
@@ -207,7 +207,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function staticSetAndInstanceGetUseSameCtx(): void
+    public function test_static_set_and_instance_get_use_same_ctx(): void
     {
         $key1 = new ContextKey();
         $key2 = new ContextKey();
@@ -224,7 +224,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function staticWithoutPassedCtxUsesCurrent(): void
+    public function test_static_without_passed_ctx_uses_current(): void
     {
         $ctx = Context::withValue(new ContextKey(), '111');
         $first = Context::getCurrent();
@@ -240,7 +240,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function staticWithPassedCtxDoesNotUseCurrent(): void
+    public function test_static_with_passed_ctx_does_not_use_current(): void
     {
         $key1 = new ContextKey();
         $currentCtx = Context::withValue($key1, '111');
@@ -253,7 +253,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function storageSwitchSwitchesContext(): void
+    public function test_storage_switch_switches_context(): void
     {
         $main = new Context();
         $fork = new Context();
@@ -288,7 +288,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function storageForkKeepsForkedRoot(): void
+    public function test_storage_fork_keeps_forked_root(): void
     {
         $main = new Context();
 

--- a/tests/Context/Unit/Propagation/ArrayAccessGetterSetterTest.php
+++ b/tests/Context/Unit/Propagation/ArrayAccessGetterSetterTest.php
@@ -13,7 +13,7 @@ use stdClass;
 
 class ArrayAccessGetterSetterTest extends TestCase
 {
-    public function testGetFromMapArray(): void
+    public function test_get_from_map_array(): void
     {
         $carrier = ['a' => 'alpha'];
         $map = new ArrayAccessGetterSetter();
@@ -22,7 +22,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $this->assertSame(['a'], $map->keys($carrier));
     }
 
-    public function testGetArrayValuesFromCarrier(): void
+    public function test_get_array_values_from_carrier(): void
     {
         // Carrier contains an array as one of the values
         $carrier = [
@@ -35,7 +35,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $this->assertSame(['a', 'b'], $map->keys($carrier));
     }
 
-    public function testGetNumericalKeyFromCarrier(): void
+    public function test_get_numerical_key_from_carrier(): void
     {
         // Carrier contains an array as one of the values
         $carrier = [
@@ -48,7 +48,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $this->assertSame([1, 'b'], $map->keys($carrier));
     }
 
-    public function testGetFromUnsupportedCarrier(): void
+    public function test_get_from_unsupported_carrier(): void
     {
         $carrier = new stdClass();
         $map = new ArrayAccessGetterSetter();
@@ -56,7 +56,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $map->get($carrier, 'a');
     }
 
-    public function testKeysFromMapArrayAccess(): void
+    public function test_keys_from_map_array_access(): void
     {
         $carrier = new ArrayObject(['a' => 'alpha']);
         $map = new ArrayAccessGetterSetter();
@@ -64,7 +64,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $map->keys($carrier);
     }
 
-    public function testKeysFromUnsupportedCarrier(): void
+    public function test_keys_from_unsupported_carrier(): void
     {
         $carrier = new stdClass();
         $map = new ArrayAccessGetterSetter();
@@ -72,7 +72,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $map->keys($carrier);
     }
 
-    public function testKeysKeyedArrayAccessObject(): void
+    public function test_keys_keyed_array_access_object(): void
     {
         $carrier = $this->createMock(KeyedArrayAccessInterface::class);
         $carrier->method('keys')->willReturn(['a', 'b']);
@@ -82,7 +82,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $this->assertSame(['a', 'b'], $map->keys($carrier));
     }
 
-    public function testSetMapArray(): void
+    public function test_set_map_array(): void
     {
         $carrier = ['a' => 'alpha'];
         $map = new ArrayAccessGetterSetter();
@@ -92,7 +92,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $this->assertSame('bravo', $value);
     }
 
-    public function testSetMapArrayAccess(): void
+    public function test_set_map_array_access(): void
     {
         $carrier = new ArrayObject(['a' => 'alpha']);
         $map = new ArrayAccessGetterSetter();
@@ -102,7 +102,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $this->assertSame('bravo', $value);
     }
 
-    public function testSetUnsupportedCarrier(): void
+    public function test_set_unsupported_carrier(): void
     {
         $carrier = new stdClass();
         $map = new ArrayAccessGetterSetter();
@@ -111,7 +111,7 @@ class ArrayAccessGetterSetterTest extends TestCase
         $map->set($carrier, 'a', 'alpha');
     }
 
-    public function testSetEmptyKey(): void
+    public function test_set_empty_key(): void
     {
         $carrier = ['a' => 'alpha'];
         $map = new ArrayAccessGetterSetter();

--- a/tests/Context/Unit/Propagation/MultiTextMapPropagatorTest.php
+++ b/tests/Context/Unit/Propagation/MultiTextMapPropagatorTest.php
@@ -70,7 +70,7 @@ class MultiTextMapPropagatorTest extends MockeryTestCase
         ]))->inject($carrier, null, $context);
     }
 
-    public function test_extract_noPropagators(): void
+    public function test_extract_no_propagators(): void
     {
         $this->assertSame(
             Context::getRoot(),
@@ -78,7 +78,7 @@ class MultiTextMapPropagatorTest extends MockeryTestCase
         );
     }
 
-    public function test_extract_foundAll(): void
+    public function test_extract_found_all(): void
     {
         $carrier = [];
 
@@ -101,7 +101,7 @@ class MultiTextMapPropagatorTest extends MockeryTestCase
         );
     }
 
-    public function test_extract_notFound(): void
+    public function test_extract_not_found(): void
     {
         $carrier = [];
 

--- a/tests/Context/Unit/Propagation/NoopTextMapPropagatorTest.php
+++ b/tests/Context/Unit/Propagation/NoopTextMapPropagatorTest.php
@@ -15,7 +15,7 @@ class NoopTextMapPropagatorTest extends TestCase
         $this->assertEmpty(NoopTextMapPropagator::getInstance()->fields());
     }
 
-    public function test_extract_contextIsUnchanged(): void
+    public function test_extract_context_is_unchanged(): void
     {
         $this->assertSame(
             Context::getRoot(),
@@ -23,7 +23,7 @@ class NoopTextMapPropagatorTest extends TestCase
         );
     }
 
-    public function test_inject_injectsNothing(): void
+    public function test_inject_injects_nothing(): void
     {
         $carrier = [];
         NoopTextMapPropagator::getInstance()->inject($carrier);

--- a/tests/Context/Unit/ScopeTest.php
+++ b/tests/Context/Unit/ScopeTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class ScopeTest extends TestCase
 {
-    public function testScopeCloseRestoresContext(): void
+    public function test_scope_close_restores_context(): void
     {
         $key = new ContextKey();
         $ctx = (new Context())->with($key, 'test');
@@ -24,7 +24,7 @@ class ScopeTest extends TestCase
         $this->assertNull(Context::getValue($key));
     }
 
-    public function testNestedScope(): void
+    public function test_nested_scope(): void
     {
         $key = new ContextKey();
         $ctx1 = (new Context())->with($key, 'test1');
@@ -42,7 +42,7 @@ class ScopeTest extends TestCase
         $this->assertNull(Context::getValue($key));
     }
 
-    public function testDetachedScopeDetach(): void
+    public function test_detached_scope_detach(): void
     {
         $scope1 = Context::attach(Context::getCurrent());
 
@@ -50,7 +50,7 @@ class ScopeTest extends TestCase
         $this->assertSame(ScopeInterface::DETACHED, $scope1->detach() & ScopeInterface::DETACHED); // @phpstan-ignore-line
     }
 
-    public function testOrderMismatchScopeDetach(): void
+    public function test_order_mismatch_scope_detach(): void
     {
         $scope1 = Context::attach(Context::getCurrent());
         $scope2 = Context::attach(Context::getCurrent());
@@ -59,7 +59,7 @@ class ScopeTest extends TestCase
         $this->assertSame(0, $scope2->detach());
     }
 
-    public function testInactiveScopeDetach(): void
+    public function test_inactive_scope_detach(): void
     {
         $scope1 = Context::attach(Context::getCurrent());
 

--- a/tests/Contrib/Unit/AbstractHttpExporterTest.php
+++ b/tests/Contrib/Unit/AbstractHttpExporterTest.php
@@ -42,7 +42,7 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
      * @dataProvider exporterResponseStatusDataProvider
      * @psalm-suppress PossiblyUndefinedMethod
      */
-    public function testExporterResponseStatus($responseStatus, $expected): void
+    public function test_exporter_response_status($responseStatus, $expected): void
     {
         $this->getClientInterfaceMock()->method('sendRequest')
             ->willReturn(
@@ -74,7 +74,7 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
     /**
      * @dataProvider invalidDsnDataProvider
      */
-    public function testThrowsExceptionIfInvalidDsnIsPassed($invalidDsn): void
+    public function test_throws_exception_if_invalid_dsn_is_passed($invalidDsn): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -97,7 +97,7 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
      * @dataProvider clientExceptionDataProvider
      * @psalm-suppress PossiblyUndefinedMethod
      */
-    public function testClientExceptionDecidesReturnCode($exception, $expected): void
+    public function test_client_exception_decides_return_code($exception, $expected): void
     {
         $client = $this->getClientInterfaceMock();
         $client->method('sendRequest')
@@ -129,7 +129,7 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
         ];
     }
 
-    public function testFromConnectionString(): void
+    public function test_from_connection_string(): void
     {
         $exporterClass = static::getExporterClass();
 

--- a/tests/Contrib/Unit/NewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/NewrelicSpanConverterTest.php
@@ -11,9 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class NewrelicSpanConverterTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_should_convert_a_span_to_a_payload_for_newrelic(): void
     {
         $span = (new SpanData())
@@ -40,9 +37,6 @@ class NewrelicSpanConverterTest extends TestCase
         $this->assertEquals($attribute, $row['attributes']['service']);
     }
 
-    /**
-     * @test
-     */
     public function test_attributes_maintain_types(): void
     {
         $listOfStrings = ['string-1', 'string-2'];

--- a/tests/Contrib/Unit/NewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/NewrelicSpanConverterTest.php
@@ -14,7 +14,7 @@ class NewrelicSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_should_convert_a_span_to_a_payload_for_newrelic()
+    public function test_should_convert_a_span_to_a_payload_for_newrelic(): void
     {
         $span = (new SpanData())
             ->setName('guard.validate')
@@ -43,7 +43,7 @@ class NewrelicSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_attributes_maintain_types()
+    public function test_attributes_maintain_types(): void
     {
         $listOfStrings = ['string-1', 'string-2'];
         $listOfNumbers = [1, 2, 3, 3.1415, 42];

--- a/tests/Contrib/Unit/NewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/NewrelicSpanConverterTest.php
@@ -14,7 +14,7 @@ class NewrelicSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function shouldConvertASpanToAPayloadForNewrelic()
+    public function test_should_convert_a_span_to_a_payload_for_newrelic()
     {
         $span = (new SpanData())
             ->setName('guard.validate')
@@ -43,7 +43,7 @@ class NewrelicSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function attributesMaintainTypes()
+    public function test_attributes_maintain_types()
     {
         $listOfStrings = ['string-1', 'string-2'];
         $listOfNumbers = [1, 2, 3, 3.1415, 42];

--- a/tests/Contrib/Unit/OTLPGrpcExporterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcExporterTest.php
@@ -32,7 +32,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
     /**
      * @psalm-suppress UndefinedConstant
      */
-    public function testExporterHappyPath(): void
+    public function test_exporter_happy_path(): void
     {
         $exporter = new Exporter(
             //These first parameters were copied from the constructor's default values
@@ -57,7 +57,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         $this->assertSame(SpanExporterInterface::STATUS_SUCCESS, $exporterStatusCode);
     }
 
-    public function testExporterUnexpectedGrpcResponseStatus(): void
+    public function test_exporter_unexpected_grpc_response_status(): void
     {
         $exporter = new Exporter(
             //These first parameters were copied from the constructor's default values
@@ -82,19 +82,19 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         $this->assertSame(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE, $exporterStatusCode);
     }
 
-    public function testExporterGrpcRespondsAsUnavailable(): void
+    public function test_exporter_grpc_responds_as_unavailable(): void
     {
         $this->assertEquals(SpanExporterInterface::STATUS_FAILED_RETRYABLE, (new Exporter())->export([new SpanData()]));
     }
 
-    public function testRefusesInvalidHeaders(): void
+    public function test_refuses_invalid_headers(): void
     {
         $foo = new Exporter('localhost:4317', true, '', 'a:bc');
 
         $this->assertEquals([], $foo->getHeaders());
     }
 
-    public function testSetHeadersWithEnvironmentVariables(): void
+    public function test_set_headers_with_environment_variables(): void
     {
         $this->setEnvironmentVariable('OTEL_EXPORTER_OTLP_HEADERS', 'x-aaa=foo,x-bbb=barf');
 
@@ -103,7 +103,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         $this->assertEquals(['x-aaa' => ['foo'], 'x-bbb' => ['barf']], $exporter->getHeaders());
     }
 
-    public function testSetHeadersInConstructor(): void
+    public function test_set_headers_in_constructor(): void
     {
         $exporter = new Exporter('localhost:4317', true, '', 'x-aaa=foo,x-bbb=bar');
 
@@ -117,7 +117,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
     /**
      * @test
      */
-    public function shouldBeOkToExporterEmptySpansCollection(): void
+    public function test_should_be_ok_to_exporter_empty_spans_collection(): void
     {
         $this->assertEquals(
             SpanExporterInterface::STATUS_SUCCESS,
@@ -125,7 +125,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         );
     }
 
-    public function testHeadersShouldRefuseArray(): void
+    public function test_headers_should_refuse_array(): void
     {
         $headers = [
             'key' => ['value'],
@@ -136,7 +136,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         (new Exporter())->metadataFromHeaders($headers);
     }
 
-    public function testMetadataFromHeaders(): void
+    public function test_metadata_from_headers(): void
     {
         $metadata = (new Exporter())->metadataFromHeaders('key=value');
         $this->assertEquals(['key' => ['value']], $metadata);
@@ -154,7 +154,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         return $property->getValue($exporter);
     }
 
-    public function testClientOptions()
+    public function test_client_options()
     {
         // default options
         $exporter = new Exporter('localhost:4317');
@@ -223,7 +223,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         return $mockClient;
     }
 
-    public function testFromConnectionString(): void
+    public function test_from_connection_string(): void
     {
         $this->assertNotSame(
             Exporter::fromConnectionString(),

--- a/tests/Contrib/Unit/OTLPGrpcExporterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcExporterTest.php
@@ -114,9 +114,6 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         $this->assertEquals(['x-aaa' => ['foo'], 'x-bbb' => ['bar'], 'key' => ['value']], $exporter->getHeaders());
     }
 
-    /**
-     * @test
-     */
     public function test_should_be_ok_to_exporter_empty_spans_collection(): void
     {
         $this->assertEquals(

--- a/tests/Contrib/Unit/OTLPGrpcExporterTest.php
+++ b/tests/Contrib/Unit/OTLPGrpcExporterTest.php
@@ -154,7 +154,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         return $property->getValue($exporter);
     }
 
-    public function test_client_options()
+    public function test_client_options(): void
     {
         // default options
         $exporter = new Exporter('localhost:4317');

--- a/tests/Contrib/Unit/OTLPHttpExporterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpExporterTest.php
@@ -151,7 +151,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
     /**
      * @dataProvider exporterEndpointDataProvider
      */
-    public function test_exporter_with_config_via_env_vars(?string $endpoint, string $expectedEndpoint)
+    public function test_exporter_with_config_via_env_vars(?string $endpoint, string $expectedEndpoint): void
     {
         $mock = new MockHandler([
             new Response(200, [], 'ff'),

--- a/tests/Contrib/Unit/OTLPHttpExporterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpExporterTest.php
@@ -130,7 +130,6 @@ class OTLPHttpExporterTest extends AbstractExporterTest
     }
 
     /**
-     * @test
      * @dataProvider invalidHeadersDataHandler
      */
     public function test_invalid_headers($input): void
@@ -193,7 +192,6 @@ class OTLPHttpExporterTest extends AbstractExporterTest
     }
 
     /**
-     * @test
      * @psalm-suppress PossiblyInvalidArgument
      */
     public function test_should_be_ok_to_exporter_empty_spans_collection(): void
@@ -209,7 +207,6 @@ class OTLPHttpExporterTest extends AbstractExporterTest
     }
 
     /**
-     * @test
      * @testdox Exporter Refuses OTLP/JSON Protocol
      * https://github.com/open-telemetry/opentelemetry-specification/issues/786
      * @psalm-suppress PossiblyInvalidArgument

--- a/tests/Contrib/Unit/OTLPHttpExporterTest.php
+++ b/tests/Contrib/Unit/OTLPHttpExporterTest.php
@@ -47,7 +47,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
     /**
      * @dataProvider exporterResponseStatusDataProvider
      */
-    public function testExporterResponseStatus($responseStatus, $expected): void
+    public function test_exporter_response_status($responseStatus, $expected): void
     {
         $client = $this->createMock(ClientInterface::class);
         $client->method('sendRequest')->willReturn(
@@ -79,7 +79,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
     /**
      * @dataProvider clientExceptionsShouldDecideReturnCodeDataProvider
      */
-    public function testClientExceptionsShouldDecideReturnCode($exception, $expected): void
+    public function test_client_exceptions_should_decide_return_code($exception, $expected): void
     {
         $client = $this->createMock(ClientInterface::class);
         $client->method('sendRequest')->willThrowException($exception);
@@ -110,7 +110,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
     /**
      * @dataProvider processHeadersDataHandler
      */
-    public function testProcessHeaders($input, $expected): void
+    public function test_process_headers($input, $expected): void
     {
         $headers = (new Exporter(new Client(), new HttpFactory(), new HttpFactory()))->processHeaders($input);
 
@@ -133,7 +133,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
      * @test
      * @dataProvider invalidHeadersDataHandler
      */
-    public function testInvalidHeaders($input): void
+    public function test_invalid_headers($input): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $headers = (new Exporter(new Client(), new HttpFactory(), new HttpFactory()))->processHeaders($input);
@@ -151,7 +151,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
     /**
      * @dataProvider exporterEndpointDataProvider
      */
-    public function testExporterWithConfigViaEnvVars(?string $endpoint, string $expectedEndpoint)
+    public function test_exporter_with_config_via_env_vars(?string $endpoint, string $expectedEndpoint)
     {
         $mock = new MockHandler([
             new Response(200, [], 'ff'),
@@ -196,7 +196,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
      * @test
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function shouldBeOkToExporterEmptySpansCollection(): void
+    public function test_should_be_ok_to_exporter_empty_spans_collection(): void
     {
         $this->assertEquals(
             SpanExporterInterface::STATUS_SUCCESS,
@@ -214,7 +214,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
      * https://github.com/open-telemetry/opentelemetry-specification/issues/786
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function failsExporterRefusesOTLPJson(): void
+    public function test_fails_exporter_refuses_otlp_json(): void
     {
         $this->setEnvironmentVariable('OTEL_EXPORTER_OTLP_PROTOCOL', 'http/json');
 
@@ -232,7 +232,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
      * @dataProvider exporterInvalidEndpointDataProvider
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function testExporterRefusesInvalidEndpoint($endpoint): void
+    public function test_exporter_refuses_invalid_endpoint($endpoint): void
     {
         $this->setEnvironmentVariable('OTEL_EXPORTER_OTLP_ENDPOINT', $endpoint);
 
@@ -253,7 +253,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
         ];
     }
 
-    public function testFromConnectionString(): void
+    public function test_from_connection_string(): void
     {
         $this->assertNotSame(
             Exporter::fromConnectionString(),

--- a/tests/Contrib/Unit/OTLPSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPSpanConverterTest.php
@@ -25,9 +25,6 @@ use PHPUnit\Framework\TestCase;
 
 class OTLPSpanConverterTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_should_convert_a_span_to_a_payload_for_otlp(): void
     {
         $context = SpanContext::getInvalid();
@@ -59,7 +56,6 @@ class OTLPSpanConverterTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider attributeAreCoercedCorrectlyDataProvider
      */
     public function test_attribute_are_coerced_correctly($actual, $expected): void

--- a/tests/Contrib/Unit/OTLPSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPSpanConverterTest.php
@@ -62,7 +62,7 @@ class OTLPSpanConverterTest extends TestCase
      * @test
      * @dataProvider attributeAreCoercedCorrectlyDataProvider
      */
-    public function test_attribute_are_coerced_correctly($actual, $expected)
+    public function test_attribute_are_coerced_correctly($actual, $expected): void
     {
         $span = (new SpanData())
             ->setName('batch.manager')
@@ -138,7 +138,7 @@ class OTLPSpanConverterTest extends TestCase
         ];
     }
 
-    public function test_otlp_happy_path_span()
+    public function test_otlp_happy_path_span(): void
     {
         $start_time = 1617313804325769988;
         $end_time = 1617313804325783095;
@@ -248,7 +248,7 @@ class OTLPSpanConverterTest extends TestCase
     /**
      * @covers OpenTelemetry\Contrib\Otlp\SpanConverter::as_otlp_resource_attributes
      */
-    public function test_resources_from_multiple_spans_are_not_duplicated()
+    public function test_resources_from_multiple_spans_are_not_duplicated(): void
     {
         $span = $this->createMock(SpanData::class);
         $resource = $this->createMock(ResourceInfo::class);
@@ -260,7 +260,7 @@ class OTLPSpanConverterTest extends TestCase
         $this->assertCount(2, $result[0]->getResource()->getAttributes());
     }
 
-    public function test_otlp_no_spans()
+    public function test_otlp_no_spans(): void
     {
         $spans = [];
 

--- a/tests/Contrib/Unit/OTLPSpanConverterTest.php
+++ b/tests/Contrib/Unit/OTLPSpanConverterTest.php
@@ -28,7 +28,7 @@ class OTLPSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function shouldConvertASpanToAPayloadForOtlp(): void
+    public function test_should_convert_a_span_to_a_payload_for_otlp(): void
     {
         $context = SpanContext::getInvalid();
 
@@ -62,7 +62,7 @@ class OTLPSpanConverterTest extends TestCase
      * @test
      * @dataProvider attributeAreCoercedCorrectlyDataProvider
      */
-    public function attributeAreCoercedCorrectly($actual, $expected)
+    public function test_attribute_are_coerced_correctly($actual, $expected)
     {
         $span = (new SpanData())
             ->setName('batch.manager')
@@ -138,7 +138,7 @@ class OTLPSpanConverterTest extends TestCase
         ];
     }
 
-    public function testOtlpHappyPathSpan()
+    public function test_otlp_happy_path_span()
     {
         $start_time = 1617313804325769988;
         $end_time = 1617313804325783095;
@@ -248,7 +248,7 @@ class OTLPSpanConverterTest extends TestCase
     /**
      * @covers OpenTelemetry\Contrib\Otlp\SpanConverter::as_otlp_resource_attributes
      */
-    public function testResourcesFromMultipleSpansAreNotDuplicated()
+    public function test_resources_from_multiple_spans_are_not_duplicated()
     {
         $span = $this->createMock(SpanData::class);
         $resource = $this->createMock(ResourceInfo::class);
@@ -260,7 +260,7 @@ class OTLPSpanConverterTest extends TestCase
         $this->assertCount(2, $result[0]->getResource()->getAttributes());
     }
 
-    public function testOtlpNoSpans()
+    public function test_otlp_no_spans()
     {
         $spans = [];
 
@@ -273,7 +273,7 @@ class OTLPSpanConverterTest extends TestCase
      * @dataProvider spanKindProvider
      * @covers OpenTelemetry\Contrib\Otlp\SpanConverter::as_otlp_span_kind
      */
-    public function testSpanKind($kind, $expected): void
+    public function test_span_kind($kind, $expected): void
     {
         $span = (new SpanData())->setKind($kind);
         $row = (new SpanConverter())->convert([$span])[0]->getInstrumentationLibrarySpans()[0]->getSpans()[0];
@@ -295,7 +295,7 @@ class OTLPSpanConverterTest extends TestCase
     /**
      * @covers OpenTelemetry\Contrib\Otlp\SpanConverter::as_otlp_span
      */
-    public function testSpanWithErrorStatus(): void
+    public function test_span_with_error_status(): void
     {
         $span = (new SpanData())->setStatus(StatusData::error());
         $row = (new SpanConverter())->convert([$span])[0]->getInstrumentationLibrarySpans()[0]->getSpans()[0];

--- a/tests/Contrib/Unit/PrometheusExporterTest.php
+++ b/tests/Contrib/Unit/PrometheusExporterTest.php
@@ -13,7 +13,7 @@ use Prometheus\Counter as PrometheusCounter;
 
 class PrometheusExporterTest extends TestCase
 {
-    public function testEmptyMetricsExportReturnsSuccess()
+    public function test_empty_metrics_export_returns_success()
     {
         $exporter = new PrometheusExporter($this->createMock(CollectorRegistry::class));
 
@@ -26,7 +26,7 @@ class PrometheusExporterTest extends TestCase
     /**
      * @dataProvider provideCounterData
      */
-    public function testPrometheusRegistryMethodIsCalledForCounterExport(int $count, array $labels)
+    public function test_prometheus_registry_method_is_called_for_counter_export(int $count, array $labels)
     {
         $counter = new Counter('prometheus_test_counter');
         $counter->add($count);

--- a/tests/Contrib/Unit/PrometheusExporterTest.php
+++ b/tests/Contrib/Unit/PrometheusExporterTest.php
@@ -13,7 +13,7 @@ use Prometheus\Counter as PrometheusCounter;
 
 class PrometheusExporterTest extends TestCase
 {
-    public function test_empty_metrics_export_returns_success()
+    public function test_empty_metrics_export_returns_success(): void
     {
         $exporter = new PrometheusExporter($this->createMock(CollectorRegistry::class));
 
@@ -26,7 +26,7 @@ class PrometheusExporterTest extends TestCase
     /**
      * @dataProvider provideCounterData
      */
-    public function test_prometheus_registry_method_is_called_for_counter_export(int $count, array $labels)
+    public function test_prometheus_registry_method_is_called_for_counter_export(int $count, array $labels): void
     {
         $counter = new Counter('prometheus_test_counter');
         $counter->add($count);

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -23,7 +23,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_should_convert_a_span_to_a_payload_for_zipkin()
+    public function test_should_convert_a_span_to_a_payload_for_zipkin(): void
     {
         $span = (new SpanData())
             ->setName('guard.validate')
@@ -85,7 +85,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_should_omit_empty_keys_from_zipkin_span()
+    public function test_should_omit_empty_keys_from_zipkin_span(): void
     {
         $span = (new SpanData());
 
@@ -103,7 +103,7 @@ class ZipkinSpanConverterTest extends TestCase
      * @test
      * @dataProvider spanKindProvider
      */
-    public function test_should_convert_otel_span_to_a_zipkin_span(int $internalSpanKind, string $expectedSpanKind)
+    public function test_should_convert_otel_span_to_a_zipkin_span(int $internalSpanKind, string $expectedSpanKind): void
     {
         $span = (new SpanData())
             ->setKind($internalSpanKind);
@@ -128,7 +128,7 @@ class ZipkinSpanConverterTest extends TestCase
      * @test
      * @dataProvider unmappedSpanKindProvider
      */
-    public function test_should_convert_an_unmapped_otel_internal_span_to_a_zipkin_span_of_unspecified_kind($kind)
+    public function test_should_convert_an_unmapped_otel_internal_span_to_a_zipkin_span_of_unspecified_kind($kind): void
     {
         $span = (new SpanData())
             ->setKind($kind);
@@ -150,7 +150,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_should_convert_an_event_without_attributes_to_an_annotation_with_only_its_name()
+    public function test_should_convert_an_event_without_attributes_to_an_annotation_with_only_its_name(): void
     {
         $span = (new SpanData())
             ->addEvent('event.name', new Attributes());
@@ -165,7 +165,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_should_use_otel_ipv_4_and_port_correctly_for_zipkin_remote_endpoint()
+    public function test_should_use_otel_ipv_4_and_port_correctly_for_zipkin_remote_endpoint(): void
     {
         $span = (new SpanData())
             ->addAttribute('net.peer.ip', '255.255.255.255')
@@ -183,7 +183,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_should_use_otel_ipv_6_correctly_for_zipkin_remote_endpoint()
+    public function test_should_use_otel_ipv_6_correctly_for_zipkin_remote_endpoint(): void
     {
         $span = (new SpanData())
             ->addAttribute('net.peer.ip', '::1')
@@ -198,7 +198,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_tags_are_coerced_correctly_to_strings()
+    public function test_tags_are_coerced_correctly_to_strings(): void
     {
         $listOfStrings = ['string-1', 'string-2'];
         $listOfNumbers = [1, 2, 3, 3.1415, 42];

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -23,7 +23,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function shouldConvertASpanToAPayloadForZipkin()
+    public function test_should_convert_a_span_to_a_payload_for_zipkin()
     {
         $span = (new SpanData())
             ->setName('guard.validate')
@@ -85,7 +85,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function shouldOmitEmptyKeysFromZipkinSpan()
+    public function test_should_omit_empty_keys_from_zipkin_span()
     {
         $span = (new SpanData());
 
@@ -103,7 +103,7 @@ class ZipkinSpanConverterTest extends TestCase
      * @test
      * @dataProvider spanKindProvider
      */
-    public function shouldConvertOTELSpanToAZipkinSpan(int $internalSpanKind, string $expectedSpanKind)
+    public function test_should_convert_otel_span_to_a_zipkin_span(int $internalSpanKind, string $expectedSpanKind)
     {
         $span = (new SpanData())
             ->setKind($internalSpanKind);
@@ -128,7 +128,7 @@ class ZipkinSpanConverterTest extends TestCase
      * @test
      * @dataProvider unmappedSpanKindProvider
      */
-    public function shouldConvertAnUnmappedOTELInternalSpanToAZipkinSpanOfUnspecifiedKind($kind)
+    public function test_should_convert_an_unmapped_otel_internal_span_to_a_zipkin_span_of_unspecified_kind($kind)
     {
         $span = (new SpanData())
             ->setKind($kind);
@@ -150,7 +150,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function shouldConvertAnEventWithoutAttributesToAnAnnotationWithOnlyItsName()
+    public function test_should_convert_an_event_without_attributes_to_an_annotation_with_only_its_name()
     {
         $span = (new SpanData())
             ->addEvent('event.name', new Attributes());
@@ -165,7 +165,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function shouldUseOTELIpv4AndPortCorrectlyForZipkinRemoteEndpoint()
+    public function test_should_use_otel_ipv_4_and_port_correctly_for_zipkin_remote_endpoint()
     {
         $span = (new SpanData())
             ->addAttribute('net.peer.ip', '255.255.255.255')
@@ -183,7 +183,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function shouldUseOTELIpv6CorrectlyForZipkinRemoteEndpoint()
+    public function test_should_use_otel_ipv_6_correctly_for_zipkin_remote_endpoint()
     {
         $span = (new SpanData())
             ->addAttribute('net.peer.ip', '::1')
@@ -198,7 +198,7 @@ class ZipkinSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function tagsAreCoercedCorrectlyToStrings()
+    public function test_tags_are_coerced_correctly_to_strings()
     {
         $listOfStrings = ['string-1', 'string-2'];
         $listOfNumbers = [1, 2, 3, 3.1415, 42];

--- a/tests/Contrib/Unit/ZipkinSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinSpanConverterTest.php
@@ -20,9 +20,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ZipkinSpanConverterTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_should_convert_a_span_to_a_payload_for_zipkin(): void
     {
         $span = (new SpanData())
@@ -82,9 +79,6 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertSame('AuthService', $row['remoteEndpoint']['serviceName']);
     }
 
-    /**
-     * @test
-     */
     public function test_should_omit_empty_keys_from_zipkin_span(): void
     {
         $span = (new SpanData());
@@ -100,7 +94,6 @@ class ZipkinSpanConverterTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider spanKindProvider
      */
     public function test_should_convert_otel_span_to_a_zipkin_span(int $internalSpanKind, string $expectedSpanKind): void
@@ -125,7 +118,6 @@ class ZipkinSpanConverterTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider unmappedSpanKindProvider
      */
     public function test_should_convert_an_unmapped_otel_internal_span_to_a_zipkin_span_of_unspecified_kind($kind): void
@@ -147,9 +139,6 @@ class ZipkinSpanConverterTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
     public function test_should_convert_an_event_without_attributes_to_an_annotation_with_only_its_name(): void
     {
         $span = (new SpanData())
@@ -162,9 +151,6 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertSame('"event.name"', $annotation['value']);
     }
 
-    /**
-     * @test
-     */
     public function test_should_use_otel_ipv_4_and_port_correctly_for_zipkin_remote_endpoint(): void
     {
         $span = (new SpanData())
@@ -180,9 +166,6 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertSame(80, $row['remoteEndpoint']['port']);
     }
 
-    /**
-     * @test
-     */
     public function test_should_use_otel_ipv_6_correctly_for_zipkin_remote_endpoint(): void
     {
         $span = (new SpanData())
@@ -195,9 +178,6 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertSame('00000000000000000000000000000001', bin2hex($row['remoteEndpoint']['ipv6'])); //Couldn't figure out how to do a direct assertion against binary data
     }
 
-    /**
-     * @test
-     */
     public function test_tags_are_coerced_correctly_to_strings(): void
     {
         $listOfStrings = ['string-1', 'string-2'];

--- a/tests/Contrib/Unit/ZipkinToNewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinToNewrelicSpanConverterTest.php
@@ -15,7 +15,7 @@ class ZipkinToNewrelicSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_should_convert_a_span_to_a_payload_for_zipkin()
+    public function test_should_convert_a_span_to_a_payload_for_zipkin(): void
     {
         $span = (new SpanData())
             ->setName('guard.validate')
@@ -49,7 +49,7 @@ class ZipkinToNewrelicSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function test_tags_are_coerced_correctly_to_strings()
+    public function test_tags_are_coerced_correctly_to_strings(): void
     {
         $listOfStrings = ['string-1', 'string-2'];
         $listOfNumbers = [1, 2, 3, 3.1415, 42];

--- a/tests/Contrib/Unit/ZipkinToNewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinToNewrelicSpanConverterTest.php
@@ -15,7 +15,7 @@ class ZipkinToNewrelicSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function shouldConvertASpanToAPayloadForZipkin()
+    public function test_should_convert_a_span_to_a_payload_for_zipkin()
     {
         $span = (new SpanData())
             ->setName('guard.validate')
@@ -49,7 +49,7 @@ class ZipkinToNewrelicSpanConverterTest extends TestCase
     /**
      * @test
      */
-    public function tagsAreCoercedCorrectlyToStrings()
+    public function test_tags_are_coerced_correctly_to_strings()
     {
         $listOfStrings = ['string-1', 'string-2'];
         $listOfNumbers = [1, 2, 3, 3.1415, 42];

--- a/tests/Contrib/Unit/ZipkinToNewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinToNewrelicSpanConverterTest.php
@@ -12,9 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 class ZipkinToNewrelicSpanConverterTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_should_convert_a_span_to_a_payload_for_zipkin(): void
     {
         $span = (new SpanData())
@@ -46,9 +43,6 @@ class ZipkinToNewrelicSpanConverterTest extends TestCase
         $this->assertSame(1505855799433901, $annotation['timestamp']);
     }
 
-    /**
-     * @test
-     */
     public function test_tags_are_coerced_correctly_to_strings(): void
     {
         $listOfStrings = ['string-1', 'string-2'];

--- a/tests/SDK/Integration/AlwaysOffSamplerTest.php
+++ b/tests/SDK/Integration/AlwaysOffSamplerTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class AlwaysOffSamplerTest extends TestCase
 {
-    public function testAlwaysOffSampler(): void
+    public function test_always_off_sampler(): void
     {
         $parentTraceState = $this->createMock(API\TraceStateInterface::class);
         $sampler = new AlwaysOffSampler();
@@ -29,7 +29,7 @@ class AlwaysOffSamplerTest extends TestCase
         $this->assertEquals($parentTraceState, $decision->getTraceState());
     }
 
-    public function testAlwaysOnSamplerDescription(): void
+    public function test_always_on_sampler_description(): void
     {
         $sampler = new AlwaysOffSampler();
         $this->assertEquals('AlwaysOffSampler', $sampler->getDescription());

--- a/tests/SDK/Integration/AlwaysOnSamplerTest.php
+++ b/tests/SDK/Integration/AlwaysOnSamplerTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class AlwaysOnSamplerTest extends TestCase
 {
-    public function testAlwaysOnSamplerDecision(): void
+    public function test_always_on_sampler_decision(): void
     {
         $parentTraceState = $this->createMock(API\TraceStateInterface::class);
         $sampler = new AlwaysOnSampler();
@@ -29,7 +29,7 @@ class AlwaysOnSamplerTest extends TestCase
         $this->assertEquals($parentTraceState, $decision->getTraceState());
     }
 
-    public function testAlwaysOnSamplerDescription(): void
+    public function test_always_on_sampler_description(): void
     {
         $sampler = new AlwaysOnSampler();
         $this->assertEquals('AlwaysOnSampler', $sampler->getDescription());

--- a/tests/SDK/Integration/Context/SpanContextTest.php
+++ b/tests/SDK/Integration/Context/SpanContextTest.php
@@ -17,7 +17,7 @@ class SpanContextTest extends TestCase
      * @param string $traceId
      * @param string $spanId
      */
-    public function testInvalidSpan(string $traceId, string $spanId): void
+    public function test_invalid_span(string $traceId, string $spanId): void
     {
         $spanContext = SpanContext::create($traceId, $spanId);
         $this->assertSame(SpanContext::INVALID_TRACE, $spanContext->getTraceId());
@@ -38,31 +38,31 @@ class SpanContextTest extends TestCase
         ];
     }
 
-    public function testValidSpan(): void
+    public function test_valid_span(): void
     {
         $spanContext = SpanContext::create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', API\SpanContextInterface::TRACE_FLAG_SAMPLED);
         $this->assertTrue($spanContext->isValid());
     }
 
-    public function testContextIsRemoteFromRestore(): void
+    public function test_context_is_remote_from_restore(): void
     {
         $spanContext = SpanContext::createFromRemoteParent('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', API\SpanContextInterface::TRACE_FLAG_SAMPLED);
         $this->assertTrue($spanContext->isRemote());
     }
 
-    public function testContextIsNotRemoteFromConstructor(): void
+    public function test_context_is_not_remote_from_constructor(): void
     {
         $spanContext = SpanContext::create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', API\SpanContextInterface::TRACE_FLAG_SAMPLED);
         $this->assertFalse($spanContext->isRemote());
     }
 
-    public function testSampledSpan(): void
+    public function test_sampled_span(): void
     {
         $spanContext = SpanContext::create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', API\SpanContextInterface::TRACE_FLAG_SAMPLED);
         $this->assertTrue($spanContext->isSampled());
     }
 
-    public function testGettersWork()
+    public function test_getters_work()
     {
         $trace = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
         $span = 'bbbbbbbbbbbbbbbb';
@@ -74,7 +74,7 @@ class SpanContextTest extends TestCase
         $this->assertFalse($spanContext->isSampled());
     }
 
-    public function testRandomGeneratedIdsCreateValidContext()
+    public function test_random_generated_ids_create_valid_context()
     {
         $idGenerator = new RandomIdGenerator();
         $context = SpanContext::create($idGenerator->generateTraceId(), $idGenerator->generateSpanId(), 0);

--- a/tests/SDK/Integration/Context/SpanContextTest.php
+++ b/tests/SDK/Integration/Context/SpanContextTest.php
@@ -62,7 +62,7 @@ class SpanContextTest extends TestCase
         $this->assertTrue($spanContext->isSampled());
     }
 
-    public function test_getters_work()
+    public function test_getters_work(): void
     {
         $trace = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
         $span = 'bbbbbbbbbbbbbbbb';
@@ -74,7 +74,7 @@ class SpanContextTest extends TestCase
         $this->assertFalse($spanContext->isSampled());
     }
 
-    public function test_random_generated_ids_create_valid_context()
+    public function test_random_generated_ids_create_valid_context(): void
     {
         $idGenerator = new RandomIdGenerator();
         $context = SpanContext::create($idGenerator->generateTraceId(), $idGenerator->generateSpanId(), 0);

--- a/tests/SDK/Integration/ParentBasedTest.php
+++ b/tests/SDK/Integration/ParentBasedTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class ParentBasedTest extends TestCase
 {
-    public function testParentBasedRootSpan(): void
+    public function test_parent_based_root_span(): void
     {
         $rootSampler = $this->createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE);
 
@@ -31,7 +31,7 @@ class ParentBasedTest extends TestCase
     /**
      * @dataProvider parentContextData
      */
-    public function testParentBased(
+    public function test_parent_based(
         $parentContext,
         ?SamplerInterface $remoteParentSampled = null,
         ?SamplerInterface $remoteParentNotSampled = null,
@@ -73,7 +73,7 @@ class ParentBasedTest extends TestCase
         ];
     }
 
-    public function testParentBasedDescription(): void
+    public function test_parent_based_description(): void
     {
         $rootSampler = $this->createMock(SamplerInterface::class);
         $rootSampler->expects($this->once())->method('getDescription')->willReturn('Foo');

--- a/tests/SDK/Integration/SpanProcessorTest.php
+++ b/tests/SDK/Integration/SpanProcessorTest.php
@@ -15,7 +15,7 @@ class SpanProcessorTest extends TestCase
     /**
      * @test
      */
-    public function parentContextShouldBePassedToSpanProcessor()
+    public function test_parent_context_should_be_passed_to_span_processor()
     {
         $parentContext = new Context();
 
@@ -34,7 +34,7 @@ class SpanProcessorTest extends TestCase
     /**
      * @test
      */
-    public function currentContextShouldBePassedToSpanProcessorByDefault()
+    public function test_current_context_should_be_passed_to_span_processor_by_default()
     {
         $currentContext = Context::getCurrent();
 

--- a/tests/SDK/Integration/SpanProcessorTest.php
+++ b/tests/SDK/Integration/SpanProcessorTest.php
@@ -12,9 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 class SpanProcessorTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_parent_context_should_be_passed_to_span_processor(): void
     {
         $parentContext = new Context();
@@ -31,9 +28,6 @@ class SpanProcessorTest extends TestCase
         $tracer->spanBuilder('test.span')->setParent($parentContext)->startSpan();
     }
 
-    /**
-     * @test
-     */
     public function test_current_context_should_be_passed_to_span_processor_by_default(): void
     {
         $currentContext = Context::getCurrent();

--- a/tests/SDK/Integration/SpanProcessorTest.php
+++ b/tests/SDK/Integration/SpanProcessorTest.php
@@ -15,7 +15,7 @@ class SpanProcessorTest extends TestCase
     /**
      * @test
      */
-    public function test_parent_context_should_be_passed_to_span_processor()
+    public function test_parent_context_should_be_passed_to_span_processor(): void
     {
         $parentContext = new Context();
 
@@ -34,7 +34,7 @@ class SpanProcessorTest extends TestCase
     /**
      * @test
      */
-    public function test_current_context_should_be_passed_to_span_processor_by_default()
+    public function test_current_context_should_be_passed_to_span_processor_by_default(): void
     {
         $currentContext = Context::getCurrent();
 

--- a/tests/SDK/Integration/TraceIdRatioBasedSamplerTest.php
+++ b/tests/SDK/Integration/TraceIdRatioBasedSamplerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class TraceIdRatioBasedSamplerTest extends TestCase
 {
-    public function testInvalidProbabilityTraceIdRatioBasedSampler(): void
+    public function test_invalid_probability_trace_id_ratio_based_sampler(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $sampler = new TraceIdRatioBasedSampler(-0.5);
@@ -23,7 +23,7 @@ class TraceIdRatioBasedSamplerTest extends TestCase
         $sampler = new TraceIdRatioBasedSampler(1.5);
     }
 
-    public function testNeverTraceIdRatioBasedSamplerDecision(): void
+    public function test_never_trace_id_ratio_based_sampler_decision(): void
     {
         $sampler = new TraceIdRatioBasedSampler(0.0);
         $decision = $sampler->shouldSample(
@@ -35,7 +35,7 @@ class TraceIdRatioBasedSamplerTest extends TestCase
         $this->assertEquals(SamplingResult::DROP, $decision->getDecision());
     }
 
-    public function testAlwaysTraceIdRatioBasedSamplerDecision(): void
+    public function test_always_trace_id_ratio_based_sampler_decision(): void
     {
         $sampler = new TraceIdRatioBasedSampler(1.0);
         $decision = $sampler->shouldSample(
@@ -47,7 +47,7 @@ class TraceIdRatioBasedSamplerTest extends TestCase
         $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
     }
 
-    public function testFailingTraceIdRatioBasedSamplerDecision(): void
+    public function test_failing_trace_id_ratio_based_sampler_decision(): void
     {
         $sampler = new TraceIdRatioBasedSampler(0.99);
         $decision = $sampler->shouldSample(
@@ -59,7 +59,7 @@ class TraceIdRatioBasedSamplerTest extends TestCase
         $this->assertEquals(SamplingResult::DROP, $decision->getDecision());
     }
 
-    public function testPassingTraceIdRatioBasedSamplerDecision(): void
+    public function test_passing_trace_id_ratio_based_sampler_decision(): void
     {
         $sampler = new TraceIdRatioBasedSampler(0.01);
         $decision = $sampler->shouldSample(
@@ -71,7 +71,7 @@ class TraceIdRatioBasedSamplerTest extends TestCase
         $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
     }
 
-    public function testIgnoreParentSampledFlag(): void
+    public function test_ignore_parent_sampled_flag(): void
     {
         $parentTraceState = $this->createMock(API\TraceStateInterface::class);
         $sampler = new TraceIdRatioBasedSampler(0.0);
@@ -86,7 +86,7 @@ class TraceIdRatioBasedSamplerTest extends TestCase
         $this->assertEquals($parentTraceState, $samplingResult->getTraceState());
     }
 
-    public function testTraceIdRatioBasedSamplerDescription(): void
+    public function test_trace_id_ratio_based_sampler_description(): void
     {
         $sampler = new TraceIdRatioBasedSampler(0.0001);
         $this->assertEquals('TraceIdRatioBasedSampler{0.000100}', $sampler->getDescription());

--- a/tests/SDK/Integration/TracerTest.php
+++ b/tests/SDK/Integration/TracerTest.php
@@ -22,7 +22,7 @@ class TracerTest extends TestCase
     /**
      * @test
      */
-    public function noopSpanShouldBeStartedWhenSamplingResultIsDrop(): void
+    public function test_noop_span_should_be_started_when_sampling_result_is_drop(): void
     {
         $alwaysOffSampler = new AlwaysOffSampler();
         $processor = $this->createMock(SpanProcessorInterface::class);
@@ -39,7 +39,7 @@ class TracerTest extends TestCase
     /**
      * @test
      */
-    public function samplerMayOverrideParentsTraceState(): void
+    public function test_sampler_may_override_parents_trace_state(): void
     {
         $parentTraceState = new TraceState('orig-key=orig_value');
         $parentContext = (new Context())
@@ -74,7 +74,7 @@ class TracerTest extends TestCase
     /**
      * @test
      */
-    public function spanShouldReceiveInstrumentationLibrary(): void
+    public function test_span_should_receive_instrumentation_library(): void
     {
         $tracerProvider = new TracerProvider();
         $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest', 'dev');

--- a/tests/SDK/Integration/TracerTest.php
+++ b/tests/SDK/Integration/TracerTest.php
@@ -19,9 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 class TracerTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_noop_span_should_be_started_when_sampling_result_is_drop(): void
     {
         $alwaysOffSampler = new AlwaysOffSampler();
@@ -36,9 +33,6 @@ class TracerTest extends TestCase
         $this->assertNotEquals(API\SpanContextInterface::TRACE_FLAG_SAMPLED, $span->getContext()->getTraceFlags());
     }
 
-    /**
-     * @test
-     */
     public function test_sampler_may_override_parents_trace_state(): void
     {
         $parentTraceState = new TraceState('orig-key=orig_value');
@@ -71,9 +65,6 @@ class TracerTest extends TestCase
         $this->assertEquals($newTraceState, $span->getContext()->getTraceState());
     }
 
-    /**
-     * @test
-     */
     public function test_span_should_receive_instrumentation_library(): void
     {
         $tracerProvider = new TracerProvider();

--- a/tests/SDK/Unit/AttributesTest.php
+++ b/tests/SDK/Unit/AttributesTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class AttributesTest extends TestCase
 {
-    public function test_attribute_limits_compare()
+    public function test_attribute_limits_compare(): void
     {
         $attrLimits1 = new AttributeLimits(10, 20);
         $attrLimits2 = new AttributeLimits(10, 20);
@@ -21,7 +21,7 @@ class AttributesTest extends TestCase
     }
 
     /** @test Test numeric attribute key is not cast to integer value */
-    public function test_numeric_attribute_name()
+    public function test_numeric_attribute_name(): void
     {
         $attributes = new Attributes(['1' => '2']);
         $this->assertCount(1, $attributes);
@@ -34,7 +34,7 @@ class AttributesTest extends TestCase
     /**
      * @psalm-suppress PossiblyNullReference
      */
-    public function test_attribute_limits()
+    public function test_attribute_limits(): void
     {
         $boolValue = true;
         $intValue = 42;
@@ -71,7 +71,7 @@ class AttributesTest extends TestCase
     /**
      * @psalm-suppress PossiblyNullReference
      */
-    public function test_apply_limits()
+    public function test_apply_limits(): void
     {
         $attributes = new Attributes([
             'short' => '123',

--- a/tests/SDK/Unit/AttributesTest.php
+++ b/tests/SDK/Unit/AttributesTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class AttributesTest extends TestCase
 {
-    public function testAttributeLimitsCompare()
+    public function test_attribute_limits_compare()
     {
         $attrLimits1 = new AttributeLimits(10, 20);
         $attrLimits2 = new AttributeLimits(10, 20);
@@ -21,7 +21,7 @@ class AttributesTest extends TestCase
     }
 
     /** @test Test numeric attribute key is not cast to integer value */
-    public function testNumericAttributeName()
+    public function test_numeric_attribute_name()
     {
         $attributes = new Attributes(['1' => '2']);
         $this->assertCount(1, $attributes);
@@ -34,7 +34,7 @@ class AttributesTest extends TestCase
     /**
      * @psalm-suppress PossiblyNullReference
      */
-    public function testAttributeLimits()
+    public function test_attribute_limits()
     {
         $boolValue = true;
         $intValue = 42;
@@ -71,7 +71,7 @@ class AttributesTest extends TestCase
     /**
      * @psalm-suppress PossiblyNullReference
      */
-    public function testApplyLimits()
+    public function test_apply_limits()
     {
         $attributes = new Attributes([
             'short' => '123',

--- a/tests/SDK/Unit/Behavior/LogsMessagesTraitTest.php
+++ b/tests/SDK/Unit/Behavior/LogsMessagesTraitTest.php
@@ -28,7 +28,6 @@ class LogsMessagesTraitTest extends TestCase
     }
 
     /**
-     * @test
      * @testdox Proxies logging methods through to logger
      * @dataProvider logLevelProvider
      */

--- a/tests/SDK/Unit/Behavior/LogsMessagesTraitTest.php
+++ b/tests/SDK/Unit/Behavior/LogsMessagesTraitTest.php
@@ -32,7 +32,7 @@ class LogsMessagesTraitTest extends TestCase
      * @testdox Proxies logging methods through to logger
      * @dataProvider logLevelProvider
      */
-    public function testLogMethods(string $method, string $expectedLogLevel): void
+    public function test_log_methods(string $method, string $expectedLogLevel): void
     {
         $instance = $this->createInstance();
         $this->logger->expects($this->once())->method('log')->with(

--- a/tests/SDK/Unit/EnvironmentVariablesTraitTest.php
+++ b/tests/SDK/Unit/EnvironmentVariablesTraitTest.php
@@ -26,7 +26,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     /**
      * @test
      */
-    public function environmentVariables_integer_get()
+    public function test_environment_variables_integer_get()
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', '100');
@@ -37,7 +37,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     /**
      * @test
      */
-    public function environmentVariables_integer_failure()
+    public function test_environment_variables_integer_failure()
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', 'foo');
@@ -48,7 +48,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     /**
      * @test
      */
-    public function environmentVariables_integer_usesDefaultIfEnvVarNotDefined()
+    public function environment_variables_integer_uses_default_if_env_var_not_defined()
     {
         $mock = new MockWithTrait();
         $this->assertSame(20, $mock->getIntFromEnvironment('OTEL_FOO', 20));
@@ -57,7 +57,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     /**
      * @test
      */
-    public function environmentVariables_string_get()
+    public function test_environment_variables_string_get()
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', 'foo');
@@ -70,7 +70,7 @@ class EnvironmentVariablesTraitTest extends TestCase
      * @test
      * @dataProvider emptyProvider
      */
-    public function environmentVariables_string_usesDefaultWhenEmptyValue(?string $input)
+    public function test_environment_variables_string_uses_default_when_empty_value(?string $input)
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);
@@ -78,11 +78,11 @@ class EnvironmentVariablesTraitTest extends TestCase
         $this->assertSame('bar', $value);
     }
 
-    /*
+    /**
      * @test
      * @dataProvider emptyProvider
      */
-    public function environmentVariables_int_usesDefaultWhenEmptyValue(?int $input)
+    public function test_environment_variables_int_uses_default_when_empty_value(?string $input)
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);
@@ -90,11 +90,11 @@ class EnvironmentVariablesTraitTest extends TestCase
         $this->assertSame(99, $value);
     }
 
-    /*
+    /**
      * @test
      * @dataProvider emptyProvider
      */
-    public function environmentVariables_bool_usesDefaultWhenEmptyValue(?bool $input)
+    public function test_environment_variables_bool_uses_default_when_empty_value(?string $input)
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);
@@ -114,7 +114,7 @@ class EnvironmentVariablesTraitTest extends TestCase
      * @test
      * @dataProvider booleanProvider
      */
-    public function environmentVariables_bool_get(string $input, bool $default, bool $expected)
+    public function environment_variables_bool_get(string $input, bool $default, bool $expected)
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_BOOL', $input);

--- a/tests/SDK/Unit/EnvironmentVariablesTraitTest.php
+++ b/tests/SDK/Unit/EnvironmentVariablesTraitTest.php
@@ -23,9 +23,6 @@ class EnvironmentVariablesTraitTest extends TestCase
         $this->restoreEnvironmentVariables();
     }
 
-    /**
-     * @test
-     */
     public function test_environment_variables_integer_get(): void
     {
         $mock = new MockWithTrait();
@@ -34,9 +31,6 @@ class EnvironmentVariablesTraitTest extends TestCase
         $this->assertSame(100, $value);
     }
 
-    /**
-     * @test
-     */
     public function test_environment_variables_integer_failure(): void
     {
         $mock = new MockWithTrait();
@@ -45,18 +39,12 @@ class EnvironmentVariablesTraitTest extends TestCase
         $mock->getIntFromEnvironment('OTEL_FOO', 99);
     }
 
-    /**
-     * @test
-     */
     public function environment_variables_integer_uses_default_if_env_var_not_defined()
     {
         $mock = new MockWithTrait();
         $this->assertSame(20, $mock->getIntFromEnvironment('OTEL_FOO', 20));
     }
 
-    /**
-     * @test
-     */
     public function test_environment_variables_string_get(): void
     {
         $mock = new MockWithTrait();
@@ -67,7 +55,6 @@ class EnvironmentVariablesTraitTest extends TestCase
 
     /**
      * The SDK MUST interpret an empty value of an environment variable the same way as when the variable is unset
-     * @test
      * @dataProvider emptyProvider
      */
     public function test_environment_variables_string_uses_default_when_empty_value(?string $input): void
@@ -79,7 +66,6 @@ class EnvironmentVariablesTraitTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider emptyProvider
      */
     public function test_environment_variables_int_uses_default_when_empty_value(?string $input): void
@@ -91,7 +77,6 @@ class EnvironmentVariablesTraitTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider emptyProvider
      */
     public function test_environment_variables_bool_uses_default_when_empty_value(?string $input): void
@@ -111,7 +96,6 @@ class EnvironmentVariablesTraitTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider booleanProvider
      */
     public function environment_variables_bool_get(string $input, bool $default, bool $expected)

--- a/tests/SDK/Unit/EnvironmentVariablesTraitTest.php
+++ b/tests/SDK/Unit/EnvironmentVariablesTraitTest.php
@@ -26,7 +26,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     /**
      * @test
      */
-    public function test_environment_variables_integer_get()
+    public function test_environment_variables_integer_get(): void
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', '100');
@@ -37,7 +37,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     /**
      * @test
      */
-    public function test_environment_variables_integer_failure()
+    public function test_environment_variables_integer_failure(): void
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', 'foo');
@@ -57,7 +57,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     /**
      * @test
      */
-    public function test_environment_variables_string_get()
+    public function test_environment_variables_string_get(): void
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', 'foo');
@@ -70,7 +70,7 @@ class EnvironmentVariablesTraitTest extends TestCase
      * @test
      * @dataProvider emptyProvider
      */
-    public function test_environment_variables_string_uses_default_when_empty_value(?string $input)
+    public function test_environment_variables_string_uses_default_when_empty_value(?string $input): void
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);
@@ -82,7 +82,7 @@ class EnvironmentVariablesTraitTest extends TestCase
      * @test
      * @dataProvider emptyProvider
      */
-    public function test_environment_variables_int_uses_default_when_empty_value(?string $input)
+    public function test_environment_variables_int_uses_default_when_empty_value(?string $input): void
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);
@@ -94,7 +94,7 @@ class EnvironmentVariablesTraitTest extends TestCase
      * @test
      * @dataProvider emptyProvider
      */
-    public function test_environment_variables_bool_uses_default_when_empty_value(?string $input)
+    public function test_environment_variables_bool_uses_default_when_empty_value(?string $input): void
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);

--- a/tests/SDK/Unit/EnvironmentVariablesTraitTest.php
+++ b/tests/SDK/Unit/EnvironmentVariablesTraitTest.php
@@ -98,7 +98,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     /**
      * @dataProvider booleanProvider
      */
-    public function environment_variables_bool_get(string $input, bool $default, bool $expected)
+    public function test_environment_variables_bool_get(string $input, bool $default, bool $expected)
     {
         $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_BOOL', $input);

--- a/tests/SDK/Unit/GlobalLoggerHolderTest.php
+++ b/tests/SDK/Unit/GlobalLoggerHolderTest.php
@@ -19,7 +19,7 @@ class GlobalLoggerHolderTest extends TestCase
     /**
      * @test
      */
-    public function setAndGet(): void
+    public function test_set_and_get(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
 
@@ -34,7 +34,7 @@ class GlobalLoggerHolderTest extends TestCase
     /**
      * @test
      */
-    public function returnsDefaultLoggerWhenNotSet(): void
+    public function test_returns_default_logger_when_not_set(): void
     {
         $this->assertFalse(GlobalLoggerHolder::isSet());
         $logger = GlobalLoggerHolder::get();
@@ -44,7 +44,7 @@ class GlobalLoggerHolderTest extends TestCase
     /**
      * @test
      */
-    public function disableCreatesNullLogger(): void
+    public function test_disable_creates_null_logger(): void
     {
         $this->assertFalse(GlobalLoggerHolder::isSet());
         GlobalLoggerHolder::disable();

--- a/tests/SDK/Unit/GlobalLoggerHolderTest.php
+++ b/tests/SDK/Unit/GlobalLoggerHolderTest.php
@@ -16,9 +16,6 @@ class GlobalLoggerHolderTest extends TestCase
         GlobalLoggerHolder::unset();
     }
 
-    /**
-     * @test
-     */
     public function test_set_and_get(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -31,9 +28,6 @@ class GlobalLoggerHolderTest extends TestCase
         $this->assertFalse(GlobalLoggerHolder::isSet());
     }
 
-    /**
-     * @test
-     */
     public function test_returns_default_logger_when_not_set(): void
     {
         $this->assertFalse(GlobalLoggerHolder::isSet());
@@ -41,9 +35,6 @@ class GlobalLoggerHolderTest extends TestCase
         $this->assertFalse(GlobalLoggerHolder::isSet());
     }
 
-    /**
-     * @test
-     */
     public function test_disable_creates_null_logger(): void
     {
         $this->assertFalse(GlobalLoggerHolder::isSet());

--- a/tests/SDK/Unit/Logs/SimplePsrFileLoggerTest.php
+++ b/tests/SDK/Unit/Logs/SimplePsrFileLoggerTest.php
@@ -41,7 +41,7 @@ class SimplePsrFileLoggerTest extends TestCase
     /**
      * @dataProvider logLevelProvider
      */
-    public function testLog(string $logLevel): void
+    public function test_log(string $logLevel): void
     {
         $this->assertFalse($this->root->hasChild(self::LOG_FILE));
 
@@ -62,14 +62,14 @@ class SimplePsrFileLoggerTest extends TestCase
         return $result;
     }
 
-    public function testLogInvalidLogLevel(): void
+    public function test_log_invalid_log_level(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         $this->logger->log('foo', 'foo', ['bar']);
     }
 
-    public function testLogInvalidJson(): void
+    public function test_log_invalid_json(): void
     {
         $this->assertFalse($this->root->hasChild(self::LOG_FILE));
 

--- a/tests/SDK/Unit/Metrics/CounterTest.php
+++ b/tests/SDK/Unit/Metrics/CounterTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class CounterTest extends TestCase
 {
-    public function test_counter_increments()
+    public function test_counter_increments(): void
     {
         $counter = new Counter('some_counter');
 
@@ -20,7 +20,7 @@ class CounterTest extends TestCase
         $this->assertSame(1, $counter->getValue());
     }
 
-    public function test_counter_does_not_accept_negative_numbers()
+    public function test_counter_does_not_accept_negative_numbers(): void
     {
         $counter = new Counter('some_counter');
 

--- a/tests/SDK/Unit/Metrics/CounterTest.php
+++ b/tests/SDK/Unit/Metrics/CounterTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class CounterTest extends TestCase
 {
-    public function testCounterIncrements()
+    public function test_counter_increments()
     {
         $counter = new Counter('some_counter');
 
@@ -20,7 +20,7 @@ class CounterTest extends TestCase
         $this->assertSame(1, $counter->getValue());
     }
 
-    public function testCounterDoesNotAcceptNegativeNumbers()
+    public function test_counter_does_not_accept_negative_numbers()
     {
         $counter = new Counter('some_counter');
 

--- a/tests/SDK/Unit/Metrics/Exporters/AbstractExporterTest.php
+++ b/tests/SDK/Unit/Metrics/Exporters/AbstractExporterTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractExporterTest extends TestCase
 {
-    public function testEmptyMetricsExportReturnsSuccess()
+    public function test_empty_metrics_export_returns_success()
     {
         $this->assertEquals(
             API\ExporterInterface::SUCCESS,
@@ -18,7 +18,7 @@ class AbstractExporterTest extends TestCase
         );
     }
 
-    public function testErrorReturnsIfTryingToExportNotAMetric()
+    public function test_error_returns_if_trying_to_export_not_a_metric()
     {
         /**
          * @phpstan-ignore-next-line

--- a/tests/SDK/Unit/Metrics/Exporters/AbstractExporterTest.php
+++ b/tests/SDK/Unit/Metrics/Exporters/AbstractExporterTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractExporterTest extends TestCase
 {
-    public function test_empty_metrics_export_returns_success()
+    public function test_empty_metrics_export_returns_success(): void
     {
         $this->assertEquals(
             API\ExporterInterface::SUCCESS,
@@ -18,7 +18,7 @@ class AbstractExporterTest extends TestCase
         );
     }
 
-    public function test_error_returns_if_trying_to_export_not_a_metric()
+    public function test_error_returns_if_trying_to_export_not_a_metric(): void
     {
         /**
          * @phpstan-ignore-next-line

--- a/tests/SDK/Unit/Metrics/HasLabelTest.php
+++ b/tests/SDK/Unit/Metrics/HasLabelTest.php
@@ -18,7 +18,7 @@ class HasLabelTest extends TestCase
         };
     }
 
-    public function test_has_label_accepts_values()
+    public function test_has_label_accepts_values(): void
     {
         $this->assertEmpty($this->labelable->getLabels());
 
@@ -29,7 +29,7 @@ class HasLabelTest extends TestCase
         $this->assertSame($expected, $this->labelable->getLabels());
     }
 
-    public function test_has_label_accepts_only_strings()
+    public function test_has_label_accepts_only_strings(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/tests/SDK/Unit/Metrics/HasLabelTest.php
+++ b/tests/SDK/Unit/Metrics/HasLabelTest.php
@@ -18,7 +18,7 @@ class HasLabelTest extends TestCase
         };
     }
 
-    public function testHasLabelAcceptsValues()
+    public function test_has_label_accepts_values()
     {
         $this->assertEmpty($this->labelable->getLabels());
 
@@ -29,7 +29,7 @@ class HasLabelTest extends TestCase
         $this->assertSame($expected, $this->labelable->getLabels());
     }
 
-    public function testHasLabelAcceptsOnlyStrings()
+    public function test_has_label_accepts_only_strings()
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/tests/SDK/Unit/Metrics/MeterTest.php
+++ b/tests/SDK/Unit/Metrics/MeterTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class MeterTest extends TestCase
 {
-    public function testMeter()
+    public function test_meter()
     {
         $meter = new Meter('Meter', '0.1');
 
@@ -20,7 +20,7 @@ class MeterTest extends TestCase
         $this->assertSame('0.1', $meter->getVersion());
     }
 
-    public function testMeterCounter()
+    public function test_meter_counter()
     {
         $meter = new Meter('Meter', '0.1');
 
@@ -32,7 +32,7 @@ class MeterTest extends TestCase
         $this->assertEquals($counterDescription, $counter->getDescription());
     }
 
-    public function testMeterUpDownCounter()
+    public function test_meter_up_down_counter()
     {
         $meter = new Meter('Meter', '0.1');
 
@@ -44,7 +44,7 @@ class MeterTest extends TestCase
         $this->assertEquals($upDownCounterDescription, $upDownCounter->getDescription());
     }
 
-    public function testMeterValueRecorder()
+    public function test_meter_value_recorder()
     {
         $meter = new Meter('Meter', '0.1');
 

--- a/tests/SDK/Unit/Metrics/MeterTest.php
+++ b/tests/SDK/Unit/Metrics/MeterTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class MeterTest extends TestCase
 {
-    public function test_meter()
+    public function test_meter(): void
     {
         $meter = new Meter('Meter', '0.1');
 
@@ -20,7 +20,7 @@ class MeterTest extends TestCase
         $this->assertSame('0.1', $meter->getVersion());
     }
 
-    public function test_meter_counter()
+    public function test_meter_counter(): void
     {
         $meter = new Meter('Meter', '0.1');
 
@@ -32,7 +32,7 @@ class MeterTest extends TestCase
         $this->assertEquals($counterDescription, $counter->getDescription());
     }
 
-    public function test_meter_up_down_counter()
+    public function test_meter_up_down_counter(): void
     {
         $meter = new Meter('Meter', '0.1');
 
@@ -44,7 +44,7 @@ class MeterTest extends TestCase
         $this->assertEquals($upDownCounterDescription, $upDownCounter->getDescription());
     }
 
-    public function test_meter_value_recorder()
+    public function test_meter_value_recorder(): void
     {
         $meter = new Meter('Meter', '0.1');
 

--- a/tests/SDK/Unit/Metrics/Providers/GlobalMeterProviderTest.php
+++ b/tests/SDK/Unit/Metrics/Providers/GlobalMeterProviderTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class GlobalMeterProviderTest extends TestCase
 {
-    public function test_global_meter_provider_setters_and_getters()
+    public function test_global_meter_provider_setters_and_getters(): void
     {
         $defaultProvider = GlobalMeterProvider::getGlobalProvider();
 

--- a/tests/SDK/Unit/Metrics/Providers/GlobalMeterProviderTest.php
+++ b/tests/SDK/Unit/Metrics/Providers/GlobalMeterProviderTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class GlobalMeterProviderTest extends TestCase
 {
-    public function testGLobalMeterProviderSettersAndGetters()
+    public function test_global_meter_provider_setters_and_getters()
     {
         $defaultProvider = GlobalMeterProvider::getGlobalProvider();
 

--- a/tests/SDK/Unit/Metrics/UpDownCounterTest.php
+++ b/tests/SDK/Unit/Metrics/UpDownCounterTest.php
@@ -13,7 +13,7 @@ class UpDownCounterTest extends TestCase
     /**
      * @test
      */
-    public function testValidPositiveIntAdd()
+    public function test_valid_positive_int_add()
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(5);
@@ -21,7 +21,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(2);
         $this->assertEquals(7, $retVal);
     }
-    public function testValidNegativeIntAdd()
+    public function test_valid_negative_int_add()
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(-5);
@@ -30,7 +30,7 @@ class UpDownCounterTest extends TestCase
         $this->assertEquals(-7, $retVal);
     }
 
-    public function testValidPositiveAndNegativeIntAdd()
+    public function test_valid_positive_and_negative_int_add()
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(5);
@@ -38,7 +38,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(-2);
         $this->assertEquals(3, $retVal);
     }
-    public function testValidNegativeAndPositiveAdd()
+    public function test_valid_negative_and_positive_add()
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(-5);
@@ -47,7 +47,7 @@ class UpDownCounterTest extends TestCase
         $this->assertEquals(-3, $retVal);
     }
 
-    public function testValidPositiveFloastAdd()
+    public function test_valid_positive_float_add()
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(5.2222);
@@ -55,7 +55,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(2.6666);
         $this->assertEquals(7, $retVal);
     }
-    public function testValidNegativeFloatAdd()
+    public function test_valid_negative_float_add()
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(-5.2222);
@@ -64,7 +64,7 @@ class UpDownCounterTest extends TestCase
         $this->assertEquals(-7, $retVal);
     }
 
-    public function testValidPositiveAndNegativeFloatAdd()
+    public function test_valid_positive_and_negative_float_add()
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(5.2222);
@@ -72,7 +72,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(-2.6666);
         $this->assertEquals(3, $retVal);
     }
-    public function testValidNegativeAndPositiveFloatAdd()
+    public function test_valid_negative_and_positive_float_add()
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(-5.2222);
@@ -80,7 +80,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(2.6666);
         $this->assertEquals(-3, $retVal);
     }
-    public function testInvalidUpDownCounterAddThrowsException()
+    public function test_invalid_up_down_counter_add_throws_exception()
     {
         $counter = new UpDownCounter('name', 'description');
         $this->expectException(InvalidArgumentException::class);

--- a/tests/SDK/Unit/Metrics/UpDownCounterTest.php
+++ b/tests/SDK/Unit/Metrics/UpDownCounterTest.php
@@ -10,9 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 class UpDownCounterTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_valid_positive_int_add(): void
     {
         $counter = new UpDownCounter('name', 'description');

--- a/tests/SDK/Unit/Metrics/UpDownCounterTest.php
+++ b/tests/SDK/Unit/Metrics/UpDownCounterTest.php
@@ -13,7 +13,7 @@ class UpDownCounterTest extends TestCase
     /**
      * @test
      */
-    public function test_valid_positive_int_add()
+    public function test_valid_positive_int_add(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(5);
@@ -21,7 +21,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(2);
         $this->assertEquals(7, $retVal);
     }
-    public function test_valid_negative_int_add()
+    public function test_valid_negative_int_add(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(-5);
@@ -30,7 +30,7 @@ class UpDownCounterTest extends TestCase
         $this->assertEquals(-7, $retVal);
     }
 
-    public function test_valid_positive_and_negative_int_add()
+    public function test_valid_positive_and_negative_int_add(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(5);
@@ -38,7 +38,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(-2);
         $this->assertEquals(3, $retVal);
     }
-    public function test_valid_negative_and_positive_add()
+    public function test_valid_negative_and_positive_add(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(-5);
@@ -47,7 +47,7 @@ class UpDownCounterTest extends TestCase
         $this->assertEquals(-3, $retVal);
     }
 
-    public function test_valid_positive_float_add()
+    public function test_valid_positive_float_add(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(5.2222);
@@ -55,7 +55,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(2.6666);
         $this->assertEquals(7, $retVal);
     }
-    public function test_valid_negative_float_add()
+    public function test_valid_negative_float_add(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(-5.2222);
@@ -64,7 +64,7 @@ class UpDownCounterTest extends TestCase
         $this->assertEquals(-7, $retVal);
     }
 
-    public function test_valid_positive_and_negative_float_add()
+    public function test_valid_positive_and_negative_float_add(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(5.2222);
@@ -72,7 +72,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(-2.6666);
         $this->assertEquals(3, $retVal);
     }
-    public function test_valid_negative_and_positive_float_add()
+    public function test_valid_negative_and_positive_float_add(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $retVal = $counter->add(-5.2222);
@@ -80,7 +80,7 @@ class UpDownCounterTest extends TestCase
         $retVal = $counter->add(2.6666);
         $this->assertEquals(-3, $retVal);
     }
-    public function test_invalid_up_down_counter_add_throws_exception()
+    public function test_invalid_up_down_counter_add_throws_exception(): void
     {
         $counter = new UpDownCounter('name', 'description');
         $this->expectException(InvalidArgumentException::class);

--- a/tests/SDK/Unit/Metrics/ValueRecorderTest.php
+++ b/tests/SDK/Unit/Metrics/ValueRecorderTest.php
@@ -13,7 +13,7 @@ class ValueRecorderTest extends TestCase
     /**
      * @test
      */
-    public function testValidPositiveIntRecord()
+    public function test_valid_positive_int_record()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5);
@@ -28,7 +28,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(7, $metric->getSum());
     }
 
-    public function testValidNegativeIntRecord()
+    public function test_valid_negative_int_record()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5);
@@ -43,7 +43,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(-7, $metric->getSum());
     }
 
-    public function testValidPositiveAndNegativeIntRecord()
+    public function test_valid_positive_and_negative_int_record()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5);
@@ -58,7 +58,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(3, $metric->getSum());
     }
 
-    public function testValidNegativeAndPositiveRecord()
+    public function test_valid_negative_and_positive_record()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5);
@@ -73,7 +73,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(-3, $metric->getSum());
     }
 
-    public function testValidPositiveFloastRecord()
+    public function test_valid_positive_float_record()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5.2222);
@@ -88,7 +88,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(7.8888, $metric->getSum());
     }
 
-    public function testValidNegativeFloatRecord()
+    public function test_valid_negative_float_record()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5.2222);
@@ -103,7 +103,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(-7.8888, $metric->getSum());
     }
 
-    public function testValidPositiveAndNegativeFloatRecord()
+    public function test_valid_positive_and_negative_float_record()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5.2222);
@@ -118,7 +118,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(2.5556, $metric->getSum());
     }
 
-    public function testValidNegativeAndPositiveFloatRecord()
+    public function test_valid_negative_and_positive_float_record()
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5.2222);
@@ -133,7 +133,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(-2.5556, $metric->getSum());
     }
 
-    public function testValueRecorderInitialization()
+    public function test_value_recorder_initialization()
     {
         $metric = new ValueRecorder('name', 'description');
         $this->assertEquals(0, $metric->getCount());
@@ -143,7 +143,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(0, $metric->getMean());
     }
 
-    public function testInvalidValueRecorderRecordThrowsException()
+    public function test_invalid_value_recorder_record_throws_exception()
     {
         $metric = new ValueRecorder('name', 'description');
         $this->expectException(InvalidArgumentException::class);

--- a/tests/SDK/Unit/Metrics/ValueRecorderTest.php
+++ b/tests/SDK/Unit/Metrics/ValueRecorderTest.php
@@ -13,7 +13,7 @@ class ValueRecorderTest extends TestCase
     /**
      * @test
      */
-    public function test_valid_positive_int_record()
+    public function test_valid_positive_int_record(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5);
@@ -28,7 +28,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(7, $metric->getSum());
     }
 
-    public function test_valid_negative_int_record()
+    public function test_valid_negative_int_record(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5);
@@ -43,7 +43,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(-7, $metric->getSum());
     }
 
-    public function test_valid_positive_and_negative_int_record()
+    public function test_valid_positive_and_negative_int_record(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5);
@@ -58,7 +58,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(3, $metric->getSum());
     }
 
-    public function test_valid_negative_and_positive_record()
+    public function test_valid_negative_and_positive_record(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5);
@@ -73,7 +73,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(-3, $metric->getSum());
     }
 
-    public function test_valid_positive_float_record()
+    public function test_valid_positive_float_record(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5.2222);
@@ -88,7 +88,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(7.8888, $metric->getSum());
     }
 
-    public function test_valid_negative_float_record()
+    public function test_valid_negative_float_record(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5.2222);
@@ -103,7 +103,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(-7.8888, $metric->getSum());
     }
 
-    public function test_valid_positive_and_negative_float_record()
+    public function test_valid_positive_and_negative_float_record(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(5.2222);
@@ -118,7 +118,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(2.5556, $metric->getSum());
     }
 
-    public function test_valid_negative_and_positive_float_record()
+    public function test_valid_negative_and_positive_float_record(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $metric->record(-5.2222);
@@ -133,7 +133,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(-2.5556, $metric->getSum());
     }
 
-    public function test_value_recorder_initialization()
+    public function test_value_recorder_initialization(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $this->assertEquals(0, $metric->getCount());
@@ -143,7 +143,7 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(0, $metric->getMean());
     }
 
-    public function test_invalid_value_recorder_record_throws_exception()
+    public function test_invalid_value_recorder_record_throws_exception(): void
     {
         $metric = new ValueRecorder('name', 'description');
         $this->expectException(InvalidArgumentException::class);

--- a/tests/SDK/Unit/Metrics/ValueRecorderTest.php
+++ b/tests/SDK/Unit/Metrics/ValueRecorderTest.php
@@ -10,9 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 class ValueRecorderTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_valid_positive_int_record(): void
     {
         $metric = new ValueRecorder('name', 'description');

--- a/tests/SDK/Unit/Resource/ResourceTest.php
+++ b/tests/SDK/Unit/Resource/ResourceTest.php
@@ -19,13 +19,13 @@ class ResourceTest extends TestCase
         $this->restoreEnvironmentVariables();
     }
 
-    public function testEmptyResource(): void
+    public function test_empty_resource(): void
     {
         $resource = ResourceInfo::emptyResource();
         $this->assertEmpty($resource->getAttributes());
     }
 
-    public function testGetAttributes(): void
+    public function test_get_attributes(): void
     {
         $attributes = new Attributes();
         $attributes->setAttribute('name', 'test');
@@ -51,7 +51,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function testDefaultResource()
+    public function test_default_resource()
     {
         $attributes = new Attributes(
             [
@@ -75,7 +75,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function testMerge()
+    public function test_merge()
     {
         $primary = ResourceInfo::create(new Attributes(['name' => 'primary', 'empty' => '']));
         $secondary = ResourceInfo::create(new Attributes(['version' => '1.0.0', 'empty' => 'value']));
@@ -94,7 +94,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function testImmutableCreate()
+    public function test_immutable_create()
     {
         $attributes = new Attributes();
         $attributes->setAttribute('name', 'test');
@@ -113,7 +113,7 @@ class ResourceTest extends TestCase
      * @test
      * @dataProvider environmentResourceProvider
      */
-    public function resource_fromEnvironment(string $envAttributes, array $userAttributes, array $expected)
+    public function test_resource_from_environment(string $envAttributes, array $userAttributes, array $expected)
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', $envAttributes);
         $resource = ResourceInfo::create(new Attributes($userAttributes));
@@ -141,7 +141,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function resource_serviceNameDefault()
+    public function test_resource_service_name_default()
     {
         $resource = ResourceInfo::create(new Attributes([]));
         $this->assertEquals('unknown_service', $resource->getAttributes()->get('service.name'));
@@ -150,7 +150,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function resource_withEmptyEnvironmentVariable()
+    public function test_resource_with_empty_environment_variable()
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', '');
         $this->assertInstanceOf(ResourceInfo::class, ResourceInfo::create(new Attributes([])));
@@ -159,7 +159,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function resource_withInvalidEnvironmentVariable()
+    public function test_resource_with_invalid_environment_variable()
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'foo');
         $this->assertInstanceOf(ResourceInfo::class, ResourceInfo::create(new Attributes([])));
@@ -168,7 +168,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function resource_fromEnvironment_serviceNameTakesPrecedenceOverResourceAttribute()
+    public function test_resource_from_environment_service_name_takes_precedence_over_resource_attribute()
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'service.name=bar');
         $this->setEnvironmentVariable('OTEL_SERVICE_NAME', 'foo');
@@ -179,7 +179,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function resource_fromEnvironment_resourceAttributeTakesPrecedenceOverDefault()
+    public function test_resource_from_environment_resource_attribute_takes_precedence_over_default()
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'service.name=foo');
         $resource = ResourceInfo::create(new Attributes([]));

--- a/tests/SDK/Unit/Resource/ResourceTest.php
+++ b/tests/SDK/Unit/Resource/ResourceTest.php
@@ -51,7 +51,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function test_default_resource()
+    public function test_default_resource(): void
     {
         $attributes = new Attributes(
             [
@@ -75,7 +75,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function test_merge()
+    public function test_merge(): void
     {
         $primary = ResourceInfo::create(new Attributes(['name' => 'primary', 'empty' => '']));
         $secondary = ResourceInfo::create(new Attributes(['version' => '1.0.0', 'empty' => 'value']));
@@ -94,7 +94,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function test_immutable_create()
+    public function test_immutable_create(): void
     {
         $attributes = new Attributes();
         $attributes->setAttribute('name', 'test');
@@ -113,7 +113,7 @@ class ResourceTest extends TestCase
      * @test
      * @dataProvider environmentResourceProvider
      */
-    public function test_resource_from_environment(string $envAttributes, array $userAttributes, array $expected)
+    public function test_resource_from_environment(string $envAttributes, array $userAttributes, array $expected): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', $envAttributes);
         $resource = ResourceInfo::create(new Attributes($userAttributes));
@@ -141,7 +141,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function test_resource_service_name_default()
+    public function test_resource_service_name_default(): void
     {
         $resource = ResourceInfo::create(new Attributes([]));
         $this->assertEquals('unknown_service', $resource->getAttributes()->get('service.name'));
@@ -150,7 +150,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function test_resource_with_empty_environment_variable()
+    public function test_resource_with_empty_environment_variable(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', '');
         $this->assertInstanceOf(ResourceInfo::class, ResourceInfo::create(new Attributes([])));
@@ -159,7 +159,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function test_resource_with_invalid_environment_variable()
+    public function test_resource_with_invalid_environment_variable(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'foo');
         $this->assertInstanceOf(ResourceInfo::class, ResourceInfo::create(new Attributes([])));
@@ -168,7 +168,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function test_resource_from_environment_service_name_takes_precedence_over_resource_attribute()
+    public function test_resource_from_environment_service_name_takes_precedence_over_resource_attribute(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'service.name=bar');
         $this->setEnvironmentVariable('OTEL_SERVICE_NAME', 'foo');
@@ -179,7 +179,7 @@ class ResourceTest extends TestCase
     /**
      * @test
      */
-    public function test_resource_from_environment_resource_attribute_takes_precedence_over_default()
+    public function test_resource_from_environment_resource_attribute_takes_precedence_over_default(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'service.name=foo');
         $resource = ResourceInfo::create(new Attributes([]));

--- a/tests/SDK/Unit/Resource/ResourceTest.php
+++ b/tests/SDK/Unit/Resource/ResourceTest.php
@@ -48,9 +48,6 @@ class ResourceTest extends TestCase
         $this->assertSame('test', $name);
     }
 
-    /**
-     * @test
-     */
     public function test_default_resource(): void
     {
         $attributes = new Attributes(
@@ -72,9 +69,6 @@ class ResourceTest extends TestCase
         $this->assertEquals('dev', $sdkversion);
     }
 
-    /**
-     * @test
-     */
     public function test_merge(): void
     {
         $primary = ResourceInfo::create(new Attributes(['name' => 'primary', 'empty' => '']));
@@ -91,9 +85,6 @@ class ResourceTest extends TestCase
         $this->assertEquals('value', $empty);
     }
 
-    /**
-     * @test
-     */
     public function test_immutable_create(): void
     {
         $attributes = new Attributes();
@@ -110,7 +101,6 @@ class ResourceTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider environmentResourceProvider
      */
     public function test_resource_from_environment(string $envAttributes, array $userAttributes, array $expected): void
@@ -138,36 +128,24 @@ class ResourceTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     */
     public function test_resource_service_name_default(): void
     {
         $resource = ResourceInfo::create(new Attributes([]));
         $this->assertEquals('unknown_service', $resource->getAttributes()->get('service.name'));
     }
 
-    /**
-     * @test
-     */
     public function test_resource_with_empty_environment_variable(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', '');
         $this->assertInstanceOf(ResourceInfo::class, ResourceInfo::create(new Attributes([])));
     }
 
-    /**
-     * @test
-     */
     public function test_resource_with_invalid_environment_variable(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'foo');
         $this->assertInstanceOf(ResourceInfo::class, ResourceInfo::create(new Attributes([])));
     }
 
-    /**
-     * @test
-     */
     public function test_resource_from_environment_service_name_takes_precedence_over_resource_attribute(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'service.name=bar');
@@ -176,9 +154,6 @@ class ResourceTest extends TestCase
         $this->assertEquals('foo', $resource->getAttributes()->get('service.name'));
     }
 
-    /**
-     * @test
-     */
     public function test_resource_from_environment_resource_attribute_takes_precedence_over_default(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'service.name=foo');

--- a/tests/SDK/Unit/Trace/Behavior/UsesSpanConverterTraitTest.php
+++ b/tests/SDK/Unit/Trace/Behavior/UsesSpanConverterTraitTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class UsesSpanConverterTraitTest extends TestCase
 {
-    public function testAccessors(): void
+    public function test_accessors(): void
     {
         $instance = $this->createInstance();
         $converter = $this->createSpanConverterInterfaceMock();
@@ -24,7 +24,7 @@ class UsesSpanConverterTraitTest extends TestCase
         );
     }
 
-    public function testFallbackConverter(): void
+    public function test_fallback_converter(): void
     {
         $this->assertInstanceOf(
             NullSpanConverter::class,

--- a/tests/SDK/Unit/Trace/EventTest.php
+++ b/tests/SDK/Unit/Trace/EventTest.php
@@ -17,7 +17,7 @@ class EventTest extends TestCase
 
     private ?AttributesInterface $attributes = null;
 
-    public function testGetName(): void
+    public function test_get_name(): void
     {
         $this->assertSame(
             self::EVENT_NAME,
@@ -25,7 +25,7 @@ class EventTest extends TestCase
         );
     }
 
-    public function testGetAttributes(): void
+    public function test_get_attributes(): void
     {
         $this->assertSame(
             $this->getAttributesInterfaceMock(),
@@ -33,7 +33,7 @@ class EventTest extends TestCase
         );
     }
 
-    public function testGetEpochNanos(): void
+    public function test_get_epoch_nanos(): void
     {
         $this->assertSame(
             $this->getClock()->now(),
@@ -41,7 +41,7 @@ class EventTest extends TestCase
         );
     }
 
-    public function testGetTotalAttributeCount(): void
+    public function test_get_total_attribute_count(): void
     {
         $this->assertSame(
             self::ATTR_CONT,
@@ -49,7 +49,7 @@ class EventTest extends TestCase
         );
     }
 
-    public function testGetDroppedAttributesCount(): void
+    public function test_get_dropped_attributes_count(): void
     {
         $this->assertSame(
             self::DROPPED_ATTR_CONT,

--- a/tests/SDK/Unit/Trace/ExporterFactoryTest.php
+++ b/tests/SDK/Unit/Trace/ExporterFactoryTest.php
@@ -33,7 +33,7 @@ class ExporterFactoryTest extends TestCase
     /**
      * @dataProvider endpointProvider
      */
-    public function testExporterHasCorrectEndpoint($name, $input, $expectedClass): void
+    public function test_exporter_has_correct_endpoint($name, $input, $expectedClass): void
     {
         $factory = new ExporterFactory($name);
         $exporter = $factory->fromConnectionString($input);
@@ -56,7 +56,7 @@ class ExporterFactoryTest extends TestCase
     /**
      * @dataProvider invalidConnectionStringProvider
      */
-    public function testInvalidConnectionString(string $name, string $input): void
+    public function test_invalid_connection_string(string $name, string $input): void
     {
         $this->expectException(Exception::class);
         $factory = new ExporterFactory($name);
@@ -73,7 +73,7 @@ class ExporterFactoryTest extends TestCase
         ];
     }
 
-    public function testAcceptsNoneExporterEnvVar()
+    public function test_accepts_none_exporter_env_var()
     {
         $this->setEnvironmentVariable('OTEL_TRACES_EXPORTER', 'none');
         $factory = new ExporterFactory('test.fromEnv');
@@ -84,7 +84,7 @@ class ExporterFactoryTest extends TestCase
      * @dataProvider envProvider
      * @psalm-param class-string $expected
      */
-    public function testCreateFromEnvironment(string $exporter, array $env, string $expected)
+    public function test_create_from_environment(string $exporter, array $env, string $expected)
     {
         $this->setEnvironmentVariable('OTEL_TRACES_EXPORTER', $exporter);
         foreach ($env as $k => $v) {
@@ -126,7 +126,7 @@ class ExporterFactoryTest extends TestCase
     /**
      * @dataProvider invalidEnvProvider
      */
-    public function testThrowsExceptionForInvalidOrUnsupportedExporterConfigs(string $exporter, array $env = [])
+    public function test_throws_exception_for_invalid_or_unsupported_exporter_configs(string $exporter, array $env = [])
     {
         $this->setEnvironmentVariable('OTEL_TRACES_EXPORTER', $exporter);
         foreach ($env as $k => $v) {
@@ -158,7 +158,7 @@ class ExporterFactoryTest extends TestCase
         ];
     }
 
-    public function testNonExistingExporterEnvVar(): void
+    public function test_non_existing_exporter_env_var(): void
     {
         $this->expectException(Exception::class);
 

--- a/tests/SDK/Unit/Trace/ExporterFactoryTest.php
+++ b/tests/SDK/Unit/Trace/ExporterFactoryTest.php
@@ -73,7 +73,7 @@ class ExporterFactoryTest extends TestCase
         ];
     }
 
-    public function test_accepts_none_exporter_env_var()
+    public function test_accepts_none_exporter_env_var(): void
     {
         $this->setEnvironmentVariable('OTEL_TRACES_EXPORTER', 'none');
         $factory = new ExporterFactory('test.fromEnv');
@@ -84,7 +84,7 @@ class ExporterFactoryTest extends TestCase
      * @dataProvider envProvider
      * @psalm-param class-string $expected
      */
-    public function test_create_from_environment(string $exporter, array $env, string $expected)
+    public function test_create_from_environment(string $exporter, array $env, string $expected): void
     {
         $this->setEnvironmentVariable('OTEL_TRACES_EXPORTER', $exporter);
         foreach ($env as $k => $v) {
@@ -126,7 +126,7 @@ class ExporterFactoryTest extends TestCase
     /**
      * @dataProvider invalidEnvProvider
      */
-    public function test_throws_exception_for_invalid_or_unsupported_exporter_configs(string $exporter, array $env = [])
+    public function test_throws_exception_for_invalid_or_unsupported_exporter_configs(string $exporter, array $env = []): void
     {
         $this->setEnvironmentVariable('OTEL_TRACES_EXPORTER', $exporter);
         foreach ($env as $k => $v) {

--- a/tests/SDK/Unit/Trace/NonRecordingSpanTest.php
+++ b/tests/SDK/Unit/Trace/NonRecordingSpanTest.php
@@ -9,12 +9,12 @@ use PHPUnit\Framework\TestCase;
 
 class NonRecordingSpanTest extends TestCase
 {
-    public function testIsNotRecording(): void
+    public function test_is_not_recording(): void
     {
         $this->assertFalse(API\NonRecordingSpan::getInvalid()->isRecording());
     }
 
-    public function testHasInvalidContextAndDefaultSpanOptions(): void
+    public function test_has_invalid_context_and_default_span_options(): void
     {
         $context = API\NonRecordingSpan::getInvalid()->getContext();
         $this->assertSame(API\SpanContextInterface::TRACE_FLAG_DEFAULT, $context->getTraceFlags());

--- a/tests/SDK/Unit/Trace/RandomIdGeneratorTest.php
+++ b/tests/SDK/Unit/Trace/RandomIdGeneratorTest.php
@@ -13,7 +13,7 @@ class RandomIdGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function GeneratedTraceIdIsValid()
+    public function test_generated_trace_id_is_valid()
     {
         $idGenerator = new RandomIdGenerator();
         $traceId = $idGenerator->generateTraceId();
@@ -24,7 +24,7 @@ class RandomIdGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function generatedSpanIdIsValid()
+    public function test_generated_span_id_is_valid()
     {
         $idGenerator = new RandomIdGenerator();
         $spanId = $idGenerator->generateSpanId();
@@ -35,7 +35,7 @@ class RandomIdGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function fallbackAlgorithm()
+    public function test_fallback_algorithm()
     {
         $idGenerator = new RandomIdGenerator();
         $reflection = new \ReflectionClass(RandomIdGenerator::class);

--- a/tests/SDK/Unit/Trace/RandomIdGeneratorTest.php
+++ b/tests/SDK/Unit/Trace/RandomIdGeneratorTest.php
@@ -13,7 +13,7 @@ class RandomIdGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function test_generated_trace_id_is_valid()
+    public function test_generated_trace_id_is_valid(): void
     {
         $idGenerator = new RandomIdGenerator();
         $traceId = $idGenerator->generateTraceId();
@@ -24,7 +24,7 @@ class RandomIdGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function test_generated_span_id_is_valid()
+    public function test_generated_span_id_is_valid(): void
     {
         $idGenerator = new RandomIdGenerator();
         $spanId = $idGenerator->generateSpanId();
@@ -35,7 +35,7 @@ class RandomIdGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function test_fallback_algorithm()
+    public function test_fallback_algorithm(): void
     {
         $idGenerator = new RandomIdGenerator();
         $reflection = new \ReflectionClass(RandomIdGenerator::class);

--- a/tests/SDK/Unit/Trace/RandomIdGeneratorTest.php
+++ b/tests/SDK/Unit/Trace/RandomIdGeneratorTest.php
@@ -10,9 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 class RandomIdGeneratorTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function test_generated_trace_id_is_valid(): void
     {
         $idGenerator = new RandomIdGenerator();
@@ -21,9 +18,6 @@ class RandomIdGeneratorTest extends TestCase
         $this->assertEquals(1, preg_match(SpanContext::VALID_TRACE, $traceId));
     }
 
-    /**
-     * @test
-     */
     public function test_generated_span_id_is_valid(): void
     {
         $idGenerator = new RandomIdGenerator();
@@ -32,9 +26,6 @@ class RandomIdGeneratorTest extends TestCase
         $this->assertEquals(1, preg_match(SpanContext::VALID_SPAN, $spanId));
     }
 
-    /**
-     * @test
-     */
     public function test_fallback_algorithm(): void
     {
         $idGenerator = new RandomIdGenerator();

--- a/tests/SDK/Unit/Trace/SamplerFactoryTest.php
+++ b/tests/SDK/Unit/Trace/SamplerFactoryTest.php
@@ -22,7 +22,7 @@ class SamplerFactoryTest extends TestCase
      * @test
      * @dataProvider samplerProvider
      */
-    public function samplerFactory_createSamplerFromEnvironment(string $samplerName, string $expected, string $arg = null)
+    public function test_sampler_factory_create_sampler_from_environment(string $samplerName, string $expected, string $arg = null)
     {
         $this->setEnvironmentVariable('OTEL_TRACES_SAMPLER', $samplerName);
         $this->setEnvironmentVariable('OTEL_TRACES_SAMPLER_ARG', $arg);
@@ -46,7 +46,7 @@ class SamplerFactoryTest extends TestCase
      * @test
      * @dataProvider invalidSamplerProvider
      */
-    public function samplerFactory_throwsExceptionForInvalidOrUnsupported(?string $sampler, string $arg = null)
+    public function test_sampler_factory_throws_exception_for_invalid_or_unsupported(?string $sampler, string $arg = null)
     {
         $this->setEnvironmentVariable('OTEL_TRACES_SAMPLER', $sampler);
         $this->setEnvironmentVariable('OTEL_TRACES_SAMPLER_ARG', $arg);

--- a/tests/SDK/Unit/Trace/SamplerFactoryTest.php
+++ b/tests/SDK/Unit/Trace/SamplerFactoryTest.php
@@ -22,7 +22,7 @@ class SamplerFactoryTest extends TestCase
      * @test
      * @dataProvider samplerProvider
      */
-    public function test_sampler_factory_create_sampler_from_environment(string $samplerName, string $expected, string $arg = null)
+    public function test_sampler_factory_create_sampler_from_environment(string $samplerName, string $expected, string $arg = null): void
     {
         $this->setEnvironmentVariable('OTEL_TRACES_SAMPLER', $samplerName);
         $this->setEnvironmentVariable('OTEL_TRACES_SAMPLER_ARG', $arg);
@@ -46,7 +46,7 @@ class SamplerFactoryTest extends TestCase
      * @test
      * @dataProvider invalidSamplerProvider
      */
-    public function test_sampler_factory_throws_exception_for_invalid_or_unsupported(?string $sampler, string $arg = null)
+    public function test_sampler_factory_throws_exception_for_invalid_or_unsupported(?string $sampler, string $arg = null): void
     {
         $this->setEnvironmentVariable('OTEL_TRACES_SAMPLER', $sampler);
         $this->setEnvironmentVariable('OTEL_TRACES_SAMPLER_ARG', $arg);

--- a/tests/SDK/Unit/Trace/SamplerFactoryTest.php
+++ b/tests/SDK/Unit/Trace/SamplerFactoryTest.php
@@ -19,7 +19,6 @@ class SamplerFactoryTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider samplerProvider
      */
     public function test_sampler_factory_create_sampler_from_environment(string $samplerName, string $expected, string $arg = null): void
@@ -43,7 +42,6 @@ class SamplerFactoryTest extends TestCase
         ];
     }
     /**
-     * @test
      * @dataProvider invalidSamplerProvider
      */
     public function test_sampler_factory_throws_exception_for_invalid_or_unsupported(?string $sampler, string $arg = null): void

--- a/tests/SDK/Unit/Trace/SamplingResultTest.php
+++ b/tests/SDK/Unit/Trace/SamplingResultTest.php
@@ -14,7 +14,7 @@ class SamplingResultTest extends TestCase
     /**
      * @dataProvider provideAttributesAndLinks
      */
-    public function test_attributes_and_links_getters($attributes, $traceState)
+    public function test_attributes_and_links_getters($attributes, $traceState): void
     {
         $result = new SamplingResult(SamplingResult::DROP, $attributes, $traceState);
 

--- a/tests/SDK/Unit/Trace/SamplingResultTest.php
+++ b/tests/SDK/Unit/Trace/SamplingResultTest.php
@@ -14,7 +14,7 @@ class SamplingResultTest extends TestCase
     /**
      * @dataProvider provideAttributesAndLinks
      */
-    public function testAttributesAndLinksGetters($attributes, $traceState)
+    public function test_attributes_and_links_getters($attributes, $traceState)
     {
         $result = new SamplingResult(SamplingResult::DROP, $attributes, $traceState);
 

--- a/tests/SDK/Unit/Trace/SpanBuilderTest.php
+++ b/tests/SDK/Unit/Trace/SpanBuilderTest.php
@@ -45,7 +45,7 @@ class SpanBuilderTest extends MockeryTestCase
         );
     }
 
-    public function test_addLink(): void
+    public function test_add_link(): void
     {
         /** @var Span $span */
         $span = $this
@@ -59,7 +59,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_addLink_invalid(): void
+    public function test_add_link_invalid(): void
     {
         /** @var Span $span */
         $span = $this
@@ -73,7 +73,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_addLink_droppingLinks(): void
+    public function test_add_link_dropping_links(): void
     {
         $maxNumberOfLinks = 8;
         $spanBuilder = (new TracerProvider([], null, null, (new SpanLimitsBuilder())->setLinkCountLimit($maxNumberOfLinks)->build()))
@@ -100,7 +100,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_addLink_truncateLinkAttributes(): void
+    public function test_add_link_truncate_link_attributes(): void
     {
         /** @var Span $span */
         $span = (new TracerProvider([], null, null, (new SpanLimitsBuilder())->setAttributePerLinkCountLimit(1)->build()))
@@ -122,7 +122,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_addLink_truncateLinkAttributeValue(): void
+    public function test_add_link_truncate_link_attribute_value(): void
     {
         $maxLength = 25;
 
@@ -159,7 +159,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_addLink_noEffectAfterStartSpan(): void
+    public function test_add_link_no_effect_after_start_span(): void
     {
         $spanBuilder = $this->tracer->spanBuilder(self::SPAN_NAME);
 
@@ -184,7 +184,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_setAttribute(): void
+    public function test_set_attribute(): void
     {
         /** @var Span $span */
         $span = $this
@@ -209,7 +209,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_setAttribute_afterEnd(): void
+    public function test_set_attribute_after_end(): void
     {
         /** @var Span $span */
         $span = $this
@@ -227,7 +227,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_setAttribute_dropping(): void
+    public function test_set_attribute_dropping(): void
     {
         $maxNumberOfAttributes = 8;
         $spanBuilder = (new TracerProvider(
@@ -254,7 +254,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_addAttributesViaSampler(): void
+    public function test_add_attributes_via_sampler(): void
     {
         $sampler = new class() implements SamplerInterface {
             public function shouldSample(
@@ -284,7 +284,7 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertSame('meow', $attributes->get('cat'));
     }
 
-    public function test_setAttributes(): void
+    public function test_set_attributes(): void
     {
         $attributes = new Attributes(['id' => 1, 'foo' => 'bar']);
 
@@ -300,7 +300,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_setAttributes_overridesValues(): void
+    public function test_set_attributes_overrides_values(): void
     {
         $attributes = new Attributes(['id' => 1, 'foo' => 'bar']);
 
@@ -322,7 +322,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_isRecording_default(): void
+    public function test_is_recording_default(): void
     {
         /** @var Span $span */
         $span = $this->tracer->spanBuilder(self::SPAN_NAME)->startSpan();
@@ -330,7 +330,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_isRecording_sampler(): void
+    public function test_is_recording_sampler(): void
     {
         /** @var Span $span */
         $span = (new TracerProvider([], new AlwaysOffSampler()))
@@ -342,7 +342,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_getKind_default(): void
+    public function test_get_kind_default(): void
     {
         /** @var Span $span */
         $span = $this->tracer->spanBuilder(self::SPAN_NAME)->startSpan();
@@ -350,7 +350,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_getKind(): void
+    public function test_get_kind(): void
     {
         /** @var Span $span */
         $span = $this->tracer->spanBuilder(self::SPAN_NAME)->setSpanKind(API\SpanKind::KIND_CONSUMER)->startSpan();
@@ -358,7 +358,7 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_startTimestamp(): void
+    public function test_start_timestamp(): void
     {
         /** @var Span $span */
         $span = $this->tracer->spanBuilder(self::SPAN_NAME)->setStartTimestamp(123)->startSpan();
@@ -366,7 +366,7 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertSame(123, $span->toSpanData()->getStartEpochNanos());
     }
 
-    public function test_setNoParent(): void
+    public function test_set_no_parent(): void
     {
         $parentSpan = $this->tracer->spanBuilder(self::SPAN_NAME)->startSpan();
         $parentScope = $parentSpan->activate();
@@ -408,7 +408,7 @@ class SpanBuilderTest extends MockeryTestCase
         $parentSpan->end();
     }
 
-    public function test_setNoParent_override(): void
+    public function test_set_no_parent_override(): void
     {
         $parentSpan = $this->tracer->spanBuilder(self::SPAN_NAME)->startSpan();
         $parentContext = Context::getCurrent()->withContextValue($parentSpan);
@@ -457,7 +457,7 @@ class SpanBuilderTest extends MockeryTestCase
         $parentSpan->end();
     }
 
-    public function test_setParent_emptyContext(): void
+    public function test_set_parent_empty_context(): void
     {
         $emptyContext = Context::getCurrent();
         $parentSpan = $this->tracer->spanBuilder(self::SPAN_NAME)->startSpan();
@@ -486,7 +486,7 @@ class SpanBuilderTest extends MockeryTestCase
         $parentSpan->end();
     }
 
-    public function test_setParent_currentSpan(): void
+    public function test_set_parent_current_span(): void
     {
         $parentSpan = $this->tracer->spanBuilder(self::SPAN_NAME)->startSpan();
         $parentScope = $parentSpan->activate();
@@ -515,7 +515,7 @@ class SpanBuilderTest extends MockeryTestCase
         $parentSpan->end();
     }
 
-    public function test_setParent_invalidContext(): void
+    public function test_set_parent_invalid_context(): void
     {
         $parentSpan = Span::getInvalid();
 

--- a/tests/SDK/Unit/Trace/SpanExporter/AbstractExporterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/AbstractExporterTest.php
@@ -17,21 +17,21 @@ abstract class AbstractExporterTest extends TestCase
      */
     abstract public function createExporter(): SpanExporterInterface;
 
-    public function testShutdown(): void
+    public function test_shutdown(): void
     {
         $this->assertTrue(
             $this->createExporter()->shutdown()
         );
     }
 
-    public function testForceFlush(): void
+    public function test_force_flush(): void
     {
         $this->assertTrue(
             $this->createExporter()->forceFlush()
         );
     }
 
-    public function testFailsIfNotRunning(): void
+    public function test_fails_if_not_test_running(): void
     {
         $exporter = $this->createExporter();
 
@@ -41,7 +41,7 @@ abstract class AbstractExporterTest extends TestCase
         $this->assertSame(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE, $exporter->export([$span]));
     }
 
-    public function testExportEmptySpanCollection(): void
+    public function test_export_empty_span_collection(): void
     {
         $this->assertEquals(
             SpanExporterInterface::STATUS_SUCCESS,

--- a/tests/SDK/Unit/Trace/SpanExporter/ConsoleSpanExporterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/ConsoleSpanExporterTest.php
@@ -48,7 +48,7 @@ class ConsoleSpanExporterTest extends AbstractExporterTest
         ],],
     ];
 
-    public function testExportSuccess(): void
+    public function test_export_success(): void
     {
         $converter = $this->createMock(SpanConverterInterface::class);
         $converter->expects($this->once())
@@ -67,7 +67,7 @@ class ConsoleSpanExporterTest extends AbstractExporterTest
         ob_end_clean();
     }
 
-    public function testExportFailed(): void
+    public function test_export_failed(): void
     {
         $resource = fopen('php://stdin', 'rb');
         $converter = $this->createMock(SpanConverterInterface::class);
@@ -88,7 +88,7 @@ class ConsoleSpanExporterTest extends AbstractExporterTest
         fclose($resource);
     }
 
-    public function testExportOutput(): void
+    public function test_export_output(): void
     {
         try {
             $expected = json_encode(self::TEST_DATA, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT) . PHP_EOL;
@@ -108,7 +108,7 @@ class ConsoleSpanExporterTest extends AbstractExporterTest
         ]);
     }
 
-    public function testFromConnectionString(): void
+    public function test_from_connection_string(): void
     {
         $this->assertInstanceOf(
             ConsoleSpanExporter::class,

--- a/tests/SDK/Unit/Trace/SpanExporter/FriendlySpanConverterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/FriendlySpanConverterTest.php
@@ -76,7 +76,7 @@ class FriendlySpanConverterTest extends TestCase
         ],
     ];
 
-    public function testConvert(): void
+    public function test_convert(): void
     {
         $this->assertEquals(
             self::TEST_DATA,

--- a/tests/SDK/Unit/Trace/SpanExporter/LoggerDecoratorTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/LoggerDecoratorTest.php
@@ -17,7 +17,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
      */
     private ?SpanExporterInterface $decorated;
 
-    public function testFromConnectionString(): void
+    public function test_from_connection_string(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -27,7 +27,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
     /**
      * @psalm-suppress PossiblyUndefinedMethod
      */
-    public function testShutDown(): void
+    public function test_shut_down(): void
     {
         $this->getSpanExporterInterfaceMock()
             ->expects($this->once())
@@ -42,7 +42,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
     /**
      * @psalm-suppress PossiblyUndefinedMethod
      */
-    public function testForceFlush(): void
+    public function test_force_flush(): void
     {
         $this->getSpanExporterInterfaceMock()
             ->expects($this->once())
@@ -58,7 +58,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
      * @psalm-suppress PossiblyUndefinedMethod
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function testExportSuccess(): void
+    public function test_export_success(): void
     {
         $this->getSpanExporterInterfaceMock()
             ->expects($this->once())
@@ -80,7 +80,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
      * @psalm-suppress PossiblyUndefinedMethod
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function testExportFailedRetryable(): void
+    public function test_export_failed_retryable(): void
     {
         $this->getSpanExporterInterfaceMock()
             ->expects($this->once())
@@ -102,7 +102,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
      * @psalm-suppress PossiblyUndefinedMethod
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function testExportFailedNotRetryable(): void
+    public function test_export_failed_not_retryable(): void
     {
         $this->getSpanExporterInterfaceMock()
             ->expects($this->once())

--- a/tests/SDK/Unit/Trace/SpanExporter/LoggerExporterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/LoggerExporterTest.php
@@ -21,7 +21,7 @@ class LoggerExporterTest extends AbstractExporterTest
         return new LoggerExporter(self::SERVICE_NAME);
     }
 
-    public function testFromConnectionString(): void
+    public function test_from_connection_string(): void
     {
         /** @noinspection UnnecessaryAssertionInspection */
         $this->assertInstanceOf(
@@ -38,7 +38,7 @@ class LoggerExporterTest extends AbstractExporterTest
      * @psalm-suppress PossiblyUndefinedMethod
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function testExportGranularityAggregate(): void
+    public function test_export_granularity_aggregate(): void
     {
         $this->getLoggerInterfaceMock()
             ->expects($this->once())
@@ -57,7 +57,7 @@ class LoggerExporterTest extends AbstractExporterTest
      * @psalm-suppress PossiblyUndefinedMethod
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function testExportGranularitySpan(): void
+    public function test_export_granularity_span(): void
     {
         $spans = $this->createSpanMocks();
 
@@ -76,7 +76,7 @@ class LoggerExporterTest extends AbstractExporterTest
      * @psalm-suppress PossiblyUndefinedMethod
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function testLoggerThrowsException(): void
+    public function test_loggerThrowsException(): void
     {
         $this->getLoggerInterfaceMock()
             ->method('log')

--- a/tests/SDK/Unit/Trace/SpanExporter/LoggerExporterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/LoggerExporterTest.php
@@ -76,7 +76,7 @@ class LoggerExporterTest extends AbstractExporterTest
      * @psalm-suppress PossiblyUndefinedMethod
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function test_loggerThrowsException(): void
+    public function test_logger_throws_exception(): void
     {
         $this->getLoggerInterfaceMock()
             ->method('log')

--- a/tests/SDK/Unit/Trace/SpanExporter/NullSpanConverterTest.php
+++ b/tests/SDK/Unit/Trace/SpanExporter/NullSpanConverterTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class NullSpanConverterTest extends TestCase
 {
-    public function testImplementsSpanConverterInterface(): void
+    public function test_implements_span_converter_interface(): void
     {
         $this->assertInstanceOf(
             SpanConverterInterface::class,
@@ -19,7 +19,7 @@ class NullSpanConverterTest extends TestCase
         );
     }
 
-    public function testConvert(): void
+    public function test_convert(): void
     {
         $this->assertSame(
             [],

--- a/tests/SDK/Unit/Trace/SpanLimitsBuilderTest.php
+++ b/tests/SDK/Unit/Trace/SpanLimitsBuilderTest.php
@@ -17,7 +17,7 @@ class SpanLimitsBuilderTest extends TestCase
     /**
      * @test
      */
-    public function spanLimitsBuilder_usesDefaultValues()
+    public function test_span_limits_builder_uses_default_values()
     {
         $builder = new SpanLimitsBuilder();
         $spanLimits = $builder->build();
@@ -27,7 +27,7 @@ class SpanLimitsBuilderTest extends TestCase
     /**
      * @test
      */
-    public function spanLimitsBuilder_usesEnvironmentVariable()
+    public function test_span_limits_builder_uses_environment_variable()
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 111);
         $builder = new SpanLimitsBuilder();
@@ -38,7 +38,7 @@ class SpanLimitsBuilderTest extends TestCase
     /**
      * @test
      */
-    public function spanLimitsBuilder_usesConfiguredValue()
+    public function test_span_limits_builder_uses_configured_value()
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 111);
         $builder = new SpanLimitsBuilder();
@@ -50,7 +50,7 @@ class SpanLimitsBuilderTest extends TestCase
     /**
      * @test
      */
-    public function spanLimitsBuilder_throwsExceptionOnInvalidValueFromEnvironment()
+    public function test_span_limits_builder_throws_exception_on_invalid_value_from_environment()
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 'fruit');
         $builder = new SpanLimitsBuilder();

--- a/tests/SDK/Unit/Trace/SpanLimitsBuilderTest.php
+++ b/tests/SDK/Unit/Trace/SpanLimitsBuilderTest.php
@@ -17,7 +17,7 @@ class SpanLimitsBuilderTest extends TestCase
     /**
      * @test
      */
-    public function test_span_limits_builder_uses_default_values()
+    public function test_span_limits_builder_uses_default_values(): void
     {
         $builder = new SpanLimitsBuilder();
         $spanLimits = $builder->build();
@@ -27,7 +27,7 @@ class SpanLimitsBuilderTest extends TestCase
     /**
      * @test
      */
-    public function test_span_limits_builder_uses_environment_variable()
+    public function test_span_limits_builder_uses_environment_variable(): void
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 111);
         $builder = new SpanLimitsBuilder();
@@ -38,7 +38,7 @@ class SpanLimitsBuilderTest extends TestCase
     /**
      * @test
      */
-    public function test_span_limits_builder_uses_configured_value()
+    public function test_span_limits_builder_uses_configured_value(): void
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 111);
         $builder = new SpanLimitsBuilder();
@@ -50,7 +50,7 @@ class SpanLimitsBuilderTest extends TestCase
     /**
      * @test
      */
-    public function test_span_limits_builder_throws_exception_on_invalid_value_from_environment()
+    public function test_span_limits_builder_throws_exception_on_invalid_value_from_environment(): void
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 'fruit');
         $builder = new SpanLimitsBuilder();

--- a/tests/SDK/Unit/Trace/SpanLimitsBuilderTest.php
+++ b/tests/SDK/Unit/Trace/SpanLimitsBuilderTest.php
@@ -14,9 +14,6 @@ class SpanLimitsBuilderTest extends TestCase
 {
     use EnvironmentVariables;
 
-    /**
-     * @test
-     */
     public function test_span_limits_builder_uses_default_values(): void
     {
         $builder = new SpanLimitsBuilder();
@@ -24,9 +21,6 @@ class SpanLimitsBuilderTest extends TestCase
         $this->assertEquals(SpanLimits::DEFAULT_EVENT_ATTRIBUTE_COUNT_LIMIT, $spanLimits->getAttributeLimits()->getAttributeCountLimit());
     }
 
-    /**
-     * @test
-     */
     public function test_span_limits_builder_uses_environment_variable(): void
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 111);
@@ -35,9 +29,6 @@ class SpanLimitsBuilderTest extends TestCase
         $this->assertEquals(111, $spanLimits->getAttributeLimits()->getAttributeCountLimit());
     }
 
-    /**
-     * @test
-     */
     public function test_span_limits_builder_uses_configured_value(): void
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 111);
@@ -47,9 +38,6 @@ class SpanLimitsBuilderTest extends TestCase
         $this->assertEquals(222, $spanLimits->getAttributeLimits()->getAttributeCountLimit());
     }
 
-    /**
-     * @test
-     */
     public function test_span_limits_builder_throws_exception_on_invalid_value_from_environment(): void
     {
         $this->setEnvironmentVariable('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 'fruit');

--- a/tests/SDK/Unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -350,7 +350,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         }
     }
 
-    public function test_create_non_numeric_environment_value_throws_exception()
+    public function test_create_non_numeric_environment_value_throws_exception(): void
     {
         $this->setEnvironmentVariable('OTEL_BSP_MAX_QUEUE_SIZE', 'fruit');
         $exporter = $this->createMock(SpanExporterInterface::class);

--- a/tests/SDK/Unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -36,7 +36,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $this->restoreEnvironmentVariables();
     }
 
-    public function test_allowsNullExporter(): void
+    public function test_allows_null_exporter(): void
     {
         $proc = new BatchSpanProcessor(null, $this->testClock);
         $span = $this->createSampledSpanMock();
@@ -47,7 +47,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $this->assertTrue(true); // phpunit requires an assertion
     }
 
-    public function test_export_batchSizeMet(): void
+    public function test_export_batch_size_met(): void
     {
         $batchSize = 3;
         $queueSize = 5; // queue is larger than batch
@@ -77,7 +77,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         }
     }
 
-    public function test_export_batchSizeGreaterThanQueueSize_isRejected(): void
+    public function test_export_batch_size_greater_than_queue_size_is_rejected(): void
     {
         $batchSize = 3;
         $queueSize = 2; // queue is smaller than batch
@@ -101,7 +101,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
     /**
      * @dataProvider scheduledDelayProvider
      */
-    public function test_export_scheduledDelay(int $exportDelay, int $advanceByNano, bool $expectedFlush): void
+    public function test_export_scheduled_delay(int $exportDelay, int $advanceByNano, bool $expectedFlush): void
     {
         $batchSize = 2;
         $queueSize = 5;
@@ -143,7 +143,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         ];
     }
 
-    public function test_export_delayLimitReached_partiallyFilledBatch(): void
+    public function test_export_delay_limit_reached_partially_filled_batch(): void
     {
         $batchSize = 4;
         $queueSize = 5;
@@ -190,7 +190,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         }
     }
 
-    public function test_export_delayLimitNotReached_partiallyFilledBatch(): void
+    public function test_export_delay_limit_not_reached_partially_filled_batch(): void
     {
         $batchSize = 3;
         $queueSize = 5;
@@ -219,7 +219,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown-1
      */
-    public function test_export_includesForceFlushOnShutdown(): void
+    public function test_export_includes_force_flush_on_shutdown(): void
     {
         $batchSize = 3;
 
@@ -237,7 +237,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $proc->shutdown();
     }
 
-    public function test_export_afterShutdown(): void
+    public function test_export_after_shutdown(): void
     {
         $exporter = $this->createMock(SpanExporterInterface::class);
         $exporter->expects($this->atLeastOnce())->method('shutdown');
@@ -252,7 +252,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $proc->shutdown();
     }
 
-    public function test_export_onlySampledSpans(): void
+    public function test_export_only_sampled_spans(): void
     {
         $sampledSpan = $this->createSampledSpanMock();
         $nonSampledSpan = $this->createNonSampledSpanMock();
@@ -280,7 +280,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $batchProcessor->forceFlush();
     }
 
-    public function test_forceFlush_endedSpans(): void
+    public function test_force_flush_ended_spans(): void
     {
         $batchSize = 3;
         $queueSize = 3;
@@ -319,7 +319,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $processor->forceFlush();
     }
 
-    public function test_shutdown_shutdownsExporter(): void
+    public function test_shutdown_shutdowns_exporter(): void
     {
         $exporter = $this->createMock(SpanExporterInterface::class);
         $processor = new BatchSpanProcessor($exporter, $this->testClock);
@@ -328,7 +328,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $processor->shutdown();
     }
 
-    public function test_create_fromEnvironmentVariables(): void
+    public function test_create_from_environment_variables(): void
     {
         $exporter = $this->createMock(SpanExporterInterface::class);
 
@@ -350,7 +350,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         }
     }
 
-    public function test_create_nonNumericEnvironmentValue_throwsException()
+    public function test_create_non_numeric_environment_value_throws_exception()
     {
         $this->setEnvironmentVariable('OTEL_BSP_MAX_QUEUE_SIZE', 'fruit');
         $exporter = $this->createMock(SpanExporterInterface::class);

--- a/tests/SDK/Unit/Trace/SpanProcessor/MultiSpanProcessorTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessor/MultiSpanProcessorTest.php
@@ -15,7 +15,7 @@ class MultiSpanProcessorTest extends TestCase
 {
     private array $spanProcessors = [];
 
-    public function testGetSpanProcessors(): void
+    public function test_get_span_processors(): void
     {
         $this->assertEquals(
             $this->getSpanProcessors(),
@@ -23,7 +23,7 @@ class MultiSpanProcessorTest extends TestCase
         );
     }
 
-    public function testAddSpanProcessor(): void
+    public function test_add_span_processor(): void
     {
         $multiProcessor = $this->createMultiSpanProcessor();
         $processor = $this->createMock(SpanProcessorInterface::class);
@@ -39,7 +39,7 @@ class MultiSpanProcessorTest extends TestCase
         );
     }
 
-    public function testOnStart(): void
+    public function test_on_start(): void
     {
         /** @var MockObject $processor */
         foreach ($this->getSpanProcessors() as $processor) {
@@ -53,7 +53,7 @@ class MultiSpanProcessorTest extends TestCase
             );
     }
 
-    public function testOnEnd(): void
+    public function test_on_end(): void
     {
         /** @var MockObject $processor */
         foreach ($this->getSpanProcessors() as $processor) {
@@ -67,7 +67,7 @@ class MultiSpanProcessorTest extends TestCase
             );
     }
 
-    public function testShutdown(): void
+    public function test_shutdown(): void
     {
         /** @var MockObject $processor */
         foreach ($this->getSpanProcessors() as $processor) {
@@ -82,7 +82,7 @@ class MultiSpanProcessorTest extends TestCase
         );
     }
 
-    public function testShutdownOneFailed(): void
+    public function test_shutdown_one_failed(): void
     {
         /** @var MockObject $processor */
         foreach ($this->getSpanProcessors() as $i => $processor) {
@@ -97,7 +97,7 @@ class MultiSpanProcessorTest extends TestCase
         );
     }
 
-    public function testForceFlush(): void
+    public function test_force_flush(): void
     {
         /** @var MockObject $processor */
         foreach ($this->getSpanProcessors() as $processor) {
@@ -112,7 +112,7 @@ class MultiSpanProcessorTest extends TestCase
         );
     }
 
-    public function testForceFlushOneFailed(): void
+    public function test_force_flush_one_failed(): void
     {
         /** @var MockObject $processor */
         foreach ($this->getSpanProcessors() as $i => $processor) {

--- a/tests/SDK/Unit/Trace/SpanProcessor/SimpleSpanProcessorTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessor/SimpleSpanProcessorTest.php
@@ -49,13 +49,13 @@ class SimpleSpanProcessorTest extends MockeryTestCase
         $this->simpleSpanProcessor = new SimpleSpanProcessor($this->spanExporter);
     }
 
-    public function test_onStart(): void
+    public function test_on_start(): void
     {
         $this->simpleSpanProcessor->onStart($this->readWriteSpan, Context::getRoot());
         $this->spanExporter->shouldNotReceive('export');
     }
 
-    public function test_onEnd_sampledSpan(): void
+    public function test_on_end_sampled_span(): void
     {
         $spanData = new SpanData();
         $this->readableSpan->expects('getContext')->andReturn($this->sampledSpanContext);
@@ -64,7 +64,7 @@ class SimpleSpanProcessorTest extends MockeryTestCase
         $this->simpleSpanProcessor->onEnd($this->readableSpan);
     }
 
-    public function test_onEnd_nonSampledSpan(): void
+    public function test_on_end_non_sampled_span(): void
     {
         $this->readableSpan->expects('getContext')->andReturn($this->nonSampledSpanContext);
         $this->spanExporter->shouldNotReceive('export');
@@ -74,7 +74,7 @@ class SimpleSpanProcessorTest extends MockeryTestCase
 
     // TODO: Add test to ensure exporter is retried on failure.
 
-    public function test_forceFlush(): void
+    public function test_force_flush(): void
     {
         $this->assertTrue($this->simpleSpanProcessor->forceFlush());
     }

--- a/tests/SDK/Unit/Trace/SpanProcessorFactoryTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessorFactoryTest.php
@@ -27,7 +27,7 @@ class SpanProcessorFactoryTest extends TestCase
      * @dataProvider processorProvider
      * @psalm-suppress ArgumentTypeCoercion
      */
-    public function test_span_processor_factory_create_span_processor_from_environment(string $processorName, string $expected)
+    public function test_span_processor_factory_create_span_processor_from_environment(string $processorName, string $expected): void
     {
         $this->setEnvironmentVariable('OTEL_PHP_TRACES_PROCESSOR', $processorName);
         $factory = new SpanProcessorFactory();
@@ -46,7 +46,7 @@ class SpanProcessorFactoryTest extends TestCase
      * @test
      * @dataProvider invalidProcessorProvider
      */
-    public function test_span_processor_factory_invalid_span_processor(?string $processor)
+    public function test_span_processor_factory_invalid_span_processor(?string $processor): void
     {
         $this->setEnvironmentVariable('OTEL_PHP_TRACES_PROCESSOR', $processor);
         $factory = new SpanProcessorFactory();

--- a/tests/SDK/Unit/Trace/SpanProcessorFactoryTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessorFactoryTest.php
@@ -23,7 +23,6 @@ class SpanProcessorFactoryTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider processorProvider
      * @psalm-suppress ArgumentTypeCoercion
      */
@@ -43,7 +42,6 @@ class SpanProcessorFactoryTest extends TestCase
         ];
     }
     /**
-     * @test
      * @dataProvider invalidProcessorProvider
      */
     public function test_span_processor_factory_invalid_span_processor(?string $processor): void

--- a/tests/SDK/Unit/Trace/SpanProcessorFactoryTest.php
+++ b/tests/SDK/Unit/Trace/SpanProcessorFactoryTest.php
@@ -27,7 +27,7 @@ class SpanProcessorFactoryTest extends TestCase
      * @dataProvider processorProvider
      * @psalm-suppress ArgumentTypeCoercion
      */
-    public function spanProcessorFactory_createSpanProcessorFromEnvironment(string $processorName, string $expected)
+    public function test_span_processor_factory_create_span_processor_from_environment(string $processorName, string $expected)
     {
         $this->setEnvironmentVariable('OTEL_PHP_TRACES_PROCESSOR', $processorName);
         $factory = new SpanProcessorFactory();
@@ -46,7 +46,7 @@ class SpanProcessorFactoryTest extends TestCase
      * @test
      * @dataProvider invalidProcessorProvider
      */
-    public function spanProcessorFactory_invalidSpanProcessor(?string $processor)
+    public function test_span_processor_factory_invalid_span_processor(?string $processor)
     {
         $this->setEnvironmentVariable('OTEL_PHP_TRACES_PROCESSOR', $processor);
         $factory = new SpanProcessorFactory();
@@ -54,6 +54,7 @@ class SpanProcessorFactoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $factory->fromEnvironment($exporter);
     }
+
     public function invalidProcessorProvider()
     {
         return [

--- a/tests/SDK/Unit/Trace/SpanTest.php
+++ b/tests/SDK/Unit/Trace/SpanTest.php
@@ -95,7 +95,7 @@ class SpanTest extends MockeryTestCase
 
     // region API
 
-    public function test_getCurrentSpan_default(): void
+    public function test_get_current_span_default(): void
     {
         $this->assertSame(
             Span::getInvalid(),
@@ -103,7 +103,7 @@ class SpanTest extends MockeryTestCase
         );
     }
 
-    public function test_getCurrentSpan_setSpan(): void
+    public function test_get_current_span_set_span(): void
     {
         $span = Span::wrap(SpanContext::getInvalid());
 
@@ -117,7 +117,7 @@ class SpanTest extends MockeryTestCase
         $scope->detach();
     }
 
-    public function test_getSpan_defaultContext(): void
+    public function test_get_span_default_context(): void
     {
         $span = Span::fromContext(Context::getRoot());
 
@@ -127,7 +127,7 @@ class SpanTest extends MockeryTestCase
         );
     }
 
-    public function test_getSpan_explicitContext(): void
+    public function test_get_span_explicit_context(): void
     {
         $span = Span::fromContext(Context::getRoot());
 
@@ -139,7 +139,7 @@ class SpanTest extends MockeryTestCase
         );
     }
 
-    public function test_inProcessContext(): void
+    public function test_in_process_context(): void
     {
         $span = Span::wrap(SpanContext::getInvalid());
         $scope = $span->activate();
@@ -164,7 +164,7 @@ class SpanTest extends MockeryTestCase
 
     // region SDK
 
-    public function test_nothingChangesAfterEnd(): void
+    public function test_nothing_changes_after_end(): void
     {
         $span = $this->createTestSpan();
         $span->end();
@@ -195,7 +195,7 @@ class SpanTest extends MockeryTestCase
         $this->assertTrue($span->hasEnded());
     }
 
-    public function test_toSpanData_activeSpan(): void
+    public function test_to_span_data_active_span(): void
     {
         $span = $this->createTestSpan();
 
@@ -223,7 +223,7 @@ class SpanTest extends MockeryTestCase
         $this->assertFalse($span->isRecording());
     }
 
-    public function test_toSpanData_endedSpan(): void
+    public function test_to_span_data_ended_span(): void
     {
         $span = $this->createTestSpan();
         $this->spanDoWork($span, API\StatusCode::STATUS_ERROR, 'ERR');
@@ -248,7 +248,7 @@ class SpanTest extends MockeryTestCase
         );
     }
 
-    public function test_toSpanData_rootSpan(): void
+    public function test_to_span_data_root_span(): void
     {
         $span = $this->createTestRootSpan();
         $this->spanDoWork($span);
@@ -258,7 +258,7 @@ class SpanTest extends MockeryTestCase
         $this->assertFalse(SpanContext::isValidSpanId($span->toSpanData()->getParentSpanId()));
     }
 
-    public function test_toSpanData_childSpan(): void
+    public function test_to_span_data_child_span(): void
     {
         $span = $this->createTestSpan();
         $this->spanDoWork($span);
@@ -270,7 +270,7 @@ class SpanTest extends MockeryTestCase
         $this->assertSame($this->parentSpanId, $span->toSpanData()->getParentSpanId());
     }
 
-    public function test_toSpanData_initialAttributes(): void
+    public function test_to_span_data_initial_attributes(): void
     {
         $span = $this->createTestSpanWithAttributes(self::ATTRIBUTES);
         $span->setAttribute('another_key', 'another_value');
@@ -281,7 +281,7 @@ class SpanTest extends MockeryTestCase
         $this->assertSame(0, $spanData->getTotalDroppedAttributes());
     }
 
-    public function test_toSpanData_isImmutable(): void
+    public function test_to_span_data_is_immutable(): void
     {
         $span = $this->createTestSpanWithAttributes(self::ATTRIBUTES);
 
@@ -309,7 +309,7 @@ class SpanTest extends MockeryTestCase
         $this->assertCount(1, $spanData->getEvents());
     }
 
-    public function test_toSpanData_status(): void
+    public function test_to_span_data_status(): void
     {
         $span = $this->createTestSpan(API\SpanKind::KIND_CONSUMER);
         $this->testClock->advanceSeconds();
@@ -320,28 +320,28 @@ class SpanTest extends MockeryTestCase
         $this->assertEquals(StatusData::create(API\StatusCode::STATUS_ERROR, 'ERR'), $span->toSpanData()->getStatus());
     }
 
-    public function test_toSpanData_kind(): void
+    public function test_to_span_data_kind(): void
     {
         $span = $this->createTestSpan(API\SpanKind::KIND_SERVER);
         $this->assertSame(API\SpanKind::KIND_SERVER, $span->toSpanData()->getKind());
         $span->end();
     }
 
-    public function test_getKind(): void
+    public function test_get_kind(): void
     {
         $span = $this->createTestSpan(API\SpanKind::KIND_SERVER);
         $this->assertSame(API\SpanKind::KIND_SERVER, $span->getKind());
         $span->end();
     }
 
-    public function test_getAttribute(): void
+    public function test_get_attribute(): void
     {
         $span = $this->createTestSpanWithAttributes(self::ATTRIBUTES);
         $this->assertSame(3.14, $span->getAttribute('float_attribute'));
         $span->end();
     }
 
-    public function test_setAttribute_emptyKey(): void
+    public function test_set_attribute_empty_key(): void
     {
         $span = $this->createTestSpan();
         $this->assertEmpty($span->toSpanData()->getAttributes());
@@ -349,14 +349,14 @@ class SpanTest extends MockeryTestCase
         $this->assertEmpty($span->toSpanData()->getAttributes());
     }
 
-    public function test_getInstrumentationLibraryInfo(): void
+    public function test_get_instrumentation_library_info(): void
     {
         $span = $this->createTestSpanWithAttributes(self::ATTRIBUTES);
         $this->assertSame($this->instrumentationLibrary, $span->getInstrumentationLibrary());
         $span->end();
     }
 
-    public function test_updateSpanName(): void
+    public function test_update_span_name(): void
     {
         $span = $this->createTestRootSpan();
         $this->assertSame(self::SPAN_NAME, $span->getName());
@@ -365,7 +365,7 @@ class SpanTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_getDuration_activeSpan(): void
+    public function test_get_duration_active_span(): void
     {
         $span = $this->createTestSpan();
         $this->testClock->advanceSeconds();
@@ -377,7 +377,7 @@ class SpanTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_getDuration_endedSpan(): void
+    public function test_get_duration_ended_span(): void
     {
         $span = $this->createTestSpan();
         $this->testClock->advanceSeconds();
@@ -389,7 +389,7 @@ class SpanTest extends MockeryTestCase
         $this->assertSame($elapsedNanos, $span->getDuration());
     }
 
-    public function test_setAttributes(): void
+    public function test_set_attributes(): void
     {
         $span = $this->createTestRootSpan();
 
@@ -410,7 +410,7 @@ class SpanTest extends MockeryTestCase
         $this->assertSame(['a', 'b'], $attributes->get('str_array'));
     }
 
-    public function test_setAttributes_overridesAttribute(): void
+    public function test_set_attributes_overrides_attribute(): void
     {
         $span = $this->createTestSpanWithAttributes(self::ATTRIBUTES);
         $this->assertFalse($span->toSpanData()->getAttributes()->get('bool_attribute'));
@@ -418,14 +418,14 @@ class SpanTest extends MockeryTestCase
         $this->assertTrue($span->toSpanData()->getAttributes()->get('bool_attribute'));
     }
 
-    public function test_setAttributes_empty(): void
+    public function test_set_attributes_empty(): void
     {
         $span = $this->createTestRootSpan();
         $span->setAttributes(new Attributes());
         $this->assertEmpty($span->toSpanData()->getAttributes());
     }
 
-    public function test_addEvent(): void
+    public function test_add_event(): void
     {
         $span = $this->createTestRootSpan();
         $span->addEvent('event1');
@@ -443,7 +443,7 @@ class SpanTest extends MockeryTestCase
         $this->assertEvent($events[$idx], 'event3', new Attributes(), AbstractClock::secondsToNanos(10));
     }
 
-    public function test_addEvent_attributeLength(): void
+    public function test_add_event_attribute_length(): void
     {
         $maxLength = 25;
 
@@ -479,7 +479,7 @@ class SpanTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_recordException(): void
+    public function test_record_exception(): void
     {
         $exception = new Exception('ERR');
         $span = $this->createTestRootSpan();
@@ -503,7 +503,7 @@ class SpanTest extends MockeryTestCase
         );
     }
 
-    public function test_recordException_additionalAttributes(): void
+    public function test_record_exception_additional_attributes(): void
     {
         $exception = new Exception('ERR');
         $span = $this->createTestRootSpan();
@@ -530,7 +530,7 @@ class SpanTest extends MockeryTestCase
         );
     }
 
-    public function test_attributeLength(): void
+    public function test_attribute_length(): void
     {
         $maxLength = 25;
 
@@ -564,7 +564,7 @@ class SpanTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_droppingAttributes(): void
+    public function test_dropping_attributes(): void
     {
         $maxNumberOfAttributes = 8;
         $span = $this->createTestSpan(API\SpanKind::KIND_INTERNAL, (new SpanLimitsBuilder())->setAttributeCountLimit($maxNumberOfAttributes)->build());
@@ -585,7 +585,7 @@ class SpanTest extends MockeryTestCase
         $this->assertSame(8, $spanData->getTotalDroppedAttributes());
     }
 
-    public function test_droppingAttributes_providedViaSpanBuilder(): void
+    public function test_dropping_attributes_provided_via_span_builder(): void
     {
         $maxNumberOfAttributes = 8;
 
@@ -614,7 +614,7 @@ class SpanTest extends MockeryTestCase
         $this->assertSame(8, $spanData->getTotalDroppedAttributes());
     }
 
-    public function test_droppingEvents(): void
+    public function test_dropping_events(): void
     {
         $maxNumberOfEvents = 8;
         $span = $this->createTestSpan(API\SpanKind::KIND_INTERNAL, (new SpanLimitsBuilder())->setEventCountLimit($maxNumberOfEvents)->build());

--- a/tests/SDK/Unit/Trace/TracerProviderFactoryTest.php
+++ b/tests/SDK/Unit/Trace/TracerProviderFactoryTest.php
@@ -31,7 +31,6 @@ class TracerProviderFactoryTest extends TestCase
     }
 
     /**
-     * @test
      * @covers ::create
      * @covers ::__construct
      */
@@ -50,7 +49,6 @@ class TracerProviderFactoryTest extends TestCase
     }
 
     /**
-     * @test
      * @covers ::create
      */
     public function test_factory_logs_warnings_and_continues(): void

--- a/tests/SDK/Unit/Trace/TracerProviderFactoryTest.php
+++ b/tests/SDK/Unit/Trace/TracerProviderFactoryTest.php
@@ -35,7 +35,7 @@ class TracerProviderFactoryTest extends TestCase
      * @covers ::create
      * @covers ::__construct
      */
-    public function test_factory_creates_tracer()
+    public function test_factory_creates_tracer(): void
     {
         $exporterFactory = $this->createMock(ExporterFactory::class);
         $samplerFactory = $this->createMock(SamplerFactory::class);

--- a/tests/SDK/Unit/Trace/TracerProviderFactoryTest.php
+++ b/tests/SDK/Unit/Trace/TracerProviderFactoryTest.php
@@ -35,7 +35,7 @@ class TracerProviderFactoryTest extends TestCase
      * @covers ::create
      * @covers ::__construct
      */
-    public function factory_createsTracer()
+    public function test_factory_creates_tracer()
     {
         $exporterFactory = $this->createMock(ExporterFactory::class);
         $samplerFactory = $this->createMock(SamplerFactory::class);
@@ -53,7 +53,7 @@ class TracerProviderFactoryTest extends TestCase
      * @test
      * @covers ::create
      */
-    public function factory_logsWarningsAndContinues(): void
+    public function test_factory_logs_warnings_and_continues(): void
     {
         $exporterFactory = $this->createMock(ExporterFactory::class);
         $samplerFactory = $this->createMock(SamplerFactory::class);

--- a/tests/SDK/Unit/Trace/TracerProviderTest.php
+++ b/tests/SDK/Unit/Trace/TracerProviderTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class TracerProviderTest extends TestCase
 {
-    public function testReusesSameInstance(): void
+    public function test_reuses_same_instance(): void
     {
         $provider = new TracerProvider(null);
 
@@ -29,7 +29,7 @@ class TracerProviderTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function test_tracerProvider_returnsNoopTracerIfNoDefaultIsSet(): void
+    public function test_tracer_provider_returns_noop_tracer_if_no_default_is_set(): void
     {
         $this->assertInstanceOf(NoopTracer::class, TracerProvider::getDefaultTracer());
     }
@@ -38,14 +38,14 @@ class TracerProviderTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function test_tracerProvider_acceptsDefaultTracer(): void
+    public function test_tracer_provider_accepts_default_tracer(): void
     {
         $tracer = $this->getMockBuilder(API\TracerInterface::class)->getMock();
         TracerProvider::setDefaultTracer($tracer);
         $this->assertSame($tracer, TracerProvider::getDefaultTracer());
     }
 
-    public function testGetTracerWithDefaultName(): void
+    public function test_get_tracer_with_default_name(): void
     {
         $provider = new TracerProvider(null);
 
@@ -55,7 +55,7 @@ class TracerProviderTest extends TestCase
         $this->assertSame($t1, $t2);
     }
 
-    public function testShutDown(): void
+    public function test_shut_down(): void
     {
         $provider = new TracerProvider(null);
 
@@ -64,7 +64,7 @@ class TracerProviderTest extends TestCase
         $this->assertTrue($provider->shutdown());
     }
 
-    public function testForceFlush(): void
+    public function test_force_flush(): void
     {
         $provider = new TracerProvider([]);
 
@@ -73,7 +73,7 @@ class TracerProviderTest extends TestCase
         $this->assertTrue($provider->forceFlush());
     }
 
-    public function testGetSampler(): void
+    public function test_get_sampler(): void
     {
         $sampler = $this->createMock(SamplerInterface::class);
         $provider = new TracerProvider([], $sampler);
@@ -84,7 +84,7 @@ class TracerProviderTest extends TestCase
         );
     }
 
-    public function testGetTracerAfterShutdown(): void
+    public function test_get_tracer_after_shutdown(): void
     {
         $provider = new TracerProvider([]);
         $provider->shutdown();

--- a/tests/SDK/Unit/Trace/TracerSharedStateTest.php
+++ b/tests/SDK/Unit/Trace/TracerSharedStateTest.php
@@ -53,7 +53,7 @@ class TracerSharedStateTest extends MockeryTestCase
         );
     }
 
-    public function test_construct_noSpanProcessors(): void
+    public function test_construct_no_span_processors(): void
     {
         $this->assertInstanceOf(
             NoopSpanProcessor::class,
@@ -61,7 +61,7 @@ class TracerSharedStateTest extends MockeryTestCase
         );
     }
 
-    public function test_construct_oneSpanProcessor(): void
+    public function test_construct_one_span_processor(): void
     {
         $processor = Mockery::mock(SpanProcessorInterface::class);
 
@@ -71,7 +71,7 @@ class TracerSharedStateTest extends MockeryTestCase
         );
     }
 
-    public function test_construct_multipleSpanProcessors(): void
+    public function test_construct_multiple_span_processors(): void
     {
         $processor1 = Mockery::mock(SpanProcessorInterface::class);
         $processor2 = Mockery::mock(SpanProcessorInterface::class);

--- a/tests/SDK/Unit/Trace/TracerTest.php
+++ b/tests/SDK/Unit/Trace/TracerTest.php
@@ -20,7 +20,7 @@ class TracerTest extends TestCase
             ->getTracer('name', 'version');
     }
 
-    public function test_spanBuilder_default(): void
+    public function test_span_builder_default(): void
     {
         $this->assertInstanceOf(
             SpanBuilder::class,
@@ -28,7 +28,7 @@ class TracerTest extends TestCase
         );
     }
 
-    public function test_spanBuilder_propagatesInstrumentationLibraryInfoToSpan(): void
+    public function test_span_builder_propagates_instrumentation_library_info_to_span(): void
     {
         /** @var ReadableSpanInterface $span */
         $span = $this->tracer->spanBuilder('span')->startSpan();
@@ -37,7 +37,7 @@ class TracerTest extends TestCase
         $this->assertSame('version', $span->getInstrumentationLibrary()->getVersion());
     }
 
-    public function test_spanBuilder_fallbackSpanName(): void
+    public function test_span_builder_fallback_span_name(): void
     {
         /** @var ReadableSpanInterface $span */
         $span = $this->tracer->spanBuilder('  ')->startSpan();


### PR DESCRIPTION
Ensures every PHPUnit test method follows the same style:
- snake_case
- `test_` prefix
- no `@test` entry in docblock
- `void` return type

All other methods in the test classes remain in camelCase. These include:
- `setUp`/`tearDown` methods
- data providers
- protected/private methods
- external functions

---
Some tests were not running due to having a docblock with a missing `*`. For example:
```
/*
 * @test
 */
 ```

Others had typos that were easily visible once changed to snake_case.

---
Closes #529 