### PR TITLE
replace E_USER_NOTICE with E_USER_DEPRECATED

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
+    convertDeprecationsToExceptions="true"
     forceCoversAnnotation="true"
     processIsolation="false"
     stopOnError="false"

--- a/src/SDK/Common/Dev/Compatibility/Util.php
+++ b/src/SDK/Common/Dev/Compatibility/Util.php
@@ -17,7 +17,7 @@ class Util
             $notice .= sprintf('Please, use "%s" instead.', $alternativeClassName);
         }
 
-        trigger_error($notice, E_USER_DEPRECATED);
+        trigger_error($notice, \E_USER_DEPRECATED);
     }
 
     public static function triggerMethodDeprecationNotice(
@@ -38,6 +38,6 @@ class Util
             $notice .= sprintf('Please, use "%s" instead.', $method);
         }
 
-        trigger_error($notice, E_USER_DEPRECATED);
+        trigger_error($notice, \E_USER_DEPRECATED);
     }
 }

--- a/src/SDK/Common/Dev/Compatibility/Util.php
+++ b/src/SDK/Common/Dev/Compatibility/Util.php
@@ -17,7 +17,7 @@ class Util
             $notice .= sprintf('Please, use "%s" instead.', $alternativeClassName);
         }
 
-        trigger_error($notice, E_USER_NOTICE);
+        trigger_error($notice, E_USER_DEPRECATED);
     }
 
     public static function triggerMethodDeprecationNotice(
@@ -38,6 +38,6 @@ class Util
             $notice .= sprintf('Please, use "%s" instead.', $method);
         }
 
-        trigger_error($notice, E_USER_NOTICE);
+        trigger_error($notice, E_USER_DEPRECATED);
     }
 }

--- a/tests/Unit/SDK/Common/Dev/Compatibility/UtilTest.php
+++ b/tests/Unit/SDK/Common/Dev/Compatibility/UtilTest.php
@@ -14,21 +14,21 @@ class UtilTest extends TestCase
 {
     public function test_trigger_class_deprecation_notice(): void
     {
-        $this->expectNotice();
+        $this->expectDeprecation();
 
         Util::triggerClassDeprecationNotice(Util::class, self::class);
     }
 
     public function test_trigger_method_deprecation_notice_without_class(): void
     {
-        $this->expectNotice();
+        $this->expectDeprecation();
 
         Util::triggerMethodDeprecationNotice(Util::class, __METHOD__);
     }
 
     public function test_trigger_method_deprecation_notice_with_class(): void
     {
-        $this->expectNotice();
+        $this->expectDeprecation();
 
         Util::triggerMethodDeprecationNotice(Util::class, 'foo', self::class);
     }


### PR DESCRIPTION
Since it is a notice about a deprecation it should also use E_USER_DEPRECATED as log level.
NOTICE seems to be not the appropriate log level.

In my case it broke the application in dev mode where Notices are considered errors.
