### PR TITLE
fixing w3c-tracecontext test startup

### DIFF
--- a/docker-compose.w3cTraceContext.yaml
+++ b/docker-compose.w3cTraceContext.yaml
@@ -1,6 +1,7 @@
 version: '3.7'
 services:
   php:
+    user: root
     build:
       context: .
       dockerfile: docker/Dockerfile

--- a/tests/TraceContext/W3CTestService/symfony-setup
+++ b/tests/TraceContext/W3CTestService/symfony-setup
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+set -x
+
+git config --global user.email "otel@open-telemetry.example.com"
 
 # Install Symfony
 curl -sS https://get.symfony.com/cli/installer | bash
@@ -21,16 +24,18 @@ composer require open-telemetry/opentelemetry "*"
 composer config repositories.local \
     '{"type": "path", "url": "/usr/src/open-telemetry/", "options": {"symLink": true }}' \
     --file composer.json
+composer config minimum-stability dev --file composer.json
+composer require php-http/mock-client "*"
+composer require nyholm/psr7 "*"
 rm composer.lock
 composer clearcache
 composer install
 
 # Start the server to start listening in the background
-symfony server:start -d --port=8001
+symfony server:start -d --port=8001 --no-tls
 
 # Setup the TraceContext Test Service
-apt-get install -y python3-pip 
-pip3 install aiohttp
+apk add --no-cache py3-pip py3-aiohttp
 
 cd ..
 rm -rf trace-context

--- a/tests/Unit/API/Trace/NonRecordingSpanTest.php
+++ b/tests/Unit/API/Trace/NonRecordingSpanTest.php
@@ -88,10 +88,8 @@ class NonRecordingSpanTest extends TestCase
 
     public function test_end(): void
     {
-        $this->assertNull(
-            // @phpstan-ignore-next-line
-            $this->createNonRecordingSpan()->end()
-        );
+        // @phpstan-ignore-next-line
+        $this->assertNull($this->createNonRecordingSpan()->end());
     }
 
     private function createNonRecordingSpan(): NonRecordingSpan


### PR DESCRIPTION
make w3c-trace-context was suffering from some bitrot, so this change gets it building and
running again. The tests themselves still fail due to further code-related bitrot.