### PR TITLE
fixing psr4 warnings in BC layer

### DIFF
--- a/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibraryInterface.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibraryInterface.php
@@ -13,7 +13,7 @@ interface InstrumentationLibraryInterface extends Moved
 /**
  * @codeCoverageIgnoreStart
  */
-class_alias(InstrumentationLibraryInterface::class, 'OpenTelemetry\SDK\InstrumentationLibraryInterface');
+class_alias(Moved::class, 'OpenTelemetry\SDK\InstrumentationLibraryInterface');
 /**
  * @codeCoverageIgnoreEnd
  */

--- a/src/SDK/Common/Dev/Compatibility/_load.php
+++ b/src/SDK/Common/Dev/Compatibility/_load.php
@@ -10,5 +10,5 @@ require_once __DIR__ . '/BC/ClockInterface.php';
 require_once __DIR__ . '/BC/AbstractClock.php';
 require_once __DIR__ . '/BC/SystemClock.php';
 require_once __DIR__ . '/BC/GlobalLoggerHolder.php';
-require_once __DIR__ . '/BC/InstrumentationScopeInterface.php';
+require_once __DIR__ . '/BC/InstrumentationLibraryInterface.php';
 require_once __DIR__ . '/BC/InstrumentationLibrary.php';


### PR DESCRIPTION
This should resolve "does not comply with psr-4 autoloading standard" for InstrumentationLibraryInterface