### PR TITLE
Allow custom counters implementing CounterInterface to be exported

### DIFF
--- a/src/Contrib/Prometheus/PrometheusExporter.php
+++ b/src/Contrib/Prometheus/PrometheusExporter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Prometheus;
 
 use OpenTelemetry\API\Metrics as API;
-use OpenTelemetry\SDK\Metrics\Counter;
 use OpenTelemetry\SDK\Metrics\Exceptions\CantBeExported;
 use OpenTelemetry\SDK\Metrics\Exporters\AbstractExporter;
 use Prometheus\CollectorRegistry;
@@ -28,8 +27,8 @@ class PrometheusExporter extends AbstractExporter
     protected function doExport(iterable $metrics): void
     {
         foreach ($metrics as $metric) {
-            switch (get_class($metric)) {
-                case Counter::class:
+            switch (true) {
+                case $metric instanceof API\CounterInterface:
                     $this->exportCounter($metric);
 
                     break;


### PR DESCRIPTION
`PrometheusExporter::doExport()` only allows instances of `OpenTelemetry\SDK\Metrics\Counter` class to be exported. This makes it impossible to export counters extending the `Counter` class or just implementing `CounterInterface`.

Allowing any counters implementing `CounterInterface` to be exported would make things easier.