### PR TITLE
Replace apache/thrift with packaged/thrift

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -361,7 +361,7 @@ return [
         'src',
         'proto',
         'thrift',
-        'vendor/apache/thrift',
+        'vendor/packaged/thrift',
         'vendor/composer/xdebug-handler/src',
         'vendor/guzzlehttp',
         'vendor/psr',

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "apache/thrift": "^0.15.0",
+        "packaged/thrift": "^0.15.0",
         "google/protobuf": "^3.3.0",
         "grpc/grpc": "^1.30",
         "nyholm/dsn": "^2.0.0",


### PR DESCRIPTION
As discussesdin https://github.com/open-telemetry/opentelemetry-php/issues/296#issuecomment-987684152 , the original `apache/thrift`composer package includes the code of all language implementations, which makes the package rather huge (~15mb).
 The package `packaged/thrift` only includes the thrift PHP code extracted from the original repo as a drop-in replacement. According to [packagist](https://packagist.org/?query=thrift), this package is even more widely used than the original one.