### PR TITLE
Add phpunit annotations for compliance tests

### DIFF
--- a/tests/Integration/SDK/Context/SpanContextTest.php
+++ b/tests/Integration/SDK/Context/SpanContextTest.php
@@ -39,12 +39,20 @@ class SpanContextTest extends TestCase
         ];
     }
 
+    /**
+     * @group trace-compliance
+     * @covers ::isValid
+     */
     public function test_valid_span(): void
     {
         $spanContext = SpanContext::create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', API\SpanContextInterface::TRACE_FLAG_SAMPLED);
         $this->assertTrue($spanContext->isValid());
     }
 
+    /**
+     * @group trace-compliance
+     * @covers ::isRemote
+     */
     public function test_context_is_remote_from_restore(): void
     {
         $spanContext = SpanContext::createFromRemoteParent('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb', API\SpanContextInterface::TRACE_FLAG_SAMPLED);

--- a/tests/Integration/SDK/TracerTest.php
+++ b/tests/Integration/SDK/TracerTest.php
@@ -14,6 +14,7 @@ use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use OpenTelemetry\SDK\Trace\Span;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
+use OpenTelemetry\SDK\Trace\Tracer;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -68,6 +69,9 @@ class TracerTest extends TestCase
         $this->assertEquals($newTraceState, $span->getContext()->getTraceState());
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_span_should_receive_instrumentation_scope(): void
     {
         $tracerProvider = new TracerProvider();
@@ -81,6 +85,9 @@ class TracerTest extends TestCase
         $this->assertEquals('http://url', $spanInstrumentationScope->getSchemaUrl());
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_span_builder_propagates_instrumentation_scope_info_to_span(): void
     {
         /** @var Span $span */
@@ -92,4 +99,5 @@ class TracerTest extends TestCase
         $this->assertSame('name', $span->getInstrumentationScope()->getName());
         $this->assertSame('version', $span->getInstrumentationScope()->getVersion());
     }
+
 }

--- a/tests/Integration/SDK/TracerTest.php
+++ b/tests/Integration/SDK/TracerTest.php
@@ -14,7 +14,6 @@ use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use OpenTelemetry\SDK\Trace\Span;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
-use OpenTelemetry\SDK\Trace\Tracer;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -99,5 +98,4 @@ class TracerTest extends TestCase
         $this->assertSame('name', $span->getInstrumentationScope()->getName());
         $this->assertSame('version', $span->getInstrumentationScope()->getVersion());
     }
-
 }

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -68,6 +68,9 @@ class ResourceInfoFactoryTest extends TestCase
         yield 'Should keep empty schemaUrl when not equal schemas have been merged before' => [['http://url-1', 'http://url-2', 'http://url-2'], null];
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_resource_service_name_default(): void
     {
         $resource = ResourceInfoFactory::defaultResource();

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -489,6 +489,7 @@ class SpanTest extends MockeryTestCase
         $span->setAttributes(new Attributes());
         $this->assertEmpty($span->toSpanData()->getAttributes());
     }
+
     /**
      * @group trace-compliance
      * @covers ::addEvent

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -114,6 +114,9 @@ class SpanTest extends MockeryTestCase
         );
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_start_span(): void
     {
         $this->createTestSpan(API\SpanKind::KIND_INTERNAL);
@@ -122,6 +125,9 @@ class SpanTest extends MockeryTestCase
             ->once();
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_end_span(): void
     {
         $span = $this->createTestSpan(API\SpanKind::KIND_CONSUMER);
@@ -139,6 +145,9 @@ class SpanTest extends MockeryTestCase
         $this->assertSame(self::START_EPOCH, $span->getStartEpochNanos());
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_get_current_span_set_span(): void
     {
         $span = Span::wrap(SpanContext::getInvalid());
@@ -200,6 +209,9 @@ class SpanTest extends MockeryTestCase
 
     // region SDK
 
+    /**
+     * @group trace-compliance
+     */
     public function test_nothing_changes_after_end(): void
     {
         $span = $this->createTestSpan();
@@ -231,6 +243,10 @@ class SpanTest extends MockeryTestCase
         $this->assertTrue($span->hasEnded());
     }
 
+    /**
+     * @group trace-compliance
+     * @covers ::isRecording
+     */
     public function test_to_span_data_active_span(): void
     {
         $span = $this->createTestSpan();
@@ -259,6 +275,9 @@ class SpanTest extends MockeryTestCase
         $this->assertFalse($span->isRecording());
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_to_span_data_ended_span(): void
     {
         $span = $this->createTestSpan();
@@ -317,6 +336,9 @@ class SpanTest extends MockeryTestCase
         $this->assertSame(0, $spanData->getTotalDroppedAttributes());
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_to_span_data_is_immutable(): void
     {
         $span = $this->createTestSpanWithAttributes(self::ATTRIBUTES);
@@ -392,6 +414,9 @@ class SpanTest extends MockeryTestCase
         $span->end();
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_update_span_name(): void
     {
         $span = $this->createTestRootSpan();
@@ -425,6 +450,10 @@ class SpanTest extends MockeryTestCase
         $this->assertSame($elapsedNanos, $span->getDuration());
     }
 
+    /**
+     * @group trace-compliance
+     * @covers ::setAttributes
+     */
     public function test_set_attributes(): void
     {
         $span = $this->createTestRootSpan();
@@ -460,9 +489,9 @@ class SpanTest extends MockeryTestCase
         $span->setAttributes(new Attributes());
         $this->assertEmpty($span->toSpanData()->getAttributes());
     }
-
     /**
      * @group trace-compliance
+     * @covers ::addEvent
      */
     public function test_add_event(): void
     {
@@ -518,6 +547,9 @@ class SpanTest extends MockeryTestCase
         $span->end();
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_record_exception(): void
     {
         $exception = new Exception('ERR');
@@ -603,6 +635,9 @@ class SpanTest extends MockeryTestCase
         $span->end();
     }
 
+    /**
+     * @group trace-compliance
+     */
     public function test_dropping_attributes(): void
     {
         $maxNumberOfAttributes = 8;

--- a/tests/Unit/SDK/Trace/StatusDataTest.php
+++ b/tests/Unit/SDK/Trace/StatusDataTest.php
@@ -40,6 +40,7 @@ class StatusDataTest extends TestCase
     /**
      * @dataProvider getStatuses
      * @psalm-param StatusCode::STATUS_* $code
+     * @group trace-compliance
      */
     public function test_statuses_description(string $code): void
     {


### PR DESCRIPTION
Possible spec matrix changes:

- [x]  `Associate Tracer with InstrumentationScope`

- [x] [Default value](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value) for service.name
