### PR TITLE
Move InstrumentationLibrary key generation logic out of TracerProvider/SpanConverter [#619]

### DIFF
--- a/src/Contrib/Otlp/SpanConverter.php
+++ b/src/Contrib/Otlp/SpanConverter.php
@@ -20,7 +20,7 @@ use Opentelemetry\Proto\Trace\V1\Span\Link;
 use Opentelemetry\Proto\Trace\V1\Span\SpanKind;
 use Opentelemetry\Proto\Trace\V1\Status;
 use Opentelemetry\Proto\Trace\V1\Status\StatusCode;
-use OpenTelemetry\SDK\Common\Util\Helpers;
+use OpenTelemetry\SDK\Common\Instrumentation\KeyGenerator;
 use OpenTelemetry\SDK\Trace\SpanConverterInterface;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
 
@@ -191,7 +191,7 @@ class SpanConverter implements SpanConverterInterface
             $isSpansEmpty = false;
 
             $il = $span->getInstrumentationLibrary();
-            $ilKey = Helpers::generateInstrumentationLibraryInstanceKey($il->getName(), $il->getVersion(), $il->getSchemaUrl());
+            $ilKey = KeyGenerator::generateInstanceKey($il->getName(), $il->getVersion(), $il->getSchemaUrl());
             if (!isset($ils[$ilKey])) {
                 $convertedSpans[$ilKey] = [];
                 $ils[$ilKey] = new InstrumentationLibrary(['name' => $il->getName(), 'version' => $il->getVersion() ?? '']);

--- a/src/Contrib/Otlp/SpanConverter.php
+++ b/src/Contrib/Otlp/SpanConverter.php
@@ -20,6 +20,7 @@ use Opentelemetry\Proto\Trace\V1\Span\Link;
 use Opentelemetry\Proto\Trace\V1\Span\SpanKind;
 use Opentelemetry\Proto\Trace\V1\Status;
 use Opentelemetry\Proto\Trace\V1\Status\StatusCode;
+use OpenTelemetry\SDK\Common\Util\Helpers;
 use OpenTelemetry\SDK\Trace\SpanConverterInterface;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
 
@@ -186,14 +187,14 @@ class SpanConverter implements SpanConverterInterface
         $isSpansEmpty = true; //Waiting for the loop to prove otherwise
 
         $ils = $convertedSpans = $schemas = [];
-        foreach ($spans as $span) {
+        foreach ($spans as /** @var SpanDataInterface $span */  $span) {
             $isSpansEmpty = false;
 
             $il = $span->getInstrumentationLibrary();
-            $ilKey = sprintf('%s@%s %s', $il->getName(), $il->getVersion()??'', $il->getSchemaUrl()??'');
+            $ilKey = Helpers::generateInstrumentationLibraryInstanceKey($il->getName(), $il->getVersion(), $il->getSchemaUrl());
             if (!isset($ils[$ilKey])) {
                 $convertedSpans[$ilKey] = [];
-                $ils[$ilKey] = new InstrumentationLibrary(['name' => $il->getName(), 'version' => $il->getVersion()??'']);
+                $ils[$ilKey] = new InstrumentationLibrary(['name' => $il->getName(), 'version' => $il->getVersion() ?? '']);
                 $schemas[$ilKey] = $il->getSchemaUrl();
             }
             $convertedSpans[$ilKey][] = $this->as_otlp_span($span);

--- a/src/SDK/Common/Instrumentation/KeyGenerator.php
+++ b/src/SDK/Common/Instrumentation/KeyGenerator.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Util;
+namespace OpenTelemetry\SDK\Common\Instrumentation;
 
-class Helpers
+class KeyGenerator
 {
     /**
      * Generate a unique key for an instance of InstrumentationLibrary, with parameters matching those of the
@@ -14,7 +14,7 @@ class Helpers
      * @param ?string $schemaUrl
      * @return string
      */
-    public static function generateInstrumentationLibraryInstanceKey(string $name, ?string $version, ?string $schemaUrl): string
+    public static function generateInstanceKey(string $name, ?string $version, ?string $schemaUrl): string
     {
         return sprintf('%s@%s %s', $name, ($version ?? 'unknown'), ($schemaUrl ?? ''));
     }

--- a/src/SDK/Common/Util/Helpers.php
+++ b/src/SDK/Common/Util/Helpers.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Util;
 
-use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationLibrary;
-
 class Helpers
 {
     /**
-     * Generate a unique key for an instance of {@see InstrumentationLibrary}, with parameters matching those of the
+     * Generate a unique key for an instance of InstrumentationLibrary, with parameters matching those of the
      * class' constructor.
      * @param string $name
      * @param ?string $version

--- a/src/SDK/Common/Util/Helpers.php
+++ b/src/SDK/Common/Util/Helpers.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Util;
+
+use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationLibrary;
+
+class Helpers
+{
+    /**
+     * Generate a unique key for an instance of {@see InstrumentationLibrary}, with parameters matching those of the
+     * class' constructor.
+     * @param string $name
+     * @param ?string $version
+     * @param ?string $schemaUrl
+     * @return string
+     */
+    public static function generateInstrumentationLibraryInstanceKey(string $name, ?string $version, ?string $schemaUrl): string
+    {
+        return sprintf('%s@%s %s', $name, ($version ?? 'unknown'), ($schemaUrl ?? ''));
+    }
+}

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -8,7 +8,7 @@ use function is_array;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NoopTracer;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationLibrary;
-use OpenTelemetry\SDK\Common\Util\Helpers;
+use OpenTelemetry\SDK\Common\Instrumentation\KeyGenerator;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
@@ -68,7 +68,7 @@ final class TracerProvider implements API\TracerProviderInterface
             return NoopTracer::getInstance();
         }
 
-        $key = Helpers::generateInstrumentationLibraryInstanceKey($name, $version, $schemaUrl);
+        $key = KeyGenerator::generateInstanceKey($name, $version, $schemaUrl);
 
         if (isset($this->tracers[$key]) && $this->tracers[$key] instanceof API\TracerInterface) {
             return $this->tracers[$key];

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -8,6 +8,7 @@ use function is_array;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NoopTracer;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationLibrary;
+use OpenTelemetry\SDK\Common\Util\Helpers;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
@@ -67,7 +68,7 @@ final class TracerProvider implements API\TracerProviderInterface
             return NoopTracer::getInstance();
         }
 
-        $key = sprintf('%s@%s %s', $name, ($version ?? 'unknown'), ($schemaUrl ?? ''));
+        $key = Helpers::generateInstrumentationLibraryInstanceKey($name, $version, $schemaUrl);
 
         if (isset($this->tracers[$key]) && $this->tracers[$key] instanceof API\TracerInterface) {
             return $this->tracers[$key];

--- a/tests/Unit/SDK/Common/Instrumentation/KeyGeneratorTest.php
+++ b/tests/Unit/SDK/Common/Instrumentation/KeyGeneratorTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class KeyGeneratorTest extends TestCase
 {
-    public function test_non_empty(): void
+    public function test_non_null(): void
     {
         $name = 'foo';
         $version = 'bar';
@@ -23,12 +23,22 @@ class KeyGeneratorTest extends TestCase
         $this->assertSame(sprintf('%s@%s %s', $name, $version, $schemaUrl), $key);
     }
 
-    public function test_null_version_schema(): void
+    public function test_null_version_and_null_schema(): void
     {
         $name = 'foo';
 
         $key = KeyGenerator::generateInstanceKey($name, null, null);
 
         $this->assertSame(sprintf('%s@unknown ', $name), $key);
+    }
+
+    public function test_non_null_version_and_null_schema(): void
+    {
+        $name = 'foo';
+        $version = 'bar';
+
+        $key = KeyGenerator::generateInstanceKey($name, $version, null);
+
+        $this->assertSame(sprintf('%s@%s ', $name, $version), $key);
     }
 }

--- a/tests/Unit/SDK/Common/Instrumentation/KeyGeneratorTest.php
+++ b/tests/Unit/SDK/Common/Instrumentation/KeyGeneratorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Common\Instrumentation;
+
+use OpenTelemetry\SDK\Common\Instrumentation\KeyGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\SDK\Common\Instrumentation\KeyGenerator
+ */
+class KeyGeneratorTest extends TestCase
+{
+    public function test_non_empty(): void
+    {
+        $name = 'foo';
+        $version = 'bar';
+        $schemaUrl = 'https://baz';
+
+        $key = KeyGenerator::generateInstanceKey($name, $version, $schemaUrl);
+
+        $this->assertSame(sprintf('%s@%s %s', $name, $version, $schemaUrl), $key);
+    }
+
+    public function test_null_version_schema(): void
+    {
+        $name = 'foo';
+
+        $key = KeyGenerator::generateInstanceKey($name, null, null);
+
+        $this->assertSame(sprintf('%s@unknown ', $name), $key);
+    }
+}


### PR DESCRIPTION
PR for Issue #619.

Factors key generation logic for InstrumentationLibrary instances out to a helper method in a utils class, replacing generation in `TracerProvider` and `SpanConverter` with calls to the new method.