### PR TITLE
Improve StackTraceFormatter

### DIFF
--- a/src/SDK/Common/Exception/StackTraceFormatter.php
+++ b/src/SDK/Common/Exception/StackTraceFormatter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Util;
+namespace OpenTelemetry\SDK\Common\Exception;
 
 use function basename;
 use function count;
@@ -21,8 +21,11 @@ use Throwable;
  * }
  * @psalm-type Frames = non-empty-list<Frame>
  */
-class TracingUtil
+final class StackTraceFormatter
 {
+    private function __construct()
+    {
+    }
 
     /**
      * Formats an exception in a java-like format.
@@ -32,7 +35,7 @@ class TracingUtil
      *
      * @see https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Throwable.html#printStackTrace()
      */
-    public static function formatStackTrace(Throwable $e): string
+    public static function format(Throwable $e): string
     {
         $s = '';
         $seen = [];

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -161,7 +161,7 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
             TracingUtil::class
         );
 
-        return TracingUtil::formatStackTrace($e, $seen);
+        return TracingUtil::formatStackTrace($e);
     }
 
     /** @inheritDoc */

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -13,9 +13,9 @@ use OpenTelemetry\SDK\Common\Attribute\AttributeLimits;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 use OpenTelemetry\SDK\Common\Dev\Compatibility\Util as BcUtil;
+use OpenTelemetry\SDK\Common\Exception\StackTraceFormatter;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;
-use OpenTelemetry\SDK\Common\Util\TracingUtil;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use Throwable;
 
@@ -157,11 +157,11 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
     {
         BcUtil::triggerMethodDeprecationNotice(
             __METHOD__,
-            'formatStackTrace',
-            TracingUtil::class
+            'format',
+            StackTraceFormatter::class
         );
 
-        return TracingUtil::formatStackTrace($e);
+        return StackTraceFormatter::format($e);
     }
 
     /** @inheritDoc */
@@ -235,7 +235,7 @@ final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
         $eventAttributes = new Attributes([
                 'exception.type' => get_class($exception),
                 'exception.message' => $exception->getMessage(),
-                'exception.stacktrace' => TracingUtil::formatStackTrace($exception),
+                'exception.stacktrace' => StackTraceFormatter::format($exception),
             ]);
 
         foreach ($attributes as $key => $value) {

--- a/tests/Unit/SDK/Common/Util/test_stacktrace_basic.phpt
+++ b/tests/Unit/SDK/Common/Util/test_stacktrace_basic.phpt
@@ -2,7 +2,7 @@
 Basic stacktrace format
 --FILE--
 <?php
-use OpenTelemetry\SDK\Common\Util\TracingUtil;
+use OpenTelemetry\SDK\Common\Exception\StackTraceFormatter;
 
 require_once 'vendor/autoload.php';
 
@@ -19,13 +19,13 @@ function create(): Throwable {
     return new Exception();
 }
 
-echo TracingUtil::formatStackTrace(new Exception()), "\n", "\n";
-echo TracingUtil::formatStackTrace(new Exception('message')), "\n", "\n";
-echo TracingUtil::formatStackTrace(new Exception('outer', 0, new Exception('inner'))), "\n", "\n";
+echo StackTraceFormatter::format(new Exception()), "\n", "\n";
+echo StackTraceFormatter::format(new Exception('message')), "\n", "\n";
+echo StackTraceFormatter::format(new Exception('outer', 0, new Exception('inner'))), "\n", "\n";
 
-echo TracingUtil::formatStackTrace(create()), "\n", "\n";
-echo TracingUtil::formatStackTrace((new Test)->create()), "\n", "\n";
-echo TracingUtil::formatStackTrace(Test::createStatic()), "\n", "\n";
+echo StackTraceFormatter::format(create()), "\n", "\n";
+echo StackTraceFormatter::format((new Test)->create()), "\n", "\n";
+echo StackTraceFormatter::format(Test::createStatic()), "\n", "\n";
 ?>
 --EXPECTF--
 Exception

--- a/tests/Unit/SDK/Common/Util/test_stacktrace_basic.phpt
+++ b/tests/Unit/SDK/Common/Util/test_stacktrace_basic.phpt
@@ -1,0 +1,52 @@
+--TEST--
+Basic stacktrace format
+--FILE--
+<?php
+use OpenTelemetry\SDK\Common\Util\TracingUtil;
+
+require_once 'vendor/autoload.php';
+
+class Test {
+    public static function createStatic(): Throwable {
+        return new Exception();
+    }
+    public function create(): Throwable {
+        return new Exception();
+    }
+}
+
+function create(): Throwable {
+    return new Exception();
+}
+
+echo TracingUtil::formatStackTrace(new Exception()), "\n", "\n";
+echo TracingUtil::formatStackTrace(new Exception('message')), "\n", "\n";
+echo TracingUtil::formatStackTrace(new Exception('outer', 0, new Exception('inner'))), "\n", "\n";
+
+echo TracingUtil::formatStackTrace(create()), "\n", "\n";
+echo TracingUtil::formatStackTrace((new Test)->create()), "\n", "\n";
+echo TracingUtil::formatStackTrace(Test::createStatic()), "\n", "\n";
+?>
+--EXPECTF--
+Exception
+	at {main}(test_stacktrace_basic.php:19)
+
+Exception: message
+	at {main}(test_stacktrace_basic.php:20)
+
+Exception: outer
+	at {main}(test_stacktrace_basic.php:21)
+Caused by: Exception: inner
+	... 1 more
+
+Exception
+	at create(test_stacktrace_basic.php:16)
+	at {main}(test_stacktrace_basic.php:23)
+
+Exception
+	at Test.create(test_stacktrace_basic.php:11)
+	at {main}(test_stacktrace_basic.php:24)
+
+Exception
+	at Test.createStatic(test_stacktrace_basic.php:8)
+	at {main}(test_stacktrace_basic.php:25)

--- a/tests/Unit/SDK/Common/Util/test_stacktrace_circular.phpt
+++ b/tests/Unit/SDK/Common/Util/test_stacktrace_circular.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Circular reference in exception
+--FILE--
+<?php
+use OpenTelemetry\SDK\Common\Util\TracingUtil;
+
+require_once 'vendor/autoload.php';
+
+class TestException extends Exception {
+    public function __construct(string $message = "", int $code = 0) {
+        parent::__construct($message, $code, new Exception('', 0, $this));
+    }
+}
+
+echo TracingUtil::formatStackTrace(new TestException()), "\n", "\n";
+echo TracingUtil::formatStackTrace(new TestException('message')), "\n", "\n";
+?>
+--EXPECTF--
+TestException
+	at {main}(%s:%d)
+Caused by: Exception
+	at TestException.__construct(%s:%d)
+	... 1 more
+Caused by: [CIRCULAR REFERENCE: TestException]
+
+TestException: message
+	at {main}(%s:%d)
+Caused by: Exception
+	at TestException.__construct(%s:%d)
+	... 1 more
+Caused by: [CIRCULAR REFERENCE: TestException: message]

--- a/tests/Unit/SDK/Common/Util/test_stacktrace_circular.phpt
+++ b/tests/Unit/SDK/Common/Util/test_stacktrace_circular.phpt
@@ -2,7 +2,7 @@
 Circular reference in exception
 --FILE--
 <?php
-use OpenTelemetry\SDK\Common\Util\TracingUtil;
+use OpenTelemetry\SDK\Common\Exception\StackTraceFormatter;
 
 require_once 'vendor/autoload.php';
 
@@ -12,8 +12,8 @@ class TestException extends Exception {
     }
 }
 
-echo TracingUtil::formatStackTrace(new TestException()), "\n", "\n";
-echo TracingUtil::formatStackTrace(new TestException('message')), "\n", "\n";
+echo StackTraceFormatter::format(new TestException()), "\n", "\n";
+echo StackTraceFormatter::format(new TestException('message')), "\n", "\n";
 ?>
 --EXPECTF--
 TestException

--- a/tests/Unit/SDK/Common/Util/test_stacktrace_n_more.phpt
+++ b/tests/Unit/SDK/Common/Util/test_stacktrace_n_more.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Frames should only be collapsed iff matching frames of enclosing exception
+--FILE--
+<?php
+use OpenTelemetry\SDK\Common\Util\TracingUtil;
+
+require_once 'vendor/autoload.php';
+
+function create(?Throwable $e = null): Throwable {
+    return new Exception('', 0, $e);
+}
+
+$outer = create(create());
+echo TracingUtil::formatStackTrace($outer), "\n", "\n";
+
+$inner = create();
+$outer = create($inner);
+echo TracingUtil::formatStackTrace($outer), "\n", "\n";
+?>
+--EXPECTF--
+Exception
+	at create(%s:%d)
+	at {main}(%s:%d)
+Caused by: Exception
+	... 2 more
+
+Exception
+	at create(%s:%d)
+	at {main}(%s:%d)
+Caused by: Exception
+	at create(%s:%d)
+	at {main}(%s:%d)

--- a/tests/Unit/SDK/Common/Util/test_stacktrace_n_more.phpt
+++ b/tests/Unit/SDK/Common/Util/test_stacktrace_n_more.phpt
@@ -2,7 +2,7 @@
 Frames should only be collapsed iff matching frames of enclosing exception
 --FILE--
 <?php
-use OpenTelemetry\SDK\Common\Util\TracingUtil;
+use OpenTelemetry\SDK\Common\Exception\StackTraceFormatter;
 
 require_once 'vendor/autoload.php';
 
@@ -11,11 +11,11 @@ function create(?Throwable $e = null): Throwable {
 }
 
 $outer = create(create());
-echo TracingUtil::formatStackTrace($outer), "\n", "\n";
+echo StackTraceFormatter::format($outer), "\n", "\n";
 
 $inner = create();
 $outer = create($inner);
-echo TracingUtil::formatStackTrace($outer), "\n", "\n";
+echo StackTraceFormatter::format($outer), "\n", "\n";
 ?>
 --EXPECTF--
 Exception

--- a/tests/Unit/SDK/Common/Util/test_stacktrace_namespaced.phpt
+++ b/tests/Unit/SDK/Common/Util/test_stacktrace_namespaced.phpt
@@ -5,7 +5,7 @@ Namespaced stacktrace format
 namespace Abc\Def;
 
 use Exception;
-use OpenTelemetry\SDK\Common\Util\TracingUtil;
+use OpenTelemetry\SDK\Common\Exception\StackTraceFormatter;
 use Throwable;
 
 require_once 'vendor/autoload.php';
@@ -26,12 +26,12 @@ function create(): Throwable {
     return new Exception();
 }
 
-echo TracingUtil::formatStackTrace(new TestException()), "\n", "\n";
-echo TracingUtil::formatStackTrace(new Exception('outer', 0, new TestException('inner'))), "\n", "\n";
+echo StackTraceFormatter::format(new TestException()), "\n", "\n";
+echo StackTraceFormatter::format(new Exception('outer', 0, new TestException('inner'))), "\n", "\n";
 
-echo TracingUtil::formatStackTrace(create()), "\n", "\n";
-echo TracingUtil::formatStackTrace((new Test)->create()), "\n", "\n";
-echo TracingUtil::formatStackTrace(Test::createStatic()), "\n", "\n";
+echo StackTraceFormatter::format(create()), "\n", "\n";
+echo StackTraceFormatter::format((new Test)->create()), "\n", "\n";
+echo StackTraceFormatter::format(Test::createStatic()), "\n", "\n";
 ?>
 --EXPECTF--
 Abc.Def.TestException

--- a/tests/Unit/SDK/Common/Util/test_stacktrace_namespaced.phpt
+++ b/tests/Unit/SDK/Common/Util/test_stacktrace_namespaced.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Namespaced stacktrace format
+--FILE--
+<?php
+namespace Abc\Def;
+
+use Exception;
+use OpenTelemetry\SDK\Common\Util\TracingUtil;
+use Throwable;
+
+require_once 'vendor/autoload.php';
+
+class TestException extends Exception {
+}
+
+class Test {
+    public static function createStatic(): Throwable {
+        return new Exception();
+    }
+    public function create(): Throwable {
+        return new Exception();
+    }
+}
+
+function create(): Throwable {
+    return new Exception();
+}
+
+echo TracingUtil::formatStackTrace(new TestException()), "\n", "\n";
+echo TracingUtil::formatStackTrace(new Exception('outer', 0, new TestException('inner'))), "\n", "\n";
+
+echo TracingUtil::formatStackTrace(create()), "\n", "\n";
+echo TracingUtil::formatStackTrace((new Test)->create()), "\n", "\n";
+echo TracingUtil::formatStackTrace(Test::createStatic()), "\n", "\n";
+?>
+--EXPECTF--
+Abc.Def.TestException
+	at {main}(%s:%d)
+
+Exception: outer
+	at {main}(%s:%d)
+Caused by: Abc.Def.TestException: inner
+	... 1 more
+
+Exception
+	at Abc.Def.create(%s:%d)
+	at {main}(%s:%d)
+
+Exception
+	at Abc.Def.Test.create(%s:%d)
+	at {main}(%s:%d)
+
+Exception
+	at Abc.Def.Test.createStatic(%s:%d)
+	at {main}(%s:%d)

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -15,11 +15,11 @@ use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
+use OpenTelemetry\SDK\Common\Exception\StackTraceFormatter;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScope;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;
 use OpenTelemetry\SDK\Common\Time\ClockInterface;
 use OpenTelemetry\SDK\Common\Time\Util as TimeUtil;
-use OpenTelemetry\SDK\Common\Util\TracingUtil;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 use OpenTelemetry\SDK\Trace\Event;
@@ -571,7 +571,7 @@ class SpanTest extends MockeryTestCase
             new Attributes([
                 'exception.type' => 'Exception',
                 'exception.message' => 'ERR',
-                'exception.stacktrace' => TracingUtil::formatStackTrace($exception),
+                'exception.stacktrace' => StackTraceFormatter::format($exception),
             ]),
             $event->getAttributes()
         );
@@ -597,7 +597,7 @@ class SpanTest extends MockeryTestCase
             new Attributes([
                 'exception.type' => 'Exception',
                 'exception.message' => 'ERR',
-                'exception.stacktrace' => TracingUtil::formatStackTrace($exception),
+                'exception.stacktrace' => StackTraceFormatter::format($exception),
                 'foo' => 'bar',
             ]),
             $event->getAttributes()


### PR DESCRIPTION
Resolves some issues with the stacktrace formatter.
- Fix "... n more" to fold only identical frames, currently we might lose information due to folding on first seen frame instead of folding last n identical frames as described by Java ("These lines indicate that the remainder of the stack trace for this exception matches the indicated number of frames from the bottom of the stack trace of the exception that was caused by this exception (the "enclosing" exception).")
- Fix exception class names not being converted to dotted format
- Fix functions being shown as `main`
- Fix out-of-memory on circular exception

Example output to highlight some of the differences:
```
# new
Abc.Def.Test: bar
	at Abc.Def.Test.create(Test.php:10)
	at Abc.Def.run(example.php:8)
	at {main}(example.php:12)
Caused by: Abc.Def.Test: foo
	at Abc.Def.Test.create(Test.php:10)
	at Abc.Def.run(example.php:7)
	... 1 more
```

```
# old
Abc\Def\Test: bar
 at Abc.Def.Test.create(Test.php:10)
 at main(example.php:8)
 at main(example.php:12)
Caused by: Abc\Def\Test: foo
 ... 3 more
```

Additionally this changes the output format:
- indent is now 1 tab instead of 1 space
- empty messages are no longer displayed (no `: `) - what is the desired behavior? Java prints nothing for `null` and `: ` for empty.
- main is now displayed as `{main}` instead of `main` to avoid confusion with a function named `main` (curly brackets for consistency with `{closure}`)

Currently it's not possible to run the tests with PHPUnit (`<directory suffix=".phpt">./tests/Unit</directory>`) due to PHPUnit loading the scripts using `require`, which changes the stacktrace. [run-tests.php](https://github.com/php/php-src/blob/master/run-tests.php) can be used instead (not executed automatically for now in hopes that this will be resolved).