### PR TITLE
removing brick/math from phan config

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -371,7 +371,6 @@ return [
         'vendor/promphp/prometheus_client_php/src',
         'vendor/google/protobuf/src',
         'vendor/nyholm/dsn/src',
-        'vendor/brick/math/src',
     ],
 
     // A list of individual files to include in analysis


### PR DESCRIPTION
was not removed in #642 along with the rest of the library