### PR TITLE
Remove `null` default value from parameters that are never `null`

### DIFF
--- a/examples/traces/features/always_off_trace_example.php
+++ b/examples/traces/features/always_off_trace_example.php
@@ -5,6 +5,7 @@ require __DIR__ . '/../../../vendor/autoload.php';
 
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
@@ -15,7 +16,9 @@ $samplingResult = $sampler->shouldSample(
     Context::getCurrent(),
     md5((string) microtime(true)),
     'io.opentelemetry.example',
-    API\SpanKind::KIND_INTERNAL
+    API\SpanKind::KIND_INTERNAL,
+    Attributes::create([]),
+    [],
 );
 
 if (SamplingResult::RECORD_AND_SAMPLE === $samplingResult->getDecision()) {

--- a/src/SDK/Trace/Sampler/AlwaysOffSampler.php
+++ b/src/SDK/Trace/Sampler/AlwaysOffSampler.php
@@ -29,8 +29,8 @@ class AlwaysOffSampler implements SamplerInterface
         string $traceId,
         string $spanName,
         int $spanKind,
-        ?AttributesInterface $attributes = null,
-        array $links = []
+        AttributesInterface $attributes,
+        array $links
     ): SamplingResult {
         $parentSpan = Span::fromContext($parentContext);
         $parentSpanContext = $parentSpan->getContext();

--- a/src/SDK/Trace/Sampler/AlwaysOnSampler.php
+++ b/src/SDK/Trace/Sampler/AlwaysOnSampler.php
@@ -29,8 +29,8 @@ class AlwaysOnSampler implements SamplerInterface
         string $traceId,
         string $spanName,
         int $spanKind,
-        ?AttributesInterface $attributes = null,
-        array $links = []
+        AttributesInterface $attributes,
+        array $links
     ): SamplingResult {
         $parentSpan = Span::fromContext($parentContext);
         $parentSpanContext = $parentSpan->getContext();

--- a/src/SDK/Trace/Sampler/ParentBased.php
+++ b/src/SDK/Trace/Sampler/ParentBased.php
@@ -71,8 +71,8 @@ class ParentBased implements SamplerInterface
         string $traceId,
         string $spanName,
         int $spanKind,
-        ?AttributesInterface $attributes = null,
-        array $links = []
+        AttributesInterface $attributes,
+        array $links
     ): SamplingResult {
         $parentSpan = Span::fromContext($parentContext);
         $parentSpanContext = $parentSpan->getContext();

--- a/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -44,8 +44,8 @@ class TraceIdRatioBasedSampler implements SamplerInterface
         string $traceId,
         string $spanName,
         int $spanKind,
-        ?AttributesInterface $attributes = null,
-        array $links = []
+        AttributesInterface $attributes,
+        array $links
     ): SamplingResult {
         // TODO: Add config to adjust which spans get sampled (only default from specification is implemented)
         $parentSpan = Span::fromContext($parentContext);

--- a/src/SDK/Trace/SamplerInterface.php
+++ b/src/SDK/Trace/SamplerInterface.php
@@ -22,7 +22,7 @@ interface SamplerInterface
      *                        Typically in situations when the Span to be created starts a new Trace.
      * @param string $spanName Name of the Span to be created.
      * @param int $spanKind Span kind.
-     * @param \OpenTelemetry\SDK\Common\Attribute\AttributesInterface|null $attributes Initial set of Attributes for the Span being constructed.
+     * @param AttributesInterface $attributes Initial set of Attributes for the Span being constructed.
      * @param list<LinkInterface> $links Collection of links that will be associated with the Span to be created.
      *                     Typically, useful for batch operations.
      *                     @see https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#links-between-spans
@@ -33,8 +33,8 @@ interface SamplerInterface
         string $traceId,
         string $spanName,
         int $spanKind,
-        ?AttributesInterface $attributes = null,
-        array $links = []
+        AttributesInterface $attributes,
+        array $links
     ): SamplingResult;
 
     /**

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -31,8 +31,8 @@ final class SpanBuilder implements API\SpanBuilderInterface
      */
     private int $spanKind = API\SpanKind::KIND_INTERNAL;
 
-    /** @var list<LinkInterface>|null */
-    private ?array $links = null;
+    /** @var list<LinkInterface> */
+    private array $links = [];
 
     private AttributesBuilderInterface $attributesBuilder;
     private int $totalNumberOfLinksAdded = 0;
@@ -74,10 +74,6 @@ final class SpanBuilder implements API\SpanBuilderInterface
         }
 
         $this->totalNumberOfLinksAdded++;
-
-        if (null === $this->links) {
-            $this->links = [];
-        }
 
         if (count($this->links) === $this->tracerSharedState->getSpanLimits()->getLinkCountLimit()) {
             return $this;
@@ -152,10 +148,6 @@ final class SpanBuilder implements API\SpanBuilderInterface
             $traceId = $parentSpanContext->getTraceId();
         }
 
-        // Reset links and attributes back to null to prevent mutation of the started span.
-        $links = $this->links ?? [];
-        $this->links = null;
-
         $samplingResult = $this
             ->tracerSharedState
             ->getSampler()
@@ -165,7 +157,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
                 $this->spanName,
                 $this->spanKind,
                 $this->attributesBuilder->build(),
-                $links
+                $this->links,
             );
         $samplingDecision = $samplingResult->getDecision();
         $samplingResultTraceState = $samplingResult->getTraceState();
@@ -197,7 +189,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
             $this->tracerSharedState->getSpanProcessor(),
             $this->tracerSharedState->getResource(),
             $attributesBuilder,
-            $links,
+            $this->links,
             $this->totalNumberOfLinksAdded,
             $this->startEpochNanos
         );

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -71,7 +71,7 @@ class BatchSpanProcessor implements SpanProcessorInterface
     /**
      * @inheritDoc
      */
-    public function onStart(ReadWriteSpanInterface $span, ?Context $parentContext = null): void
+    public function onStart(ReadWriteSpanInterface $span, Context $parentContext): void
     {
     }
 

--- a/src/SDK/Trace/SpanProcessor/MultiSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/MultiSpanProcessor.php
@@ -37,7 +37,7 @@ final class MultiSpanProcessor implements SpanProcessorInterface
     }
 
     /** @inheritDoc */
-    public function onStart(ReadWriteSpanInterface $span, ?Context $parentContext = null): void
+    public function onStart(ReadWriteSpanInterface $span, Context $parentContext): void
     {
         foreach ($this->processors as $processor) {
             $processor->onStart($span, $parentContext);

--- a/src/SDK/Trace/SpanProcessor/NoopSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/NoopSpanProcessor.php
@@ -23,7 +23,7 @@ class NoopSpanProcessor implements SpanProcessorInterface
     }
 
     /** @inheritDoc */
-    public function onStart(ReadWriteSpanInterface $span, ?Context $parentContext = null): void
+    public function onStart(ReadWriteSpanInterface $span, Context $parentContext): void
     {
     } //@codeCoverageIgnore
 

--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -24,7 +24,7 @@ class SimpleSpanProcessor implements SpanProcessorInterface
     }
 
     /** @inheritDoc */
-    public function onStart(ReadWriteSpanInterface $span, ?Context $parentContext = null): void
+    public function onStart(ReadWriteSpanInterface $span, Context $parentContext): void
     {
     }
 

--- a/src/SDK/Trace/SpanProcessorInterface.php
+++ b/src/SDK/Trace/SpanProcessorInterface.php
@@ -12,7 +12,7 @@ interface SpanProcessorInterface
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#onstart
      */
-    public function onStart(ReadWriteSpanInterface $span, ?Context $parentContext = null): void;
+    public function onStart(ReadWriteSpanInterface $span, Context $parentContext): void;
 
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#onendspan

--- a/tests/Integration/SDK/AlwaysOffSamplerTest.php
+++ b/tests/Integration/SDK/AlwaysOffSamplerTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +26,9 @@ class AlwaysOffSamplerTest extends TestCase
             $this->createParentContext(true, false, $parentTraceState),
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
 
         $this->assertEquals(SamplingResult::DROP, $decision->getDecision());

--- a/tests/Integration/SDK/AlwaysOnSamplerTest.php
+++ b/tests/Integration/SDK/AlwaysOnSamplerTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +26,9 @@ class AlwaysOnSamplerTest extends TestCase
             $this->createParentContext(true, false, $parentTraceState),
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
 
         $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());

--- a/tests/Integration/SDK/ParentBasedTest.php
+++ b/tests/Integration/SDK/ParentBasedTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\SamplingResult;
@@ -27,7 +28,9 @@ class ParentBasedTest extends TestCase
             Context::getRoot(),
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
     }
 
@@ -49,7 +52,9 @@ class ParentBasedTest extends TestCase
             $parentContext,
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
         $this->assertEquals($expectedDecision, $decision->getDecision());
     }

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -340,8 +340,8 @@ class SpanBuilderTest extends MockeryTestCase
                 string $traceId,
                 string $spanName,
                 int $spanKind,
-                ?AttributesInterface $attributes = null,
-                array $links = []
+                AttributesInterface $attributes,
+                array $links
             ): SamplingResult {
                 return new SamplingResult(SamplingResult::RECORD_AND_SAMPLE, ['cat' => 'meow']);
             }

--- a/tests/Integration/SDK/TraceIdRatioBasedSamplerTest.php
+++ b/tests/Integration/SDK/TraceIdRatioBasedSamplerTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\TraceIdRatioBasedSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +25,9 @@ class TraceIdRatioBasedSamplerTest extends TestCase
             Context::getRoot(),
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
         $this->assertEquals(SamplingResult::DROP, $decision->getDecision());
     }
@@ -36,7 +39,9 @@ class TraceIdRatioBasedSamplerTest extends TestCase
             Context::getRoot(),
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
         $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
     }
@@ -48,7 +53,9 @@ class TraceIdRatioBasedSamplerTest extends TestCase
             Context::getRoot(),
             '4bf92f3577b34da6afffffffffffffff',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
         $this->assertEquals(SamplingResult::DROP, $decision->getDecision());
     }
@@ -60,7 +67,9 @@ class TraceIdRatioBasedSamplerTest extends TestCase
             Context::getRoot(),
             '4bf92f3577b34da6a000000000000000',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
         $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
     }
@@ -73,7 +82,9 @@ class TraceIdRatioBasedSamplerTest extends TestCase
             $this->createParentContext(true, true, $parentTraceState),
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
 
         $this->assertEquals(SamplingResult::DROP, $samplingResult->getDecision());

--- a/tests/Unit/SDK/Trace/Sampler/AlwaysOffSamplerTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/AlwaysOffSamplerTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK;
 
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,9 @@ class AlwaysOffSamplerTest extends TestCase
             $parentContext,
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
 
         $this->assertEquals(SamplingResult::DROP, $decision->getDecision());

--- a/tests/Unit/SDK/Trace/Sampler/AlwaysOnSamplerTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/AlwaysOnSamplerTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK\Trace\Sampler;
 
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,9 @@ class AlwaysOnSamplerTest extends TestCase
             $parentContext,
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
 
         $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());

--- a/tests/Unit/SDK/Trace/Sampler/ParentBasedTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/ParentBasedTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NonRecordingSpan;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\SamplingResult;
@@ -49,7 +50,9 @@ class ParentBasedTest extends TestCase
             Context::getRoot(),
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
     }
 
@@ -72,7 +75,9 @@ class ParentBasedTest extends TestCase
             $parentContext,
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
         $this->assertEquals($expectedDecision, $decision->getDecision());
     }

--- a/tests/Unit/SDK/Trace/Sampler/TraceIdRatioBasedSamplerTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/TraceIdRatioBasedSamplerTest.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Tests\SDK\Unit\Trace\Sampler;
 use InvalidArgumentException;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\TraceIdRatioBasedSampler;
 use OpenTelemetry\SDK\Trace\SamplingResult;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +28,9 @@ class TraceIdRatioBasedSamplerTest extends TestCase
             Context::getRoot(),
             '4bf92f3577b34da6a3ce929d0e0e4736',
             'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL
+            API\SpanKind::KIND_INTERNAL,
+            Attributes::create([]),
+            [],
         );
         $this->assertEquals(SamplingResult::RECORD_AND_SAMPLE, $decision->getDecision());
     }

--- a/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -9,6 +9,7 @@ use Exception;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;
 use OpenTelemetry\SDK\Common\Time\ClockInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
@@ -44,7 +45,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
     {
         $proc = new BatchSpanProcessor(null, $this->testClock);
         $span = $this->createSampledSpanMock();
-        $proc->onStart($span);
+        $proc->onStart($span, Context::getCurrent());
         $proc->onEnd($span);
         $proc->forceFlush();
         $proc->shutdown();
@@ -250,7 +251,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $proc->shutdown();
 
         $span = $this->createSampledSpanMock();
-        $proc->onStart($span);
+        $proc->onStart($span, Context::getCurrent());
         $proc->onEnd($span);
         $proc->forceFlush();
         $proc->shutdown();

--- a/tests/Unit/SDK/Trace/SpanProcessor/MultiSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/MultiSpanProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Trace\SpanProcessor;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessor\MultiSpanProcessor;
@@ -52,7 +53,8 @@ class MultiSpanProcessorTest extends TestCase
 
         $this->createMultiSpanProcessor()
             ->onStart(
-                $this->createMock(ReadWriteSpanInterface::class)
+                $this->createMock(ReadWriteSpanInterface::class),
+                Context::getCurrent(),
             );
     }
 


### PR DESCRIPTION
Prevents having to handle `null` values for parameters that will never be null. Might simplifiy user implementations and removes ambiguity if the meaning of `null` is not obvious.