### PR TITLE
Updating .github workflow for psalm-security-analysis  based on outpu…

### DIFF
--- a/.github/workflows/psalm-security-analysis.yml
+++ b/.github/workflows/psalm-security-analysis.yml
@@ -1,7 +1,12 @@
+---
 name: Psalm Security Analysis
 
-on: [push, pull_request]
-
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
 jobs:
   psalm:
     name: Psalm


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-php/pull/640 failed a psalm security check.
[this](https://github.com/open-telemetry/opentelemetry-php/runs/5747247389?check_suite_focus=true#step:5:51) action run mentions that we should avoid using `on:push` and should use `on:pull_request`. 

This PR attempts to do just that.