### PR TITLE
honour grpc exporter provided endpoint url

### DIFF
--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -77,8 +77,9 @@ class Exporter implements SpanExporterInterface
         $opts = $this->getClientOptions();
 
         $this->client = $client ?? new TraceServiceClient(
-            $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) ?:
-            $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, $endpointURL),
+            $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) ?
+                $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) :
+                $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, $endpointURL),
             $opts
         );
     }


### PR DESCRIPTION
A bug when fetching settings from environment was causing the grpc exporter to always use our default
value, rather than the one provided to the exporter's constructor.

Fixes #638 