### PR TITLE
Satisfy base spec for Jaeger Thrift span conversion

### DIFF
--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -15,6 +15,8 @@ class SpanConverter
 {
     const STATUS_CODE_TAG_KEY = 'op.status_code';
     const STATUS_DESCRIPTION_TAG_KEY = 'op.status_description';
+    const KEY_INSTRUMENTATION_LIBRARY_NAME = 'otel.library.name';
+    const KEY_INSTRUMENTATION_LIBRARY_VERSION = 'otel.library.version';
 
     public function __construct()
     {
@@ -33,6 +35,14 @@ class SpanConverter
             self::STATUS_CODE_TAG_KEY => $span->getStatus()->getCode(),
             self::STATUS_DESCRIPTION_TAG_KEY => $span->getStatus()->getDescription(),
         ];
+
+        if (!empty($span->getInstrumentationLibrary()->getName())) {
+            $tags[SpanConverter::KEY_INSTRUMENTATION_LIBRARY_NAME] = $span->getInstrumentationLibrary()->getName();
+        }
+
+        if ($span->getInstrumentationLibrary()->getVersion() !== null) {
+            $tags[SpanConverter::KEY_INSTRUMENTATION_LIBRARY_VERSION] = $span->getInstrumentationLibrary()->getVersion();
+        }
 
         foreach ($span->getAttributes() as $k => $v) {
             $tags[$k] = $this->sanitiseTagValue($v);

--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -15,8 +15,8 @@ use RuntimeException;
 class SpanConverter
 {
     const STATUS_CODE_TAG_KEY = 'otel.status_code';
-    const STATUS_OK_WITH_ALL_UPPERCASE_LETTERS = 'OK';
-    const STATUS_ERROR_WITH_ALL_UPPERCASE_LETTERS = 'ERROR';
+    const STATUS_OK = 'OK';
+    const STATUS_ERROR = 'ERROR';
     const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
     const KEY_INSTRUMENTATION_LIBRARY_NAME = 'otel.library.name';
     const KEY_INSTRUMENTATION_LIBRARY_VERSION = 'otel.library.version';
@@ -40,12 +40,12 @@ class SpanConverter
         if ($span->getStatus()->getCode() !== StatusCode::STATUS_UNSET) {
             switch ($span->getStatus()->getCode()) {
                 case StatusCode::STATUS_OK:
-                    $tags[self::STATUS_CODE_TAG_KEY] = self::STATUS_OK_WITH_ALL_UPPERCASE_LETTERS;
+                    $tags[self::STATUS_CODE_TAG_KEY] = self::STATUS_OK;
 
                     break;
                 case StatusCode::STATUS_ERROR:
                     //This is where the error flag section of the spec should be implemented - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#error-flag, see Go for reference - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/jaeger/jaeger.go#L154
-                    $tags[self::STATUS_CODE_TAG_KEY] = self::STATUS_ERROR_WITH_ALL_UPPERCASE_LETTERS;
+                    $tags[self::STATUS_CODE_TAG_KEY] = self::STATUS_ERROR;
 
                     break;
             }

--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -15,6 +15,8 @@ use RuntimeException;
 class SpanConverter
 {
     const STATUS_CODE_TAG_KEY = 'otel.status_code';
+    const STATUS_OK_WITH_ALL_UPPERCASE_LETTERS = 'OK';
+    const STATUS_ERROR_WITH_ALL_UPPERCASE_LETTERS = 'ERROR';
     const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
     const KEY_INSTRUMENTATION_LIBRARY_NAME = 'otel.library.name';
     const KEY_INSTRUMENTATION_LIBRARY_VERSION = 'otel.library.version';
@@ -38,12 +40,12 @@ class SpanConverter
         if ($span->getStatus()->getCode() !== StatusCode::STATUS_UNSET) {
             switch ($span->getStatus()->getCode()) {
                 case StatusCode::STATUS_OK:
-                    $tags[self::STATUS_CODE_TAG_KEY] = 'OK';
+                    $tags[self::STATUS_CODE_TAG_KEY] = self::STATUS_OK_WITH_ALL_UPPERCASE_LETTERS;
 
                     break;
                 case StatusCode::STATUS_ERROR:
                     //This is where the error flag section of the spec should be implemented - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#error-flag, see Go for reference - https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/jaeger/jaeger.go#L154
-                    $tags[self::STATUS_CODE_TAG_KEY] = 'ERROR';
+                    $tags[self::STATUS_CODE_TAG_KEY] = self::STATUS_ERROR_WITH_ALL_UPPERCASE_LETTERS;
 
                     break;
             }

--- a/tests/Unit/Contrib/JaegerSpanConverterTest.php
+++ b/tests/Unit/Contrib/JaegerSpanConverterTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Contrib\Unit;
 
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Contrib\Jaeger\SpanConverter;
+use OpenTelemetry\SDK\InstrumentationLibrary;
 use OpenTelemetry\SDK\Trace\StatusData;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
@@ -44,6 +45,10 @@ class JaegerSpanConverterTest extends TestCase
                     'status_description'
                 )
             )
+            ->setInstrumentationLibrary(new InstrumentationLibrary(
+                'instrumentation_library_name',
+                'instrumentation_library_version'
+            ))
             ->addAttribute('keyForBoolean', true)
             ->addAttribute('keyForArray', ['1stElement', '2ndElement']);
 
@@ -51,11 +56,20 @@ class JaegerSpanConverterTest extends TestCase
 
         $this->assertSame('op.status_code', $jtSpan->tags[0]->key);
         $this->assertSame('Error', $jtSpan->tags[0]->vStr);
+
         $this->assertSame('op.status_description', $jtSpan->tags[1]->key);
         $this->assertSame('status_description', $jtSpan->tags[1]->vStr);
-        $this->assertSame('keyForBoolean', $jtSpan->tags[2]->key);
-        $this->assertSame('true', $jtSpan->tags[2]->vStr);
-        $this->assertSame('keyForArray', $jtSpan->tags[3]->key);
-        $this->assertSame('1stElement,2ndElement', $jtSpan->tags[3]->vStr);
+
+        $this->assertSame('otel.library.name', $jtSpan->tags[2]->key);
+        $this->assertSame('instrumentation_library_name', $jtSpan->tags[2]->vStr);
+
+        $this->assertSame('otel.library.version', $jtSpan->tags[3]->key);
+        $this->assertSame('instrumentation_library_version', $jtSpan->tags[3]->vStr);
+
+        $this->assertSame('keyForBoolean', $jtSpan->tags[4]->key);
+        $this->assertSame('true', $jtSpan->tags[4]->vStr);
+
+        $this->assertSame('keyForArray', $jtSpan->tags[5]->key);
+        $this->assertSame('1stElement,2ndElement', $jtSpan->tags[5]->vStr);
     }
 }

--- a/tests/Unit/Contrib/JaegerSpanConverterTest.php
+++ b/tests/Unit/Contrib/JaegerSpanConverterTest.php
@@ -41,7 +41,7 @@ class JaegerSpanConverterTest extends TestCase
         $span = (new SpanData())
             ->setStatus(
                 new StatusData(
-                    StatusCode::STATUS_ERROR,
+                    StatusCode::STATUS_OK,
                     'status_description'
                 )
             )
@@ -54,10 +54,10 @@ class JaegerSpanConverterTest extends TestCase
 
         $jtSpan = (new SpanConverter())->convert($span);
 
-        $this->assertSame('op.status_code', $jtSpan->tags[0]->key);
-        $this->assertSame('Error', $jtSpan->tags[0]->vStr);
+        $this->assertSame('otel.status_code', $jtSpan->tags[0]->key);
+        $this->assertSame('OK', $jtSpan->tags[0]->vStr);
 
-        $this->assertSame('op.status_description', $jtSpan->tags[1]->key);
+        $this->assertSame('otel.status_description', $jtSpan->tags[1]->key);
         $this->assertSame('status_description', $jtSpan->tags[1]->vStr);
 
         $this->assertSame('otel.library.name', $jtSpan->tags[2]->key);

--- a/tests/Unit/Contrib/JaegerSpanConverterTest.php
+++ b/tests/Unit/Contrib/JaegerSpanConverterTest.php
@@ -72,4 +72,20 @@ class JaegerSpanConverterTest extends TestCase
         $this->assertSame('keyForArray', $jtSpan->tags[5]->key);
         $this->assertSame('1stElement,2ndElement', $jtSpan->tags[5]->vStr);
     }
+
+    public function test_should_correctly_convert_error_status_to_jaeger_thrift_tags()
+    {
+        $span = (new SpanData())
+            ->setStatus(
+                new StatusData(
+                    StatusCode::STATUS_ERROR,
+                    ''
+                )
+            );
+
+        $jtSpan = (new SpanConverter())->convert($span);
+
+        $this->assertSame('otel.status_code', $jtSpan->tags[0]->key);
+        $this->assertSame('ERROR', $jtSpan->tags[0]->vStr);
+    }
 }


### PR DESCRIPTION
The[ Jaeger spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#opentelemetry-to-jaeger-transformation) mentions near the top that the "[generic spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/non-otlp.md#dropped-links-count)" for all exporters also applies, so this implements those requirements (except for the "dropped" ones. I opened an issue in the [spec repo](https://github.com/open-telemetry/opentelemetry-specification/issues/2268) about whether those should be followed)

I drew inspiration from these other language libraries' implementations while putting this together

[Java](https://github.com/open-telemetry/opentelemetry-java/blob/e0854d6ac11cfe4c3794255d365b2272939674a4/exporters/jaeger-thrift/src/main/java/io/opentelemetry/exporter/jaeger/thrift/Adapter.java)
[Go](https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/jaeger/jaeger.go)
[JS](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-exporter-jaeger/src/transform.ts)

*The new comment is a reminder for implementation of the main Jaeger spec later