### PR TITLE
Add Rector and PHP 7.4 rules

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,7 +43,10 @@ make all
 This does the following things:
 
 * Installs/updates all the required dependencies for the project
+* Uses [Rector](https://github.com/rectorphp/rector) to refactor your code according to our standards.
 * Uses [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) to style your code using our style preferences.
+* Uses [Deptrac](https://github.com/qossmic/deptrac) to check for dependency violations inside our code base
+* Makes sure the composer files for the different components are valid
 * Runs all of our [phpunit](https://phpunit.de/) unit tests.
 * Performs static analysis with [Phan](https://github.com/phan/phan), [Psalm](https://psalm.dev/)
   and [PHPStan](https://phpstan.org/user-guide/getting-started)
@@ -88,11 +91,32 @@ SEMCONV_VERSION=1.8.0 make semconv
 
 Run this command in the root of this repository.
 
+## Automatic Refactoring and Upgrading
+
+We use [Rector](https://github.com/rectorphp/rector) to automatically refactor our code according to given standards
+and upgrade the code to supported PHP versions.
+The associated configuration can be found [here](./.rector.php)
+
+To refactor your code following our given standards, you can run:
+
+```bash
+make rector
+```
+
+This command applies the changes to the code base.
+Make sure to run `make style` (see below) after running the `rector`command as the changes might not follow our coding standard.
+
+If you want to simply check what changes would be applied by rector, you can run:
+
+```bash
+make rector-dry
+```
+This command will simply print out the changes `rector`would make without actually changing any code.
+
 ## Styling
 
 We use [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) for our code linting and standards fixer. The
-associated configuration for this standards fixer can be found in the root of the
-repository [here](https://github.com/open-telemetry/opentelemetry-php/blob/master/.php_cs)
+associated configuration can be found [here](./.php-cs-fixer.php)
 
 To ensure that your code follows our coding standards, you can run:
 
@@ -100,7 +124,7 @@ To ensure that your code follows our coding standards, you can run:
 make style
 ```
 
-This command executes a required test that also runs during CI. This process performs the required fixes and prints them
+This command executes a required check that also runs during CI. This process performs the required fixes and prints them
 out. Code that doesn't meet the style pattern will emit a failure with GitHub actions.
 
 ## Static Analysis
@@ -158,6 +182,21 @@ make test
 
 This will output the test output as well as a test coverage analysis (text + html - see `tests/coverage/html`). Code
 that doesn't pass our currently defined tests will emit a failure in CI
+
+## Dependency Validation
+
+To make sure the different components of the library are distributable as separate packages, we have to check
+    for dependency violations inside the code base. Dependencies must create a [DAC](https://en.wikipedia.org/wiki/Directed_acyclic_graph) in order to not create recursive dependencies.
+For this purpose we use [Deptrac](https://github.com/qossmic/deptrac) and the respective configuration can be found
+[here](./deptrac.yaml)
+
+To validatethe dependencies inside the code base, you can run:
+
+```bash
+make deptrac
+```
+This command will create an error for any violation of the defined dependencies. If you add new dependencies to the code base,
+please configure them in the rector configuration.
 
 ## PhpMetrics
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PHP_VERSION ?= 7.4
 DC_RUN_PHP = docker-compose run --rm php
 
-all: update rector style packages-composer deptrac phan psalm phpstan test
+all: update rector style deptrac packages-composer  phan psalm phpstan test
 install:
 	$(DC_RUN_PHP) env XDEBUG_MODE=off composer install
 update:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PHP_VERSION ?= 7.4
 DC_RUN_PHP = docker-compose run --rm php
 
-all: update style packages-composer deptrac phan psalm phpstan test
+all: update rector style packages-composer deptrac phan psalm phpstan test
 install:
 	$(DC_RUN_PHP) env XDEBUG_MODE=off composer install
 update:
@@ -60,6 +60,10 @@ bash:
 	$(DC_RUN_PHP) bash
 style:
 	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --using-cache=no -vvv
+rector:
+	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/rector process src
+rector-dry:
+	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/rector process src --dry-run
 deptrac:
 	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/deptrac --formatter=table --report-uncovered --no-cache
 w3c-test-service:

--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
         "psalm/plugin-phpunit": "^0.16",
         "psalm/psalm": "^4.0",
         "qossmic/deptrac-shim": "^0.22.1",
+        "rector/rector": "^0.13.7",
         "symfony/http-client": "^5.2"
     },
     "suggest": {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN chmod +x /usr/local/bin/install-php-extensions; \
         pcntl \
         grpc \
         sockets \
+        intl \
         @composer \
     ; \
     # strip debug symbols from extensions to reduce size

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+    ]);
+
+    $rectorConfig->sets([
+        SetList::PHP_74,
+    ]);
+};

--- a/src/API/Baggage/BaggageBuilder.php
+++ b/src/API/Baggage/BaggageBuilder.php
@@ -26,7 +26,7 @@ final class BaggageBuilder implements BaggageBuilderInterface
     /** @inheritDoc */
     public function set(string $key, $value, MetadataInterface $metadata = null): BaggageBuilderInterface
     {
-        $metadata = $metadata ?? Metadata::getEmpty();
+        $metadata ??= Metadata::getEmpty();
 
         $this->entries[$key] = new Entry($value, $metadata);
 

--- a/src/API/Baggage/Propagation/BaggagePropagator.php
+++ b/src/API/Baggage/Propagation/BaggagePropagator.php
@@ -40,8 +40,8 @@ final class BaggagePropagator implements TextMapPropagatorInterface
 
     public function inject(&$carrier, PropagationSetterInterface $setter = null, Context $context = null): void
     {
-        $setter = $setter ?? ArrayAccessGetterSetter::getInstance();
-        $context = $context ?? Context::getCurrent();
+        $setter ??= ArrayAccessGetterSetter::getInstance();
+        $context ??= Context::getCurrent();
 
         $baggage = Baggage::fromContext($context);
 
@@ -71,8 +71,8 @@ final class BaggagePropagator implements TextMapPropagatorInterface
 
     public function extract($carrier, PropagationGetterInterface $getter = null, Context $context = null): Context
     {
-        $getter = $getter ?? ArrayAccessGetterSetter::getInstance();
-        $context = $context ?? Context::getCurrent();
+        $getter ??= ArrayAccessGetterSetter::getInstance();
+        $context ??= Context::getCurrent();
 
         if (!$baggageHeader = $getter->get($carrier, self::BAGGAGE)) {
             return $context;

--- a/src/API/Trace/Propagation/B3MultiPropagator.php
+++ b/src/API/Trace/Propagation/B3MultiPropagator.php
@@ -99,8 +99,8 @@ final class B3MultiPropagator implements TextMapPropagatorInterface
     /** {@inheritdoc} */
     public function inject(&$carrier, PropagationSetterInterface $setter = null, Context $context = null): void
     {
-        $setter = $setter ?? ArrayAccessGetterSetter::getInstance();
-        $context = $context ?? Context::getCurrent();
+        $setter ??= ArrayAccessGetterSetter::getInstance();
+        $context ??= Context::getCurrent();
         $spanContext = AbstractSpan::fromContext($context)->getContext();
 
         if (!$spanContext->isValid()) {
@@ -114,8 +114,8 @@ final class B3MultiPropagator implements TextMapPropagatorInterface
 
     public function extract($carrier, PropagationGetterInterface $getter = null, Context $context = null): Context
     {
-        $getter = $getter ?? ArrayAccessGetterSetter::getInstance();
-        $context = $context ?? Context::getCurrent();
+        $getter ??= ArrayAccessGetterSetter::getInstance();
+        $context ??= Context::getCurrent();
 
         $spanContext = self::extractImpl($carrier, $getter);
         if (!$spanContext->isValid()) {

--- a/src/API/Trace/Propagation/TraceContextPropagator.php
+++ b/src/API/Trace/Propagation/TraceContextPropagator.php
@@ -53,8 +53,8 @@ final class TraceContextPropagator implements TextMapPropagatorInterface
     /** {@inheritdoc} */
     public function inject(&$carrier, PropagationSetterInterface $setter = null, Context $context = null): void
     {
-        $setter = $setter ?? ArrayAccessGetterSetter::getInstance();
-        $context = $context ?? Context::getCurrent();
+        $setter ??= ArrayAccessGetterSetter::getInstance();
+        $context ??= Context::getCurrent();
         $spanContext = AbstractSpan::fromContext($context)->getContext();
 
         if (!$spanContext->isValid()) {
@@ -75,8 +75,8 @@ final class TraceContextPropagator implements TextMapPropagatorInterface
     /** {@inheritdoc} */
     public function extract($carrier, PropagationGetterInterface $getter = null, Context $context = null): Context
     {
-        $getter = $getter ?? ArrayAccessGetterSetter::getInstance();
-        $context = $context ?? Context::getCurrent();
+        $getter ??= ArrayAccessGetterSetter::getInstance();
+        $context ??= Context::getCurrent();
 
         $spanContext = self::extractImpl($carrier, $getter);
         if (!$spanContext->isValid()) {

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -78,7 +78,7 @@ final class Context
      */
     public static function getValue(ContextKey $key, ?Context $ctx=null)
     {
-        $ctx = $ctx ?? self::getCurrent();
+        $ctx ??= self::getCurrent();
 
         return $ctx->get($key);
     }

--- a/src/Context/Propagation/MultiTextMapPropagator.php
+++ b/src/Context/Propagation/MultiTextMapPropagator.php
@@ -51,7 +51,7 @@ final class MultiTextMapPropagator implements TextMapPropagatorInterface
 
     public function extract($carrier, PropagationGetterInterface $getter = null, Context $context = null): Context
     {
-        $context = $context ?? Context::getCurrent();
+        $context ??= Context::getCurrent();
 
         foreach ($this->propagators as $propagator) {
             $context = $propagator->extract($carrier, $getter, $context);

--- a/src/Contrib/Jaeger/JaegerTransport.php
+++ b/src/Contrib/Jaeger/JaegerTransport.php
@@ -12,6 +12,7 @@ use OpenTelemetry\SDK\Behavior\LogsMessagesTrait;
 use Thrift\Exception\TTransportException;
 use Thrift\Protocol\TCompactProtocol;
 
+// @phan-file-suppress PhanUndeclaredClassMethod
 final class JaegerTransport implements TransportInterface
 {
     use LogsMessagesTrait;

--- a/src/Contrib/Jaeger/JaegerTransport.php
+++ b/src/Contrib/Jaeger/JaegerTransport.php
@@ -23,9 +23,9 @@ final class JaegerTransport implements TransportInterface
     private $transport;
     private $client;
 
-    private $buffer = [];
+    private array $buffer = [];
     private $process = null;
-    private $maxBufferSize = 0;
+    private int $maxBufferSize = 0;
 
     public function __construct(ParsedEndpointUrl $parsedEndpoint, $maxBufferSize = 0)
     {

--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -192,9 +192,7 @@ class SpanConverter implements SpanConverterInterface
     private static function convertOtelEventsToJaegerLogs(SpanDataInterface $span): array
     {
         return array_map(
-            function ($event) {
-                return self::convertSingleOtelEventToJaegerLog($event);
-            },
+            fn($event) => self::convertSingleOtelEventToJaegerLog($event),
             $span->getEvents()
         );
     }
@@ -217,9 +215,7 @@ class SpanConverter implements SpanConverterInterface
     private static function convertOtelLinksToJaegerSpanReferences(SpanDataInterface $span): array
     {
         return array_map(
-            function ($link) {
-                return self::convertSingleOtelLinkToJaegerSpanReference($link);
-            },
+            fn($link) => self::convertSingleOtelLinkToJaegerSpanReference($link),
             $span->getLinks()
         );
     }

--- a/src/Contrib/Jaeger/SpanConverter.php
+++ b/src/Contrib/Jaeger/SpanConverter.php
@@ -192,7 +192,7 @@ class SpanConverter implements SpanConverterInterface
     private static function convertOtelEventsToJaegerLogs(SpanDataInterface $span): array
     {
         return array_map(
-            fn($event) => self::convertSingleOtelEventToJaegerLog($event),
+            fn ($event) => self::convertSingleOtelEventToJaegerLog($event),
             $span->getEvents()
         );
     }
@@ -215,7 +215,7 @@ class SpanConverter implements SpanConverterInterface
     private static function convertOtelLinksToJaegerSpanReferences(SpanDataInterface $span): array
     {
         return array_map(
-            fn($link) => self::convertSingleOtelLinkToJaegerSpanReference($link),
+            fn ($link) => self::convertSingleOtelLinkToJaegerSpanReference($link),
             $span->getLinks()
         );
     }

--- a/src/Contrib/Jaeger/TagFactory/TagFactory.php
+++ b/src/Contrib/Jaeger/TagFactory/TagFactory.php
@@ -67,9 +67,7 @@ class TagFactory
     private static function recursivelySerializeArray($value): string
     {
         if (is_array($value)) {
-            return join(',', array_map(function ($val) {
-                return self::recursivelySerializeArray($val);
-            }, $value));
+            return join(',', array_map(fn($val) => self::recursivelySerializeArray($val), $value));
         }
 
         // Casting false to string makes an empty string

--- a/src/Contrib/Jaeger/TagFactory/TagFactory.php
+++ b/src/Contrib/Jaeger/TagFactory/TagFactory.php
@@ -67,7 +67,7 @@ class TagFactory
     private static function recursivelySerializeArray($value): string
     {
         if (is_array($value)) {
-            return join(',', array_map(fn($val) => self::recursivelySerializeArray($val), $value));
+            return join(',', array_map(fn ($val) => self::recursivelySerializeArray($val), $value));
         }
 
         // Casting false to string makes an empty string

--- a/src/SDK/Common/Time/ClockFactory.php
+++ b/src/SDK/Common/Time/ClockFactory.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\SDK\Common\Time;
 
 final class ClockFactory implements ClockFactoryInterface
 {
-    private static ?ClockInterface $default;
+    private static ?ClockInterface $default = null;
 
     public static function create(): self
     {

--- a/src/SDK/Common/Time/StopWatchFactory.php
+++ b/src/SDK/Common/Time/StopWatchFactory.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\SDK\Common\Time;
 
 final class StopWatchFactory implements StopWatchFactoryInterface
 {
-    private static ?StopWatchInterface $default;
+    private static ?StopWatchInterface $default = null;
 
     private ClockInterface $clock;
     private ?int $initialStartTime;

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -41,10 +41,10 @@ final class TracerProvider implements API\TracerProviderInterface
         }
 
         $spanProcessors = is_array($spanProcessors) ? $spanProcessors : [$spanProcessors];
-        $resource = $resource ?? ResourceInfoFactory::defaultResource();
-        $sampler = $sampler ?? new ParentBased(new AlwaysOnSampler());
-        $idGenerator = $idGenerator ?? new RandomIdGenerator();
-        $spanLimits = $spanLimits ?? (new SpanLimitsBuilder())->build();
+        $resource ??= ResourceInfoFactory::defaultResource();
+        $sampler ??= new ParentBased(new AlwaysOnSampler());
+        $idGenerator ??= new RandomIdGenerator();
+        $spanLimits ??= (new SpanLimitsBuilder())->build();
 
         $this->tracerSharedState = new TracerSharedState(
             $idGenerator,


### PR DESCRIPTION
As discussed (long ago) we want to use [Rector](https://github.com/rectorphp/rector) to automatically refactor our code base to be more consistent and automate the upgrade to higher PHP Versions once support for a specific version is dropped.
This PR adds rector as a dependecy and applies rules to upgrade the code base completely to PHP 7.4.
(I will add more rector rules gardually in future PRs, as otherwise this will be a nightmare to review)

- Adds rector as a dev dependency
- Adds rector make targets and inclues them in "make all"
- Applies rector PHP 7.4 rules to the code base
- Adds rector info (and missing deptract info) to DEVELOPMENT.md
- Adds intl extension to dev image for better rector performance