### PR TITLE
Resource Detector Unit Tests

### DIFF
--- a/tests/Unit/SDK/Resource/Detectors/ComposerTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ComposerTest.php
@@ -22,8 +22,6 @@ class ComposerTest extends TestCase
         $version = InstalledVersions::getPrettyVersion($name);
 
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
         $this->assertSame($name, $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
         $this->assertSame($version, $resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
     }

--- a/tests/Unit/SDK/Resource/Detectors/ComposerTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ComposerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use Composer\InstalledVersions;
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\Composer
+ */
+class ComposerTest extends TestCase
+{
+    public function test_composer_get_resource(): void
+    {
+        $resouceDetector = new Detectors\Composer();
+        $resource = $resouceDetector->getResource();
+        $name = 'open-telemetry/opentelemetry';
+        $version = InstalledVersions::getPrettyVersion($name);
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
+        $this->assertSame($name, $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        $this->assertSame($version, $resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/CompositeTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/CompositeTest.php
@@ -6,8 +6,8 @@ namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
 
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
-use OpenTelemetry\SemConv\ResourceAttributes;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,43 +24,17 @@ class CompositeTest extends TestCase
         $this->assertEmpty($resource->getAttributes());
     }
 
-    /**
-     * @dataProvider resourceDetectorProvider
-     */
-    public function test_composite_get_resource(iterable $resourceDetectors, array $expectedAttributes, ?string $expectedSchemaURL): void
+    public function test_composite_get_resource(): void
     {
-        $resource = (new Detectors\Composite($resourceDetectors))->getResource();
-        foreach ($expectedAttributes as $name => $value) {
-            $this->assertSame($value, $resource->getAttributes()->get($name));
-        }
-        $this->assertSame($expectedSchemaURL, $resource->getSchemaUrl());
-    }
+        $resource = ResourceInfo::create(new Attributes(['foo' => 'user-foo', 'bar' => 'user-bar']));
 
-    public function resourceDetectorProvider()
-    {
-        return [
-            'Sdks' => [
-                [
-                    new Detectors\Sdk(),
-                    new Detectors\SdkProvided(),
-                ],
-                [
-                    ResourceAttributes::TELEMETRY_SDK_NAME => 'opentelemetry',
-                    ResourceAttributes::TELEMETRY_SDK_LANGUAGE => 'php',
-                    ResourceAttributes::SERVICE_NAME => 'unknown_service',
-                ],
-                ResourceAttributes::SCHEMA_URL,
-            ],
-            'Constant' => [
-                [
-                    new Detectors\Constant(ResourceInfo::create(new Attributes(['foo' => 'constant-foo', 'bar' => 'constant-bar']))),
-                ],
-                [
-                    'foo' => 'constant-foo',
-                    'bar' => 'constant-bar',
-                ],
-                null,
-            ],
-        ];
+        $resourceDetector = $this->createMock(ResourceDetectorInterface::class);
+        $resourceDetector->method('getResource')->willReturn($resource);
+
+        $resource = (new Detectors\Composite([$resourceDetector]))->getResource();
+
+        $this->assertSame('user-foo', $resource->getAttributes()->get('foo'));
+        $this->assertSame('user-bar', $resource->getAttributes()->get('bar'));
+        $this->assertNull($resource->getSchemaUrl());
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/CompositeTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/CompositeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\Composite
+ */
+class CompositeTest extends TestCase
+{
+    public function test_composite_with_empty_resource_detectors(): void
+    {
+        $resouceDetector = new Detectors\Composite([]);
+        $resource = $resouceDetector->getResource();
+
+        $this->assertNull($resource->getSchemaUrl());
+        $this->assertEmpty($resource->getAttributes());
+    }
+
+    /**
+     * @dataProvider resourceDetectorProvider
+     */
+    public function test_composite_get_resource(iterable $resourceDetectors, array $expectedAttributes, ?string $expectedSchemaURL): void
+    {
+        $resource = (new Detectors\Composite($resourceDetectors))->getResource();
+        foreach ($expectedAttributes as $name => $value) {
+            $this->assertSame($value, $resource->getAttributes()->get($name));
+        }
+        $this->assertSame($expectedSchemaURL, $resource->getSchemaUrl());
+    }
+
+    public function resourceDetectorProvider()
+    {
+        return [
+            'Sdks' => [
+                [
+                    new Detectors\Sdk(),
+                    new Detectors\SdkProvided(),
+                ],
+                [
+                    ResourceAttributes::TELEMETRY_SDK_NAME => 'opentelemetry',
+                    ResourceAttributes::TELEMETRY_SDK_LANGUAGE => 'php',
+                    ResourceAttributes::SERVICE_NAME => 'unknown_service',
+                ],
+                ResourceAttributes::SCHEMA_URL,
+            ],
+            'Constant' => [
+                [
+                    new Detectors\Constant(ResourceInfo::create(new Attributes(['foo' => 'constant-foo', 'bar' => 'constant-bar']))),
+                ],
+                [
+                    'foo' => 'constant-foo',
+                    'bar' => 'constant-bar',
+                ],
+                null,
+            ],
+        ];
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/ConstantTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ConstantTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\Constant
+ */
+class ConstantTest extends TestCase
+{
+    public function test_constant_get_resource_with_empty_resource(): void
+    {
+        $resouceDetector = new Detectors\Constant(ResourceInfo::create(new Attributes()));
+        $resource = $resouceDetector->getResource();
+
+        $this->assertNull($resource->getSchemaUrl());
+        $this->assertEmpty($resource->getAttributes());
+    }
+
+    public function test_constant_get_resource_with_custom_resource(): void
+    {
+        $resouceDetector = new Detectors\Constant(ResourceInfo::create(new Attributes(['foo' => 'user-foo', 'bar' => 'user-bar'])));
+        $resource = $resouceDetector->getResource();
+
+        $this->assertNull($resource->getSchemaUrl());
+
+        $this->assertSame('user-foo', $resource->getAttributes()->get('foo'));
+        $this->assertSame('user-bar', $resource->getAttributes()->get('bar'));
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/EnvironmentTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/EnvironmentTest.php
@@ -38,10 +38,8 @@ class EnvironmentTest extends TestCase
         $resouceDetector = new Detectors\Environment();
         $resource = $resouceDetector->getResource();
 
-        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
         $this->assertSame('value_foo', $resource->getAttributes()->get('key_foo'));
         $this->assertSame('value_bar', $resource->getAttributes()->get('key_bar'));
-        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
     }
 
     public function test_environment_get_resource_with_service_name(): void
@@ -51,7 +49,6 @@ class EnvironmentTest extends TestCase
         $resouceDetector = new Detectors\Environment();
         $resource = $resouceDetector->getResource();
 
-        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
         $this->assertNotEmpty($resource->getAttributes());
         $this->assertSame('test-service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
     }
@@ -63,7 +60,6 @@ class EnvironmentTest extends TestCase
         $resouceDetector = new Detectors\Environment();
         $resource = $resouceDetector->getResource();
 
-        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
         $this->assertNotEmpty($resource->getAttributes());
         $this->assertSame('test-service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
     }
@@ -76,7 +72,6 @@ class EnvironmentTest extends TestCase
         $resouceDetector = new Detectors\Environment();
         $resource = $resouceDetector->getResource();
 
-        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
         $this->assertNotEmpty($resource->getAttributes());
         $this->assertSame('user-test-service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
     }

--- a/tests/Unit/SDK/Resource/Detectors/EnvironmentTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/EnvironmentTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\Environment
+ */
+class EnvironmentTest extends TestCase
+{
+    use EnvironmentVariables;
+
+    public function tearDown(): void
+    {
+        $this->restoreEnvironmentVariables();
+    }
+
+    public function test_environment_default_get_resource(): void
+    {
+        $resouceDetector = new Detectors\Environment();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertEmpty($resource->getAttributes());
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+    }
+
+    public function test_environment_get_resource_with_resource_attributes(): void
+    {
+        $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'key_foo=value_foo,key_bar=value_bar');
+
+        $resouceDetector = new Detectors\Environment();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertSame('value_foo', $resource->getAttributes()->get('key_foo'));
+        $this->assertSame('value_bar', $resource->getAttributes()->get('key_bar'));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+    }
+
+    public function test_environment_get_resource_with_service_name(): void
+    {
+        $this->setEnvironmentVariable('OTEL_SERVICE_NAME', 'test-service');
+
+        $resouceDetector = new Detectors\Environment();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertNotEmpty($resource->getAttributes());
+        $this->assertSame('test-service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+    }
+
+    public function test_environment_get_resource_with_service_name_from_resource_attributes(): void
+    {
+        $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'service.name=test-service');
+
+        $resouceDetector = new Detectors\Environment();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertNotEmpty($resource->getAttributes());
+        $this->assertSame('test-service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+    }
+
+    public function test_environment_get_resource_service_name_precedence_over_resource_attributes(): void
+    {
+        $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', 'service.name=env-test-service');
+        $this->setEnvironmentVariable('OTEL_SERVICE_NAME', 'user-test-service');
+
+        $resouceDetector = new Detectors\Environment();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertNotEmpty($resource->getAttributes());
+        $this->assertSame('user-test-service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\Host
+ */
+class HostTest extends TestCase
+{
+    public function test_host_get_resource(): void
+    {
+        $resouceDetector = new Detectors\Host();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::HOST_NAME));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::HOST_ARCH));
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -19,7 +19,7 @@ class HostTest extends TestCase
         $resource = $resouceDetector->getResource();
 
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::HOST_NAME));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::HOST_ARCH));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_NAME));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_ARCH));
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/OperatingSystemTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/OperatingSystemTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\OperatingSystem
+ */
+class OperatingSystemTest extends TestCase
+{
+    public function test_operating_system_get_resource(): void
+    {
+        $resouceDetector = new Detectors\OperatingSystem();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::OS_TYPE));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::OS_DESCRIPTION));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::OS_NAME));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::OS_VERSION));
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/OperatingSystemTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/OperatingSystemTest.php
@@ -19,9 +19,9 @@ class OperatingSystemTest extends TestCase
         $resource = $resouceDetector->getResource();
 
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::OS_TYPE));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::OS_DESCRIPTION));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::OS_NAME));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::OS_VERSION));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::OS_TYPE));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::OS_DESCRIPTION));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::OS_NAME));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::OS_VERSION));
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/ProcessRuntimeTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ProcessRuntimeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\ProcessRuntime
+ */
+class ProcessRuntimeTest extends TestCase
+{
+    public function test_process_runtime_get_resource(): void
+    {
+        $resouceDetector = new Detectors\ProcessRuntime();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/ProcessRuntimeTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ProcessRuntimeTest.php
@@ -19,7 +19,7 @@ class ProcessRuntimeTest extends TestCase
         $resource = $resouceDetector->getResource();
 
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/ProcessTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ProcessTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\Process
+ */
+class ProcessTest extends TestCase
+{
+    public function test_process_get_resource(): void
+    {
+        $resouceDetector = new Detectors\Process();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
+        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/ProcessTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ProcessTest.php
@@ -19,9 +19,9 @@ class ProcessTest extends TestCase
         $resource = $resouceDetector->getResource();
 
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertIsInt($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
+        $this->assertIsArray($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/SdkProvidedTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/SdkProvidedTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\SdkProvided
+ */
+class SdkProvidedTest extends TestCase
+{
+    public function test_sdk_provided_get_resource(): void
+    {
+        $resouceDetector = new Detectors\SdkProvided();
+        $resource = $resouceDetector->getResource();
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertSame('unknown_service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+    }
+}

--- a/tests/Unit/SDK/Resource/Detectors/SdkTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/SdkTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
+
+use Composer\InstalledVersions;
+use OpenTelemetry\SDK\Resource\Detectors;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers OpenTelemetry\SDK\Resource\Detectors\Sdk
+ */
+class SdkTest extends TestCase
+{
+    public function test_sdk_get_resource(): void
+    {
+        $resouceDetector = new Detectors\Sdk();
+        $resource = $resouceDetector->getResource();
+        $version = InstalledVersions::getVersion('open-telemetry/opentelemetry');
+
+        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertSame('opentelemetry', $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_NAME));
+        $this->assertSame('php', $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_LANGUAGE));
+        $this->assertSame($version, $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_VERSION));
+    }
+}

--- a/tests/Unit/SDK/Resource/ResourceTest.php
+++ b/tests/Unit/SDK/Resource/ResourceTest.php
@@ -277,7 +277,7 @@ class ResourceTest extends TestCase
             'attributes from env var' => [
                 'foo=foo,bar=bar',
                 [],
-                ['foo' => 'foo'],
+                ['foo' => 'foo', 'bar' => 'bar'],
             ],
             'user attributes have higher priority' => [
                 'foo=env-foo,bar=env-bar,baz=env-baz',


### PR DESCRIPTION
Closes #622.

Added separate unit tests files for Resource Detectors. These tests highly overlap with tests in ResourceTest.php but they were not included in the coverage.