### PR TITLE
Revert "replace E_USER_NOTICE with E_USER_DEPRECATED"

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,6 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
-    convertDeprecationsToExceptions="true"
     forceCoversAnnotation="true"
     processIsolation="false"
     stopOnError="false"

--- a/src/SDK/Common/Dev/Compatibility/Util.php
+++ b/src/SDK/Common/Dev/Compatibility/Util.php
@@ -17,7 +17,7 @@ class Util
             $notice .= sprintf('Please, use "%s" instead.', $alternativeClassName);
         }
 
-        trigger_error($notice, \E_USER_DEPRECATED);
+        trigger_error($notice, E_USER_NOTICE);
     }
 
     public static function triggerMethodDeprecationNotice(
@@ -38,6 +38,6 @@ class Util
             $notice .= sprintf('Please, use "%s" instead.', $method);
         }
 
-        trigger_error($notice, \E_USER_DEPRECATED);
+        trigger_error($notice, E_USER_NOTICE);
     }
 }

--- a/tests/Unit/SDK/Common/Dev/Compatibility/UtilTest.php
+++ b/tests/Unit/SDK/Common/Dev/Compatibility/UtilTest.php
@@ -14,21 +14,21 @@ class UtilTest extends TestCase
 {
     public function test_trigger_class_deprecation_notice(): void
     {
-        $this->expectDeprecation();
+        $this->expectNotice();
 
         Util::triggerClassDeprecationNotice(Util::class, self::class);
     }
 
     public function test_trigger_method_deprecation_notice_without_class(): void
     {
-        $this->expectDeprecation();
+        $this->expectNotice();
 
         Util::triggerMethodDeprecationNotice(Util::class, __METHOD__);
     }
 
     public function test_trigger_method_deprecation_notice_with_class(): void
     {
-        $this->expectDeprecation();
+        $this->expectNotice();
 
         Util::triggerMethodDeprecationNotice(Util::class, 'foo', self::class);
     }


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-php#647
We were discussing this PR internally, and think that the original behaviour was correct and intentional - the BC layer is for the protection of code running in production mode, but not development mode.