### PR TITLE
Add support for OTLP signal specific environment overrides [#590]

### DIFF
--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -11,7 +11,6 @@ use OpenTelemetry\Contrib\Otlp\SpanConverter;
 use Opentelemetry\Proto\Collector\Trace\V1\ExportTraceServiceRequest;
 use Opentelemetry\Proto\Collector\Trace\V1\TraceServiceClient;
 use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
-use OpenTelemetry\SDK\Common\Environment\Resolver as EnvResolver;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SDK\Trace\Behavior\SpanExporterTrait;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
@@ -53,20 +52,20 @@ class Exporter implements SpanExporterInterface
         $this->certificateFile = $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE)
             ?: $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);
 
-        $this->compression = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
+        $this->compression = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
             $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) :
             $this->getEnumFromEnvironment(
                 Env::OTEL_EXPORTER_OTLP_COMPRESSION,
                 $compression ? Values::VALUE_GZIP : Values::VALUE_NONE
             );
 
-        $this->timeout = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT) ?
+        $this->timeout = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT) ?
             $this->getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, $timeout) :
             $this->getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TIMEOUT, $timeout);
 
         $this->setSpanConverter(new SpanConverter());
 
-        $this->metadata = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
+        $this->metadata = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
             $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS, $headers) :
             $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS, $headers);
 

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -48,9 +48,7 @@ class Exporter implements SpanExporterInterface
         int $timeout = 10,
         TraceServiceClient $client = null
     ) {
-        $this->insecure = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE) ?
-            $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE, $insecure) :
-            $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
+        $this->insecure = $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
 
         $this->certificateFile = $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE)
             ?: $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -14,7 +14,6 @@ use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SDK\Trace\Behavior\SpanExporterTrait;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
-use OpenTelemetry\SDK\Common\Environment\Resolver as EnvResolver;
 
 class Exporter implements SpanExporterInterface
 {
@@ -48,18 +47,16 @@ class Exporter implements SpanExporterInterface
         int $timeout = 10,
         TraceServiceClient $client = null
     ) {
-
         $this->insecure = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_INSECURE) ?
             $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure) :
             $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
 
-        if (!empty($certificateFile) || EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_CERTIFICATE)) 
-            {
-                $this->certificateFile = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) ?
+        if (!empty($certificateFile) || $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_CERTIFICATE)) {
+            $this->certificateFile = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) ?
                     $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) :
                     $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);
-            }
-        
+        }
+
         $this->compression = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
             $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) :
             $this->getEnumFromEnvironment(

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -48,24 +48,34 @@ class Exporter implements SpanExporterInterface
         int $timeout = 10,
         TraceServiceClient $client = null
     ) {
-        // Set default values based on presence of env variable
-        $this->insecure = $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
-        if (!empty($certificateFile) || EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_CERTIFICATE)) {
-            $this->certificateFile = $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);
-        }
-        $this->compression = $this->getEnumFromEnvironment(
-            Env::OTEL_EXPORTER_OTLP_COMPRESSION,
-            $compression ? Values::VALUE_GZIP : Values::VALUE_NONE
-        );
-        $this->timeout = $this->getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TIMEOUT, $timeout);
+        $this->insecure = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE) ?
+            $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE, $insecure) :
+            $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
+
+        $this->certificateFile = $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE)
+            ?: $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);
+
+        $this->compression = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
+            $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) :
+            $this->getEnumFromEnvironment(
+                Env::OTEL_EXPORTER_OTLP_COMPRESSION,
+                $compression ? Values::VALUE_GZIP : Values::VALUE_NONE
+            );
+
+        $this->timeout = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT) ?
+            $this->getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, $timeout) :
+            $this->getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TIMEOUT, $timeout);
 
         $this->setSpanConverter(new SpanConverter());
 
-        $this->metadata = $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS, $headers);
+        $this->metadata = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
+            $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS, $headers) :
+            $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS, $headers);
 
         $opts = $this->getClientOptions();
 
         $this->client = $client ?? new TraceServiceClient(
+            $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) ?:
             $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, $endpointURL),
             $opts
         );

--- a/src/Contrib/OtlpHttp/Exporter.php
+++ b/src/Contrib/OtlpHttp/Exporter.php
@@ -11,7 +11,6 @@ use Nyholm\Dsn\DsnParser;
 use OpenTelemetry\Contrib\Otlp\ExporterTrait;
 use OpenTelemetry\Contrib\Otlp\SpanConverter;
 use Opentelemetry\Proto\Collector\Trace\V1\ExportTraceServiceRequest;
-use OpenTelemetry\SDK\Common\Environment\Resolver as EnvResolver;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SDK\Trace\Behavior\HttpSpanExporterTrait;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
@@ -65,11 +64,11 @@ class Exporter implements SpanExporterInterface
             )
         );
 
-        $this->headers = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
+        $this->headers = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
             $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) :
             $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS);
 
-        $this->compression = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
+        $this->compression = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
             $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, self::DEFAULT_COMPRESSION) :
             $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_COMPRESSION, self::DEFAULT_COMPRESSION);
 
@@ -78,7 +77,7 @@ class Exporter implements SpanExporterInterface
         $this->setStreamFactory($streamFactory);
         $this->setSpanConverter($spanConverter ?? new SpanConverter());
 
-        $protocol = EnvResolver::hasVariable(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) ?
+        $protocol = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) ?
             $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, self::OTLP_PROTOCOL) :
             $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_PROTOCOL, self::OTLP_PROTOCOL);
 

--- a/src/Contrib/OtlpHttp/Exporter.php
+++ b/src/Contrib/OtlpHttp/Exporter.php
@@ -18,7 +18,6 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use OpenTelemetry\SDK\Common\Environment\Resolver as EnvResolver;
 
 class Exporter implements SpanExporterInterface
 {
@@ -56,7 +55,8 @@ class Exporter implements SpanExporterInterface
         StreamFactoryInterface $streamFactory,
         SpanConverter $spanConverter = null
     ) {
-        $tracesEndpoint = $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) ?:
+        $tracesEndpoint = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) ?
+            $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) :
             $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, self::DEFAULT_ENDPOINT);
 
         $this->setEndpointUrl(

--- a/src/Contrib/OtlpHttp/Exporter.php
+++ b/src/Contrib/OtlpHttp/Exporter.php
@@ -18,6 +18,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use OpenTelemetry\SDK\Common\Environment\Resolver as EnvResolver;
 
 class Exporter implements SpanExporterInterface
 {

--- a/src/SDK/Common/Environment/EnvironmentVariablesTrait.php
+++ b/src/SDK/Common/Environment/EnvironmentVariablesTrait.php
@@ -46,4 +46,9 @@ trait EnvironmentVariablesTrait
     {
         return Accessor::getRatio($key, $default ? (string) $default : null);
     }
+
+    public function hasEnvironmentVariable(string $key): bool
+    {
+        return Resolver::hasVariable($key);
+    }
 }


### PR DESCRIPTION
Fixes #590 
Modified the OTLP gPRC and HTTP trace exporters to allow for configuration options overrides by signal specific options to comply with OpenTelemetry specs.