### PR TITLE
Revert "ignoring some new phpstan failures"

### DIFF
--- a/tests/Unit/Contrib/AbstractHttpExporterTest.php
+++ b/tests/Unit/Contrib/AbstractHttpExporterTest.php
@@ -133,7 +133,6 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
     {
         $exporterClass = static::getExporterClass();
 
-        // @phpstan-ignore-next-line
         $this->assertNotSame(
             call_user_func([$exporterClass, 'fromConnectionString'], self::EXPORTER_DSN, $exporterClass, 'foo'),
             call_user_func([$exporterClass, 'fromConnectionString'], self::EXPORTER_DSN, $exporterClass, 'foo')

--- a/tests/Unit/Contrib/OTLPGrpcExporterTest.php
+++ b/tests/Unit/Contrib/OTLPGrpcExporterTest.php
@@ -207,7 +207,6 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
 
     public function test_from_connection_string(): void
     {
-        // @phpstan-ignore-next-line
         $this->assertNotSame(
             Exporter::fromConnectionString(),
             Exporter::fromConnectionString()

--- a/tests/Unit/Contrib/OTLPHttpExporterTest.php
+++ b/tests/Unit/Contrib/OTLPHttpExporterTest.php
@@ -212,7 +212,6 @@ class OTLPHttpExporterTest extends AbstractExporterTest
 
     public function test_from_connection_string(): void
     {
-        // @phpstan-ignore-next-line
         $this->assertNotSame(
             Exporter::fromConnectionString(),
             Exporter::fromConnectionString()


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-php#604 - upstream fixes in phpstan no longer complains about `assertSame`