### PR TITLE
Add test based on the Jaeger spec

### DIFF
--- a/tests/Unit/Contrib/IdConverterTest.php
+++ b/tests/Unit/Contrib/IdConverterTest.php
@@ -20,7 +20,7 @@ class IdConverterTest extends TestCase
         $this->assertEquals(-72057594037927936, IdConverter::convertOtelToJaegerSpanId($hex));
     }
 
-    public function test_correctly_converted_span_id()
+    public function test_correctly_converted_random_span_id()
     {
         // 16 char hex string
         $hex = bin2hex(random_bytes(8));
@@ -28,7 +28,7 @@ class IdConverterTest extends TestCase
         $this->assertEquals($hex, $this->dechexWithLeadingZeroes(IdConverter::convertOtelToJaegerSpanId($hex)));
     }
 
-    public function test_correctly_converted_trace_id()
+    public function test_correctly_converted_random_trace_id()
     {
         // 32 char hex string
         $hex = bin2hex(random_bytes(16));

--- a/tests/Unit/Contrib/IdConverterTest.php
+++ b/tests/Unit/Contrib/IdConverterTest.php
@@ -25,7 +25,7 @@ class IdConverterTest extends TestCase
         // 16 char hex string
         $hex = bin2hex(random_bytes(8));
 
-        $this->assertEquals($hex, dechex(IdConverter::convertOtelToJaegerSpanId($hex)));
+        $this->assertEquals($hex, $this->dechexWithLeadingZeroes(IdConverter::convertOtelToJaegerSpanId($hex)));
     }
 
     public function test_correctly_converted_trace_id()
@@ -34,8 +34,13 @@ class IdConverterTest extends TestCase
         $hex = bin2hex(random_bytes(16));
 
         $traceId = IdConverter::convertOtelToJaegerTraceIds($hex);
-        $convertedTraceId = dechex((int) $traceId['traceIdHigh']);
-        $convertedTraceId .= dechex((int) $traceId['traceIdLow']);
+        $convertedTraceId = $this->dechexWithLeadingZeroes((int) $traceId['traceIdHigh']);
+        $convertedTraceId .= $this->dechexWithLeadingZeroes((int) $traceId['traceIdLow']);
         $this->assertEquals($hex, $convertedTraceId);
+    }
+
+    private function dechexWithLeadingZeroes(int $num)
+    {
+        return str_pad(dechex($num), 16, '0', STR_PAD_LEFT);
     }
 }

--- a/tests/Unit/Contrib/IdConverterTest.php
+++ b/tests/Unit/Contrib/IdConverterTest.php
@@ -20,7 +20,7 @@ class IdConverterTest extends TestCase
         $this->assertEquals(-72057594037927936, IdConverter::convertOtelToJaegerSpanId($hex));
     }
 
-    public function test_correctly_converted_random_span_id()
+    public function test_correctly_converts_random_span_id()
     {
         // 16 char hex string
         $hex = bin2hex(random_bytes(8));
@@ -28,14 +28,24 @@ class IdConverterTest extends TestCase
         $this->assertEquals($hex, $this->dechexWithLeadingZeroes(IdConverter::convertOtelToJaegerSpanId($hex)));
     }
 
-    public function test_correctly_converted_random_trace_id()
+    public function test_correctly_converts_trace_id()
+    {
+        $hex = "0102030405060708090a0b0c0d0e0f10";
+
+        $traceId = IdConverter::convertOtelToJaegerTraceIds($hex);
+
+        $this->assertEquals(72623859790382856, $traceId['traceIdHigh']);
+        $this->assertEquals(651345242494996240, $traceId['traceIdLow']);
+    }
+
+    public function test_correctly_converts_random_trace_id()
     {
         // 32 char hex string
         $hex = bin2hex(random_bytes(16));
 
         $traceId = IdConverter::convertOtelToJaegerTraceIds($hex);
-        $convertedTraceId = $this->dechexWithLeadingZeroes((int) $traceId['traceIdHigh']);
-        $convertedTraceId .= $this->dechexWithLeadingZeroes((int) $traceId['traceIdLow']);
+        $convertedTraceId = $this->dechexWithLeadingZeroes($traceId['traceIdHigh']);
+        $convertedTraceId .= $this->dechexWithLeadingZeroes($traceId['traceIdLow']);
         $this->assertEquals($hex, $convertedTraceId);
     }
 

--- a/tests/Unit/Contrib/IdConverterTest.php
+++ b/tests/Unit/Contrib/IdConverterTest.php
@@ -30,7 +30,7 @@ class IdConverterTest extends TestCase
 
     public function test_correctly_converts_trace_id()
     {
-        $hex = "0102030405060708090a0b0c0d0e0f10";
+        $hex = '0102030405060708090a0b0c0d0e0f10';
 
         $traceId = IdConverter::convertOtelToJaegerTraceIds($hex);
 

--- a/tests/Unit/Contrib/IdConverterTest.php
+++ b/tests/Unit/Contrib/IdConverterTest.php
@@ -12,6 +12,14 @@ use PHPUnit\Framework\TestCase;
  */
 class IdConverterTest extends TestCase
 {
+    //Based on this section of the Jaeger spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#ids
+    public function test_correctly_converts_example_from_spec()
+    {
+        $hex = 'FF00000000000000';
+
+        $this->assertEquals(-72057594037927936, IdConverter::convertOtelToJaegerSpanId($hex));
+    }
+
     public function test_correctly_converted_span_id()
     {
         // 16 char hex string


### PR DESCRIPTION
Adds a specific test based on the spec example, since I tried at least twice at the logic and missed both times until @saktib fixed it all up...

Also fixes up some flakiness I noticed after running the tests a few times, like here https://github.com/open-telemetry/opentelemetry-php/runs/5763933166?check_suite_focus=true