### PR TITLE
Resolve schemaUrl when merging ResourceInfo

### DIFF
--- a/src/SDK/Resource/ResourceInfoFactory.php
+++ b/src/SDK/Resource/ResourceInfoFactory.php
@@ -24,12 +24,12 @@ class ResourceInfoFactory
     public static function merge(ResourceInfo ...$resources): ResourceInfo
     {
         $attributes = [];
-        $schemaUrl = null;
 
         foreach ($resources as $resource) {
             $attributes += $resource->getAttributes()->toArray();
-            $schemaUrl ??= $resource->getSchemaUrl();
         }
+
+        $schemaUrl = self::mergeSchemaUrl(...$resources);
 
         return ResourceInfo::create(new Attributes($attributes), $schemaUrl);
     }
@@ -92,5 +92,19 @@ class ResourceInfoFactory
     public static function emptyResource(): ResourceInfo
     {
         return ResourceInfo::create(new Attributes());
+    }
+
+    private static function mergeSchemaUrl(ResourceInfo ...$resources): ?string
+    {
+        $schemaUrl = null;
+        foreach ($resources as $resource) {
+            if ($schemaUrl !== null && $resource->getSchemaUrl() !== null && $schemaUrl !== $resource->getSchemaUrl()) {
+                // stop the merging if non-empty conflicting schemas are detected
+                return null;
+            }
+            $schemaUrl ??= $resource->getSchemaUrl();
+        }
+
+        return $schemaUrl;
     }
 }

--- a/tests/Unit/SDK/Resource/ResourceInfoTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoTest.php
@@ -242,6 +242,29 @@ class ResourceInfoTest extends TestCase
         $this->assertEquals('', $empty);
     }
 
+    /**
+     * @dataProvider schemaUrlsToMergeProvider
+     */
+    public function test_merge_schema_url(array $schemaUrlsToMerge, ?string $expectedSchemaUrl): void
+    {
+        $resourcesToMerge = [];
+        foreach ($schemaUrlsToMerge as $schemaUrl) {
+            $resourcesToMerge[] = ResourceInfo::create(new Attributes([]), $schemaUrl);
+        }
+        $result = ResourceInfoFactory::merge(...$resourcesToMerge);
+
+        $this->assertEquals($expectedSchemaUrl, $result->getSchemaUrl());
+    }
+
+    public function schemaUrlsToMergeProvider()
+    {
+        yield 'Should keep old schemaUrl when the updating one is empty' => [['http://url', null], 'http://url'];
+        yield 'Should override empty old schemaUrl with non-empty updating one' => [[null, 'http://url'], 'http://url'];
+        yield 'Should keep matching schemaUrls' => [['http://url', 'http://url'], 'http://url'];
+        yield 'Should resolve an empty schemaUrl when the old and the updating are not equal' => [['http://url-1', 'http://url-2'], null];
+        yield 'Should keep empty schemaUrl when not equal schemas have been merged before' => [['http://url-1', 'http://url-2', 'http://url-2'], null];
+    }
+
     public function test_immutable_create(): void
     {
         $attributes = new Attributes();


### PR DESCRIPTION
Continue with the #445. This PR to resolve a resulting `schemaUrl` when merging `ResourceInfo`s. Reference to [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/441bafa8eda1697c3f0b975250e421e25da496b8/specification/resource/sdk.md#merge).