### PR TITLE
Adding ResourceInfo attributes to Span attributes

### DIFF
--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -412,6 +412,11 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
         return $this->resource;
     }
 
+    public function addResourceToAttributes(): void
+    {
+        $this->setAttributes($this->resource->getAttributes());
+    }
+
     private function getImmutableAttributes(): AttributesInterface
     {
         if (null === $this->attributes) {

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -72,6 +72,7 @@ class BatchSpanProcessor implements SpanProcessorInterface
      */
     public function onStart(ReadWriteSpanInterface $span, ?Context $parentContext = null): void
     {
+        $span->addResourceToAttributes();
     }
 
     /**

--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -26,6 +26,7 @@ class SimpleSpanProcessor implements SpanProcessorInterface
     /** @inheritDoc */
     public function onStart(ReadWriteSpanInterface $span, ?Context $parentContext = null): void
     {
+        $span->addResourceToAttributes();
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
PR for issue #225. Adding ResourceInfo attributes to Span attributes that can be exported to backends. Currently, there are a handful of ResourceInfo attributes that the Resource Detectors detect. Adding ResourceInfo attributes to Span attributes consumes the AttributeLimit. Adding more detectors or setting less AttributeLimit by the user could result In user attributes not getting set and reported.