### PR TITLE
bump protobuf extension to 3.20.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,19 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0']
+        php-version: ['7.4', '8.0', '8.1']
         os: [ubuntu-latest]
-        extensions: ['ast, grpc', 'ast, grpc, protobuf']
+        extensions: ['ast, grpc', 'ast, grpc, protobuf-3.20.0']
         experimental: [false]
-        include:
-          - php-version: 8.1
-            extensions: 'ast, grpc'
-            os: ubuntu-latest
-            experimental: true
-          - php-version: 8.1
-            extensions: 'ast, grpc, protobuf'
-            os: ubuntu-latest
-            experimental: true
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Google calendar invite with the included zoom link can be found [here](https:/
 Our open issues can all be found in the [github issues tab](https://github.com/open-telemetry/opentelemetry-php/issues).  Feel free to reach out on Slack if you have any additional questions about these issues; we are always happy to talk through implementation details.
 
 ## Requirements
-The library requires a PHP version of 7.4.x or 8.0.x (PHP 8.1 compability is in the works)
+The library requires a PHP version of 7.4.x, 8.0.x or 8.1.x
 
 ### Dependencies
 
@@ -91,7 +91,7 @@ Using fibers with non-`CLI` SAPIs may require pre-loading of bindings. One way t
 
 ** The PHP protobuf extension is optional when using either the `OTLPHttp` or `OTLPGrpc` exporters.**
 
-The protobuf extension makes both exporters more performant. _Note: there are some deprecation warnings with protobuf and PHP 8.1_
+The protobuf extension makes both exporters more performant. _Note that protobuf 3.20.0+ is required for php 8.1 support_
 
 ---
 


### PR DESCRIPTION
this should make the build green for 8.1, finally. We can now consider 8.1 supported,
and so it moves out of experimental - future 8.1 breaks will fail the pipeline.