### PR TITLE
adding scope detach to examples

### DIFF
--- a/examples/AirGappedTraceDebugging.php
+++ b/examples/AirGappedTraceDebugging.php
@@ -50,7 +50,7 @@ $tracer = $tracerProvider->getTracer();
  */
 echo 'Start Logging ...' . PHP_EOL;
 $rootSpan = $tracer->spanBuilder('root')->startSpan();
-$rootSpan->activate();
+$scope = $rootSpan->activate();
 
 $spans = [];
 
@@ -75,4 +75,5 @@ foreach ($spans as $span) {
 }
 
 $rootSpan->end();
+$scope->detach();
 echo 'Finished!' . PHP_EOL;

--- a/examples/BatchExporting.php
+++ b/examples/BatchExporting.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
+use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
-use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 
 $delayMillis = 3000;
@@ -15,7 +15,7 @@ echo sprintf('Sending batches every %dms and on shutdown', $delayMillis) . PHP_E
 $tracerProvider =  new TracerProvider(
     new BatchSpanProcessor(
         new ConsoleSpanExporter(),
-        \OpenTelemetry\SDK\Common\Time\SystemClock::getDefault(),
+        null,
         2048, //max spans to queue before sending to exporter
         $delayMillis, //batch delay milliseconds
     )
@@ -24,7 +24,7 @@ $tracerProvider =  new TracerProvider(
 $tracer = $tracerProvider->getTracer();
 
 $rootSpan = $tracer->spanBuilder('root')->startSpan();
-$rootSpan->activate();
+$scope = $rootSpan->activate();
 
 //3 spans should be sent at 3 seconds
 for ($i=1;$i<=4;$i++) {
@@ -34,4 +34,5 @@ for ($i=1;$i<=4;$i++) {
 }
 //4th span and root span should be sent on shutdown
 $rootSpan->end();
+$scope->detach();
 sleep(1);

--- a/examples/ConfigurationFromEnvironment.php
+++ b/examples/ConfigurationFromEnvironment.php
@@ -24,6 +24,7 @@ $tracer = $tracerProvider->getTracer();
 echo 'Starting Tracer' . PHP_EOL;
 
 $rootSpan = $tracer->spanBuilder('root')->startSpan();
-$rootSpan->activate();
+$scope = $rootSpan->activate();
 $rootSpan->addEvent('my_event')->setAttribute('fruit', 'apple');
 $rootSpan->end();
+$scope->detach();

--- a/examples/CreatingANewTraceInTheSameProcess.php
+++ b/examples/CreatingANewTraceInTheSameProcess.php
@@ -28,6 +28,7 @@ $rootScope->detach();
 
 // This creates a new span as a parent/root, however regardless of calling "activate" on it, it will have a new TraceId
 $span = $tracer->spanBuilder('baz')->startSpan();
-$span->activate();
+$scope = $span->activate();
 
 $span->end();
+$scope->detach();

--- a/examples/DefaultTracer.php
+++ b/examples/DefaultTracer.php
@@ -18,8 +18,9 @@ $tracer = $tracerProvider->getTracer();
 echo sprintf('Created tracer: %s', get_class($tracer)) . PHP_EOL;
 
 $rootSpan = $tracer->spanBuilder('root')->startSpan();
-$rootSpan->activate();
+$scope = $rootSpan->activate();
 
 $default = TracerProvider::getDefaultTracer();
 echo sprintf('Default tracer: %s', get_class($default)) . PHP_EOL;
 $rootSpan->end();
+$scope->detach();

--- a/examples/LoggingOfSpanData.php
+++ b/examples/LoggingOfSpanData.php
@@ -67,7 +67,7 @@ $tracer = $tracerProvider->getTracer();
  */
 echo 'Start Logging ...' . PHP_EOL;
 $rootSpan = $tracer->spanBuilder('root')->startSpan();
-$rootSpan->activate();
+$scope = $rootSpan->activate();
 
 $spans = [];
 
@@ -92,4 +92,5 @@ foreach ($spans as $span) {
 }
 
 $rootSpan->end();
-echo 'Finished!' . PHP_EOL;
+$scope->detach();
+echo sprintf('Finished! Output written to %s', $logFile) . PHP_EOL;

--- a/examples/ResourceDetectors.php
+++ b/examples/ResourceDetectors.php
@@ -6,6 +6,8 @@ require __DIR__ . '/../vendor/autoload.php';
 use OpenTelemetry\SDK\Trace\TracerProviderFactory;
 
 putenv('OTEL_PHP_DETECTORS=env,sdk,sdk_provided');
+putenv('OTEL_TRACES_EXPORTER=console');
+putenv('OTEL_RESOURCE_ATTRIBUTES=foo=bar'); //env detector will add this to trace attributes
 
 echo 'Handling Resource Detectors From Environment' . PHP_EOL;
 

--- a/examples/SpanResources.php
+++ b/examples/SpanResources.php
@@ -32,7 +32,5 @@ $tracerProvider =  new TracerProvider(
 
 $tracer = $tracerProvider->getTracer();
 
-$rootSpan = $tracer->spanBuilder('root')->startSpan();
-$rootSpan->activate();
-
-$rootSpan->end();
+$span = $tracer->spanBuilder('root')->startSpan();
+$span->end();


### PR DESCRIPTION
it's important to detach scope for any activated span (especially in async runtimes), so ensure that the examples show it being done where possible.
In passing, fix some broken examples.