### PR TITLE
Fixing the Jaeger port in the tutorial

### DIFF
--- a/docs/symfony-integration.md
+++ b/docs/symfony-integration.md
@@ -83,7 +83,7 @@ services:
     jaeger:
         image: jaegertracing/all-in-one
         environment:
-            COLLECTOR_ZIPKIN_HTTP_PORT: 9412
+            COLLECTOR_ZIPKIN_HOST_PORT: 9412 # Before version 1.22.0 use COLLECTOR_ZIPKIN_HTTP_PORT
         ports:
             - 9412:9412
             - 16686:16686


### PR DESCRIPTION
After reading a few open GitHub issues, I'm aware that it is known that the Symfony/Laravel examples as a whole are not up-to-date with the sdk code, but the docker-compose tutorial is on point. So if it's okay, I want to update it to the latest Jaeger version.

https://github.com/jaegertracing/jaeger/releases/tag/v1.22.0

> --collector.zipkin.http-port is replaced by --collector.zipkin.host-port