### PR TITLE
Concurrent traces

### DIFF
--- a/examples/ConcurrentSpans.php
+++ b/examples/ConcurrentSpans.php
@@ -11,7 +11,7 @@ use OpenTelemetry\SDK\Trace\TracerProvider;
  * This example demonstrates how to have multiple concurrent spans active in the same trace, for
  * example if there were async/parallel http calls or database queries.
  */
-echo 'Starting ConsoleSpanExporter' . PHP_EOL;
+echo 'Starting ConsoleSpanExporter with concurrent spans' . PHP_EOL;
 
 $tracerProvider =  new TracerProvider(
     new SimpleSpanProcessor(

--- a/examples/ConcurrentSpans.php
+++ b/examples/ConcurrentSpans.php
@@ -7,6 +7,10 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 
+/**
+ * This example demonstrates how to have multiple concurrent spans active in the same trace, for
+ * example if there were async/parallel http calls or database queries.
+ */
 echo 'Starting ConsoleSpanExporter' . PHP_EOL;
 
 $tracerProvider =  new TracerProvider(

--- a/examples/ConcurrentTraces.php
+++ b/examples/ConcurrentTraces.php
@@ -26,18 +26,18 @@ $storage = ContextStorage::create('custom');
 $tracer = $tracerProvider->getTracer();
 
 //start and activate a root span in $storage
-$traceOneRootSpan = $tracer->spanBuilder('trace-one-root')->setStorage($storage)->startSpan();
+$traceOneRootSpan = $tracer->spanBuilder('trace-one.root')->setStorage($storage)->startSpan();
 $traceOneRootSpan->activate();
 
 //start and activate a root span in default storage
-$traceTwoRootSpan = $tracer->spanBuilder('trace-two-root')->startSpan();
+$traceTwoRootSpan = $tracer->spanBuilder('trace-two.root')->startSpan();
 $traceTwoRootSpan->activate();
 
 //start a child span, which will have a parent of the active node from $storage
-$childSpanOne = $tracer->spanBuilder('child-span-one')->setStorage($storage)->startSpan();
+$childSpanOne = $tracer->spanBuilder('trace-one.child')->setStorage($storage)->startSpan();
 
 //start another child span, which will have a parent of the active node from default storage
-$childSpanTwo = $tracer->spanBuilder('child-span-two')->startSpan();
+$childSpanTwo = $tracer->spanBuilder('trace-two.child')->startSpan();
 
 $childSpanOne->end();
 $childSpanTwo->end();

--- a/examples/ConcurrentTraces.php
+++ b/examples/ConcurrentTraces.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
-use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\Context\ContextStorage;
 use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
@@ -16,7 +15,7 @@ use OpenTelemetry\SDK\Trace\TracerProvider;
  * Although this example uses the default storage for one of the traces, in practise you would either use only the default
  * storage (eg in a shared-nothing webserver or single-task CLI process), or you would use only individual storages.
  */
-echo 'Starting Concurrent Trace Example' . PHP_EOL;
+echo 'Starting ConsoleSpanExporter with concurrent traces' . PHP_EOL;
 
 $tracerProvider =  new TracerProvider(
     new SimpleSpanProcessor(

--- a/examples/ConcurrentTraces.php
+++ b/examples/ConcurrentTraces.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\Context\ContextStorage;
+use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+
+/**
+ * This example demonstrates how to have multiple traces occurring within the one process, by creating custom storage
+ * for each trace to use. This might be used in a situation where one process can service multiple requests
+ * e.g react/swoole/roadrunner.
+ * Although this example uses the default storage for one of the traces, in practise you would either use only the default
+ * storage (eg in a shared-nothing webserver or single-task CLI process), or you would use only individual storages.
+ */
+echo 'Starting Concurrent Trace Example' . PHP_EOL;
+
+$tracerProvider =  new TracerProvider(
+    new SimpleSpanProcessor(
+        new ConsoleSpanExporter()
+    )
+);
+$storage = ContextStorage::create('custom');
+$tracer = $tracerProvider->getTracer();
+
+//start and activate a root span in $storage
+$traceOneRootSpan = $tracer->spanBuilder('trace-one-root')->setStorage($storage)->startSpan();
+$traceOneRootSpan->activate();
+
+//start and activate a root span in default storage
+$traceTwoRootSpan = $tracer->spanBuilder('trace-two-root')->startSpan();
+$traceTwoRootSpan->activate();
+
+//start a child span, which will have a parent of the active node from $storage
+$childSpanOne = $tracer->spanBuilder('child-span-one')->setStorage($storage)->startSpan();
+
+//start another child span, which will have a parent of the active node from default storage
+$childSpanTwo = $tracer->spanBuilder('child-span-two')->startSpan();
+
+$childSpanOne->end();
+$childSpanTwo->end();
+
+$traceOneRootSpan->end();
+$traceTwoRootSpan->end();

--- a/src/API/Trace/AbstractSpan.php
+++ b/src/API/Trace/AbstractSpan.php
@@ -11,7 +11,6 @@ use OpenTelemetry\Context\ScopeInterface;
 
 abstract class AbstractSpan implements SpanInterface
 {
-    private static ?self $invalidSpan = null;
     protected ContextStorageInterface $storage;
 
     /** @inheritDoc */
@@ -31,9 +30,9 @@ abstract class AbstractSpan implements SpanInterface
     }
 
     /** @inheritDoc */
-    final public static function getInvalid(): SpanInterface
+    final public static function getInvalid(?ContextStorageInterface $storage = null): SpanInterface
     {
-        return new NonRecordingSpan(SpanContext::getInvalid());
+        return (new NonRecordingSpan(SpanContext::getInvalid()))->setStorage($storage ?? Context::defaultStorage());
     }
 
     /** @inheritDoc */

--- a/src/API/Trace/AbstractSpan.php
+++ b/src/API/Trace/AbstractSpan.php
@@ -32,7 +32,7 @@ abstract class AbstractSpan implements SpanInterface
     /** @inheritDoc */
     final public static function getInvalid(?ContextStorageInterface $storage = null): SpanInterface
     {
-        return (new NonRecordingSpan(SpanContext::getInvalid()))->setStorage($storage ?? Context::defaultStorage());
+        return (new NonRecordingSpan(SpanContext::getInvalid()))->setStorage($storage ?? ContextStorage::default());
     }
 
     /** @inheritDoc */

--- a/src/API/Trace/NonRecordingSpan.php
+++ b/src/API/Trace/NonRecordingSpan.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Trace;
 
+use OpenTelemetry\Context\ContextStorage;
 use Throwable;
 
 /**
@@ -20,6 +21,7 @@ final class NonRecordingSpan extends AbstractSpan
         SpanContextInterface $context
     ) {
         $this->context = $context;
+        $this->storage = ContextStorage::default();
     }
 
     /** @inheritDoc */

--- a/src/API/Trace/NonRecordingSpan.php
+++ b/src/API/Trace/NonRecordingSpan.php
@@ -21,7 +21,7 @@ final class NonRecordingSpan extends AbstractSpan
         SpanContextInterface $context
     ) {
         $this->context = $context;
-        $this->storage = ContextStorage::default();
+        $this->storage = ContextStorage::default(); //@todo could be in another storage??
     }
 
     /** @inheritDoc */

--- a/src/API/Trace/NonRecordingSpan.php
+++ b/src/API/Trace/NonRecordingSpan.php
@@ -21,7 +21,7 @@ final class NonRecordingSpan extends AbstractSpan
         SpanContextInterface $context
     ) {
         $this->context = $context;
-        $this->storage = ContextStorage::default(); //@todo could be in another storage??
+        $this->storage = ContextStorage::default();
     }
 
     /** @inheritDoc */

--- a/src/API/Trace/NoopSpanBuilder.php
+++ b/src/API/Trace/NoopSpanBuilder.php
@@ -57,6 +57,11 @@ final class NoopSpanBuilder implements SpanBuilderInterface
         return $this;
     }
 
+    public function setStorage(ContextStorageInterface $storage): SpanBuilderInterface
+    {
+        return $this;
+    }
+
     public function startSpan(): SpanInterface
     {
         $span = AbstractSpan::fromContext($this->parent ?? $this->contextStorage->current());

--- a/src/API/Trace/NoopTracer.php
+++ b/src/API/Trace/NoopTracer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Trace;
 
-use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextStorage;
 
 final class NoopTracer implements TracerInterface
 {
@@ -21,6 +21,6 @@ final class NoopTracer implements TracerInterface
 
     public function spanBuilder(string $spanName): SpanBuilderInterface
     {
-        return new NoopSpanBuilder(Context::defaultStorage());
+        return new NoopSpanBuilder(ContextStorage::default());
     }
 }

--- a/src/API/Trace/NoopTracer.php
+++ b/src/API/Trace/NoopTracer.php
@@ -21,6 +21,6 @@ final class NoopTracer implements TracerInterface
 
     public function spanBuilder(string $spanName): SpanBuilderInterface
     {
-        return new NoopSpanBuilder(Context::storage());
+        return new NoopSpanBuilder(Context::defaultStorage());
     }
 }

--- a/src/API/Trace/SpanBuilderInterface.php
+++ b/src/API/Trace/SpanBuilderInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\API\Trace;
 
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextStorageInterface;
 
 /**
  * Obtained from a {@see TracerInterface} and used to construct a {@see SpanInterface}.
@@ -44,6 +45,11 @@ interface SpanBuilderInterface
      * @psalm-param SpanKind::KIND_* $spanKind
      */
     public function setSpanKind(int $spanKind): SpanBuilderInterface;
+
+    /**
+     * Set custom context storage
+     */
+    public function setStorage(ContextStorageInterface $storage): SpanBuilderInterface;
 
     /**
      * Starts and returns a new {@see SpanInterface}.

--- a/src/API/Trace/SpanInterface.php
+++ b/src/API/Trace/SpanInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\API\Trace;
 
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextStorageInterface;
 use OpenTelemetry\Context\ImplicitContextKeyedInterface;
 use Throwable;
 
@@ -28,7 +29,7 @@ interface SpanInterface extends ImplicitContextKeyedInterface
     /**
      * Returns an invalid {@see SpanInterface} that is used when tracing is disabled, such s when there is no available SDK.
      */
-    public static function getInvalid(): SpanInterface;
+    public static function getInvalid(?ContextStorageInterface $storage = null): SpanInterface;
 
     /**
      * Returns a non-recording {@see SpanInterface} that hold the provided *$spanContext* but has no functionality.
@@ -89,4 +90,6 @@ interface SpanInterface extends ImplicitContextKeyedInterface
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.1/specification/trace/api.md#end
      */
     public function end(int $endEpochNanos = null): void;
+
+    public function setStorage(ContextStorageInterface $storage): SpanInterface;
 }

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -9,7 +9,6 @@ namespace OpenTelemetry\Context;
  */
 class Context
 {
-    private static int $counter = 0; //debugging
     private static ?ContextStorageInterface $defaultStorage = null;
     private static ?Context $root = null;
 
@@ -50,7 +49,7 @@ class Context
      */
     public static function detach(ScopeInterface $token): Context
     {
-        //@todo what will this do with non-default storage?
+        //@todo what will this do with non-default storage? Do we need a non-static version?
         $token->detach();
 
         return self::getCurrent();
@@ -162,7 +161,6 @@ class Context
         $this->key = $key;
         $this->value = $value;
         $this->parent = $parent;
-        $this->id = ++self::$counter; //debugging
         $this->storage = $storage;
     }
 

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -138,7 +138,6 @@ class Context
 
     protected ?Context $parent;
     protected ?ContextStorageInterface $storage;
-    public int $id;
 
     /**
      * This is a general purpose read-only key-value store. Read-only in the sense that adding a new value does not

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -13,7 +13,7 @@ class Context
     private static ?Context $root = null;
 
     /**
-     * @ internal //@todo internal or not?
+     * @internal
      */
     public static function defaultStorage(): ContextStorageInterface
     {

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -13,11 +13,11 @@ class Context
     private static ?Context $root = null;
 
     /**
-     * @internal
+     * @ internal //@todo internal or not?
      */
     public static function defaultStorage(): ContextStorageInterface
     {
-        return self::$defaultStorage ??= ContextStorage::create();
+        return self::$defaultStorage ??= ContextStorage::default();
     }
 
     public function getStorage(): ContextStorageInterface
@@ -70,6 +70,7 @@ class Context
     {
         if (null === self::$root) {
             self::$root = new self();
+            self::$root->setStorage(self::defaultStorage());
         }
 
         return self::$root;

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -11,7 +11,7 @@ class Context
 {
     private static ?ContextStorageInterface $storage = null;
 
-    private static ?\OpenTelemetry\Context\Context $root = null;
+    private static ?Context $root = null;
 
     /**
      * @internal
@@ -129,7 +129,7 @@ class Context
      */
     protected $value;
 
-    protected ?\OpenTelemetry\Context\Context $parent;
+    protected ?Context $parent;
 
     /**
      * This is a general purpose read-only key-value store. Read-only in the sense that adding a new value does not

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -33,7 +33,6 @@ class Context
     public static function attach(Context $ctx): ScopeInterface
     {
         return $ctx->getStorage()->attach($ctx);
-        //return self::defaultStorage()->attach($ctx);
     }
 
     /**
@@ -51,7 +50,7 @@ class Context
      */
     public static function detach(ScopeInterface $token): Context
     {
-        //todo this probably won't work with non-default storage
+        //@todo what will this do with non-default storage?
         $token->detach();
 
         return self::getCurrent();
@@ -68,7 +67,6 @@ class Context
         return $storage ? $storage->current() : self::defaultStorage()->current();
     }
 
-    //@todo root context per storage? It probably has to live in Storage
     public static function getRoot(): self
     {
         if (null === self::$root) {
@@ -94,7 +92,7 @@ class Context
      *
      * @return mixed
      */
-    public static function getValue(ContextKey $key, $ctx=null)
+    public static function getValue(ContextKey $key, ?self $ctx=null)
     {
         $ctx = $ctx ?? static::getCurrent();
 

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\Context;
 
 final class ContextStorage implements ContextStorageInterface
 {
-    public const DEFAULT = 'default';
+    public const DEFAULT_NAME = 'default';
 
     private static ?ContextStorageInterface $default = null;
     private static string $defaultStorageClass = ContextStorage::class;
@@ -38,7 +38,7 @@ final class ContextStorage implements ContextStorageInterface
     public static function default(): ContextStorageInterface
     {
         if (self::$default === null) {
-            self::$default = self::create(self::DEFAULT);
+            self::$default = self::create(self::DEFAULT_NAME);
         }
 
         return self::$default;

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -9,7 +9,7 @@ namespace OpenTelemetry\Context;
  */
 final class ContextStorage implements ContextStorageInterface
 {
-    private static ?self $default = null;
+    private static ?ContextStorageInterface $default = null;
     private static string $defaultStorageClass = ContextStorage::class;
 
     public ContextStorageHead $current;
@@ -35,7 +35,7 @@ final class ContextStorage implements ContextStorageInterface
         return $self;
     }
 
-    public static function default(): self
+    public static function default(): ContextStorageInterface
     {
         if (self::$default === null) {
             self::$default = self::create();

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -14,6 +14,11 @@ final class ContextStorage implements ContextStorageInterface
     /** @var array<int, ContextStorageHead> */
     private array $forks = [];
 
+    public static function create(): self
+    {
+        return new self(new Context());
+    }
+
     public function __construct(Context $context)
     {
         $this->current = $this->main = new ContextStorageHead($this);

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Context;
 
-/**
- * @ internal //@todo internal or not?
- */
 final class ContextStorage implements ContextStorageInterface
 {
     public const DEFAULT = 'default';

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -11,6 +11,7 @@ final class ContextStorage implements ContextStorageInterface
 {
     private static ?ContextStorageInterface $default = null;
     private static string $defaultStorageClass = ContextStorage::class;
+    private static int $id = 0;
 
     public ContextStorageHead $current;
     private ContextStorageHead $main;
@@ -26,7 +27,7 @@ final class ContextStorage implements ContextStorageInterface
     public static function create(?string $name = null): ContextStorageInterface
     {
         $context = new Context();
-        $self = new self($context, $name ?? uniqid());
+        $self = new self($context, $name ?? 'storage-'.++self::$id);
         $context->setStorage($self);
         if (self::$defaultStorageClass === FiberNotSupportedContextStorage::class) {
             return new FiberNotSupportedContextStorage($self);

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -27,7 +27,7 @@ final class ContextStorage implements ContextStorageInterface
     public static function create(?string $name = null): ContextStorageInterface
     {
         $context = new Context();
-        $self = new self($context, $name ?? 'storage-'.++self::$id);
+        $self = new self($context, $name ?? 'storage-' . ++self::$id);
         $context->setStorage($self);
         if (self::$defaultStorageClass === FiberNotSupportedContextStorage::class) {
             return new FiberNotSupportedContextStorage($self);

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Context;
 
 /**
- * @internal
+ * @ internal //@todo internal or not?
  */
 final class ContextStorage implements ContextStorageInterface
 {
@@ -23,10 +23,10 @@ final class ContextStorage implements ContextStorageInterface
         self::$defaultStorageClass = $class;
     }
 
-    public static function create(string $name = 'default'): ContextStorageInterface
+    public static function create(?string $name = null): ContextStorageInterface
     {
         $context = new Context();
-        $self = new self($context, $name);
+        $self = new self($context, $name ?? uniqid());
         $context->setStorage($self);
         if (self::$defaultStorageClass === FiberNotSupportedContextStorage::class) {
             return new FiberNotSupportedContextStorage($self);
@@ -38,7 +38,7 @@ final class ContextStorage implements ContextStorageInterface
     public static function default(): ContextStorageInterface
     {
         if (self::$default === null) {
-            self::$default = self::create();
+            self::$default = self::create('default');
         }
 
         return self::$default;

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -9,6 +9,8 @@ namespace OpenTelemetry\Context;
  */
 final class ContextStorage implements ContextStorageInterface
 {
+    public const DEFAULT = 'default';
+
     private static ?ContextStorageInterface $default = null;
     private static string $defaultStorageClass = ContextStorage::class;
     private static int $id = 0;
@@ -39,7 +41,7 @@ final class ContextStorage implements ContextStorageInterface
     public static function default(): ContextStorageInterface
     {
         if (self::$default === null) {
-            self::$default = self::create('default');
+            self::$default = self::create(self::DEFAULT);
         }
 
         return self::$default;

--- a/src/Context/ContextStorageInterface.php
+++ b/src/Context/ContextStorageInterface.php
@@ -6,6 +6,8 @@ namespace OpenTelemetry\Context;
 
 interface ContextStorageInterface
 {
+    public static function create(): self;
+
     public function fork(int $id): void;
 
     public function switch(int $id): void;

--- a/src/Context/FiberNotSupportedContextStorage.php
+++ b/src/Context/FiberNotSupportedContextStorage.php
@@ -27,6 +27,11 @@ final class FiberNotSupportedContextStorage implements ContextStorageInterface
         $this->storage = $storage;
     }
 
+    public static function create(): self
+    {
+        return new self(ContextStorage::create());
+    }
+
     public function fork(int $id): void
     {
         $this->storage->fork($id);

--- a/src/Context/ZendObserverFiber.php
+++ b/src/Context/ZendObserverFiber.php
@@ -42,9 +42,9 @@ class ZendObserverFiber
                     return false;
                 }
             }
-            $fibers->zend_observer_fiber_init_register(fn (int $initializing) => Context::storage()->fork($initializing)); //@phpstan-ignore-line
-            $fibers->zend_observer_fiber_switch_register(fn (int $from, int $to) => Context::storage()->switch($to)); //@phpstan-ignore-line
-            $fibers->zend_observer_fiber_destroy_register(fn (int $destroying) => Context::storage()->destroy($destroying)); //@phpstan-ignore-line
+            $fibers->zend_observer_fiber_init_register(fn (int $initializing) => Context::defaultStorage()->fork($initializing)); //@phpstan-ignore-line
+            $fibers->zend_observer_fiber_switch_register(fn (int $from, int $to) => Context::defaultStorage()->switch($to)); //@phpstan-ignore-line
+            $fibers->zend_observer_fiber_destroy_register(fn (int $destroying) => Context::defaultStorage()->destroy($destroying)); //@phpstan-ignore-line
             self::$fibers = $fibers;
         }
 

--- a/src/Context/ZendObserverFiber.php
+++ b/src/Context/ZendObserverFiber.php
@@ -42,9 +42,9 @@ class ZendObserverFiber
                     return false;
                 }
             }
-            $fibers->zend_observer_fiber_init_register(fn (int $initializing) => Context::defaultStorage()->fork($initializing)); //@phpstan-ignore-line
-            $fibers->zend_observer_fiber_switch_register(fn (int $from, int $to) => Context::defaultStorage()->switch($to)); //@phpstan-ignore-line
-            $fibers->zend_observer_fiber_destroy_register(fn (int $destroying) => Context::defaultStorage()->destroy($destroying)); //@phpstan-ignore-line
+            $fibers->zend_observer_fiber_init_register(fn (int $initializing) => ContextStorage::default()->fork($initializing)); //@phpstan-ignore-line
+            $fibers->zend_observer_fiber_switch_register(fn (int $from, int $to) => ContextStorage::default()->switch($to)); //@phpstan-ignore-line
+            $fibers->zend_observer_fiber_destroy_register(fn (int $destroying) => ContextStorage::default()->destroy($destroying)); //@phpstan-ignore-line
             self::$fibers = $fibers;
         }
 

--- a/src/Context/fiber/initialize_fiber_handler.php
+++ b/src/Context/fiber/initialize_fiber_handler.php
@@ -18,5 +18,5 @@ $observer = new ZendObserverFiber();
 if ($observer->isEnabled() && $observer->init()) {
     // ffi fiber support enabled
 } else {
-    Context::setStorage(new FiberNotSupportedContextStorage(Context::storage()));
+    ContextStorage::setDefaultStorageClass(FiberNotSupportedContextStorage::class);
 }

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -13,6 +13,8 @@ use function get_class;
 use function in_array;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextStorage;
+use OpenTelemetry\Context\ContextStorageInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributeLimits;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
@@ -86,6 +88,7 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
         SpanProcessorInterface $spanProcessor,
         ResourceInfo $resource,
         ?AttributesInterface $attributes,
+        ?ContextStorageInterface $storage,
         array $links,
         int $totalRecordedLinks,
         int $startEpochNanos
@@ -103,6 +106,7 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
         $this->attributes = Attributes::withLimits($attributes ?? new Attributes(), $spanLimits->getAttributeLimits());
         $this->status = StatusData::unset();
         $this->spanLimits = $spanLimits;
+        $this->storage = $storage ?? ContextStorage::default();
     }
 
     /**
@@ -127,6 +131,7 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
         SpanProcessorInterface $spanProcessor,
         ResourceInfo $resource,
         ?AttributesInterface $attributes,
+        ?ContextStorageInterface $storage,
         array $links,
         int $totalRecordedLinks,
         int $startEpochNanos
@@ -141,6 +146,7 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
             $spanProcessor,
             $resource,
             $attributes,
+            $storage,
             $links,
             $totalRecordedLinks,
             $startEpochNanos !== 0 ? $startEpochNanos : ClockFactory::getDefault()->now()

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -33,7 +33,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
 
     private ?Context $parentContext = null; // Null means use current context.
 
-    private ?ContextStorageInterface $storage;
+    private ContextStorageInterface $storage;
 
     /**
      * @psalm-var API\SpanKind::KIND_*

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
-use OpenTelemetry\API\Trace\SpanBuilderInterface;
-use OpenTelemetry\Context\ContextStorageInterface;
 use function in_array;
 use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\API\Trace\SpanBuilderInterface;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextStorageInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributeLimits;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
@@ -58,7 +58,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
         $this->instrumentationScope = $instrumentationScope;
         $this->tracerSharedState = $tracerSharedState;
         $this->spanLimits = $spanLimits;
-        $this->storage = Context::storage(); //default to shared storage, see self::setStorage()
+        $this->storage = Context::defaultStorage(); //default to shared storage, see self::setStorage()
     }
 
     /** @inheritDoc */
@@ -167,6 +167,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
     {
         $parentContext = $this->parentContext ?? $this->storage->current();
         $parentSpan = Span::fromContext($parentContext);
+        $parentSpan->setStorage($this->storage);
         $parentSpanContext = $parentSpan->getContext();
 
         $spanId = $this->tracerSharedState->getIdGenerator()->generateSpanId();
@@ -227,6 +228,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
             $this->tracerSharedState->getSpanProcessor(),
             $this->tracerSharedState->getResource(),
             $attributes,
+            $this->storage,
             $links,
             $this->totalNumberOfLinksAdded,
             $this->startEpochNanos

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -8,6 +8,7 @@ use function in_array;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\SpanBuilderInterface;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextStorage;
 use OpenTelemetry\Context\ContextStorageInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributeLimits;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
@@ -58,7 +59,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
         $this->instrumentationScope = $instrumentationScope;
         $this->tracerSharedState = $tracerSharedState;
         $this->spanLimits = $spanLimits;
-        $this->storage = Context::defaultStorage(); //default to shared storage, see self::setStorage()
+        $this->storage = ContextStorage::default(); //default to shared storage, see self::setStorage()
     }
 
     /** @inheritDoc */

--- a/src/SDK/Trace/Tracer.php
+++ b/src/SDK/Trace/Tracer.php
@@ -34,7 +34,7 @@ class Tracer implements API\TracerInterface
         }
 
         if ($this->tracerSharedState->hasShutdown()) {
-            // TODO: Return a noop tracer
+            // TODO: Return a noop SpanBuilder (from API?)
         }
 
         return new SpanBuilder(

--- a/tests/Integration/ConcurrentTraceTest.php
+++ b/tests/Integration/ConcurrentTraceTest.php
@@ -4,40 +4,41 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Integration;
 
+use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextStorage;
+use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
+use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * This class tests using multiple ContextStorage to generate multiple active traces at the same time.
+ * @coversNothing
+ * This class tests using multiple ContextStorage to allow multiple active traces at the same time.
  */
 class ConcurrentTraceTest extends TestCase
 {
-    public function test_stuff(): void
+    public function test_concurrent_traces_are_independent(): void
     {
         $tracerProvider =  new TracerProvider();
         $tracer = $tracerProvider->getTracer();
-        $default = ContextStorage::default();
-        $custom = ContextStorage::create('custom'); //@todo this should use the preferred storage type (fiber or non)
-        //file_put_contents('php://stdout', '^^ context for custom storage'.PHP_EOL);
-        //$context = (new Context())->setStorage($custom);
-        $context = $custom->current(); //??
-        $root = $tracer->spanBuilder('root')
-            //->setParent($context)
+        $custom = ContextStorage::create('custom');
+
+        //create two active root spans: one in default storage, one in own storage
+        $rootOne = $tracer->spanBuilder('root.one')
             ->setStorage($custom)
             ->startSpan();
-        $ctx = $root->activate();
-        $foo = $custom->current();
-        //$this->assertEquals($ctx, $foo);
+        $rootOne->activate();
+        $rootTwo = $tracer->spanBuilder('root.two')->startSpan();
+        $rootTwo->activate();
+        $this->assertNotEquals($rootOne->getContext()->getTraceId(), $rootTwo->getContext()->getTraceId(), 'trace ids are different');
+        $this->assertNotEquals($rootOne->getContext()->getSpanId(), $rootTwo->getContext()->getSpanId(), 'span ids are different');
 
-        $child = $tracer->spanBuilder('child')
-            ->setStorage($custom)
-            ->startSpan();
-        $child->end();
-        $root->end();
-
-        //@todo confirm that child is a child of root
-        //@todo further, create a span in the default storage, ensure they don't interfere with each other
+        //create a child span in each storage, ensure they parent to the active span from each storage
+        $childOne = $tracer->spanBuilder('child.one')->setStorage($custom)->startSpan();
+        $childTwo = $tracer->spanBuilder('child.two')->startSpan();
+        $this->assertSame($childOne->getContext()->getTraceId(), $rootOne->getContext()->getTraceId());
+        $this->assertSame($childTwo->getContext()->getTraceId(), $rootTwo->getContext()->getTraceId());
+        $this->assertNotSame($childOne->getContext()->getTraceId(), $childTwo->getContext()->getTraceId());
     }
 }

--- a/tests/Integration/ConcurrentTraceTest.php
+++ b/tests/Integration/ConcurrentTraceTest.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Integration;
 
-use OpenTelemetry\API\Trace\SpanContext;
-use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextStorage;
-use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
-use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Integration/ConcurrentTraceTest.php
+++ b/tests/Integration/ConcurrentTraceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Integration;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextStorage;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This class tests using multiple ContextStorage to generate multiple active traces at the same time.
+ */
+class ConcurrentTraceTest extends TestCase
+{
+    public function test_stuff(): void
+    {
+        $tracerProvider =  new TracerProvider();
+        $tracer = $tracerProvider->getTracer();
+        $default = ContextStorage::default();
+        $custom = ContextStorage::create('custom'); //@todo this should use the preferred storage type (fiber or non)
+        //file_put_contents('php://stdout', '^^ context for custom storage'.PHP_EOL);
+        //$context = (new Context())->setStorage($custom);
+        $context = $custom->current(); //??
+        $root = $tracer->spanBuilder('root')
+            //->setParent($context)
+            ->setStorage($custom)
+            ->startSpan();
+        $ctx = $root->activate();
+        $foo = $custom->current();
+        //$this->assertEquals($ctx, $foo);
+
+        $child = $tracer->spanBuilder('child')
+            ->setStorage($custom)
+            ->startSpan();
+        $child->end();
+        $root->end();
+
+        //@todo confirm that child is a child of root
+        //@todo further, create a span in the default storage, ensure they don't interfere with each other
+    }
+}

--- a/tests/Integration/ConcurrentTraceTest.php
+++ b/tests/Integration/ConcurrentTraceTest.php
@@ -18,6 +18,9 @@ use PHPUnit\Framework\TestCase;
  */
 class ConcurrentTraceTest extends TestCase
 {
+    /**
+     * @group concurrency
+     */
     public function test_concurrent_traces_are_independent(): void
     {
         $tracerProvider =  new TracerProvider();

--- a/tests/Integration/Context/Fiber/test_context_switching_not_supported.phpt
+++ b/tests/Integration/Context/Fiber/test_context_switching_not_supported.phpt
@@ -46,8 +46,6 @@ main:main
 Warning: Fiber context switching not supported in %s
 
 Warning: Fiber context switching not supported in %s
-
-Warning: Fiber context switching not supported in %s
 fiber:fiber
 main:fiber
 

--- a/tests/Integration/SDK/ConcurrentTraceTest.php
+++ b/tests/Integration/SDK/ConcurrentTraceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Integration;
+namespace OpenTelemetry\Tests\Integration\SDK;
 
 use OpenTelemetry\Context\ContextStorage;
 use OpenTelemetry\SDK\Trace\TracerProvider;

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -644,7 +644,7 @@ class SpanBuilderTest extends MockeryTestCase
         $sharedParent = $sharedStorage->current();
         $storage = ContextStorage::create(uniqid());
         $parent = $storage->current();
-        $rootShared = $this->tracer->spanBuilder('root.shared')->startSpan();
+        $rootShared = $this->tracer->spanBuilder('shared.root')->startSpan();
         $rootShared->activate();
         $this
             ->spanProcessor
@@ -652,7 +652,7 @@ class SpanBuilderTest extends MockeryTestCase
             ->with($rootShared, $sharedParent)
             ->once();
 
-        $rootCustom = $this->tracer->spanBuilder('root.custom')->setStorage($storage)->startSpan();
+        $rootCustom = $this->tracer->spanBuilder('custom.root')->setStorage($storage)->startSpan();
         $rootCustom->activate();
         $this
             ->spanProcessor
@@ -662,8 +662,8 @@ class SpanBuilderTest extends MockeryTestCase
 
         $this->assertNotSame($sharedStorage->current(), $storage->current(), 'current context is different in each storage');
 
-        $childOne = $this->tracer->spanBuilder('one')->startSpan(); //child span of root.shared
-        $childTwo = $this->tracer->spanBuilder('two')->setStorage($storage)->startSpan(); //child span of root.custom
+        $childOne = $this->tracer->spanBuilder('shared.one')->startSpan(); //child span of root.shared
+        $childTwo = $this->tracer->spanBuilder('custom.one')->setStorage($storage)->startSpan(); //child span of root.custom
         $this
             ->spanProcessor
             ->shouldHaveReceived('onStart')

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -658,7 +658,7 @@ class SpanBuilderTest extends MockeryTestCase
             ->with($rootCustom, $storage->current());
         $this->assertNotSame($storage->current(), $sharedStorage->current());
 
-        $this->assertNotSame($sharedStorage->current(), $storage->current(), 'current context is different in different storages');
+        $this->assertNotSame($sharedStorage->current(), $storage->current(), 'current context is different in each storage');
 
         $childOne = $this->tracer->spanBuilder('one')->startSpan(); //child span of root.shared
         $childTwo = $this->tracer->spanBuilder('two')->setStorage($storage)->startSpan(); //child span of root.custom
@@ -670,8 +670,5 @@ class SpanBuilderTest extends MockeryTestCase
             ->spanProcessor
             ->shouldHaveReceived('onStart')
             ->with($childTwo, $storage->current());
-
-        //$this->assertSame($storage->current(), $rootTwo);
-        //$this->assertSame($sharedStorage->current(), $rootOne);
     }
 }

--- a/tests/Unit/API/Baggage/Propagation/BaggagePropagatorTest.php
+++ b/tests/Unit/API/Baggage/Propagation/BaggagePropagatorTest.php
@@ -79,7 +79,7 @@ class BaggagePropagatorTest extends TestCase
     public function test_extract_missing_header(): void
     {
         $this->assertEquals(
-            Context::getRoot(),
+            Context::getCurrent(),
             BaggagePropagator::getInstance()->extract([])
         );
     }

--- a/tests/Unit/Context/ScopeTest.php
+++ b/tests/Unit/Context/ScopeTest.php
@@ -67,11 +67,11 @@ class ScopeTest extends TestCase
     {
         $scope1 = Context::attach(Context::getCurrent());
 
-        Context::storage()->fork(1);
-        Context::storage()->switch(1);
+        Context::defaultStorage()->fork(1);
+        Context::defaultStorage()->switch(1);
         $this->assertSame(ScopeInterface::INACTIVE, $scope1->detach() & ScopeInterface::INACTIVE);
 
-        Context::storage()->switch(0);
-        Context::storage()->destroy(1);
+        Context::defaultStorage()->switch(0);
+        Context::defaultStorage()->destroy(1);
     }
 }

--- a/tests/Unit/SDK/Trace/SpanBuilderTest.php
+++ b/tests/Unit/SDK/Trace/SpanBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OpenTelemetry\Tests\Unit\SDK\Trace;
 
 use OpenTelemetry\API\Trace\SpanInterface;

--- a/tests/Unit/SDK/Trace/SpanBuilderTest.php
+++ b/tests/Unit/SDK/Trace/SpanBuilderTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace OpenTelemetry\Tests\Unit\SDK\Trace;
+
+use OpenTelemetry\API\Trace\SpanInterface;
+use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
+use OpenTelemetry\SDK\Trace\IdGeneratorInterface;
+use OpenTelemetry\SDK\Trace\SamplerInterface;
+use OpenTelemetry\SDK\Trace\SamplingResult;
+use OpenTelemetry\SDK\Trace\SpanBuilder;
+use OpenTelemetry\SDK\Trace\SpanLimits;
+use OpenTelemetry\SDK\Trace\TracerSharedState;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\SDK\Trace\SpanBuilder
+ */
+class SpanBuilderTest extends TestCase
+{
+    private SpanBuilder $spanBuilder;
+
+    private InstrumentationScopeInterface $instrumentationScope;
+    private TracerSharedState $tracerSharedState;
+    private SpanLimits $spanLimits;
+    private IdGeneratorInterface $idGenerator;
+    private SamplerInterface $sampler;
+    private SamplingResult $samplingResult;
+
+    public function setUp(): void
+    {
+        $this->instrumentationScope = $this->createMock(InstrumentationScopeInterface::class);
+        $this->tracerSharedState = $this->createMock(TracerSharedState::class);
+        $this->spanLimits = $this->createMock(SpanLimits::class);
+        $this->idGenerator = $this->createMock(IdGeneratorInterface::class);
+        $this->sampler = $this->createMock(SamplerInterface::class);
+        $this->samplingResult = $this->createMock(SamplingResult::class);
+        $this->tracerSharedState->method('getSampler')->willReturn($this->sampler);
+        $this->tracerSharedState->method('getIdGenerator')->willReturn($this->idGenerator);
+        $this->sampler->method('shouldSample')->willReturn($this->samplingResult);
+
+        $this->spanBuilder = new SpanBuilder('span', $this->instrumentationScope, $this->tracerSharedState, $this->spanLimits);
+    }
+
+    public function test_start_span(): void
+    {
+        $this->samplingResult->method('getDecision')->willReturn(SamplingResult::RECORD_AND_SAMPLE);
+        $span = $this->spanBuilder->startSpan();
+        $this->assertInstanceOf(SpanInterface::class, $span);
+    }
+}

--- a/tests/Unit/SDK/Trace/SpanBuilderTest.php
+++ b/tests/Unit/SDK/Trace/SpanBuilderTest.php
@@ -43,9 +43,12 @@ class SpanBuilderTest extends TestCase
         $this->spanBuilder = new SpanBuilder('span', $this->instrumentationScope, $this->tracerSharedState, $this->spanLimits);
     }
 
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
     public function test_start_span(): void
     {
-        $this->samplingResult->method('getDecision')->willReturn(SamplingResult::RECORD_AND_SAMPLE);
+        $this->samplingResult->method('getDecision')->willReturn(SamplingResult::RECORD_AND_SAMPLE); //@phpstan-ignore-line
         $span = $this->spanBuilder->startSpan();
         $this->assertInstanceOf(SpanInterface::class, $span);
     }

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -41,6 +41,7 @@ use function str_repeat;
 
 /**
  * @covers OpenTelemetry\SDK\Trace\Span
+ * @coversDefaultClass OpenTelemetry\SDK\Trace\Span
  */
 class SpanTest extends MockeryTestCase
 {


### PR DESCRIPTION
To allow concurrent traces to be generated without clobbering each other, introduce the concept of "default storage", and allow the span builder to accept a storage via `setStorage()`.
If users wish to use non-default storage, they will be responsible for creating that storage, and keeping a reference to it (for example, in a psr-7 request attribute), and then passing that storage on when creating future spans.

Fixes: #671 