### PR TITLE
Refactored Environment.php to use Environment constants and accessor

### DIFF
--- a/src/SDK/Resource/Detectors/Environment.php
+++ b/src/SDK/Resource/Detectors/Environment.php
@@ -4,33 +4,27 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Resource\Detectors;
 
-use function explode;
-use function getenv;
 use OpenTelemetry\SDK\Attributes;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\Resolver as EnvResolver;
+use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SemConv\ResourceAttributes;
-use function strpos;
-use function trim;
 
 /**
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable
  */
 final class Environment implements ResourceDetectorInterface
 {
+    use EnvironmentVariablesTrait;
+
     public function getResource(): ResourceInfo
     {
-        $attributes = [];
+        $attributes = $this->getMapFromEnvironment(Env::OTEL_RESOURCE_ATTRIBUTES, '');
 
-        $string = getenv('OTEL_RESOURCE_ATTRIBUTES');
-        if ($string && false !== strpos($string, '=')) {
-            foreach (explode(',', $string) as $pair) {
-                [$key, $value] = explode('=', $pair);
-                $attributes[trim($key)] = trim($value);
-            }
-        }
         //@see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration
-        $serviceName = getenv('OTEL_SERVICE_NAME');
+        $serviceName = EnvResolver::hasVariable(Env::OTEL_SERVICE_NAME) ? $this->getStringFromEnvironment(Env::OTEL_SERVICE_NAME) : null;
         if ($serviceName) {
             $attributes[ResourceAttributes::SERVICE_NAME] = $serviceName;
         }

--- a/tests/Unit/SDK/Resource/ResourceTest.php
+++ b/tests/Unit/SDK/Resource/ResourceTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK\Resource;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use Composer\InstalledVersions;
+use InvalidArgumentException;
 use OpenTelemetry\SDK\Attributes;
 use OpenTelemetry\SDK\Resource\Detectors;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
@@ -165,6 +166,7 @@ class ResourceTest extends TestCase
     public function test_resource_with_invalid_environment_variable(): void
     {
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'foo');
+        $this->expectException(InvalidArgumentException::class);
         $this->assertInstanceOf(ResourceInfo::class, ResourceInfo::defaultResource());
     }
 


### PR DESCRIPTION
PR for #586. Using accessor and environment constant to fetch attributes from the environment variable. However, according to the [environment variable SDK configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration), OTEL_SERVICE_NAME has no default value. This will give an exception because of the way Accessor is implemented. Adding the conditional fetch for value of OTEL_SERVICE_NAME.