### PR TITLE
store root dispatcher in a static var

### DIFF
--- a/src/API/Common/Event/Dispatcher.php
+++ b/src/API/Common/Event/Dispatcher.php
@@ -5,20 +5,16 @@ declare(strict_types=1);
 namespace OpenTelemetry\API\Common\Event;
 
 use CloudEvents\V1\CloudEventInterface;
-use OpenTelemetry\Context\Context;
-use OpenTelemetry\Context\ContextKey;
 
 class Dispatcher implements DispatcherInterface
 {
-    private static ?ContextKey $key = null;
+    private static ?self $root = null;
     /** @var array<string, array<int, array<callable>>> */
     private array $listeners = [];
 
-    public static function getInstance(): self
+    public static function getRoot(): self
     {
-        $key = self::getConstantKeyInstance();
-
-        return Context::getCurrent()->get($key) ?? self::createInstance();
+        return self::$root ??= new self();
     }
 
     public function dispatch(CloudEventInterface $event): void
@@ -46,18 +42,5 @@ class Dispatcher implements DispatcherInterface
         foreach ($listeners as $listener) {
             $listener($event);
         }
-    }
-
-    private static function getConstantKeyInstance(): ContextKey
-    {
-        return self::$key ??= new ContextKey(self::class);
-    }
-
-    private static function createInstance(): self
-    {
-        $dispatcher = new self();
-        Context::getCurrent()->with(self::getConstantKeyInstance(), $dispatcher)->activate();
-
-        return $dispatcher;
     }
 }

--- a/src/API/Common/Event/EmitsEventsTrait.php
+++ b/src/API/Common/Event/EmitsEventsTrait.php
@@ -10,6 +10,6 @@ trait EmitsEventsTrait
 {
     protected static function emit(CloudEventInterface $event): void
     {
-        Dispatcher::getInstance()->dispatch($event);
+        Dispatcher::getRoot()->dispatch($event);
     }
 }

--- a/tests/Benchmark/EventBench.php
+++ b/tests/Benchmark/EventBench.php
@@ -17,7 +17,7 @@ class EventBench
 
     public function __construct()
     {
-        $this->dispatcher = Dispatcher::getInstance();
+        $this->dispatcher = Dispatcher::getRoot();
         $this->listener = function () {
         };
         $this->event = new CloudEvent(uniqid(), self::class, 'foo');

--- a/tests/Integration/API/Common/EventContextIntegrationTest.php
+++ b/tests/Integration/API/Common/EventContextIntegrationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Integration\API\Common;
+
+use OpenTelemetry\API\Common\Event\Dispatcher;
+use OpenTelemetry\Context\Context;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class EventContextIntegrationTest extends TestCase
+{
+    public function test_event_dispatcher_does_not_leak_scope(): void
+    {
+        $key = Context::createKey('-');
+        $scope = Context::getCurrent()->with($key, 1)->activate();
+        Dispatcher::getRoot();
+        $result = $scope->detach();
+
+        $this->assertSame(0, $result);
+        $this->assertNull(Context::getCurrent()->get($key));
+    }
+}

--- a/tests/Unit/API/Common/Event/DispatcherTest.php
+++ b/tests/Unit/API/Common/Event/DispatcherTest.php
@@ -31,19 +31,10 @@ class DispatcherTest extends TestCase
         $this->event->method('getType')->willReturn('foo');
     }
 
-    public function test_get_instance(): void
+    public function test_get_root_dispatcher(): void
     {
         $dispatcher = Dispatcher::getRoot();
         $this->assertInstanceOf(Dispatcher::class, $dispatcher);
-        $this->assertSame($dispatcher, Dispatcher::getRoot());
-    }
-
-    public function test_get_instance_from_parent_context(): void
-    {
-        $dispatcher = Dispatcher::getRoot();
-        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
-        $parent = Context::getCurrent()->with(new ContextKey('foo'), 'bar');
-        $parent->activate();
         $this->assertSame($dispatcher, Dispatcher::getRoot());
     }
 

--- a/tests/Unit/API/Common/Event/DispatcherTest.php
+++ b/tests/Unit/API/Common/Event/DispatcherTest.php
@@ -33,18 +33,18 @@ class DispatcherTest extends TestCase
 
     public function test_get_instance(): void
     {
-        $dispatcher = Dispatcher::getInstance();
+        $dispatcher = Dispatcher::getRoot();
         $this->assertInstanceOf(Dispatcher::class, $dispatcher);
-        $this->assertSame($dispatcher, Dispatcher::getInstance());
+        $this->assertSame($dispatcher, Dispatcher::getRoot());
     }
 
     public function test_get_instance_from_parent_context(): void
     {
-        $dispatcher = Dispatcher::getInstance();
+        $dispatcher = Dispatcher::getRoot();
         $this->assertInstanceOf(Dispatcher::class, $dispatcher);
         $parent = Context::getCurrent()->with(new ContextKey('foo'), 'bar');
         $parent->activate();
-        $this->assertSame($dispatcher, Dispatcher::getInstance());
+        $this->assertSame($dispatcher, Dispatcher::getRoot());
     }
 
     public function test_add_listener(): void

--- a/tests/Unit/API/Common/Event/DispatcherTest.php
+++ b/tests/Unit/API/Common/Event/DispatcherTest.php
@@ -6,8 +6,6 @@ namespace OpenTelemetry\Tests\Unit\API\Common\Event;
 
 use CloudEvents\V1\CloudEventInterface;
 use OpenTelemetry\API\Common\Event\Dispatcher;
-use OpenTelemetry\Context\Context;
-use OpenTelemetry\Context\ContextKey;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Unit/API/Common/Event/EmitsEventsTraitTest.php
+++ b/tests/Unit/API/Common/Event/EmitsEventsTraitTest.php
@@ -20,7 +20,7 @@ class EmitsEventsTraitTest extends TestCase
         $event->method('getType')->willReturn('bar');
         $called = false;
         $class = $this->createInstance();
-        Dispatcher::getInstance()->listen($event->getType(), function () use (&$called) {
+        Dispatcher::getRoot()->listen($event->getType(), function () use (&$called) {
             $this->assertTrue(true, 'listener was called');
             $called = true;
         });


### PR DESCRIPTION
This seems to be the safest way to store the main dispatcher. Using context to store the main event dispatcher causes a scope to be created: activating the newly-created context which stores dispatcher causes a new scope, and that can break things.
I also looked at storing dispatcher in the root context, but that can't work because contexts are immutable.

Closes #778 