### PR TITLE
static logging methods

### DIFF
--- a/src/Contrib/Jaeger/JaegerTransport.php
+++ b/src/Contrib/Jaeger/JaegerTransport.php
@@ -93,7 +93,7 @@ final class JaegerTransport implements TransportInterface
             // reset the process tag
             $this->process = null;
         } catch (TTransportException $e) {
-            $this->logError('jaeger: transport failure: ' . $e->getMessage());
+            self::logError('jaeger: transport failure: ' . $e->getMessage());
 
             return 0;
         }

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -138,12 +138,12 @@ class Exporter implements SpanExporterInterface
             \Grpc\STATUS_DATA_LOSS,
             \Grpc\STATUS_UNAUTHENTICATED,
         ], true)) {
-            $this->logWarning('Retryable error exporting grpc span', ['error' => $error]);
+            self::logWarning('Retryable error exporting grpc span', ['error' => $error]);
 
             return self::STATUS_FAILED_RETRYABLE;
         }
 
-        $this->logError('Error exporting grpc span', ['error' => $error]);
+        self::logError('Error exporting grpc span', ['error' => $error]);
 
         return self::STATUS_FAILED_NOT_RETRYABLE;
     }

--- a/src/SDK/Behavior/LogsMessagesTrait.php
+++ b/src/SDK/Behavior/LogsMessagesTrait.php
@@ -9,34 +9,34 @@ use Psr\Log\LogLevel;
 
 trait LogsMessagesTrait
 {
-    private function doLog(string $level, string $message, array $context): void
+    private static function doLog(string $level, string $message, array $context): void
     {
-        $context['source'] = get_class($this);
+        $context['source'] = get_called_class();
         LoggerHolder::get()->log($level, $message, $context);
     }
 
-    protected function logDebug(string $message, array $context = []): void
+    protected static function logDebug(string $message, array $context = []): void
     {
-        $this->doLog(LogLevel::DEBUG, $message, $context);
+        self::doLog(LogLevel::DEBUG, $message, $context);
     }
 
-    protected function logInfo(string $message, array $context = []): void
+    protected static function logInfo(string $message, array $context = []): void
     {
-        $this->doLog(LogLevel::INFO, $message, $context);
+        self::doLog(LogLevel::INFO, $message, $context);
     }
 
-    protected function logNotice(string $message, array $context = []): void
+    protected static function logNotice(string $message, array $context = []): void
     {
-        $this->doLog(LogLevel::NOTICE, $message, $context);
+        self::doLog(LogLevel::NOTICE, $message, $context);
     }
 
-    protected function logWarning(string $message, array $context = []): void
+    protected static function logWarning(string $message, array $context = []): void
     {
-        $this->doLog(LogLevel::WARNING, $message, $context);
+        self::doLog(LogLevel::WARNING, $message, $context);
     }
 
-    protected function logError(string $message, array $context = []): void
+    protected static function logError(string $message, array $context = []): void
     {
-        $this->doLog(LogLevel::ERROR, $message, $context);
+        self::doLog(LogLevel::ERROR, $message, $context);
     }
 }

--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -54,7 +54,7 @@ class SimpleSpanProcessor implements SpanProcessorInterface
         }
 
         $this->running = false;
-        $this->logDebug('Shutting down span processor');
+        self::logDebug('Shutting down span processor');
 
         if (null !== $this->exporter) {
             return $this->forceFlush() && $this->exporter->shutdown();

--- a/src/SDK/Trace/TracerProviderFactory.php
+++ b/src/SDK/Trace/TracerProviderFactory.php
@@ -31,21 +31,21 @@ final class TracerProviderFactory
         try {
             $exporter = $this->exporterFactory->fromEnvironment();
         } catch (\Throwable $t) {
-            $this->logWarning('Unable to create exporter', ['error' => $t]);
+            self::logWarning('Unable to create exporter', ['error' => $t]);
             $exporter = null;
         }
 
         try {
             $sampler = $this->samplerFactory->fromEnvironment();
         } catch (\Throwable $t) {
-            $this->logWarning('Unable to create sampler', ['error' => $t]);
+            self::logWarning('Unable to create sampler', ['error' => $t]);
             $sampler = null;
         }
 
         try {
             $spanProcessor = $this->spanProcessorFactory->fromEnvironment($exporter);
         } catch (\Throwable $t) {
-            $this->logWarning('Unable to create span processor', ['error' => $t]);
+            self::logWarning('Unable to create span processor', ['error' => $t]);
             $spanProcessor = null;
         }
 

--- a/tests/Integration/SDK/SpanLimitsBuilderTest.php
+++ b/tests/Integration/SDK/SpanLimitsBuilderTest.php
@@ -8,6 +8,9 @@ use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use OpenTelemetry\SDK\Trace\SpanLimitsBuilder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class SpanLimitsBuilderTest extends TestCase
 {
     use EnvironmentVariables;


### PR DESCRIPTION
allow logging methods in LogsMessagesTrait to be called from within either a static or non-static method.
in passing, adding a missing coversNothing annotation on a complaining integration test