### PR TITLE
Some incremental progress on Jaeger spec compliance

### DIFF
--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -32,6 +32,15 @@ class SpanConverter
         self::checkIfPHPSupports64BitIntegers();
     }
 
+    private static function checkIfPHPSupports64BitIntegers(): void
+    {
+        if (PHP_INT_SIZE < 8) {
+            $humanReadableIntSize = PHP_INT_SIZE*8;
+
+            throw new RuntimeException("Integrating with Jaeger requires usage of 64 bit integers, but your current platform is $humanReadableIntSize bit. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#ids for more information.");
+        }
+    }
+
     /**
     * Convert span to Jaeger Thrift Span format
     */
@@ -213,15 +222,6 @@ class SpanConverter
         // error_log('Cannot build tag for ' . $key . ' of type ' . gettype($value));
 
         // throw new \Exception('unsupported tag type');
-    }
-
-    private static function checkIfPHPSupports64BitIntegers(): void
-    {
-        if (PHP_INT_SIZE < 8) {
-            $humanReadableIntSize = PHP_INT_SIZE*8;
-
-            throw new RuntimeException("Integrating with Jaeger requires usage of 64 bit integers, but your current platform is $humanReadableIntSize bit. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#ids for more information.");
-        }
     }
 
     private static function convertOtlpToJaegerIds(SpanDataInterface $span): array

--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -28,6 +28,8 @@ class SpanConverter
     const JAEGER_SPAN_KIND_SERVER = 'server';
     const JAEGER_SPAN_KIND_CONSUMER = 'consumer';
     const JAEGER_SPAN_KIND_PRODUCER = 'producer';
+    const EVENT_ATTRIBUTE_KEY_NAMED_EVENT = 'event';
+    const JAEGER_KEY_EVENT = 'event';
 
     public function __construct()
     {
@@ -274,9 +276,9 @@ class SpanConverter
     {
         $timestamp = AbstractClock::nanosToMicro($event->getEpochNanos());
 
-        $eventValue = $event->getAttributes()->get('event') ?? $event->getName();
+        $eventValue = $event->getAttributes()->get(self::EVENT_ATTRIBUTE_KEY_NAMED_EVENT) ?? $event->getName();
         $attributes = $event->getAttributes()->toArray();
-        $attributes['event'] = $eventValue;
+        $attributes[self::JAEGER_KEY_EVENT] = $eventValue;
         $attributesAsTags = self::buildTags($attributes);
 
         return new Log([

--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -264,15 +264,13 @@ class SpanConverter
         $timestamp = AbstractClock::nanosToMicro($event->getEpochNanos());
 
         $eventValue = $event->getAttributes()->get("event") ?? $event->getName();
-        $allAttributes = [
-            'event' => $eventValue,
-            ...$event->getAttributes()->toArray()
-        ];
-        $allAttributesAsTags = self::buildTags($allAttributes);
+        $attributes = $event->getAttributes()->toArray();
+        $attributes['event'] = $eventValue;
+        $attributesAsTags = self::buildTags($attributes);
 
         return new Log([
             'timestamp' => $timestamp,
-            'fields' => $allAttributesAsTags
+            'fields' => $attributesAsTags
         ]);
     }
 }

--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -51,7 +51,7 @@ class SpanConverter
             'traceIdHigh' => $traceIdHigh,
             'spanId' => $spanId,
             'parentSpanId' => $parentSpanId,
-        ] = self::convertOtlpToJaegerIds($span);
+        ] = self::convertOtelToJaegerIds($span);
 
         $references = $tags = $logs = [];
         $startTime = AbstractClock::nanosToMicro($span->getStartEpochNanos());
@@ -85,7 +85,7 @@ class SpanConverter
             $tags[SpanConverter::KEY_INSTRUMENTATION_LIBRARY_VERSION] = $span->getInstrumentationLibrary()->getVersion();
         }
 
-        $jaegerSpanKind = self::convertOtlpSpanKindToJaeger($span);
+        $jaegerSpanKind = self::convertOtelSpanKindToJaeger($span);
         if ($jaegerSpanKind !== null) {
             $tags[self::KEY_SPAN_KIND] = $jaegerSpanKind;
         }
@@ -128,12 +128,12 @@ class SpanConverter
         ]);
     }
 
-    private static function convertOtlpToJaegerIds(SpanDataInterface $span): array
+    private static function convertOtelToJaegerIds(SpanDataInterface $span): array
     {
         [
             'traceIdLow' => $traceIdLow,
             'traceIdHigh' => $traceIdHigh
-        ] = self::convertOtlpToJaegerTraceIds($span->getContext()->getTraceID());
+        ] = self::convertOtelToJaegerTraceIds($span->getContext()->getTraceID());
 
         $spanId = intval($span->getContext()->getSpanID(), 16);
         $parentSpanId = intval($span->getParentSpanId(), 16);
@@ -146,7 +146,7 @@ class SpanConverter
         ];
     }
 
-    private static function convertOtlpToJaegerTraceIds(string $traceId): array
+    private static function convertOtelToJaegerTraceIds(string $traceId): array
     {
         $traceIdLow = intval(substr($traceId, 0, 16), 16);
         $traceIdHigh = intval(substr($traceId, 16, 32), 16);
@@ -157,7 +157,7 @@ class SpanConverter
         ];
     }
 
-    private static function convertOtlpSpanKindToJaeger(SpanDataInterface $span): ?string {
+    private static function convertOtelSpanKindToJaeger(SpanDataInterface $span): ?string {
         switch($span->getKind()) {
             case SpanKind::KIND_CLIENT:
                 return self::JAEGER_SPAN_KIND_CLIENT;

--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -24,10 +24,10 @@ class SpanConverter
     const KEY_INSTRUMENTATION_LIBRARY_NAME = 'otel.library.name';
     const KEY_INSTRUMENTATION_LIBRARY_VERSION = 'otel.library.version';
     const KEY_SPAN_KIND = 'span.kind';
-    const JAEGER_SPAN_KIND_CLIENT = "client";
-    const JAEGER_SPAN_KIND_SERVER = "server";
-    const JAEGER_SPAN_KIND_CONSUMER = "consumer";
-    const JAEGER_SPAN_KIND_PRODUCER = "producer";
+    const JAEGER_SPAN_KIND_CLIENT = 'client';
+    const JAEGER_SPAN_KIND_SERVER = 'server';
+    const JAEGER_SPAN_KIND_CONSUMER = 'consumer';
+    const JAEGER_SPAN_KIND_PRODUCER = 'producer';
 
     public function __construct()
     {
@@ -118,8 +118,9 @@ class SpanConverter
         ];
     }
 
-    private static function convertOtelSpanKindToJaeger(SpanDataInterface $span): ?string {
-        switch($span->getKind()) {
+    private static function convertOtelSpanKindToJaeger(SpanDataInterface $span): ?string
+    {
+        switch ($span->getKind()) {
             case SpanKind::KIND_CLIENT:
                 return self::JAEGER_SPAN_KIND_CLIENT;
             case SpanKind::KIND_SERVER:
@@ -135,7 +136,8 @@ class SpanConverter
         return null;
     }
 
-    private static function convertOtelSpanDataToJaegerTags(SpanDataInterface $span): array {
+    private static function convertOtelSpanDataToJaegerTags(SpanDataInterface $span): array
+    {
         $tags = [];
 
         if ($span->getStatus()->getCode() !== StatusCode::STATUS_UNSET) {
@@ -187,7 +189,7 @@ class SpanConverter
         // Zipkin tags must be strings, but opentelemetry
         // accepts strings, booleans, numbers, and lists of each.
         if (is_array($value)) {
-            return join(',', array_map(function($val) {
+            return join(',', array_map(function ($val) {
                 return self::sanitiseTagValue($val);
             }, $value));
         }
@@ -260,25 +262,26 @@ class SpanConverter
 
     private static function convertOtelEventsToJaegerLogs(SpanDataInterface $span): array
     {
-        return array_map(function($event) {
+        return array_map(
+            function ($event) {
                 return self::convertSingleOtelEventToJaegerLog($event);
-            }, 
+            },
             $span->getEvents()
         );
     }
 
-    private static function convertSingleOtelEventToJaegerLog(EventInterface $event): Log 
+    private static function convertSingleOtelEventToJaegerLog(EventInterface $event): Log
     {
         $timestamp = AbstractClock::nanosToMicro($event->getEpochNanos());
 
-        $eventValue = $event->getAttributes()->get("event") ?? $event->getName();
+        $eventValue = $event->getAttributes()->get('event') ?? $event->getName();
         $attributes = $event->getAttributes()->toArray();
         $attributes['event'] = $eventValue;
         $attributesAsTags = self::buildTags($attributes);
 
         return new Log([
             'timestamp' => $timestamp,
-            'fields' => $attributesAsTags
+            'fields' => $attributesAsTags,
         ]);
     }
 }

--- a/tests/Unit/Contrib/JaegerSpanConverterTest.php
+++ b/tests/Unit/Contrib/JaegerSpanConverterTest.php
@@ -17,10 +17,10 @@ use PHPUnit\Framework\TestCase;
  */
 class JaegerSpanConverterTest extends TestCase
 {
-    public function test_should_convert_an_otlp_span_to_a_jaeger_thrift_span()
+    public function test_should_convert_an_otel_span_to_a_jaeger_thrift_span()
     {
         $span = (new SpanData())
-                    ->setName('otlpSpanName');
+                    ->setName('otelSpanName');
 
         $jtSpan = (new SpanConverter())->convert($span);
 
@@ -28,7 +28,7 @@ class JaegerSpanConverterTest extends TestCase
         $this->assertSame(0, $jtSpan->traceIdHigh);
         $this->assertSame(0, $jtSpan->spanId);
         $this->assertSame(0, $jtSpan->parentSpanId);
-        $this->assertSame('otlpSpanName', $jtSpan->operationName);
+        $this->assertSame('otelSpanName', $jtSpan->operationName);
         $this->assertSame([], $jtSpan->references);
         $this->assertSame(0, $jtSpan->flags);
         $this->assertSame(1505855794194009, $jtSpan->startTime);

--- a/tests/Unit/Contrib/JaegerSpanConverterTest.php
+++ b/tests/Unit/Contrib/JaegerSpanConverterTest.php
@@ -102,15 +102,16 @@ class JaegerSpanConverterTest extends TestCase
 
         $jtSpan = (new SpanConverter())->convert($span);
 
-        $this->assertSame("span.kind", $jtSpan->tags[0]->key);
+        $this->assertSame('span.kind', $jtSpan->tags[0]->key);
         $this->assertSame($expectedJaegerTagValue, $jtSpan->tags[0]->vStr);
     }
 
-    public function provideSpanKindInputsAndExpectations() {
-        yield [SpanKind::KIND_CLIENT, "client"];
-        yield [SpanKind::KIND_SERVER, "server"];
-        yield [SpanKind::KIND_CONSUMER, "consumer"];
-        yield [SpanKind::KIND_PRODUCER, "producer"];
+    public function provideSpanKindInputsAndExpectations()
+    {
+        yield [SpanKind::KIND_CLIENT, 'client'];
+        yield [SpanKind::KIND_SERVER, 'server'];
+        yield [SpanKind::KIND_CONSUMER, 'consumer'];
+        yield [SpanKind::KIND_PRODUCER, 'producer'];
     }
 
     public function test_span_kind_internal_should_not_create_jaeger_thrift_tag()
@@ -126,36 +127,48 @@ class JaegerSpanConverterTest extends TestCase
     public function test_should_correctly_convert_span_event_to_jaeger_log()
     {
         $span = (new SpanData())
-                    ->setEvents([
-                        new Event("eventName", 1505855794194009601, new Attributes([
-                            "eventAttributeKey" => "eventAttributeValue"
-                        ]))
-                        ]);
+                    ->setEvents(
+                        [
+                        new Event(
+                            'eventName',
+                            1505855794194009601,
+                            new Attributes([
+                                    'eventAttributeKey' => 'eventAttributeValue',
+                                ])
+                        ),
+                        ]
+                    );
 
-                        $jtSpan = (new SpanConverter())->convert($span);
+        $jtSpan = (new SpanConverter())->convert($span);
 
         $this->assertSame($jtSpan->logs[0]->timestamp, 1505855794194009);
 
-        $this->assertSame($jtSpan->logs[0]->fields[0]->key, "eventAttributeKey");
-        $this->assertSame($jtSpan->logs[0]->fields[0]->vStr, "eventAttributeValue");
-        $this->assertSame($jtSpan->logs[0]->fields[1]->key, "event");
-        $this->assertSame($jtSpan->logs[0]->fields[1]->vStr, "eventName");
+        $this->assertSame($jtSpan->logs[0]->fields[0]->key, 'eventAttributeKey');
+        $this->assertSame($jtSpan->logs[0]->fields[0]->vStr, 'eventAttributeValue');
+        $this->assertSame($jtSpan->logs[0]->fields[1]->key, 'event');
+        $this->assertSame($jtSpan->logs[0]->fields[1]->vStr, 'eventName');
     }
 
     public function test_should_use_event_attribute_from_event_if_present_for_jaeger_log()
     {
         $span = (new SpanData())
-                    ->setEvents([
-                        new Event("eventName", 1505855794194009601, new Attributes([
-                            "event" => "valueForTheEventAttributeOnTheEvent"
-                        ]))
-                        ]);
+                    ->setEvents(
+                        [
+                        new Event(
+                            'eventName',
+                            1505855794194009601,
+                            new Attributes([
+                                    'event' => 'valueForTheEventAttributeOnTheEvent',
+                                ])
+                        ),
+                        ]
+                    );
 
-                        $jtSpan = (new SpanConverter())->convert($span);
+        $jtSpan = (new SpanConverter())->convert($span);
 
         $this->assertSame($jtSpan->logs[0]->timestamp, 1505855794194009);
 
-        $this->assertSame($jtSpan->logs[0]->fields[0]->key, "event");
-        $this->assertSame($jtSpan->logs[0]->fields[0]->vStr, "valueForTheEventAttributeOnTheEvent");
+        $this->assertSame($jtSpan->logs[0]->fields[0]->key, 'event');
+        $this->assertSame($jtSpan->logs[0]->fields[0]->vStr, 'valueForTheEventAttributeOnTheEvent');
     }
 }


### PR DESCRIPTION
Implements the following sections of the spec

[SpanKind](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#spankind)
[Events](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#events)

Also did some refactoring of the SpanConverter.php file since I was getting confused keeping track of where stuff was at first.

Main thing I was unsure about was how to do an array_map with a static method (ended up wrapping in an anonymous function but that seemed odd)