### PR TITLE
Add PHP version flag to codecoverage upload

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -74,4 +74,4 @@ jobs:
       run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
     - name: Code Coverage
-      run: bash <(curl -s https://codecov.io/bash)
+      run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.php-version }}


### PR DESCRIPTION
Add PHP version flag to codecoverage upload.

This will hopefully help prevent flaky codecoverage reports in the future.