### PR TITLE
Add integration tests for tracing compliance

### DIFF
--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -127,7 +127,7 @@ class SpanBuilderTest extends MockeryTestCase
 
         $span->end();
     }
-
+    
     public function test_add_link_truncate_link_attribute_value(): void
     {
         $maxLength = 25;
@@ -164,7 +164,10 @@ class SpanBuilderTest extends MockeryTestCase
 
         $span->end();
     }
-
+    
+    /**
+     * @group trace-compliance
+     */
     public function test_add_link_no_effect_after_start_span(): void
     {
         $spanBuilder = $this->tracer->spanBuilder(self::SPAN_NAME);
@@ -218,6 +221,9 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_set_attribute_after_end(): void
     {
         /** @var Span $span */
@@ -236,25 +242,31 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_set_attribute_null_string_value(): void
-    {
-        /** @var Span $span */
-        $span = $this
-            ->tracer
-            ->spanBuilder(self::SPAN_NAME)
-            ->setAttribute('nil', null)
-            ->setAttribute('empty-string', '')
-            ->startSpan();
+    /**
+     * @group trace-compliance
+     */
+    // public function test_set_attribute_empty_string_value_is_set(): void
+    // {
+    //     /** @var Span $span */
+    //     $span = $this
+    //         ->tracer
+    //         ->spanBuilder(self::SPAN_NAME)
+    //         ->setAttribute('nil', null)
+    //         ->setAttribute('empty-string', '')
+    //         ->startSpan();
 
-        $attributes = $span->toSpanData()->getAttributes();
-        $this->assertSame(1, $attributes->count());
-        $this->assertSame('', $attributes->get('empty-string'));
-        $this->assertNull($attributes->get('nil'));
+    //     $attributes = $span->toSpanData()->getAttributes();
+    //     $this->assertSame(1, $attributes->count());
+    //     $this->assertSame('', $attributes->get('empty-string'));
+    //     $this->assertNull($attributes->get('nil'));
 
-        $span->end();
-    }
+    //     $span->end();
+    // }
 
-    public function test_set_attribute_only_null_string_value(): void
+    /**
+     * @group trace-compliance
+     */
+    public function test_set_attribute_only_null_string_value_should_not_be_set(): void
     {
         /** @var Span $span */
         $span = $this
@@ -270,6 +282,9 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_set_attribute_no_effect_after_start_span(): void
     {
         $spanBuilder = $this->tracer->spanBuilder(self::SPAN_NAME);
@@ -365,7 +380,10 @@ class SpanBuilderTest extends MockeryTestCase
         $span->end();
     }
 
-    public function test_set_attributes_merge_attributes(): void
+    /**
+     * @group trace-compliance
+     */
+    public function test_setAttributes_merges_attributes_correctly(): void
     {
         $attributes = new Attributes(['id' => 2, 'foo' => 'bar', 'key' => 'val']);
 

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -127,7 +127,7 @@ class SpanBuilderTest extends MockeryTestCase
 
         $span->end();
     }
-    
+
     public function test_add_link_truncate_link_attribute_value(): void
     {
         $maxLength = 25;
@@ -164,7 +164,7 @@ class SpanBuilderTest extends MockeryTestCase
 
         $span->end();
     }
-    
+
     /**
      * @group trace-compliance
      */
@@ -383,7 +383,7 @@ class SpanBuilderTest extends MockeryTestCase
     /**
      * @group trace-compliance
      */
-    public function test_setAttributes_merges_attributes_correctly(): void
+    public function test_set_attributes_merges_attributes_correctly(): void
     {
         $attributes = new Attributes(['id' => 2, 'foo' => 'bar', 'key' => 'val']);
 

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -47,7 +47,7 @@ class SpanBuilderTest extends MockeryTestCase
             API\SpanContextInterface::TRACE_FLAG_SAMPLED,
         );
     }
-    
+
     /**
      * @group trace-compliance
      */
@@ -279,13 +279,13 @@ class SpanBuilderTest extends MockeryTestCase
             ->setAttribute('foo', 'bar')
             ->setAttribute('bar', 123)
             ->startSpan();
-            
+
         $attributes = $span->toSpanData()->getAttributes();
         $this->assertSame(2, $attributes->count());
 
         $spanBuilder
             ->setAttribute('bar1', 77);
-        
+
         $attributes = $span->toSpanData()->getAttributes();
         $this->assertSame(2, $attributes->count());
 
@@ -377,7 +377,7 @@ class SpanBuilderTest extends MockeryTestCase
             ->setAttribute('key1', 'val1')
             ->setAttributes($attributes)
             ->startSpan();
-        
+
         $attributes = $span->toSpanData()->getAttributes();
 
         $this->assertSame(5, $attributes->count());
@@ -388,7 +388,6 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertSame('val1', $attributes->get('key1'));
 
         $span->end();
-
     }
 
     public function test_set_attributes_overrides_values(): void

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -62,7 +62,6 @@ class SpanBuilderTest extends MockeryTestCase
             ->startSpan();
 
         $this->assertCount(2, $span->toSpanData()->getLinks());
-        $span->end();
     }
 
     public function test_add_link_invalid(): void
@@ -189,8 +188,6 @@ class SpanBuilderTest extends MockeryTestCase
             );
 
         $this->assertCount(1, $span->toSpanData()->getLinks());
-
-        $span->end();
     }
 
     /**
@@ -217,14 +214,12 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertSame([], $attributes->get('empty-arr'));
         $this->assertSame([1, 2, 3], $attributes->get('int-arr'));
         $this->assertNull($attributes->get('nil'));
-
-        $span->end();
     }
 
     /**
      * @group trace-compliance
      */
-    public function test_set_attribute_after_end(): void
+    public function test_set_attribute_no_effect_after_end(): void
     {
         /** @var Span $span */
         $span = $this
@@ -240,6 +235,11 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertSame(123, $attributes->get('bar'));
 
         $span->end();
+
+        $span->setAttribute('doo', 'baz');
+
+        $this->assertSame(2, $attributes->count());
+        $this->assertFalse($attributes->hasAttribute('doo'));
     }
 
     /**
@@ -278,8 +278,6 @@ class SpanBuilderTest extends MockeryTestCase
         $attributes = $span->toSpanData()->getAttributes();
         $this->assertEmpty($span->toSpanData()->getAttributes());
         $this->assertNull($attributes->get('nil'));
-
-        $span->end();
     }
 
     /**
@@ -303,8 +301,7 @@ class SpanBuilderTest extends MockeryTestCase
 
         $attributes = $span->toSpanData()->getAttributes();
         $this->assertSame(2, $attributes->count());
-
-        $span->end();
+        $this->assertFalse($attributes->hasAttribute('bar1'));
     }
 
     public function test_set_attribute_dropping(): void
@@ -330,8 +327,6 @@ class SpanBuilderTest extends MockeryTestCase
         foreach (range(1, $maxNumberOfAttributes) as $idx) {
             $this->assertSame($idx, $attributes->get("str_attribute_${idx}"));
         }
-
-        $span->end();
     }
 
     public function test_add_attributes_via_sampler(): void
@@ -376,8 +371,6 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertSame(2, $attributes->count());
         $this->assertSame('bar', $attributes->get('foo'));
         $this->assertSame(1, $attributes->get('id'));
-
-        $span->end();
     }
 
     /**
@@ -404,8 +397,6 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertSame('val', $attributes->get('key'));
         $this->assertSame('val2', $attributes->get('key2'));
         $this->assertSame('val1', $attributes->get('key1'));
-
-        $span->end();
     }
 
     public function test_set_attributes_overrides_values(): void
@@ -426,8 +417,6 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertSame(2, $attributes->count());
         $this->assertSame('bar', $attributes->get('foo'));
         $this->assertSame(1, $attributes->get('id'));
-
-        $span->end();
     }
 
     public function test_is_recording_default(): void

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -123,8 +123,6 @@ class SpanBuilderTest extends MockeryTestCase
 
         $this->assertCount(1, $span->toSpanData()->getLinks());
         $this->assertCount(1, $span->toSpanData()->getLinks()[0]->getAttributes());
-
-        $span->end();
     }
 
     public function test_add_link_truncate_link_attribute_value(): void
@@ -160,8 +158,6 @@ class SpanBuilderTest extends MockeryTestCase
             [1, 2],
             $attrs->get('int_array')
         );
-
-        $span->end();
     }
 
     /**

--- a/tests/Unit/SDK/Trace/TracerProviderTest.php
+++ b/tests/Unit/SDK/Trace/TracerProviderTest.php
@@ -19,7 +19,7 @@ class TracerProviderTest extends TestCase
      * @covers ::getTracer
      * @covers ::__construct
      */
-    public function test_reuses_same_instance(): void
+    public function test_reuses_instance_for_same_name_without_version(): void
     {
         $provider = new TracerProvider(null);
 
@@ -30,6 +30,20 @@ class TracerProviderTest extends TestCase
         $this->assertSame($t1, $t2);
         $this->assertNotSame($t1, $t3);
         $this->assertNotSame($t2, $t3);
+    }
+
+    /**
+     * @covers ::getTracer
+     * @covers ::__construct
+     * @group trace-compliance
+     */
+    public function test_get_tracer_default(): void
+    {
+        $provider = new TracerProvider(null);
+
+        $t1 = $provider->getTracer();
+
+        $this->assertInstanceOf(Tracer::class, $t1);
     }
 
     /**
@@ -52,8 +66,9 @@ class TracerProviderTest extends TestCase
     /**
      * @covers ::getTracer
      * @covers ::__construct
+     * @group trace-compliance
      */
-    public function test_reuses_same_instance_with_schema(): void
+    public function test_reuses_same_instance_with_schema_and_version(): void
     {
         $provider = new TracerProvider(null);
 
@@ -70,6 +85,7 @@ class TracerProviderTest extends TestCase
      * @covers ::getDefaultTracer
      * @runInSeparateProcess
      * @preserveGlobalState disabled
+     * @group trace-compliance
      */
     public function test_tracer_provider_returns_noop_tracer_if_no_default_is_set(): void
     {
@@ -91,6 +107,7 @@ class TracerProviderTest extends TestCase
 
     /**
      * @covers ::getTracer
+     * @group trace-compliance
      */
     public function test_get_tracer_with_default_name(): void
     {
@@ -104,6 +121,7 @@ class TracerProviderTest extends TestCase
 
     /**
      * @covers ::shutdown
+     * @group trace-compliance
      */
     public function test_shutdown(): void
     {
@@ -116,6 +134,7 @@ class TracerProviderTest extends TestCase
 
     /**
      * @covers ::forceFlush
+     * @group trace-compliance
      */
     public function test_force_flush(): void
     {
@@ -142,8 +161,9 @@ class TracerProviderTest extends TestCase
 
     /**
      * @covers ::getTracer
+     * @group trace-compliance
      */
-    public function test_get_tracer_after_shutdown(): void
+    public function test_get_tracer_returns_noop_tracer_after_shutdown(): void
     {
         $provider = new TracerProvider([]);
         $provider->shutdown();

--- a/tests/Unit/SDK/Trace/TracerProviderTest.php
+++ b/tests/Unit/SDK/Trace/TracerProviderTest.php
@@ -7,8 +7,8 @@ namespace OpenTelemetry\Tests\Unit\SDK\Trace;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NoopTracer;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
-use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\SDK\Trace\Tracer;
+use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Unit/SDK/Trace/TracerProviderTest.php
+++ b/tests/Unit/SDK/Trace/TracerProviderTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NoopTracer;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\SDK\Trace\Tracer;
 use PHPUnit\Framework\TestCase;
 
 /**


### PR DESCRIPTION
Some additional tests for the Span Builder SDK that verify:
1) Attributes are merged correctly
2) Setting attributes after calling `startSpan()` should not work
plus some additional tests for setting null and empty string values to attributes.

UPDATE: _I commented out one of the tests that I was not totally sure of. 
(unsure if `setAttribute()` should work with empty string `''` values.)_
