### PR TITLE
return no-op span builder after shutdown

### DIFF
--- a/src/SDK/Trace/Tracer.php
+++ b/src/SDK/Trace/Tracer.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\SDK\Trace;
 
 use function ctype_space;
 use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 
 class Tracer implements API\TracerInterface
@@ -34,7 +35,7 @@ class Tracer implements API\TracerInterface
         }
 
         if ($this->tracerSharedState->hasShutdown()) {
-            // TODO: Return a noop tracer
+            return new API\NoopSpanBuilder(Context::storage());
         }
 
         return new SpanBuilder(

--- a/tests/Integration/SDK/TracerTest.php
+++ b/tests/Integration/SDK/TracerTest.php
@@ -13,6 +13,7 @@ use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use OpenTelemetry\SDK\Trace\Span;
+use OpenTelemetry\SDK\Trace\SpanBuilder;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
@@ -83,5 +84,14 @@ class TracerTest extends TestCase
         $this->assertSame('dev', $spanInstrumentationScope->getVersion());
         $this->assertSame('http://url', $spanInstrumentationScope->getSchemaUrl());
         $this->assertSame(['foo' => 'bar'], $spanInstrumentationScope->getAttributes()->toArray());
+    }
+
+    public function test_returns_noop_span_builder_after_shutdown(): void
+    {
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('foo');
+        $this->assertInstanceOf(SpanBuilder::class, $tracer->spanBuilder('bar'));
+        $tracerProvider->shutdown();
+        $this->assertInstanceOf(API\NoopSpanBuilder::class, $tracer->spanBuilder('baz'));
     }
 }

--- a/tests/Unit/SDK/Trace/TracerTest.php
+++ b/tests/Unit/SDK/Trace/TracerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Trace;
 
+use OpenTelemetry\API\Trace\NoopSpanBuilder;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScope;
 use OpenTelemetry\SDK\Trace\Tracer;
 use OpenTelemetry\SDK\Trace\TracerSharedState;
@@ -51,5 +52,14 @@ class TracerTest extends TestCase
     public function test_get_instrumentation_scope(): void
     {
         $this->assertSame($this->instrumentationScope, $this->tracer->getInstrumentationScope());
+    }
+
+    /**
+     * @psalm-suppress UndefinedMethod
+     */
+    public function test_returns_noop_span_builder_if_shared_state_is_shutdown(): void
+    {
+        $this->tracerSharedState->method('hasShutdown')->willReturn(true); //@phpstan-ignore-line
+        $this->assertInstanceOf(NoopSpanBuilder::class, $this->tracer->spanBuilder('foo'));
     }
 }

--- a/tests/Unit/SDK/Trace/TracerTest.php
+++ b/tests/Unit/SDK/Trace/TracerTest.php
@@ -48,8 +48,6 @@ class TracerTest extends TestCase
         ];
     }
 
-    /**
-     */
     public function test_get_instrumentation_scope(): void
     {
         $this->assertSame($this->instrumentationScope, $this->tracer->getInstrumentationScope());


### PR DESCRIPTION
this completes a todo in code comments: when tracer shared state has shutdown, getting a span builder should return a no-op implementation