### PR TITLE
Add the base docker image to w3c context validation tests

### DIFF
--- a/docker-compose.w3cTraceContext.yaml
+++ b/docker-compose.w3cTraceContext.yaml
@@ -1,10 +1,12 @@
 version: '3.7'
 services:
   php:
-    user: root
-    build:
-      context: .
-      dockerfile: docker/Dockerfile
+    image: ghcr.io/open-telemetry/opentelemetry-php/opentelemetry-php-base:${PHP_VERSION:-7.4}
     volumes:
     - ./:/usr/src/myapp
     - ./:/usr/src/open-telemetry/
+    user: "${PHP_USER}:root"
+    environment:
+      XDEBUG_MODE: ${XDEBUG_MODE:-off}
+      XDEBUG_CONFIG: ${XDEBUG_CONFIG:-''}
+      


### PR DESCRIPTION
To speed up the test setup, the base docker image is put to use in the docker-compose file for `W3C trace-context validation tests` .
A part of Issue #589 