### PR TITLE
Add support for schemaUrl in TracerProvider and OTLP SpanConverter

### DIFF
--- a/src/API/Trace/TracerProviderInterface.php
+++ b/src/API/Trace/TracerProviderInterface.php
@@ -9,8 +9,6 @@ interface TracerProviderInterface
 {
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/api.md#get-a-tracer
-     *
-     * @todo: Support `schemaUrl`.
      */
-    public function getTracer(string $name, ?string $version = null): TracerInterface;
+    public function getTracer(string $name, ?string $version = null, ?string $schemaUrl = null): TracerInterface;
 }

--- a/src/Contrib/Otlp/SpanConverter.php
+++ b/src/Contrib/Otlp/SpanConverter.php
@@ -185,16 +185,17 @@ class SpanConverter implements SpanConverterInterface
     {
         $isSpansEmpty = true; //Waiting for the loop to prove otherwise
 
-        $ils = $convertedSpans = [];
+        $ils = $convertedSpans = $schemas = [];
         foreach ($spans as $span) {
             $isSpansEmpty = false;
 
             /** @var \OpenTelemetry\SDK\InstrumentationLibrary $il */
             $il = $span->getInstrumentationLibrary();
-            $ilKey = sprintf('%s@%s', $il->getName(), $il->getVersion()??'');
+            $ilKey = sprintf('%s@%s %s', $il->getName(), $il->getVersion()??'', $il->getSchemaUrl()??'');
             if (!isset($ils[$ilKey])) {
                 $convertedSpans[$ilKey] = [];
                 $ils[$ilKey] = new InstrumentationLibrary(['name' => $il->getName(), 'version' => $il->getVersion()??'']);
+                $schemas[$ilKey] = $il->getSchemaUrl();
             }
             $convertedSpans[$ilKey][] = $this->as_otlp_span($span);
         }
@@ -208,6 +209,7 @@ class SpanConverter implements SpanConverterInterface
             $ilSpans[] = new InstrumentationLibrarySpans([
                 'instrumentation_library' => $il,
                 'spans' => $convertedSpans[$ilKey],
+                'schema_url' => $schemas[$ilKey] ?? '',
             ]);
         }
 

--- a/src/SDK/InstrumentationLibrary.php
+++ b/src/SDK/InstrumentationLibrary.php
@@ -18,7 +18,7 @@ class InstrumentationLibrary
     public static function getEmpty(): InstrumentationLibrary
     {
         if (null === self::$empty) {
-            self::$empty = new self('', null);
+            self::$empty = new self('', null, null);
         }
 
         return self::$empty;
@@ -26,11 +26,13 @@ class InstrumentationLibrary
 
     private string $name;
     private ?string $version;
+    private ?string $schemaUrl;
 
-    public function __construct(string $name, ?string $version = null)
+    public function __construct(string $name, ?string $version = null, ?string $schemaUrl = null)
     {
         $this->name = $name;
         $this->version = $version;
+        $this->schemaUrl = $schemaUrl;
     }
 
     public function getName(): string
@@ -41,5 +43,10 @@ class InstrumentationLibrary
     public function getVersion(): ?string
     {
         return $this->version;
+    }
+
+    public function getSchemaUrl(): ?string
+    {
+        return $this->schemaUrl;
     }
 }

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -60,19 +60,19 @@ final class TracerProvider implements API\TracerProviderInterface
     }
 
     /** @inheritDoc */
-    public function getTracer(string $name = self::DEFAULT_TRACER_NAME, ?string $version = null): API\TracerInterface
+    public function getTracer(string $name = self::DEFAULT_TRACER_NAME, ?string $version = null, ?string $schemaUrl = null): API\TracerInterface
     {
         if ($this->tracerSharedState->hasShutdown()) {
             return NoopTracer::getInstance();
         }
 
-        $key = sprintf('%s@%s', $name, ($version ?? 'unknown'));
+        $key = sprintf('%s@%s %s', $name, ($version ?? 'unknown'), ($schemaUrl ?? ''));
 
         if (isset($this->tracers[$key]) && $this->tracers[$key] instanceof API\TracerInterface) {
             return $this->tracers[$key];
         }
 
-        $instrumentationLibrary = new InstrumentationLibrary($name, $version);
+        $instrumentationLibrary = new InstrumentationLibrary($name, $version, $schemaUrl);
 
         $tracer = new Tracer(
             $this->tracerSharedState,

--- a/tests/Integration/SDK/TracerTest.php
+++ b/tests/Integration/SDK/TracerTest.php
@@ -71,13 +71,14 @@ class TracerTest extends TestCase
     public function test_span_should_receive_instrumentation_library(): void
     {
         $tracerProvider = new TracerProvider();
-        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest', 'dev');
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest', 'dev', 'http://url');
         /** @var Span $span */
         $span = $tracer->spanBuilder('test.span')->startSpan();
         $spanInstrumentationLibrary = $span->getInstrumentationLibrary();
 
         $this->assertEquals('OpenTelemetry.TracerTest', $spanInstrumentationLibrary->getName());
         $this->assertEquals('dev', $spanInstrumentationLibrary->getVersion());
+        $this->assertEquals('http://url', $spanInstrumentationLibrary->getSchemaUrl());
     }
 
     public function test_span_builder_propagates_instrumentation_library_info_to_span(): void

--- a/tests/Unit/Context/ScopeTest.php
+++ b/tests/Unit/Context/ScopeTest.php
@@ -51,7 +51,7 @@ class ScopeTest extends TestCase
         $scope1 = Context::attach(Context::getCurrent());
 
         $this->assertSame(0, $scope1->detach());
-        $this->assertSame(ScopeInterface::DETACHED, $scope1->detach() & ScopeInterface::DETACHED); // @phpstan-ignore-line
+        $this->assertSame(ScopeInterface::DETACHED, $scope1->detach() & ScopeInterface::DETACHED);
     }
 
     public function test_order_mismatch_scope_detach(): void

--- a/tests/Unit/Contrib/AbstractHttpExporterTest.php
+++ b/tests/Unit/Contrib/AbstractHttpExporterTest.php
@@ -133,7 +133,6 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
     {
         $exporterClass = static::getExporterClass();
 
-        // @phpstan-ignore-next-line
         $this->assertNotSame(
             call_user_func([$exporterClass, 'fromConnectionString'], self::EXPORTER_DSN, $exporterClass, 'foo'),
             call_user_func([$exporterClass, 'fromConnectionString'], self::EXPORTER_DSN, $exporterClass, 'foo')

--- a/tests/Unit/Contrib/OTLPGrpcExporterTest.php
+++ b/tests/Unit/Contrib/OTLPGrpcExporterTest.php
@@ -207,7 +207,6 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
 
     public function test_from_connection_string(): void
     {
-        // @phpstan-ignore-next-line
         $this->assertNotSame(
             Exporter::fromConnectionString(),
             Exporter::fromConnectionString()

--- a/tests/Unit/Contrib/OTLPHttpExporterTest.php
+++ b/tests/Unit/Contrib/OTLPHttpExporterTest.php
@@ -212,7 +212,6 @@ class OTLPHttpExporterTest extends AbstractExporterTest
 
     public function test_from_connection_string(): void
     {
-        // @phpstan-ignore-next-line
         $this->assertNotSame(
             Exporter::fromConnectionString(),
             Exporter::fromConnectionString()

--- a/tests/Unit/Contrib/OTLPSpanConverterTest.php
+++ b/tests/Unit/Contrib/OTLPSpanConverterTest.php
@@ -164,7 +164,7 @@ class OTLPSpanConverterTest extends TestCase
             ->setStartEpochNanos($start_time)
             ->setEndEpochNanos($end_time)
             ->setName('http_get')
-            ->setInstrumentationLibrary(new InstrumentationLibrary('lib-test', 'v0.1.0'))
+            ->setInstrumentationLibrary(new InstrumentationLibrary('lib-test', 'v0.1.0', 'http://url'))
             ->addAttribute('user', 'alice')
             ->addAttribute('authenticated', true)
             ->addEvent('Event1', new Attributes(['success' => 'yes']), 1617313804325769955)
@@ -239,6 +239,7 @@ class OTLPSpanConverterTest extends TestCase
                             'dropped_links_count' => 0,
                         ]),
                     ],
+                    'schema_url' => 'http://url',
                 ]),
             ],
         ]);

--- a/tests/Unit/SDK/Trace/TracerProviderTest.php
+++ b/tests/Unit/SDK/Trace/TracerProviderTest.php
@@ -25,7 +25,41 @@ class TracerProviderTest extends TestCase
 
         $t1 = $provider->getTracer('foo');
         $t2 = $provider->getTracer('foo');
+        $t3 = $provider->getTracer('bar');
+
+        $this->assertSame($t1, $t2);
+        $this->assertNotSame($t1, $t3);
+        $this->assertNotSame($t2, $t3);
+    }
+
+    /**
+     * @covers ::getTracer
+     * @covers ::__construct
+     */
+    public function test_reuses_same_instance_with_version(): void
+    {
+        $provider = new TracerProvider(null);
+
+        $t1 = $provider->getTracer('foo', '1.0.0');
+        $t2 = $provider->getTracer('foo', '1.0.0');
         $t3 = $provider->getTracer('foo', '2.0.0');
+
+        $this->assertSame($t1, $t2);
+        $this->assertNotSame($t1, $t3);
+        $this->assertNotSame($t2, $t3);
+    }
+
+    /**
+     * @covers ::getTracer
+     * @covers ::__construct
+     */
+    public function test_reuses_same_instance_with_schema(): void
+    {
+        $provider = new TracerProvider(null);
+
+        $t1 = $provider->getTracer('foo', '2.0.0', 'http://url');
+        $t2 = $provider->getTracer('foo', '2.0.0', 'http://url');
+        $t3 = $provider->getTracer('foo', '2.0.0', 'http://schemaurl');
 
         $this->assertSame($t1, $t2);
         $this->assertNotSame($t1, $t3);


### PR DESCRIPTION
This PR addresses #445 by adding `schemaUrl` to the `InstrumentationLibrary` and OTLP Span converter.

`schemaUrl` for the `Resource` is already in code but it needs some rework in exporter for proper handling, which is the subject for dedicated PR.