### PR TITLE
Add Span InMemoryExporter

### DIFF
--- a/examples/traces/features/exporters/in_memory.php
+++ b/examples/traces/features/exporters/in_memory.php
@@ -14,7 +14,7 @@ $storage = new ArrayObject();
 // Boilerplate setup to create a new tracer with an in-memory exporter
 $tracer = (new TracerProvider(
     new SimpleSpanProcessor(
-        new InMemoryExporter()
+        new InMemoryExporter($storage)
     )
 ))->getTracer('io.opentelemetry.contrib.php');
 

--- a/examples/traces/features/exporters/in_memory.php
+++ b/examples/traces/features/exporters/in_memory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+
+// Create an ArrayObject as the storage for the spans
+$storage = new ArrayObject();
+
+// Boilerplate setup to create a new tracer with an in-memory exporter
+$tracer = (new TracerProvider(
+    new SimpleSpanProcessor(
+        new InMemoryExporter()
+    )
+))->getTracer('io.opentelemetry.contrib.php');
+
+// This creates a span and sets it as the current parent (and root) span
+$rootSpan = $tracer->spanBuilder('foo')->startSpan();
+$rootScope = $rootSpan->activate();
+
+// This creates child spans
+$childSpan1 = $tracer->spanBuilder('bar')->startSpan();
+$childSpan2 = $tracer->spanBuilder('bar')->startSpan();
+
+// This closes all spans
+$childSpan2->end();
+$childSpan1->end();
+$rootSpan->end();
+
+/** @var SpanDataInterface $span */
+foreach ($storage as $span) {
+    echo PHP_EOL . sprintf(
+        'TRACE: "%s", SPAN: "%s", PARENT: "%s"',
+        $span->getTraceId(),
+        $span->getSpanId(),
+        $span->getParentSpanId()
+    );
+}
+echo PHP_EOL;

--- a/src/SDK/Trace/ExporterFactory.php
+++ b/src/SDK/Trace/ExporterFactory.php
@@ -18,6 +18,7 @@ class ExporterFactory
 
     private const KNOWN_EXPORTERS = [
         'console' => '\OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter',
+        'memory' => '\OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter',
         'logger+file' => '\OpenTelemetry\SDK\Trace\SpanExporter\LoggerExporter',
         'jaeger+http' => '\OpenTelemetry\Contrib\Jaeger\Exporter',
         'zipkin+http' => '\OpenTelemetry\Contrib\Zipkin\Exporter',
@@ -47,7 +48,7 @@ class ExporterFactory
       */
     public function fromConnectionString(string $connectionString): SpanExporterInterface
     {
-        if (in_array($connectionString, ['console', 'otlp+http'])) {
+        if (in_array($connectionString, ['console', 'memory', 'otlp+http'])) {
             return self::buildExporter($connectionString);
         }
 

--- a/src/SDK/Trace/SpanExporter/InMemoryExporter.php
+++ b/src/SDK/Trace/SpanExporter/InMemoryExporter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Trace\SpanExporter;
+
+use ArrayObject;
+use OpenTelemetry\SDK\Trace\Behavior\SpanExporterTrait;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+
+class InMemoryExporter implements SpanExporterInterface
+{
+    use SpanExporterTrait;
+
+    private ArrayObject $storage;
+
+    public function __construct(?ArrayObject $storage = null)
+    {
+        $this->storage = $storage ?? new ArrayObject();
+    }
+
+    public static function fromConnectionString(string $endpointUrl = null, string $name = null, $args = null)
+    {
+        return new self();
+    }
+
+    protected function doExport(iterable $spans): int
+    {
+        foreach ($spans as $span) {
+            $this->storage[] = $span;
+        }
+
+        return SpanExporterInterface::STATUS_SUCCESS;
+    }
+
+    public function getSpans(): array
+    {
+        return (array) $this->storage;
+    }
+
+    public function getStorage(): ArrayObject
+    {
+        return $this->storage;
+    }
+}

--- a/tests/Unit/SDK/Trace/ExporterFactoryTest.php
+++ b/tests/Unit/SDK/Trace/ExporterFactoryTest.php
@@ -11,6 +11,7 @@ use Http\Discovery\Strategy\MockClientStrategy;
 use OpenTelemetry\Contrib;
 use OpenTelemetry\SDK\Trace\ExporterFactory;
 use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -50,6 +51,7 @@ class ExporterFactoryTest extends TestCase
             'otlp+grpc' => ['test.otlpgrpc', 'otlp+grpc://otlp:4317', Contrib\OtlpGrpc\Exporter::class],
             'zipkintonewrelic' => ['test.zipkintonewrelic', 'zipkintonewrelic+https://trace-api.newrelic.com/trace/v1?licenseKey=abc23423423', Contrib\ZipkinToNewrelic\Exporter::class],
             'console' => ['test.console', 'console', ConsoleSpanExporter::class],
+            'memory' => ['test.memory', 'memory', InMemoryExporter::class],
         ];
     }
 

--- a/tests/Unit/SDK/Trace/SpanExporter/InMemoryExporterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/InMemoryExporterTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter;
+
+use ArrayObject;
+use Generator;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter
+ */
+class InMemoryExporterTest extends TestCase
+{
+    /**
+     * @dataProvider provideSpans
+     */
+    public function test_export(iterable $spans): void
+    {
+        $instance = new InMemoryExporter();
+
+        $instance->export($spans);
+
+        $this->assertSame(
+            $spans,
+            $instance->getSpans()
+        );
+    }
+
+    public function test_from_connection_string(): void
+    {
+        $this->assertInstanceOf(
+            InMemoryExporter::class,
+            InMemoryExporter::fromConnectionString()
+        );
+    }
+
+    public function test_get_storage(): void
+    {
+        $storage = new ArrayObject();
+
+        $this->assertSame(
+            $storage,
+            (new InMemoryExporter($storage))->getStorage()
+        );
+    }
+
+    public function test_get_spans(): void
+    {
+        $storage = new ArrayObject();
+
+        $this->assertSame(
+            (array) $storage,
+            (new InMemoryExporter($storage))->getSpans()
+        );
+    }
+
+    public function provideSpans(): Generator
+    {
+        $spans = [];
+
+        for ($x = 0; $x < 3; $x++) {
+            $spans[] = $this->createMock(SpanDataInterface::class);
+
+            yield $x => [$spans];
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an Span InMemoryExporter for testing and debug purposes

- Adds InMemoryExporter 
- Add InMemoryExporter to list of known exporters in ExporterFactory

related: https://github.com/open-telemetry/opentelemetry-php/issues/451