### PR TITLE
ignoring some new phpstan failures

### DIFF
--- a/tests/Unit/Contrib/AbstractHttpExporterTest.php
+++ b/tests/Unit/Contrib/AbstractHttpExporterTest.php
@@ -133,6 +133,7 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
     {
         $exporterClass = static::getExporterClass();
 
+        // @phpstan-ignore-next-line
         $this->assertNotSame(
             call_user_func([$exporterClass, 'fromConnectionString'], self::EXPORTER_DSN, $exporterClass, 'foo'),
             call_user_func([$exporterClass, 'fromConnectionString'], self::EXPORTER_DSN, $exporterClass, 'foo')

--- a/tests/Unit/Contrib/OTLPGrpcExporterTest.php
+++ b/tests/Unit/Contrib/OTLPGrpcExporterTest.php
@@ -207,6 +207,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
 
     public function test_from_connection_string(): void
     {
+        // @phpstan-ignore-next-line
         $this->assertNotSame(
             Exporter::fromConnectionString(),
             Exporter::fromConnectionString()

--- a/tests/Unit/Contrib/OTLPHttpExporterTest.php
+++ b/tests/Unit/Contrib/OTLPHttpExporterTest.php
@@ -212,6 +212,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
 
     public function test_from_connection_string(): void
     {
+        // @phpstan-ignore-next-line
         $this->assertNotSame(
             Exporter::fromConnectionString(),
             Exporter::fromConnectionString()


### PR DESCRIPTION
phpstan has just started to fail on a couple of test assertions based on their phpdoc return type, eg:
`Call to method PHPUnit\Framework\Assert::assertNotSame() with mixed and mixed will always evaluate to false`
This doesn't consider that assert<Not>Same will also check for whether two objects are the same instance, so
ignore the error.