### PR TITLE
Add polyfills for PHP 8.0, 8.1, 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
         "promphp/prometheus_client_php": "^2.2.1",
         "psr/http-factory-implementation": "^1.0",
         "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/polyfill-mbstring": "^1.23"
+        "symfony/polyfill-mbstring": "^1.23",
+        "symfony/polyfill-php80": "^1.26",
+        "symfony/polyfill-php81": "^1.26",
+        "symfony/polyfill-php82": "^1.26"
     },
     "config": {
         "sort-packages": true,

--- a/src/API/composer.json
+++ b/src/API/composer.json
@@ -14,7 +14,10 @@
         "php": "^7.4 || ^8.0",
         "open-telemetry/context": "self.version",
         "open-telemetry/sem-conv": "self.version",
-        "psr/log": "^1.1|^2.0|^3.0"
+        "psr/log": "^1.1|^2.0|^3.0",
+        "symfony/polyfill-php80": "^1.26",
+        "symfony/polyfill-php81": "^1.26",
+        "symfony/polyfill-php82": "^1.26"
     },
     "autoload": {
         "psr-4": {

--- a/src/Context/composer.json
+++ b/src/Context/composer.json
@@ -11,7 +11,10 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^7.4 || ^8.0",
+        "symfony/polyfill-php80": "^1.26",
+        "symfony/polyfill-php81": "^1.26",
+        "symfony/polyfill-php82": "^1.26"
     },
     "autoload": {
         "psr-4": {

--- a/src/Contrib/composer.json
+++ b/src/Contrib/composer.json
@@ -25,7 +25,10 @@
         "promphp/prometheus_client_php": "^2.2.1",
         "psr/http-factory-implementation": "^1.0",
         "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/polyfill-mbstring": "^1.23"
+        "symfony/polyfill-mbstring": "^1.23",
+        "symfony/polyfill-php80": "^1.26",
+        "symfony/polyfill-php81": "^1.26",
+        "symfony/polyfill-php82": "^1.26"
     },
     "autoload": {
         "psr-4": {

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -21,7 +21,10 @@
         "php-http/discovery": "^1.14",
         "psr/http-factory-implementation": "^1.0",
         "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/polyfill-mbstring": "^1.23"
+        "symfony/polyfill-mbstring": "^1.23",
+        "symfony/polyfill-php80": "^1.26",
+        "symfony/polyfill-php81": "^1.26",
+        "symfony/polyfill-php82": "^1.26"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds polyfills for PHP versions 8.0, 8.1, 8.2 in order to use certain language features in our PHP 7.4 code base.

- Adds symfony/polyfill-php80
- Adds symfony/polyfill-php81
- Adds symfony/polyfill-php82

(This should also resolve the Phan error in https://github.com/open-telemetry/opentelemetry-php/pull/767)