### PR TITLE
adding covers annotations to all tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ test-unit:
 	$(DC_RUN_PHP) env XDEBUG_MODE=coverage vendor/bin/phpunit --testsuite unit --colors=always --coverage-text --testdox --coverage-clover coverage.clover --coverage-html=tests/coverage/html
 test-integration:
 	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/phpunit --testsuite integration --colors=always
+test-coverage:
+	$(DC_RUN_PHP) env XDEBUG_MODE=coverage vendor/bin/phpunit --testsuite unit --coverage-html=tests/coverage/html
 phan:
 	$(DC_RUN_PHP) env XDEBUG_MODE=off env PHAN_DISABLE_XDEBUG_WARN=1 vendor/bin/phan
 psalm:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "google/protobuf": "^v3.3.0",
+        "google/protobuf": "^3.3.0",
         "grpc/grpc": "^1.30",
         "nyholm/dsn": "^2.0.0",
         "php-http/async-client-implementation": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
-    forceCoversAnnotation="false"
+    forceCoversAnnotation="true"
     processIsolation="false"
     stopOnError="false"
     stopOnFailure="false"

--- a/src/API/Metrics/ValueRecorderInterface.php
+++ b/src/API/Metrics/ValueRecorderInterface.php
@@ -7,18 +7,15 @@ namespace OpenTelemetry\API\Metrics;
 interface ValueRecorderInterface extends MetricInterface
 {
     /**
-     * records the given value to this ValueRecorder.
+     * Records the given value to this ValueRecorder.
      *
      * @access	public
-     * @param int|float $value
-     * @return void
      */
-    public function record($value) : void;
+    public function record(float $value) : void;
 
     /**
      * Returns the sum of the values
      *
-     * @access	public
      * @return	float
      */
     public function getSum(): float;
@@ -27,7 +24,6 @@ interface ValueRecorderInterface extends MetricInterface
      * Returns the min of the values
      *
      * @access	public
-     * @return	float
      */
     public function getMin(): float;
 
@@ -35,7 +31,6 @@ interface ValueRecorderInterface extends MetricInterface
      * Returns the max of the values
      *
      * @access	public
-     * @return	float
      */
     public function getMax(): float;
 
@@ -43,7 +38,6 @@ interface ValueRecorderInterface extends MetricInterface
      * Returns the count of the values
      *
      * @access	public
-     * @return	int
      */
     public function getCount(): int;
 }

--- a/src/SDK/Metrics/ValueRecorder.php
+++ b/src/SDK/Metrics/ValueRecorder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Metrics;
 
-use InvalidArgumentException;
 use OpenTelemetry\API\Metrics as API;
 
 /*

--- a/src/SDK/Metrics/ValueRecorder.php
+++ b/src/SDK/Metrics/ValueRecorder.php
@@ -38,10 +38,7 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
 {
     use HasLabelsTrait;
 
-    /**
-     * @var float $valueSum
-     */
-    protected $valueSum = 0;
+    protected float $valueSum = 0;
 
     protected float $valueMin = INF;
 
@@ -58,8 +55,6 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
 
     /**
      * getType: get the type of metric instrument
-     *
-     * @return  int
      */
     public function getType(): int
     {
@@ -70,7 +65,6 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
      * Returns the sum of the values
      *
      * @access	public
-     * @return	float
      */
     public function getSum(): float
     {
@@ -81,7 +75,6 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
      * Returns the min of the values
      *
      * @access	public
-     * @return	float
      */
     public function getMin(): float
     {
@@ -92,7 +85,6 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
      * Returns the max of the values
      *
      * @access	public
-     * @return	float
      */
     public function getMax(): float
     {
@@ -103,7 +95,6 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
      * Returns the mean of the values
      *
      * @access	public
-     * @return	float
      */
     public function getMean(): float
     {
@@ -118,7 +109,6 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
      * Returns the count of the values
      *
      * @access	public
-     * @return	int
      */
     public function getCount(): int
     {
@@ -126,28 +116,12 @@ class ValueRecorder extends AbstractMetric implements API\ValueRecorderInterface
     }
 
     /**
-     * Updates the ValueRecorder's value with the specified value then returns
-     * the current value count.
+     * Updates the ValueRecorder's value with the specified value.
      *
      * @access	public
-     * @param int|float $value, accepts INTs or FLOATs. If value is an int, it it cast as a float.
-     * @return void
      */
-    public function record($value): void
+    public function record(float $value): void
     {
-        if (is_int($value)) {
-            /*
-             *
-             * todo: send the following message to the log when logger is implemented:
-             *       Integer detected, casting as a float.
-             */
-            $value = (float) $value;
-        }
-        if (!is_float($value)) {
-            throw new InvalidArgumentException('Only numerical values can be used
-                                                to update the ValueRecorder.');
-        }
-
         $value = round($value, $this->decimalPointPrecision);
 
         $this->valueSum += $value;

--- a/src/SDK/Trace/ImmutableSpan.php
+++ b/src/SDK/Trace/ImmutableSpan.php
@@ -37,9 +37,6 @@ final class ImmutableSpan implements SpanDataInterface
      * @param non-empty-string $name
      * @param list<LinkInterface> $links
      * @param list<EventInterface> $events
-     *@internal
-     * @psalm-internal OpenTelemetry\Sdk
-     *
      */
     public function __construct(
         Span $span,
@@ -50,7 +47,7 @@ final class ImmutableSpan implements SpanDataInterface
         int $totalAttributeCount,
         int $totalRecordedEvents,
         StatusDataInterface $status,
-        int $encEpochNanos,
+        int $endEpochNanos,
         bool $hasEnded
     ) {
         $this->span = $span;
@@ -61,7 +58,7 @@ final class ImmutableSpan implements SpanDataInterface
         $this->totalAttributeCount = $totalAttributeCount;
         $this->totalRecordedEvents = $totalRecordedEvents;
         $this->status = $status;
-        $this->endEpochNanos = $encEpochNanos;
+        $this->endEpochNanos = $endEpochNanos;
         $this->hasEnded = $hasEnded;
     }
 

--- a/src/SDK/Trace/Sampler/ParentBased.php
+++ b/src/SDK/Trace/Sampler/ParentBased.php
@@ -31,35 +31,35 @@ class ParentBased implements SamplerInterface
 {
     private SamplerInterface $root;
 
-    private SamplerInterface $remoteParentSampled;
+    private SamplerInterface $remoteParentSampler;
 
-    private SamplerInterface $remoteParentNotSampled;
+    private SamplerInterface $remoteParentNotSampler;
 
-    private SamplerInterface $localParentSampled;
+    private SamplerInterface $localParentSampler;
 
-    private SamplerInterface $localParentNotSampled;
+    private SamplerInterface $localParentNotSampler;
 
     /**
      * ParentBased sampler delegates the sampling decision based on the parent context.
      *
      * @param SamplerInterface $root Sampler called for the span with no parent (root span).
-     * @param SamplerInterface|null $remoteParentSampled Sampler called for the span with the remote sampled parent. When null, `AlwaysOnSampler` is used.
-     * @param SamplerInterface|null $remoteParentNotSampled Sampler called for the span with the remote not sampled parent. When null, `AlwaysOffSampler` is used.
-     * @param SamplerInterface|null $localParentSampled Sampler called for the span with local the sampled parent. When null, `AlwaysOnSampler` is used.
-     * @param SamplerInterface|null $localParentNotSampled Sampler called for the span with the local not sampled parent. When null, `AlwaysOffSampler` is used.
+     * @param SamplerInterface|null $remoteParentSampler Sampler called for the span with the remote sampled parent. When null, `AlwaysOnSampler` is used.
+     * @param SamplerInterface|null $remoteParentNotSampler Sampler called for the span with the remote not sampled parent. When null, `AlwaysOffSampler` is used.
+     * @param SamplerInterface|null $localParentSampler Sampler called for the span with local the sampled parent. When null, `AlwaysOnSampler` is used.
+     * @param SamplerInterface|null $localParentNotSampler Sampler called for the span with the local not sampled parent. When null, `AlwaysOffSampler` is used.
      */
     public function __construct(
         SamplerInterface $root,
-        ?SamplerInterface $remoteParentSampled = null,
-        ?SamplerInterface $remoteParentNotSampled = null,
-        ?SamplerInterface $localParentSampled = null,
-        ?SamplerInterface $localParentNotSampled = null
+        ?SamplerInterface $remoteParentSampler = null,
+        ?SamplerInterface $remoteParentNotSampler = null,
+        ?SamplerInterface $localParentSampler = null,
+        ?SamplerInterface $localParentNotSampler = null
     ) {
         $this->root = $root;
-        $this->remoteParentSampled = $remoteParentSampled ?? new AlwaysOnSampler();
-        $this->remoteParentNotSampled = $remoteParentNotSampled ?? new AlwaysOffSampler();
-        $this->localParentSampled = $localParentSampled ?? new AlwaysOnSampler();
-        $this->localParentNotSampled = $localParentNotSampled ?? new AlwaysOffSampler();
+        $this->remoteParentSampler = $remoteParentSampler ?? new AlwaysOnSampler();
+        $this->remoteParentNotSampler = $remoteParentNotSampler ?? new AlwaysOffSampler();
+        $this->localParentSampler = $localParentSampler ?? new AlwaysOnSampler();
+        $this->localParentNotSampler = $localParentNotSampler ?? new AlwaysOffSampler();
     }
 
     /**
@@ -84,13 +84,13 @@ class ParentBased implements SamplerInterface
 
         if ($parentSpanContext->isRemote()) {
             return $parentSpanContext->isSampled()
-                ? $this->remoteParentSampled->shouldSample(...func_get_args())
-                : $this->remoteParentNotSampled->shouldSample(...func_get_args());
+                ? $this->remoteParentSampler->shouldSample(...func_get_args())
+                : $this->remoteParentNotSampler->shouldSample(...func_get_args());
         }
 
         return $parentSpanContext->isSampled()
-            ? $this->localParentSampled->shouldSample(...func_get_args())
-            : $this->localParentNotSampled->shouldSample(...func_get_args());
+            ? $this->localParentSampler->shouldSample(...func_get_args())
+            : $this->localParentNotSampler->shouldSample(...func_get_args());
     }
 
     public function getDescription(): string

--- a/src/SDK/Trace/SpanProcessor/NoopSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/NoopSpanProcessor.php
@@ -25,12 +25,12 @@ class NoopSpanProcessor implements SpanProcessorInterface
     /** @inheritDoc */
     public function onStart(ReadWriteSpanInterface $span, ?Context $parentContext = null): void
     {
-    }
+    } //@codeCoverageIgnore
 
     /** @inheritDoc */
     public function onEnd(ReadableSpanInterface $span): void
     {
-    }
+    } //@codeCoverageIgnore
 
     /** @inheritDoc */
     public function forceFlush(): bool

--- a/tests/Integration/SDK/AlwaysOffSamplerTest.php
+++ b/tests/Integration/SDK/AlwaysOffSamplerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\SDK\Integration;
+namespace OpenTelemetry\Tests\Integration\SDK;
 
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
@@ -12,6 +12,9 @@ use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class AlwaysOffSamplerTest extends TestCase
 {
     public function test_always_off_sampler(): void

--- a/tests/Integration/SDK/AlwaysOnSamplerTest.php
+++ b/tests/Integration/SDK/AlwaysOnSamplerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\SDK\Integration;
+namespace OpenTelemetry\Tests\Integration\SDK;
 
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
@@ -12,6 +12,9 @@ use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class AlwaysOnSamplerTest extends TestCase
 {
     public function test_always_on_sampler_decision(): void

--- a/tests/Integration/SDK/Context/SpanContextTest.php
+++ b/tests/Integration/SDK/Context/SpanContextTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\SDK\Integration\Context;
+namespace OpenTelemetry\Tests\Integration\SDK\Context;
 
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\SpanContext;
@@ -10,6 +10,9 @@ use OpenTelemetry\API\Trace\TraceState;
 use OpenTelemetry\SDK\Trace\RandomIdGenerator;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class SpanContextTest extends TestCase
 {
     /**

--- a/tests/Integration/SDK/Context/SpanContextTest.php
+++ b/tests/Integration/SDK/Context/SpanContextTest.php
@@ -17,8 +17,6 @@ class SpanContextTest extends TestCase
 {
     /**
      * @dataProvider invalidSpanData
-     * @param string $traceId
-     * @param string $spanId
      */
     public function test_invalid_span(string $traceId, string $spanId): void
     {

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Unit\SDK\Trace;
+namespace OpenTelemetry\Tests\Integration\SDK\Trace;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
@@ -23,6 +23,9 @@ use OpenTelemetry\SDK\Trace\TracerProvider;
 use function range;
 use function str_repeat;
 
+/**
+ * @coversNothing
+ */
 class SpanBuilderTest extends MockeryTestCase
 {
     private const SPAN_NAME = 'span_name';

--- a/tests/Integration/SDK/SpanProcessorTest.php
+++ b/tests/Integration/SDK/SpanProcessorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\SDK\Integration;
+namespace OpenTelemetry\Tests\Integration\SDK;
 
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\Context\Context;
@@ -10,6 +10,9 @@ use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class SpanProcessorTest extends TestCase
 {
     public function test_parent_context_should_be_passed_to_span_processor(): void

--- a/tests/Integration/SDK/TraceIdRatioBasedSamplerTest.php
+++ b/tests/Integration/SDK/TraceIdRatioBasedSamplerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\SDK\Integration;
+namespace OpenTelemetry\Tests\Integration\SDK;
 
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
@@ -12,6 +12,9 @@ use OpenTelemetry\SDK\Trace\Sampler\TraceIdRatioBasedSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class TraceIdRatioBasedSamplerTest extends TestCase
 {
     public function test_never_trace_id_ratio_based_sampler_decision(): void

--- a/tests/Integration/SDK/TracerTest.php
+++ b/tests/Integration/SDK/TracerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\SDK\Integration;
+namespace OpenTelemetry\Tests\Integration\SDK;
 
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
@@ -17,6 +17,9 @@ use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class TracerTest extends TestCase
 {
     public function test_noop_span_should_be_started_when_sampling_result_is_drop(): void
@@ -75,5 +78,17 @@ class TracerTest extends TestCase
 
         $this->assertEquals('OpenTelemetry.TracerTest', $spanInstrumentationLibrary->getName());
         $this->assertEquals('dev', $spanInstrumentationLibrary->getVersion());
+    }
+
+    public function test_span_builder_propagates_instrumentation_library_info_to_span(): void
+    {
+        /** @var Span $span */
+        $span = (new TracerProvider())
+            ->getTracer('name', 'version')
+            ->spanBuilder('span')
+            ->startSpan();
+
+        $this->assertSame('name', $span->getInstrumentationLibrary()->getName());
+        $this->assertSame('version', $span->getInstrumentationLibrary()->getVersion());
     }
 }

--- a/tests/Unit/API/Baggage/BaggageTest.php
+++ b/tests/Unit/API/Baggage/BaggageTest.php
@@ -12,7 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers OpenTelemetry\API\Baggage\Baggage
- * @todo integration tests?
  */
 class BaggageTest extends TestCase
 {

--- a/tests/Unit/API/Baggage/BaggageTest.php
+++ b/tests/Unit/API/Baggage/BaggageTest.php
@@ -10,6 +10,10 @@ use OpenTelemetry\API\Baggage\Metadata;
 use OpenTelemetry\Context\Context;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\API\Baggage\Baggage
+ * @todo integration tests?
+ */
 class BaggageTest extends TestCase
 {
     // region contextInteraction

--- a/tests/Unit/API/Baggage/Propagation/BaggagePropagatorTest.php
+++ b/tests/Unit/API/Baggage/Propagation/BaggagePropagatorTest.php
@@ -10,6 +10,9 @@ use OpenTelemetry\API\Baggage\Propagation\BaggagePropagator;
 use OpenTelemetry\Context\Context;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\API\Baggage\Propagation\BaggagePropagator
+ */
 class BaggagePropagatorTest extends TestCase
 {
     public function test_fields(): void

--- a/tests/Unit/API/Trace/NonRecordingSpanTest.php
+++ b/tests/Unit/API/Trace/NonRecordingSpanTest.php
@@ -10,6 +10,9 @@ use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\SDK\AttributesInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\API\Trace\NonRecordingSpan
+ */
 class NonRecordingSpanTest extends TestCase
 {
     private ?SpanContextInterface $context = null;

--- a/tests/Unit/API/Trace/Propagation/TraceContextPropagatorTest.php
+++ b/tests/Unit/API/Trace/Propagation/TraceContextPropagatorTest.php
@@ -13,6 +13,9 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Trace\Span;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\API\Trace\Propagation\TraceContextPropagator
+ */
 class TraceContextPropagatorTest extends TestCase
 {
     private const TRACE_ID_BASE16 = 'ff000000000000000000000000000041';

--- a/tests/Unit/API/Trace/SpanContextTest.php
+++ b/tests/Unit/API/Trace/SpanContextTest.php
@@ -9,6 +9,9 @@ use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\TraceState;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\API\Trace\SpanContext
+ */
 class SpanContextTest extends TestCase
 {
     private const FIRST_TRACE_ID = '00000000000000000000000000000061';

--- a/tests/Unit/API/Trace/TraceStateTest.php
+++ b/tests/Unit/API/Trace/TraceStateTest.php
@@ -7,6 +7,9 @@ namespace OpenTelemetry\Tests\API\Unit\Trace;
 use OpenTelemetry\API\Trace\TraceState;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\API\Trace\TraceState
+ */
 class TraceStateTest extends TestCase
 {
     public function test_get_tracestate_value(): void

--- a/tests/Unit/Context/ContextKeyTest.php
+++ b/tests/Unit/Context/ContextKeyTest.php
@@ -7,6 +7,9 @@ namespace OpenTelemetry\Tests\Context\Unit;
 use OpenTelemetry\Context\ContextKey;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\Context\ContextKey
+ */
 class ContextKeyTest extends TestCase
 {
     public function test_name(): void

--- a/tests/Unit/Context/ContextTest.php
+++ b/tests/Unit/Context/ContextTest.php
@@ -8,6 +8,9 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextKey;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\Context\Context
+ */
 class ContextTest extends TestCase
 {
     public function test_activate(): void

--- a/tests/Unit/Context/Propagation/ArrayAccessGetterSetterTest.php
+++ b/tests/Unit/Context/Propagation/ArrayAccessGetterSetterTest.php
@@ -11,6 +11,9 @@ use OpenTelemetry\Context\Propagation\KeyedArrayAccessInterface;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+/**
+ * @covers OpenTelemetry\Context\Propagation\ArrayAccessGetterSetter
+ */
 class ArrayAccessGetterSetterTest extends TestCase
 {
     public function test_get_from_map_array(): void

--- a/tests/Unit/Context/Propagation/MultiTextMapPropagatorTest.php
+++ b/tests/Unit/Context/Propagation/MultiTextMapPropagatorTest.php
@@ -10,6 +10,9 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\Propagation\MultiTextMapPropagator;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 
+/**
+ * @covers OpenTelemetry\Context\Propagation\MultiTextMapPropagator
+ */
 class MultiTextMapPropagatorTest extends MockeryTestCase
 {
     /** @var Mockery\MockInterface&TextMapPropagatorInterface */

--- a/tests/Unit/Context/Propagation/NoopTextMapPropagatorTest.php
+++ b/tests/Unit/Context/Propagation/NoopTextMapPropagatorTest.php
@@ -8,6 +8,9 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\Context\Propagation\NoopTextMapPropagator
+ */
 class NoopTextMapPropagatorTest extends TestCase
 {
     public function test_fields(): void

--- a/tests/Unit/Context/ScopeTest.php
+++ b/tests/Unit/Context/ScopeTest.php
@@ -9,6 +9,10 @@ use OpenTelemetry\Context\ContextKey;
 use OpenTelemetry\Context\ScopeInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\Context\Context
+ * @todo check scope vs context - what should this class be testing?
+ */
 class ScopeTest extends TestCase
 {
     public function test_scope_close_restores_context(): void

--- a/tests/Unit/Contrib/JaegerExporterTest.php
+++ b/tests/Unit/Contrib/JaegerExporterTest.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\Tests\Unit\Contrib;
 
 use OpenTelemetry\Contrib\Jaeger\Exporter;
 
+/**
+ * @covers OpenTelemetry\Contrib\Jaeger\Exporter
+ */
 class JaegerExporterTest extends AbstractHttpExporterTest
 {
     use UsesHttpClientTrait;

--- a/tests/Unit/Contrib/NewrelicExporterTest.php
+++ b/tests/Unit/Contrib/NewrelicExporterTest.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\Tests\Unit\Contrib;
 
 use OpenTelemetry\Contrib\Newrelic\Exporter;
 
+/**
+ * @covers OpenTelemetry\Contrib\Newrelic\Exporter
+ */
 class NewrelicExporterTest extends AbstractHttpExporterTest
 {
     protected const EXPORTER_NAME = 'test.newrelic';

--- a/tests/Unit/Contrib/NewrelicSpanConverterTest.php
+++ b/tests/Unit/Contrib/NewrelicSpanConverterTest.php
@@ -9,6 +9,9 @@ use OpenTelemetry\SDK\Attributes;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\Contrib\Newrelic\SpanConverter
+ */
 class NewrelicSpanConverterTest extends TestCase
 {
     public function test_should_convert_a_span_to_a_payload_for_newrelic(): void

--- a/tests/Unit/Contrib/OTLPGrpcExporterTest.php
+++ b/tests/Unit/Contrib/OTLPGrpcExporterTest.php
@@ -15,6 +15,9 @@ use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter\AbstractExporterTest;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 
+/**
+ * @covers OpenTelemetry\Contrib\OtlpGrpc\Exporter
+ */
 class OTLPGrpcExporterTest extends AbstractExporterTest
 {
     use EnvironmentVariables;
@@ -101,6 +104,15 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         $exporter = new Exporter();
 
         $this->assertEquals(['x-aaa' => ['foo'], 'x-bbb' => ['barf']], $exporter->getHeaders());
+    }
+
+    public function test_set_header(): void
+    {
+        $exporter = new Exporter();
+        $exporter->setHeader('foo', 'bar');
+        $headers = $exporter->getHeaders();
+        $this->assertArrayHasKey('foo', $headers);
+        $this->assertEquals(['bar'], $headers['foo']);
     }
 
     public function test_set_headers_in_constructor(): void

--- a/tests/Unit/Contrib/OTLPHttpExporterTest.php
+++ b/tests/Unit/Contrib/OTLPHttpExporterTest.php
@@ -19,6 +19,9 @@ use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
 
+/**
+ * @covers OpenTelemetry\Contrib\OtlpHttp\Exporter
+ */
 class OTLPHttpExporterTest extends AbstractExporterTest
 {
     use EnvironmentVariables;
@@ -36,10 +39,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
         );
     }
 
-    /**
-     * @after
-     */
-    public function cleanUpEnvVars(): void
+    public function tearDown(): void
     {
         $this->restoreEnvironmentVariables();
     }
@@ -208,7 +208,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
 
     /**
      * @testdox Exporter Refuses OTLP/JSON Protocol
-     * https://github.com/open-telemetry/opentelemetry-specification/issues/786
+     * @link https://github.com/open-telemetry/opentelemetry-specification/issues/786
      * @psalm-suppress PossiblyInvalidArgument
      */
     public function test_fails_exporter_refuses_otlp_json(): void

--- a/tests/Unit/Contrib/OTLPSpanConverterTest.php
+++ b/tests/Unit/Contrib/OTLPSpanConverterTest.php
@@ -23,9 +23,12 @@ use OpenTelemetry\SDK\Trace\StatusData;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\Contrib\Otlp\SpanConverter
+ */
 class OTLPSpanConverterTest extends TestCase
 {
-    public function test_should_convert_a_span_to_a_payload_for_otlp(): void
+    public function test_convert_span_to_payload(): void
     {
         $context = SpanContext::getInvalid();
 
@@ -241,9 +244,6 @@ class OTLPSpanConverterTest extends TestCase
         $this->assertEquals($expected, $row[0]);
     }
 
-    /**
-     * @covers OpenTelemetry\Contrib\Otlp\SpanConverter::as_otlp_resource_attributes
-     */
     public function test_resources_from_multiple_spans_are_not_duplicated(): void
     {
         $span = $this->createMock(SpanData::class);
@@ -267,7 +267,6 @@ class OTLPSpanConverterTest extends TestCase
 
     /**
      * @dataProvider spanKindProvider
-     * @covers OpenTelemetry\Contrib\Otlp\SpanConverter::as_otlp_span_kind
      */
     public function test_span_kind($kind, $expected): void
     {
@@ -288,9 +287,6 @@ class OTLPSpanConverterTest extends TestCase
         ];
     }
 
-    /**
-     * @covers OpenTelemetry\Contrib\Otlp\SpanConverter::as_otlp_span
-     */
     public function test_span_with_error_status(): void
     {
         $span = (new SpanData())->setStatus(StatusData::error());

--- a/tests/Unit/Contrib/PrometheusExporterTest.php
+++ b/tests/Unit/Contrib/PrometheusExporterTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 use Prometheus\CollectorRegistry;
 use Prometheus\Counter as PrometheusCounter;
 
+/**
+ * @covers OpenTelemetry\Contrib\Prometheus\PrometheusExporter
+ */
 class PrometheusExporterTest extends TestCase
 {
     public function test_empty_metrics_export_returns_success(): void

--- a/tests/Unit/Contrib/ZipkinExporterTest.php
+++ b/tests/Unit/Contrib/ZipkinExporterTest.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\Tests\Unit\Contrib;
 
 use OpenTelemetry\Contrib\Zipkin\Exporter;
 
+/**
+ * @covers OpenTelemetry\Contrib\Zipkin\Exporter
+ */
 class ZipkinExporterTest extends AbstractHttpExporterTest
 {
     protected const EXPORTER_NAME = 'test.zipkin';

--- a/tests/Unit/Contrib/ZipkinSpanConverterTest.php
+++ b/tests/Unit/Contrib/ZipkinSpanConverterTest.php
@@ -16,7 +16,7 @@ use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass SpanConverter
+ * @covers OpenTelemetry\Contrib\Zipkin\SpanConverter
  */
 class ZipkinSpanConverterTest extends TestCase
 {

--- a/tests/Unit/Contrib/ZipkinToNewrelicExporterTest.php
+++ b/tests/Unit/Contrib/ZipkinToNewrelicExporterTest.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\Tests\Unit\Contrib;
 
 use OpenTelemetry\Contrib\ZipkinToNewrelic\Exporter;
 
+/**
+ * @covers OpenTelemetry\Contrib\ZipkinToNewrelic\Exporter
+ */
 class ZipkinToNewrelicExporterTest extends AbstractHttpExporterTest
 {
     protected const EXPORTER_NAME = 'test.zipkinToNR';

--- a/tests/Unit/Contrib/ZipkinToNewrelicSpanConverterTest.php
+++ b/tests/Unit/Contrib/ZipkinToNewrelicSpanConverterTest.php
@@ -10,6 +10,9 @@ use OpenTelemetry\SDK\Attributes;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\Contrib\ZipkinToNewrelic\SpanConverter
+ */
 class ZipkinToNewrelicSpanConverterTest extends TestCase
 {
     public function test_should_convert_a_span_to_a_payload_for_zipkin(): void

--- a/tests/Unit/SDK/AbstractClockTest.php
+++ b/tests/Unit/SDK/AbstractClockTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK;
+
+use OpenTelemetry\SDK\AbstractClock;
+use OpenTelemetry\SDK\ClockInterface;
+use OpenTelemetry\SDK\SystemClock;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\AbstractClock
+ */
+class AbstractClockTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        AbstractClock::setTestClock();
+    }
+
+    public function test_returns_default_system_clock(): void
+    {
+        $this->assertInstanceOf(SystemClock::class, AbstractClock::getDefault());
+    }
+
+    public function test_set_test_clock(): void
+    {
+        $testClock = $this->createMock(ClockInterface::class);
+        AbstractClock::setTestClock($testClock);
+        $this->assertSame($testClock, AbstractClock::getDefault());
+    }
+
+    public function test_conversions(): void
+    {
+        $this->assertEquals(1, AbstractClock::nanosToMicro((int) 1e3));
+        $this->assertEquals(1, AbstractClock::nanosToMilli((int) 1e6));
+        $this->assertEquals((int) 1e9, AbstractClock::secondsToNanos(1));
+    }
+}

--- a/tests/Unit/SDK/AttributeLimitsTest.php
+++ b/tests/Unit/SDK/AttributeLimitsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK;
+
+use OpenTelemetry\SDK\AttributeLimits;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\AttributeLimits
+ */
+class AttributesLimitsTest extends TestCase
+{
+    public function test_default_limits(): void
+    {
+        $limits = new AttributeLimits();
+        $this->assertNotNull($limits->getAttributeCountLimit());
+        $this->assertNotNull($limits->getAttributeValueLengthLimit());
+    }
+
+    public function test_limits(): void
+    {
+        $limits = new AttributeLimits(10, 20);
+        $this->assertSame(10, $limits->getAttributeCountLimit());
+        $this->assertSame(20, $limits->getAttributeValueLengthLimit());
+    }
+}

--- a/tests/Unit/SDK/AttributesTest.php
+++ b/tests/Unit/SDK/AttributesTest.php
@@ -8,6 +8,9 @@ use OpenTelemetry\SDK\AttributeLimits;
 use OpenTelemetry\SDK\Attributes;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Attributes
+ */
 class AttributesTest extends TestCase
 {
     public function test_attribute_limits_compare(): void
@@ -83,5 +86,27 @@ class AttributesTest extends TestCase
         $this->assertEquals('123', $limitedAttributes->get('short'));
         $this->assertEquals('12345', $limitedAttributes->get('long'));
         $this->assertNull($limitedAttributes->get('dropped'));
+    }
+
+    public function test_null_attribute_removes_existing(): void
+    {
+        $attributes = new Attributes([
+            'foo' => 'foo',
+            'bar' => 'bar',
+            'baz' => 'baz',
+        ]);
+        $this->assertCount(3, $attributes);
+        $attributes->setAttribute('foo', null);
+        $this->assertCount(2, $attributes);
+    }
+
+    public function test_null_missing_attribute_does_nothing(): void
+    {
+        $attributes = new Attributes([
+            'foo' => 'foo',
+        ]);
+        $this->assertCount(1, $attributes);
+        $attributes->setAttribute('bar', null);
+        $this->assertCount(1, $attributes);
     }
 }

--- a/tests/Unit/SDK/AttributesTest.php
+++ b/tests/Unit/SDK/AttributesTest.php
@@ -56,6 +56,7 @@ class AttributesTest extends TestCase
             'array' => [
                 $shortStringValue,
                 $longStringValue,
+                $boolValue,
             ],
             'ignored_key' => 'ignored_value',
         ], $attributeLimits);
@@ -65,7 +66,7 @@ class AttributesTest extends TestCase
         $this->assertEquals($floatValue, $attributes->get('float'));
         $this->assertEquals($shortStringValue, $attributes->get('short_string'));
         $this->assertEquals($longStringTrimmed, $attributes->get('long_string'));
-        $this->assertEquals([$shortStringValue, $longStringTrimmed], $attributes->get('array'));
+        $this->assertEquals([$shortStringValue, $longStringTrimmed, $boolValue], $attributes->get('array'));
 
         $this->assertEquals(6, $attributes->count());
         $this->assertNull($attributes->get('ignored_key'));
@@ -86,6 +87,7 @@ class AttributesTest extends TestCase
         $this->assertEquals('123', $limitedAttributes->get('short'));
         $this->assertEquals('12345', $limitedAttributes->get('long'));
         $this->assertNull($limitedAttributes->get('dropped'));
+        $this->assertGreaterThan(0, $limitedAttributes->getDroppedAttributesCount());
     }
 
     public function test_null_attribute_removes_existing(): void
@@ -108,5 +110,15 @@ class AttributesTest extends TestCase
         $this->assertCount(1, $attributes);
         $attributes->setAttribute('bar', null);
         $this->assertCount(1, $attributes);
+    }
+    public function test_to_array(): void
+    {
+        $values = [
+            'foo' => 'foo',
+            'bar' => 'bar',
+        ];
+        $attributes = new Attributes($values);
+        $this->assertSame($values, $attributes->toArray());
+        $this->assertEquals(2, $attributes->getTotalAddedValues());
     }
 }

--- a/tests/Unit/SDK/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/SDK/Behavior/LogsMessagesTraitTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
+/**
+ * @covers OpenTelemetry\SDK\Behavior\LogsMessagesTrait
+ */
 class LogsMessagesTraitTest extends TestCase
 {
     // @var LoggerInterface|MockObject $logger

--- a/tests/Unit/SDK/EnvironmentVariablesTraitTest.php
+++ b/tests/Unit/SDK/EnvironmentVariablesTraitTest.php
@@ -9,15 +9,21 @@ use Exception;
 use OpenTelemetry\SDK\EnvironmentVariablesTrait;
 use PHPUnit\Framework\TestCase;
 
-class MockWithTrait
-{
-    use EnvironmentVariablesTrait;
-}
-
+/**
+ * @covers OpenTelemetry\SDK\EnvironmentVariablesTrait
+ */
 class EnvironmentVariablesTraitTest extends TestCase
 {
     use EnvironmentVariables;
 
+    private $mock;
+
+    public function setUp(): void
+    {
+        $this->mock = new class() {
+            use EnvironmentVariablesTrait;
+        };
+    }
     public function tearDown(): void
     {
         $this->restoreEnvironmentVariables();
@@ -25,31 +31,27 @@ class EnvironmentVariablesTraitTest extends TestCase
 
     public function test_environment_variables_integer_get(): void
     {
-        $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', '100');
-        $value = $mock->getIntFromEnvironment('OTEL_FOO', 999);
+        $value = $this->mock->getIntFromEnvironment('OTEL_FOO', 999);
         $this->assertSame(100, $value);
     }
 
     public function test_environment_variables_integer_failure(): void
     {
-        $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', 'foo');
         $this->expectException(Exception::class);
-        $mock->getIntFromEnvironment('OTEL_FOO', 99);
+        $this->mock->getIntFromEnvironment('OTEL_FOO', 99);
     }
 
     public function environment_variables_integer_uses_default_if_env_var_not_defined()
     {
-        $mock = new MockWithTrait();
-        $this->assertSame(20, $mock->getIntFromEnvironment('OTEL_FOO', 20));
+        $this->assertSame(20, $this->mock->getIntFromEnvironment('OTEL_FOO', 20));
     }
 
     public function test_environment_variables_string_get(): void
     {
-        $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', 'foo');
-        $value = $mock->getStringFromEnvironment('OTEL_FOO', 'bar');
+        $value = $this->mock->getStringFromEnvironment('OTEL_FOO', 'bar');
         $this->assertSame('foo', $value);
     }
 
@@ -59,9 +61,8 @@ class EnvironmentVariablesTraitTest extends TestCase
      */
     public function test_environment_variables_string_uses_default_when_empty_value(?string $input): void
     {
-        $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = $mock->getStringFromEnvironment('OTEL_FOO', 'bar');
+        $value = $this->mock->getStringFromEnvironment('OTEL_FOO', 'bar');
         $this->assertSame('bar', $value);
     }
 
@@ -70,9 +71,8 @@ class EnvironmentVariablesTraitTest extends TestCase
      */
     public function test_environment_variables_int_uses_default_when_empty_value(?string $input): void
     {
-        $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = $mock->getIntFromEnvironment('OTEL_FOO', 99);
+        $value = $this->mock->getIntFromEnvironment('OTEL_FOO', 99);
         $this->assertSame(99, $value);
     }
 
@@ -81,9 +81,8 @@ class EnvironmentVariablesTraitTest extends TestCase
      */
     public function test_environment_variables_bool_uses_default_when_empty_value(?string $input): void
     {
-        $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = $mock->getBooleanFromEnvironment('OTEL_FOO', true);
+        $value = $this->mock->getBooleanFromEnvironment('OTEL_FOO', true);
         $this->assertTrue($value);
     }
 
@@ -100,9 +99,8 @@ class EnvironmentVariablesTraitTest extends TestCase
      */
     public function test_environment_variables_bool_get(string $input, bool $default, bool $expected)
     {
-        $mock = new MockWithTrait();
         $this->setEnvironmentVariable('OTEL_BOOL', $input);
-        $this->assertSame($expected, $mock->getBooleanFromEnvironment('OTEL_BOOL', $default));
+        $this->assertSame($expected, $this->mock->getBooleanFromEnvironment('OTEL_BOOL', $default));
     }
 
     public function booleanProvider()

--- a/tests/Unit/SDK/GlobalLoggerHolderTest.php
+++ b/tests/Unit/SDK/GlobalLoggerHolderTest.php
@@ -9,6 +9,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
+/**
+ * @covers OpenTelemetry\SDK\GlobalLoggerHolder
+ */
 class GlobalLoggerHolderTest extends TestCase
 {
     public function tearDown(): void

--- a/tests/Unit/SDK/InstrumentationLibraryTest.php
+++ b/tests/Unit/SDK/InstrumentationLibraryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK;
+
+use OpenTelemetry\SDK\InstrumentationLibrary;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\InstrumentationLibrary
+ */
+class InstrumentationLibraryTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState false
+     */
+    public function test_get_empty(): void
+    {
+        $library = InstrumentationLibrary::getEmpty();
+        $this->assertSame($library, InstrumentationLibrary::getEmpty());
+    }
+
+    public function test_getters(): void
+    {
+        $library = new InstrumentationLibrary('name', 'version');
+        $this->assertSame('name', $library->getName());
+        $this->assertSame('version', $library->getVersion());
+    }
+}

--- a/tests/Unit/SDK/Logs/SimplePsrFileLoggerTest.php
+++ b/tests/Unit/SDK/Logs/SimplePsrFileLoggerTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel;
 
+/**
+ * @covers OpenTelemetry\SDK\Logs\SimplePsrFileLogger
+ */
 class SimplePsrFileLoggerTest extends TestCase
 {
     private const ROOT_DIR = 'var';

--- a/tests/Unit/SDK/Metrics/CounterTest.php
+++ b/tests/Unit/SDK/Metrics/CounterTest.php
@@ -4,28 +4,46 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics;
 
+use OpenTelemetry\API\Metrics as API;
 use OpenTelemetry\SDK\Metrics\Counter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Metrics\Counter
+ */
 class CounterTest extends TestCase
 {
+    private Counter $counter;
+
+    public function setUp(): void
+    {
+        $this->counter = new Counter('some_counter');
+    }
+
+    public function test_get_type(): void
+    {
+        $this->assertSame(API\MetricKind::COUNTER, $this->counter->getType());
+    }
+
     public function test_counter_increments(): void
     {
-        $counter = new Counter('some_counter');
+        $this->assertSame(0, $this->counter->getValue());
 
-        $this->assertSame(0, $counter->getValue());
+        $this->counter->increment();
 
-        $counter->increment();
-
-        $this->assertSame(1, $counter->getValue());
+        $this->assertSame(1, $this->counter->getValue());
     }
 
     public function test_counter_does_not_accept_negative_numbers(): void
     {
-        $counter = new Counter('some_counter');
-
         $this->expectException(\InvalidArgumentException::class);
 
-        $counter->add(-1);
+        $this->counter->add(-1);
+    }
+
+    public function test_add(): void
+    {
+        $this->counter->add(5);
+        $this->assertSame(5, $this->counter->getValue());
     }
 }

--- a/tests/Unit/SDK/Metrics/Exporters/AbstractExporterTest.php
+++ b/tests/Unit/SDK/Metrics/Exporters/AbstractExporterTest.php
@@ -8,6 +8,9 @@ use OpenTelemetry\API\Metrics as API;
 use OpenTelemetry\SDK\Metrics\Exporters\AbstractExporter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Metrics\Exporters\AbstractExporter
+ */
 class AbstractExporterTest extends TestCase
 {
     public function test_empty_metrics_export_returns_success(): void

--- a/tests/Unit/SDK/Metrics/HasLabelTest.php
+++ b/tests/Unit/SDK/Metrics/HasLabelTest.php
@@ -7,6 +7,9 @@ namespace OpenTelemetry\Tests\Unit\SDK\Metrics;
 use OpenTelemetry\SDK\Metrics\HasLabelsTrait;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Metrics\HasLabelsTrait
+ */
 class HasLabelTest extends TestCase
 {
     protected $labelable;

--- a/tests/Unit/SDK/Metrics/MeterTest.php
+++ b/tests/Unit/SDK/Metrics/MeterTest.php
@@ -10,6 +10,9 @@ use OpenTelemetry\SDK\Metrics\UpDownCounter;
 use OpenTelemetry\SDK\Metrics\ValueRecorder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Metrics\Meter
+ */
 class MeterTest extends TestCase
 {
     public function test_meter(): void

--- a/tests/Unit/SDK/Metrics/Providers/GlobalMeterProviderTest.php
+++ b/tests/Unit/SDK/Metrics/Providers/GlobalMeterProviderTest.php
@@ -9,6 +9,9 @@ use OpenTelemetry\SDK\Metrics\Providers\GlobalMeterProvider;
 use OpenTelemetry\SDK\Metrics\Providers\MeterProvider;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Metrics\Providers\GlobalMeterProvider
+ */
 class GlobalMeterProviderTest extends TestCase
 {
     public function test_global_meter_provider_setters_and_getters(): void

--- a/tests/Unit/SDK/Metrics/UpDownCounterTest.php
+++ b/tests/Unit/SDK/Metrics/UpDownCounterTest.php
@@ -5,86 +5,99 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics;
 
 use InvalidArgumentException;
+use OpenTelemetry\API\Metrics as API;
 use OpenTelemetry\SDK\Metrics\UpDownCounter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Metrics\UpDownCounter
+ */
 class UpDownCounterTest extends TestCase
 {
+    private UpDownCounter $counter;
+
+    public function setUp(): void
+    {
+        $this->counter = new UpDownCounter('name', 'description');
+    }
+
+    public function test_get_type(): void
+    {
+        $this->assertSame(API\MetricKind::UP_DOWN_COUNTER, $this->counter->getType());
+    }
+
+    public function test_get_value(): void
+    {
+        $this->counter->add(1);
+        $this->assertSame(1, $this->counter->getValue());
+    }
+
     public function test_valid_positive_int_add(): void
     {
-        $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->add(5);
+        $retVal = $this->counter->add(5);
         $this->assertEquals(5, $retVal);
-        $retVal = $counter->add(2);
+        $retVal = $this->counter->add(2);
         $this->assertEquals(7, $retVal);
     }
     public function test_valid_negative_int_add(): void
     {
-        $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->add(-5);
+        $retVal = $this->counter->add(-5);
         $this->assertEquals(-5, $retVal);
-        $retVal = $counter->add(-2);
+        $retVal = $this->counter->add(-2);
         $this->assertEquals(-7, $retVal);
     }
 
     public function test_valid_positive_and_negative_int_add(): void
     {
-        $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->add(5);
+        $retVal = $this->counter->add(5);
         $this->assertEquals(5, $retVal);
-        $retVal = $counter->add(-2);
+        $retVal = $this->counter->add(-2);
         $this->assertEquals(3, $retVal);
     }
     public function test_valid_negative_and_positive_add(): void
     {
-        $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->add(-5);
+        $retVal = $this->counter->add(-5);
         $this->assertEquals(-5, $retVal);
-        $retVal = $counter->add(2);
+        $retVal = $this->counter->add(2);
         $this->assertEquals(-3, $retVal);
     }
 
     public function test_valid_positive_float_add(): void
     {
-        $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->add(5.2222);
+        $retVal = $this->counter->add(5.2222);
         $this->assertEquals(5, $retVal);
-        $retVal = $counter->add(2.6666);
+        $retVal = $this->counter->add(2.6666);
         $this->assertEquals(7, $retVal);
     }
     public function test_valid_negative_float_add(): void
     {
-        $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->add(-5.2222);
+        $retVal = $this->counter->add(-5.2222);
         $this->assertEquals(-5, $retVal);
-        $retVal = $counter->add(-2.6666);
+        $retVal = $this->counter->add(-2.6666);
         $this->assertEquals(-7, $retVal);
     }
 
     public function test_valid_positive_and_negative_float_add(): void
     {
-        $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->add(5.2222);
+        $retVal = $this->counter->add(5.2222);
         $this->assertEquals(5, $retVal);
-        $retVal = $counter->add(-2.6666);
+        $retVal = $this->counter->add(-2.6666);
         $this->assertEquals(3, $retVal);
     }
     public function test_valid_negative_and_positive_float_add(): void
     {
-        $counter = new UpDownCounter('name', 'description');
-        $retVal = $counter->add(-5.2222);
+        $retVal = $this->counter->add(-5.2222);
         $this->assertEquals(-5, $retVal);
-        $retVal = $counter->add(2.6666);
+        $retVal = $this->counter->add(2.6666);
         $this->assertEquals(-3, $retVal);
     }
     public function test_invalid_up_down_counter_add_throws_exception(): void
     {
-        $counter = new UpDownCounter('name', 'description');
         $this->expectException(InvalidArgumentException::class);
         /**
          * @phpstan-ignore-next-line
          * @psalm-suppress InvalidScalarArgument
          */
-        $counter->add('a');
+        $this->counter->add('a');
     }
 }

--- a/tests/Unit/SDK/Metrics/ValueRecorderTest.php
+++ b/tests/Unit/SDK/Metrics/ValueRecorderTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics;
 
-use InvalidArgumentException;
 use OpenTelemetry\API\Metrics as API;
 use OpenTelemetry\SDK\Metrics\ValueRecorder;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 /**
  * @covers OpenTelemetry\SDK\Metrics\ValueRecorder
@@ -29,113 +29,73 @@ class ValueRecorderTest extends TestCase
     public function test_valid_positive_int_record(): void
     {
         $this->metric->record(5);
-        $this->assertEquals(1, $this->metric->getCount());
-        $this->assertEquals(5, $this->metric->getMax());
-        $this->assertEquals(5, $this->metric->getMin());
-        $this->assertEquals(5, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 1, 5, 5, 5);
         $this->metric->record(2);
-        $this->assertEquals(2, $this->metric->getCount());
-        $this->assertEquals(5, $this->metric->getMax());
-        $this->assertEquals(2, $this->metric->getMin());
-        $this->assertEquals(7, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 2, 5, 2, 7);
     }
 
     public function test_valid_negative_int_record(): void
     {
         $this->metric->record(-5);
-        $this->assertEquals(1, $this->metric->getCount());
-        $this->assertEquals(-5, $this->metric->getMax());
-        $this->assertEquals(-5, $this->metric->getMin());
-        $this->assertEquals(-5, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 1, -5, -5, -5);
         $this->metric->record(-2);
-        $this->assertEquals(2, $this->metric->getCount());
-        $this->assertEquals(-2, $this->metric->getMax());
-        $this->assertEquals(-5, $this->metric->getMin());
-        $this->assertEquals(-7, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 2, -2, -5, -7);
     }
 
     public function test_valid_positive_and_negative_int_record(): void
     {
         $this->metric->record(5);
-        $this->assertEquals(1, $this->metric->getCount());
-        $this->assertEquals(5, $this->metric->getMax());
-        $this->assertEquals(5, $this->metric->getMin());
-        $this->assertEquals(5, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 1, 5, 5, 5);
         $this->metric->record(-2);
-        $this->assertEquals(2, $this->metric->getCount());
-        $this->assertEquals(5, $this->metric->getMax());
-        $this->assertEquals(-2, $this->metric->getMin());
-        $this->assertEquals(3, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 2, 5, -2, 3);
     }
 
     public function test_valid_negative_and_positive_record(): void
     {
         $this->metric->record(-5);
-        $this->assertEquals(1, $this->metric->getCount());
-        $this->assertEquals(-5, $this->metric->getMax());
-        $this->assertEquals(-5, $this->metric->getMin());
-        $this->assertEquals(-5, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 1, -5, -5, -5);
         $this->metric->record(2);
-        $this->assertEquals(2, $this->metric->getCount());
-        $this->assertEquals(2, $this->metric->getMax());
-        $this->assertEquals(-5, $this->metric->getMin());
-        $this->assertEquals(-3, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 2, 2, -5, -3);
     }
 
     public function test_valid_positive_float_record(): void
     {
         $this->metric->record(5.2222);
-        $this->assertEquals(1, $this->metric->getCount());
-        $this->assertEquals(5.2222, $this->metric->getMax());
-        $this->assertEquals(5.2222, $this->metric->getMin());
-        $this->assertEquals(5.2222, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 1, 5.2222, 5.2222, 5.2222);
         $this->metric->record(2.6666);
-        $this->assertEquals(2, $this->metric->getCount());
-        $this->assertEquals(5.2222, $this->metric->getMax());
-        $this->assertEquals(2.6666, $this->metric->getMin());
-        $this->assertEquals(7.8888, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 2, 5.2222, 2.6666, 7.8888);
     }
 
     public function test_valid_negative_float_record(): void
     {
         $this->metric->record(-5.2222);
-        $this->assertEquals(1, $this->metric->getCount());
-        $this->assertEquals(-5.2222, $this->metric->getMax());
-        $this->assertEquals(-5.2222, $this->metric->getMin());
-        $this->assertEquals(-5.2222, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 1, -5.2222, -5.2222, -5.2222);
         $this->metric->record(-2.6666);
-        $this->assertEquals(2, $this->metric->getCount());
-        $this->assertEquals(-2.6666, $this->metric->getMax());
-        $this->assertEquals(-5.2222, $this->metric->getMin());
-        $this->assertEquals(-7.8888, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 2, -2.6666, -5.2222, -7.8888);
     }
 
     public function test_valid_positive_and_negative_float_record(): void
     {
         $this->metric->record(5.2222);
-        $this->assertEquals(1, $this->metric->getCount());
-        $this->assertEquals(5.2222, $this->metric->getMax());
-        $this->assertEquals(5.2222, $this->metric->getMin());
-        $this->assertEquals(5.2222, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 1, 5.2222, 5.2222, 5.2222);
         $this->metric->record(-2.6666);
-        $this->assertEquals(2, $this->metric->getCount());
-        $this->assertEquals(5.2222, $this->metric->getMax());
-        $this->assertEquals(-2.6666, $this->metric->getMin());
-        $this->assertEquals(2.5556, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 2, 5.2222, -2.6666, 2.5556);
     }
 
     public function test_valid_negative_and_positive_float_record(): void
     {
         $this->metric->record(-5.2222);
-        $this->assertEquals(1, $this->metric->getCount());
-        $this->assertEquals(-5.2222, $this->metric->getMax());
-        $this->assertEquals(-5.2222, $this->metric->getMin());
-        $this->assertEquals(-5.2222, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 1, -5.2222, -5.2222, -5.2222);
         $this->metric->record(2.6666);
-        $this->assertEquals(2, $this->metric->getCount());
-        $this->assertEquals(2.6666, $this->metric->getMax());
-        $this->assertEquals(-5.2222, $this->metric->getMin());
-        $this->assertEquals(-2.5556, $this->metric->getSum());
+        $this->assertMetrics($this->metric, 2, 2.6666, -5.2222, -2.5556);
+    }
+
+    private function assertMetrics(ValueRecorder $metric, float $count, float $max, float $min, float $sum): void
+    {
+        $this->assertEquals($count, $metric->getCount());
+        $this->assertEquals($max, $metric->getMax());
+        $this->assertEquals($min, $metric->getMin());
+        $this->assertEquals($sum, $metric->getSum());
     }
 
     public function test_value_recorder_initialization(): void
@@ -147,9 +107,9 @@ class ValueRecorderTest extends TestCase
         $this->assertEquals(0, $this->metric->getMean());
     }
 
-    public function test_invalid_value_recorder_record_throws_exception(): void
+    public function test_invalid_value_recorder_record_throws_type_error(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(TypeError::class);
         /**
          * @phpstan-ignore-next-line
          * @psalm-suppress InvalidScalarArgument

--- a/tests/Unit/SDK/Metrics/ValueRecorderTest.php
+++ b/tests/Unit/SDK/Metrics/ValueRecorderTest.php
@@ -112,7 +112,7 @@ class ValueRecorderTest extends TestCase
         $this->expectException(TypeError::class);
         /**
          * @phpstan-ignore-next-line
-         * @psalm-suppress InvalidScalarArgument
+         * @psalm-suppress InvalidArgument
          */
         $this->metric->record('a');
     }

--- a/tests/Unit/SDK/Metrics/ValueRecorderTest.php
+++ b/tests/Unit/SDK/Metrics/ValueRecorderTest.php
@@ -5,149 +5,162 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics;
 
 use InvalidArgumentException;
+use OpenTelemetry\API\Metrics as API;
 use OpenTelemetry\SDK\Metrics\ValueRecorder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Metrics\ValueRecorder
+ */
 class ValueRecorderTest extends TestCase
 {
+    private ValueRecorder $metric;
+
+    public function setUp(): void
+    {
+        $this->metric = new ValueRecorder('name', 'description');
+    }
+
+    public function test_get_type(): void
+    {
+        $this->assertSame(API\MetricKind::VALUE_RECORDER, $this->metric->getType());
+    }
+
     public function test_valid_positive_int_record(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $metric->record(5);
-        $this->assertEquals(1, $metric->getCount());
-        $this->assertEquals(5, $metric->getMax());
-        $this->assertEquals(5, $metric->getMin());
-        $this->assertEquals(5, $metric->getSum());
-        $metric->record(2);
-        $this->assertEquals(2, $metric->getCount());
-        $this->assertEquals(5, $metric->getMax());
-        $this->assertEquals(2, $metric->getMin());
-        $this->assertEquals(7, $metric->getSum());
+        $this->metric->record(5);
+        $this->assertEquals(1, $this->metric->getCount());
+        $this->assertEquals(5, $this->metric->getMax());
+        $this->assertEquals(5, $this->metric->getMin());
+        $this->assertEquals(5, $this->metric->getSum());
+        $this->metric->record(2);
+        $this->assertEquals(2, $this->metric->getCount());
+        $this->assertEquals(5, $this->metric->getMax());
+        $this->assertEquals(2, $this->metric->getMin());
+        $this->assertEquals(7, $this->metric->getSum());
     }
 
     public function test_valid_negative_int_record(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $metric->record(-5);
-        $this->assertEquals(1, $metric->getCount());
-        $this->assertEquals(-5, $metric->getMax());
-        $this->assertEquals(-5, $metric->getMin());
-        $this->assertEquals(-5, $metric->getSum());
-        $metric->record(-2);
-        $this->assertEquals(2, $metric->getCount());
-        $this->assertEquals(-2, $metric->getMax());
-        $this->assertEquals(-5, $metric->getMin());
-        $this->assertEquals(-7, $metric->getSum());
+        $this->metric->record(-5);
+        $this->assertEquals(1, $this->metric->getCount());
+        $this->assertEquals(-5, $this->metric->getMax());
+        $this->assertEquals(-5, $this->metric->getMin());
+        $this->assertEquals(-5, $this->metric->getSum());
+        $this->metric->record(-2);
+        $this->assertEquals(2, $this->metric->getCount());
+        $this->assertEquals(-2, $this->metric->getMax());
+        $this->assertEquals(-5, $this->metric->getMin());
+        $this->assertEquals(-7, $this->metric->getSum());
     }
 
     public function test_valid_positive_and_negative_int_record(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $metric->record(5);
-        $this->assertEquals(1, $metric->getCount());
-        $this->assertEquals(5, $metric->getMax());
-        $this->assertEquals(5, $metric->getMin());
-        $this->assertEquals(5, $metric->getSum());
-        $metric->record(-2);
-        $this->assertEquals(2, $metric->getCount());
-        $this->assertEquals(5, $metric->getMax());
-        $this->assertEquals(-2, $metric->getMin());
-        $this->assertEquals(3, $metric->getSum());
+        $this->metric->record(5);
+        $this->assertEquals(1, $this->metric->getCount());
+        $this->assertEquals(5, $this->metric->getMax());
+        $this->assertEquals(5, $this->metric->getMin());
+        $this->assertEquals(5, $this->metric->getSum());
+        $this->metric->record(-2);
+        $this->assertEquals(2, $this->metric->getCount());
+        $this->assertEquals(5, $this->metric->getMax());
+        $this->assertEquals(-2, $this->metric->getMin());
+        $this->assertEquals(3, $this->metric->getSum());
     }
 
     public function test_valid_negative_and_positive_record(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $metric->record(-5);
-        $this->assertEquals(1, $metric->getCount());
-        $this->assertEquals(-5, $metric->getMax());
-        $this->assertEquals(-5, $metric->getMin());
-        $this->assertEquals(-5, $metric->getSum());
-        $metric->record(2);
-        $this->assertEquals(2, $metric->getCount());
-        $this->assertEquals(2, $metric->getMax());
-        $this->assertEquals(-5, $metric->getMin());
-        $this->assertEquals(-3, $metric->getSum());
+        $this->metric->record(-5);
+        $this->assertEquals(1, $this->metric->getCount());
+        $this->assertEquals(-5, $this->metric->getMax());
+        $this->assertEquals(-5, $this->metric->getMin());
+        $this->assertEquals(-5, $this->metric->getSum());
+        $this->metric->record(2);
+        $this->assertEquals(2, $this->metric->getCount());
+        $this->assertEquals(2, $this->metric->getMax());
+        $this->assertEquals(-5, $this->metric->getMin());
+        $this->assertEquals(-3, $this->metric->getSum());
     }
 
     public function test_valid_positive_float_record(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $metric->record(5.2222);
-        $this->assertEquals(1, $metric->getCount());
-        $this->assertEquals(5.2222, $metric->getMax());
-        $this->assertEquals(5.2222, $metric->getMin());
-        $this->assertEquals(5.2222, $metric->getSum());
-        $metric->record(2.6666);
-        $this->assertEquals(2, $metric->getCount());
-        $this->assertEquals(5.2222, $metric->getMax());
-        $this->assertEquals(2.6666, $metric->getMin());
-        $this->assertEquals(7.8888, $metric->getSum());
+        $this->metric->record(5.2222);
+        $this->assertEquals(1, $this->metric->getCount());
+        $this->assertEquals(5.2222, $this->metric->getMax());
+        $this->assertEquals(5.2222, $this->metric->getMin());
+        $this->assertEquals(5.2222, $this->metric->getSum());
+        $this->metric->record(2.6666);
+        $this->assertEquals(2, $this->metric->getCount());
+        $this->assertEquals(5.2222, $this->metric->getMax());
+        $this->assertEquals(2.6666, $this->metric->getMin());
+        $this->assertEquals(7.8888, $this->metric->getSum());
     }
 
     public function test_valid_negative_float_record(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $metric->record(-5.2222);
-        $this->assertEquals(1, $metric->getCount());
-        $this->assertEquals(-5.2222, $metric->getMax());
-        $this->assertEquals(-5.2222, $metric->getMin());
-        $this->assertEquals(-5.2222, $metric->getSum());
-        $metric->record(-2.6666);
-        $this->assertEquals(2, $metric->getCount());
-        $this->assertEquals(-2.6666, $metric->getMax());
-        $this->assertEquals(-5.2222, $metric->getMin());
-        $this->assertEquals(-7.8888, $metric->getSum());
+        $this->metric->record(-5.2222);
+        $this->assertEquals(1, $this->metric->getCount());
+        $this->assertEquals(-5.2222, $this->metric->getMax());
+        $this->assertEquals(-5.2222, $this->metric->getMin());
+        $this->assertEquals(-5.2222, $this->metric->getSum());
+        $this->metric->record(-2.6666);
+        $this->assertEquals(2, $this->metric->getCount());
+        $this->assertEquals(-2.6666, $this->metric->getMax());
+        $this->assertEquals(-5.2222, $this->metric->getMin());
+        $this->assertEquals(-7.8888, $this->metric->getSum());
     }
 
     public function test_valid_positive_and_negative_float_record(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $metric->record(5.2222);
-        $this->assertEquals(1, $metric->getCount());
-        $this->assertEquals(5.2222, $metric->getMax());
-        $this->assertEquals(5.2222, $metric->getMin());
-        $this->assertEquals(5.2222, $metric->getSum());
-        $metric->record(-2.6666);
-        $this->assertEquals(2, $metric->getCount());
-        $this->assertEquals(5.2222, $metric->getMax());
-        $this->assertEquals(-2.6666, $metric->getMin());
-        $this->assertEquals(2.5556, $metric->getSum());
+        $this->metric->record(5.2222);
+        $this->assertEquals(1, $this->metric->getCount());
+        $this->assertEquals(5.2222, $this->metric->getMax());
+        $this->assertEquals(5.2222, $this->metric->getMin());
+        $this->assertEquals(5.2222, $this->metric->getSum());
+        $this->metric->record(-2.6666);
+        $this->assertEquals(2, $this->metric->getCount());
+        $this->assertEquals(5.2222, $this->metric->getMax());
+        $this->assertEquals(-2.6666, $this->metric->getMin());
+        $this->assertEquals(2.5556, $this->metric->getSum());
     }
 
     public function test_valid_negative_and_positive_float_record(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $metric->record(-5.2222);
-        $this->assertEquals(1, $metric->getCount());
-        $this->assertEquals(-5.2222, $metric->getMax());
-        $this->assertEquals(-5.2222, $metric->getMin());
-        $this->assertEquals(-5.2222, $metric->getSum());
-        $metric->record(2.6666);
-        $this->assertEquals(2, $metric->getCount());
-        $this->assertEquals(2.6666, $metric->getMax());
-        $this->assertEquals(-5.2222, $metric->getMin());
-        $this->assertEquals(-2.5556, $metric->getSum());
+        $this->metric->record(-5.2222);
+        $this->assertEquals(1, $this->metric->getCount());
+        $this->assertEquals(-5.2222, $this->metric->getMax());
+        $this->assertEquals(-5.2222, $this->metric->getMin());
+        $this->assertEquals(-5.2222, $this->metric->getSum());
+        $this->metric->record(2.6666);
+        $this->assertEquals(2, $this->metric->getCount());
+        $this->assertEquals(2.6666, $this->metric->getMax());
+        $this->assertEquals(-5.2222, $this->metric->getMin());
+        $this->assertEquals(-2.5556, $this->metric->getSum());
     }
 
     public function test_value_recorder_initialization(): void
     {
-        $metric = new ValueRecorder('name', 'description');
-        $this->assertEquals(0, $metric->getCount());
-        $this->assertEquals(INF, $metric->getMax());
-        $this->assertEquals(-INF, $metric->getMin());
-        $this->assertEquals(0, $metric->getSum());
-        $this->assertEquals(0, $metric->getMean());
+        $this->assertEquals(0, $this->metric->getCount());
+        $this->assertEquals(INF, $this->metric->getMax());
+        $this->assertEquals(-INF, $this->metric->getMin());
+        $this->assertEquals(0, $this->metric->getSum());
+        $this->assertEquals(0, $this->metric->getMean());
     }
 
     public function test_invalid_value_recorder_record_throws_exception(): void
     {
-        $metric = new ValueRecorder('name', 'description');
         $this->expectException(InvalidArgumentException::class);
         /**
          * @phpstan-ignore-next-line
          * @psalm-suppress InvalidScalarArgument
          */
-        $metric->record('a');
+        $this->metric->record('a');
+    }
+
+    public function test_get_mean(): void
+    {
+        $this->metric->record(2);
+        $this->metric->record(5);
+        $this->assertSame(3.5, $this->metric->getMean());
     }
 }

--- a/tests/Unit/SDK/Resource/ResourceTest.php
+++ b/tests/Unit/SDK/Resource/ResourceTest.php
@@ -10,6 +10,9 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SemConv\ResourceAttributes;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Resource\ResourceInfo
+ */
 class ResourceTest extends TestCase
 {
     use EnvironmentVariables;

--- a/tests/Unit/SDK/SystemClockTest.php
+++ b/tests/Unit/SDK/SystemClockTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK;
+
+use OpenTelemetry\SDK\SystemClock;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\SystemClock
+ */
+class SystemClockTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState false
+     */
+    public function test_get_instance(): void
+    {
+        $clock = SystemClock::getInstance();
+        $this->assertSame($clock, SystemClock::getInstance());
+    }
+}

--- a/tests/Unit/SDK/SystemClockTest.php
+++ b/tests/Unit/SDK/SystemClockTest.php
@@ -16,7 +16,7 @@ class SystemClockTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState false
      */
-    public function test_get_instance(): void
+    public function test_get_instance_always_returns_same_clock(): void
     {
         $clock = SystemClock::getInstance();
         $this->assertSame($clock, SystemClock::getInstance());

--- a/tests/Unit/SDK/Trace/Behavior/UsesSpanConverterTraitTest.php
+++ b/tests/Unit/SDK/Trace/Behavior/UsesSpanConverterTraitTest.php
@@ -9,8 +9,14 @@ use OpenTelemetry\SDK\Trace\SpanConverterInterface;
 use OpenTelemetry\SDK\Trace\SpanExporter\NullSpanConverter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait
+ */
 class UsesSpanConverterTraitTest extends TestCase
 {
+    /**
+     * @covers ::getSpanConverter
+     */
     public function test_accessors(): void
     {
         $instance = $this->createInstance();
@@ -24,6 +30,9 @@ class UsesSpanConverterTraitTest extends TestCase
         );
     }
 
+    /**
+     * @covers ::getSpanConverter
+     */
     public function test_fallback_converter(): void
     {
         $this->assertInstanceOf(

--- a/tests/Unit/SDK/Trace/EventTest.php
+++ b/tests/Unit/SDK/Trace/EventTest.php
@@ -9,6 +9,9 @@ use OpenTelemetry\SDK\Trace\Event;
 use OpenTelemetry\Tests\Unit\SDK\Util\TestClock;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\Event
+ */
 class EventTest extends TestCase
 {
     private const EVENT_NAME = 'test-event';

--- a/tests/Unit/SDK/Trace/ImmutableSpanTest.php
+++ b/tests/Unit/SDK/Trace/ImmutableSpanTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Trace;
+
+use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\SDK\AttributesInterface;
+use OpenTelemetry\SDK\InstrumentationLibrary;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Trace\ImmutableSpan;
+use OpenTelemetry\SDK\Trace\Span;
+use OpenTelemetry\SDK\Trace\StatusDataInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Trace\ImmutableSpan
+ */
+class ImmutableSpanTest extends TestCase
+{
+    private Span $span;
+    private AttributesInterface $attributes;
+    private StatusDataInterface $status;
+    private InstrumentationLibrary $instrumentationLibrary;
+    private ResourceInfo $resource;
+    private API\SpanContextInterface $context;
+    private API\SpanContextInterface $parentContext;
+
+    private string $traceId = 'trace-id';
+    private string $spanId = 'span-id';
+    private string $parentSpanId = 'parent-span-id';
+    private int $endEpochNanos = 2000;
+    private int $startEpochNanes = 1000;
+    private int $totalAttributeCount = 1;
+    private int $totalRecordedEvents = 1;
+    private int $totalRecordedLinks = 1;
+
+    protected function setUp():void
+    {
+        $this->context = $this->createMock(API\SpanContextInterface::class);
+        $this->parentContext = $this->createMock(API\SpanContextInterface::class);
+        $this->instrumentationLibrary = $this->createMock(InstrumentationLibrary::class);
+        $this->resource = $this->createMock(ResourceInfo::class);
+
+        $this->span = $this->createMock(Span::class);
+        $this->attributes = $this->createMock(AttributesInterface::class);
+        $this->status = $this->createMock(StatusDataInterface::class);
+
+        $this->span->method('getKind')->willReturn(SpanKind::KIND_INTERNAL);
+        $this->span->method('getContext')->willReturn($this->context);
+        $this->span->method('getParentContext')->willReturn($this->parentContext);
+        $this->span->method('getInstrumentationLibrary')->willReturn($this->instrumentationLibrary);
+        $this->span->method('getResource')->willReturn($this->resource);
+        $this->span->method('getStartEpochNanos')->willReturn($this->startEpochNanes);
+        $this->span->method('getTotalRecordedLinks')->willReturn($this->totalRecordedLinks);
+        $this->context->method('getTraceId')->willReturn($this->traceId);
+        $this->context->method('getSpanId')->willReturn($this->spanId);
+        $this->parentContext->method('getSpanId')->willReturn($this->parentSpanId);
+    }
+
+    public function test_getters(): void
+    {
+        $span = new ImmutableSpan(
+            $this->span,
+            'name',
+            [],
+            [],
+            $this->attributes,
+            $this->totalAttributeCount,
+            $this->totalRecordedEvents,
+            $this->status,
+            $this->endEpochNanos,
+            false,
+        );
+
+        $this->assertSame(SpanKind::KIND_INTERNAL, $span->getKind());
+        $this->assertSame($this->context, $span->getContext());
+        $this->assertSame($this->parentContext, $span->getParentContext());
+        $this->assertSame($this->traceId, $span->getTraceId());
+        $this->assertSame($this->spanId, $span->getSpanId());
+        $this->assertSame($this->parentSpanId, $span->getParentSpanId());
+        $this->assertSame($this->startEpochNanes, $span->getStartEpochNanos());
+        $this->assertSame($this->endEpochNanos, $span->getEndEpochNanos());
+        $this->assertSame($this->instrumentationLibrary, $span->getInstrumentationLibrary());
+        $this->assertSame($this->resource, $span->getResource());
+        $this->assertSame('name', $span->getName());
+        $this->assertSame([], $span->getLinks());
+        $this->assertSame([], $span->getEvents());
+        $this->assertSame($this->attributes, $span->getAttributes());
+        $this->assertSame(1, $span->getTotalDroppedAttributes());
+        $this->assertSame(1, $span->getTotalDroppedEvents());
+        $this->assertSame(1, $span->getTotalDroppedLinks());
+        $this->assertSame($this->status, $span->getStatus());
+        $this->assertFalse($span->hasEnded());
+    }
+}

--- a/tests/Unit/SDK/Trace/LinkTest.php
+++ b/tests/Unit/SDK/Trace/LinkTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Trace;
+
+use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\SDK\AttributesInterface;
+use OpenTelemetry\SDK\Trace\Link;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Trace\Link
+ */
+class LinkTest extends TestCase
+{
+    private API\SpanContextInterface $context;
+    private AttributesInterface $attributes;
+
+    public function setUp(): void
+    {
+        $this->context = $this->createMock(API\SpanContextInterface::class);
+        $this->attributes = $this->createMock(AttributesInterface::class);
+        $this->attributes->method('count')->willReturn(5);
+    }
+
+    public function test_getters(): void
+    {
+        $link = new Link($this->context, $this->attributes);
+
+        $this->assertSame($this->context, $link->getSpanContext());
+        $this->assertSame($this->attributes, $link->getAttributes());
+        $this->assertSame(5, $link->getTotalAttributeCount());
+    }
+
+    public function test_null_attributes(): void
+    {
+        $link = new Link($this->context);
+        $this->assertSame(0, $link->getTotalAttributeCount());
+    }
+}

--- a/tests/Unit/SDK/Trace/NonRecordingSpanTest.php
+++ b/tests/Unit/SDK/Trace/NonRecordingSpanTest.php
@@ -7,6 +7,9 @@ namespace OpenTelemetry\Tests\Unit\SDK\Trace;
 use OpenTelemetry\API\Trace as API;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\API\Trace\NonRecordingSpan
+ */
 class NonRecordingSpanTest extends TestCase
 {
     public function test_is_not_recording(): void

--- a/tests/Unit/SDK/Trace/RandomIdGeneratorTest.php
+++ b/tests/Unit/SDK/Trace/RandomIdGeneratorTest.php
@@ -8,6 +8,9 @@ use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\SDK\Trace\RandomIdGenerator;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\RandomIdGenerator
+ */
 class RandomIdGeneratorTest extends TestCase
 {
     public function test_generated_trace_id_is_valid(): void

--- a/tests/Unit/SDK/Trace/Sampler/AlwaysOffSamplerTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/AlwaysOffSamplerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK;
+
+use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
+use OpenTelemetry\SDK\Trace\SamplingResult;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler
+ */
+class AlwaysOffSamplerTest extends TestCase
+{
+    /**
+     * @covers ::shouldSample
+     */
+    public function test_should_sample(): void
+    {
+        $parentContext = $this->createMock(Context::class);
+        $sampler = new AlwaysOffSampler();
+        $decision = $sampler->shouldSample(
+            $parentContext,
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            'test.opentelemetry.io',
+            API\SpanKind::KIND_INTERNAL
+        );
+
+        $this->assertEquals(SamplingResult::DROP, $decision->getDecision());
+    }
+
+    /**
+     * @covers ::getDescription
+     */
+    public function test_get_description(): void
+    {
+        $sampler = new AlwaysOffSampler();
+        $this->assertEquals('AlwaysOffSampler', $sampler->getDescription());
+    }
+}

--- a/tests/Unit/SDK/Trace/Sampler/AlwaysOnSamplerTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/AlwaysOnSamplerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Trace\Sampler;
+
+use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Trace\SamplingResult;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler
+ */
+class AlwaysOnSamplerTest extends TestCase
+{
+    /**
+     * @covers ::shouldSample
+     */
+    public function test_should_sample(): void
+    {
+        $parentContext = $this->createMock(Context::class);
+        $sampler = new AlwaysOnSampler();
+        $decision = $sampler->shouldSample(
+            $parentContext,
+            '4bf92f3577b34da6a3ce929d0e0e4736',
+            'test.opentelemetry.io',
+            API\SpanKind::KIND_INTERNAL
+        );
+
+        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
+    }
+
+    /**
+     * @covers ::getDescription
+     */
+    public function test_get_description(): void
+    {
+        $sampler = new AlwaysOnSampler();
+        $this->assertEquals('AlwaysOnSampler', $sampler->getDescription());
+    }
+}

--- a/tests/Unit/SDK/Trace/SamplingResultTest.php
+++ b/tests/Unit/SDK/Trace/SamplingResultTest.php
@@ -9,6 +9,9 @@ use OpenTelemetry\SDK\Attributes;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SamplingResult
+ */
 class SamplingResultTest extends TestCase
 {
     /**

--- a/tests/Unit/SDK/Trace/SpanExporter/ConsoleSpanExporterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/ConsoleSpanExporterTest.php
@@ -9,6 +9,9 @@ use OpenTelemetry\SDK\Trace\SpanDataInterface;
 use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter
+ */
 class ConsoleSpanExporterTest extends AbstractExporterTest
 {
     public function createExporter(): ConsoleSpanExporter

--- a/tests/Unit/SDK/Trace/SpanExporter/FriendlySpanConverterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/FriendlySpanConverterTest.php
@@ -16,8 +16,9 @@ use OpenTelemetry\SDK\Trace\SpanExporter\FriendlySpanConverter;
 use OpenTelemetry\SDK\Trace\StatusDataInterface;
 use PHPUnit\Framework\TestCase;
 
-//use DG\BypassFinals;
-
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanExporter\FriendlySpanConverter
+ */
 class FriendlySpanConverterTest extends TestCase
 {
     private const TEST_DATA = [

--- a/tests/Unit/SDK/Trace/SpanExporter/LoggerDecoratorTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/LoggerDecoratorTest.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LogLevel;
 use RuntimeException;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanExporter\LoggerDecorator
+ */
 class LoggerDecoratorTest extends AbstractLoggerAwareTest
 {
     /**

--- a/tests/Unit/SDK/Trace/SpanExporter/LoggerExporterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/LoggerExporterTest.php
@@ -8,6 +8,9 @@ use Exception;
 use OpenTelemetry\SDK\Trace\SpanExporter\LoggerExporter;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanExporter\LoggerExporter
+ */
 class LoggerExporterTest extends AbstractExporterTest
 {
     use LoggerAwareTestTrait;

--- a/tests/Unit/SDK/Trace/SpanExporter/NullSpanConverterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/NullSpanConverterTest.php
@@ -4,21 +4,15 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter;
 
-use OpenTelemetry\SDK\Trace\SpanConverterInterface;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
 use OpenTelemetry\SDK\Trace\SpanExporter\NullSpanConverter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanExporter\NullSpanConverter
+ */
 class NullSpanConverterTest extends TestCase
 {
-    public function test_implements_span_converter_interface(): void
-    {
-        $this->assertInstanceOf(
-            SpanConverterInterface::class,
-            new NullSpanConverter()
-        );
-    }
-
     public function test_convert(): void
     {
         $this->assertSame(

--- a/tests/Unit/SDK/Trace/SpanLimitsBuilderTest.php
+++ b/tests/Unit/SDK/Trace/SpanLimitsBuilderTest.php
@@ -10,6 +10,9 @@ use OpenTelemetry\SDK\Trace\SpanLimits;
 use OpenTelemetry\SDK\Trace\SpanLimitsBuilder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanLimitsBuilder
+ */
 class SpanLimitsBuilderTest extends TestCase
 {
     use EnvironmentVariables;

--- a/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -17,6 +17,9 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
 use OpenTelemetry\Tests\Unit\SDK\Util\TestClock;
 use ReflectionObject;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor
+ */
 class BatchSpanProcessorTest extends MockeryTestCase
 {
     use EnvironmentVariables;

--- a/tests/Unit/SDK/Trace/SpanProcessor/MultiSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/MultiSpanProcessorTest.php
@@ -11,6 +11,9 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\MultiSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanProcessor\MultiSpanProcessor
+ */
 class MultiSpanProcessorTest extends TestCase
 {
     private array $spanProcessors = [];

--- a/tests/Unit/SDK/Trace/SpanProcessor/NoopSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/NoopSpanProcessorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Trace\SpanProcessor;
+
+use OpenTelemetry\SDK\Trace\SpanProcessor\NoopSpanProcessor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass OpenTelemetry\SDK\Trace\SpanProcessor\NoopSpanProcessor
+ */
+class NoopSpanProcessorTest extends TestCase
+{
+    /**
+     * @covers ::getInstance
+     */
+    public function test_get_instance(): void
+    {
+        $instance = NoopSpanProcessor::getInstance();
+        $this->assertSame($instance, NoopSpanProcessor::getInstance());
+    }
+
+    /**
+     * @covers ::forceFlush
+     */
+    public function test_force_flush(): void
+    {
+        $instance = NoopSpanProcessor::getInstance();
+        $this->assertTrue($instance->forceFlush());
+    }
+
+    /**
+     * @covers ::shutDown
+     */
+    public function test_shutdown(): void
+    {
+        $instance = NoopSpanProcessor::getInstance();
+        $this->assertTrue($instance->shutdown());
+    }
+}

--- a/tests/Unit/SDK/Trace/SpanProcessor/SimpleSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/SimpleSpanProcessorTest.php
@@ -16,6 +16,9 @@ use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor
+ */
 class SimpleSpanProcessorTest extends MockeryTestCase
 {
     private SimpleSpanProcessor $simpleSpanProcessor;
@@ -85,5 +88,11 @@ class SimpleSpanProcessorTest extends MockeryTestCase
 
         $this->assertTrue($this->simpleSpanProcessor->shutdown());
         $this->assertTrue($this->simpleSpanProcessor->shutdown());
+    }
+
+    public function test_shutdown_with_no_exporter(): void
+    {
+        $processor = new SimpleSpanProcessor(null);
+        $this->assertTrue($processor->shutdown());
     }
 }

--- a/tests/Unit/SDK/Trace/SpanProcessorFactoryTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessorFactoryTest.php
@@ -13,6 +13,9 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessorFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\SpanProcessorFactory
+ */
 class SpanProcessorFactoryTest extends TestCase
 {
     use EnvironmentVariables;

--- a/tests/Unit/SDK/Trace/StatusDataTest.php
+++ b/tests/Unit/SDK/Trace/StatusDataTest.php
@@ -8,11 +8,13 @@ use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\Trace\StatusData;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers OpenTelemetry\SDK\Trace\StatusData
+ */
 class StatusDataTest extends TestCase
 {
     /**
      * @dataProvider getStatuses
-     *
      * @psalm-param StatusCode::STATUS_* $code
      */
     public function test_statuses(string $code): void
@@ -37,7 +39,6 @@ class StatusDataTest extends TestCase
 
     /**
      * @dataProvider getStatuses
-     *
      * @psalm-param StatusCode::STATUS_* $code
      */
     public function test_statuses_description(string $code): void

--- a/tests/Unit/SDK/Trace/TracerProviderTest.php
+++ b/tests/Unit/SDK/Trace/TracerProviderTest.php
@@ -10,8 +10,15 @@ use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass OpenTelemetry\SDK\Trace\TracerProvider
+ */
 class TracerProviderTest extends TestCase
 {
+    /**
+     * @covers ::getTracer
+     * @covers ::__construct
+     */
     public function test_reuses_same_instance(): void
     {
         $provider = new TracerProvider(null);
@@ -26,6 +33,7 @@ class TracerProviderTest extends TestCase
     }
 
     /**
+     * @covers ::getDefaultTracer
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
@@ -35,6 +43,8 @@ class TracerProviderTest extends TestCase
     }
 
     /**
+     * @covers ::setDefaultTracer
+     * @covers ::getDefaultTracer
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
@@ -45,6 +55,9 @@ class TracerProviderTest extends TestCase
         $this->assertSame($tracer, TracerProvider::getDefaultTracer());
     }
 
+    /**
+     * @covers ::getTracer
+     */
     public function test_get_tracer_with_default_name(): void
     {
         $provider = new TracerProvider(null);
@@ -55,7 +68,10 @@ class TracerProviderTest extends TestCase
         $this->assertSame($t1, $t2);
     }
 
-    public function test_shut_down(): void
+    /**
+     * @covers ::shutdown
+     */
+    public function test_shutdown(): void
     {
         $provider = new TracerProvider(null);
 
@@ -64,6 +80,9 @@ class TracerProviderTest extends TestCase
         $this->assertTrue($provider->shutdown());
     }
 
+    /**
+     * @covers ::forceFlush
+     */
     public function test_force_flush(): void
     {
         $provider = new TracerProvider([]);
@@ -73,6 +92,9 @@ class TracerProviderTest extends TestCase
         $this->assertTrue($provider->forceFlush());
     }
 
+    /**
+     * @covers ::getSampler
+     */
     public function test_get_sampler(): void
     {
         $sampler = $this->createMock(SamplerInterface::class);
@@ -84,6 +106,9 @@ class TracerProviderTest extends TestCase
         );
     }
 
+    /**
+     * @covers ::getTracer
+     */
     public function test_get_tracer_after_shutdown(): void
     {
         $provider = new TracerProvider([]);


### PR DESCRIPTION
- Adding `@covers` to all test classes, and enforcing coverage for all future tests in phpunit config. Integration tests are all marked as `@coversNothing`, and they already do not contribute to code coverage due to recent splitting of unit/integration github actions).
- Adding and updating tests to cover some easier now-uncovered code
- Putting back `test-coverage` make target (which I recently removed but almost immediately regretted)
