### PR TITLE
fixing BC alias for InstrumentationLibrary

### DIFF
--- a/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibraryInterface.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibraryInterface.php
@@ -13,7 +13,7 @@ interface InstrumentationLibraryInterface extends Moved
 /**
  * @codeCoverageIgnoreStart
  */
-class_alias(Moved::class, 'OpenTelemetry\SDK\InstrumentationLibraryInterface');
+class_alias(InstrumentationLibraryInterface::class, 'OpenTelemetry\SDK\InstrumentationLibraryInterface');
 /**
  * @codeCoverageIgnoreEnd
  */

--- a/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibraryInterface.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibraryInterface.php
@@ -13,7 +13,7 @@ interface InstrumentationLibraryInterface extends Moved
 /**
  * @codeCoverageIgnoreStart
  */
-class_alias(InstrumentationLibraryInterface::class, 'OpenTelemetry\SDK\InstrumentationLibraryInterface');
+class_alias(InstrumentationLibraryInterface::class, 'OpenTelemetry\SDK\Common\Instrumentation\InstrumentationLibraryInterface');
 /**
  * @codeCoverageIgnoreEnd
  */


### PR DESCRIPTION
Correctly aliasing the renamed InstrumentationLibraryInterface to the new InstrumentationScopeInterface
Fixes #702