### PR TITLE
fixing psalm error

### DIFF
--- a/src/SDK/Trace/RandomIdGenerator.php
+++ b/src/SDK/Trace/RandomIdGenerator.php
@@ -21,7 +21,10 @@ class RandomIdGenerator implements IdGeneratorInterface
         return $this->randomHex(self::SPAN_ID_HEX_LENGTH);
     }
 
-    public function randomHex(int $hexLength): string
+    /**
+     * @psalm-suppress ArgumentTypeCoercion $hexLength is always a positive integer
+     */
+    private function randomHex(int $hexLength): string
     {
         try {
             return bin2hex(random_bytes(intdiv($hexLength, 2)));


### PR DESCRIPTION
psalm has started to complain that random_bytes must receive a positive integer. We always
provide a positive integer, so suppress the warning. In passing, make randomHex method
private, since it is not called from anywhere that I can find.