### PR TITLE
Change `Sampler`s to return `null` instead of provided attributes

### DIFF
--- a/src/SDK/Trace/Sampler/AlwaysOnSampler.php
+++ b/src/SDK/Trace/Sampler/AlwaysOnSampler.php
@@ -38,7 +38,7 @@ class AlwaysOnSampler implements SamplerInterface
 
         return new SamplingResult(
             SamplingResult::RECORD_AND_SAMPLE,
-            $attributes,
+            null,
             $traceState
         );
     }

--- a/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -60,7 +60,7 @@ class TraceIdRatioBasedSampler implements SamplerInterface
         $traceIdCondition = $lowerOrderBytes < round($this->probability * $traceIdLimit);
         $decision = $traceIdCondition ? SamplingResult::RECORD_AND_SAMPLE : SamplingResult::DROP;
 
-        return new SamplingResult($decision, $attributes, $traceState);
+        return new SamplingResult($decision, null, $traceState);
     }
 
     public function getDescription(): string


### PR DESCRIPTION
Returned attributes are additional attributes; `AlwaysOffSampler` already returns `null`.
["A set of span Attributes that will also be added to the Span."](https://github.com/open-telemetry/opentelemetry-specification/blob/5fb819c72e34cb21fe1ce5acba1dc93c2216ecb1/specification/trace/sdk.md#shouldsample)