### PR TITLE
Prevent concurrent `::export()` calls in span processor

### DIFF
--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -4,61 +4,85 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace\SpanProcessor;
 
+use Closure;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\SDK\Behavior\LogsMessagesTrait;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
+use SplQueue;
 
 class SimpleSpanProcessor implements SpanProcessorInterface
 {
-    use LogsMessagesTrait;
+    private SpanExporterInterface $exporter;
 
-    private ?SpanExporterInterface $exporter;
-    private bool $running = true;
+    private bool $running = false;
+    /** @var SplQueue<Closure> */
+    private SplQueue $queue;
 
-    public function __construct(SpanExporterInterface $exporter = null)
+    private bool $closed = false;
+
+    public function __construct(SpanExporterInterface $exporter)
     {
         $this->exporter = $exporter;
+
+        $this->queue = new SplQueue();
     }
 
-    /** @inheritDoc */
     public function onStart(ReadWriteSpanInterface $span, Context $parentContext): void
     {
     }
 
-    /** @inheritDoc */
     public function onEnd(ReadableSpanInterface $span): void
     {
-        if (!$this->running || !$span->getContext()->isSampled()) {
+        if ($this->closed) {
+            return;
+        }
+        if (!$span->getContext()->isSampled()) {
             return;
         }
 
-        if (null !== $this->exporter) {
-            $this->exporter->export([$span->toSpanData()])->await();
-        }
+        $spanData = $span->toSpanData();
+        $this->flush(fn () => $this->exporter->export([$spanData])->await());
     }
 
-    /** @inheritDoc */
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
-        return true;
-    }
-
-    /** @inheritDoc */
-    public function shutdown(?CancellationInterface $cancellation = null): bool
-    {
-        if (!$this->running) {
-            return true;
+        if ($this->closed) {
+            return $this->queue->isEmpty();
         }
 
-        $this->running = false;
-        self::logDebug('Shutting down span processor');
+        return $this->flush(fn (): bool => $this->exporter->forceFlush($cancellation));
+    }
 
-        if (null !== $this->exporter) {
-            return $this->forceFlush() && $this->exporter->shutdown();
+    public function shutdown(?CancellationInterface $cancellation = null): bool
+    {
+        if ($this->closed) {
+            return $this->queue->isEmpty();
+        }
+
+        $this->closed = true;
+
+        return $this->flush(fn (): bool => $this->exporter->shutdown($cancellation));
+    }
+
+    private function flush(Closure $task): bool
+    {
+        $this->queue->enqueue($task);
+
+        if ($this->running) {
+            return false;
+        }
+
+        $this->running = true;
+
+        try {
+            while (!$this->queue->isEmpty()) {
+                $this->queue->dequeue()();
+            }
+        } finally {
+            $this->running = false;
         }
 
         return true;

--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -6,20 +6,19 @@ namespace OpenTelemetry\SDK\Trace\SpanProcessor;
 
 use Closure;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Behavior\LogsMessagesTrait;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
 use SplQueue;
 use function sprintf;
 use Throwable;
 
-class SimpleSpanProcessor implements SpanProcessorInterface, LoggerAwareInterface
+class SimpleSpanProcessor implements SpanProcessorInterface
 {
-    use LoggerAwareTrait;
+    use LogsMessagesTrait;
 
     private SpanExporterInterface $exporter;
 
@@ -100,9 +99,7 @@ class SimpleSpanProcessor implements SpanProcessorInterface, LoggerAwareInterfac
 
                         continue;
                     }
-                    if ($this->logger !== null) {
-                        $this->logger->error(sprintf('Unhandled %s error', $taskName), ['exception' => $e]);
-                    }
+                    self::logError(sprintf('Unhandled %s error', $taskName), ['exception' => $e]);
                 }
             }
         } finally {

--- a/src/SDK/Trace/SpanProcessorFactory.php
+++ b/src/SDK/Trace/SpanProcessorFactory.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
 use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
+use OpenTelemetry\SDK\Common\Time\ClockFactory;
 use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessor\NoopSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
@@ -18,10 +19,21 @@ class SpanProcessorFactory
 
     public function fromEnvironment(?SpanExporterInterface $exporter = null): SpanProcessorInterface
     {
+        if ($exporter === null) {
+            return new NoopSpanProcessor();
+        }
+
         $name = $this->getEnumFromEnvironment(Env::OTEL_PHP_TRACES_PROCESSOR);
         switch ($name) {
             case Values::VALUE_BATCH:
-                return new BatchSpanProcessor($exporter);
+                return new BatchSpanProcessor(
+                    $exporter,
+                    ClockFactory::getDefault(),
+                    $this->getIntFromEnvironment(Env::OTEL_BSP_MAX_QUEUE_SIZE, BatchSpanProcessor::DEFAULT_MAX_QUEUE_SIZE),
+                    $this->getIntFromEnvironment(Env::OTEL_BSP_SCHEDULE_DELAY, BatchSpanProcessor::DEFAULT_SCHEDULE_DELAY),
+                    $this->getIntFromEnvironment(Env::OTEL_BSP_EXPORT_TIMEOUT, BatchSpanProcessor::DEFAULT_EXPORT_TIMEOUT),
+                    $this->getIntFromEnvironment(Env::OTEL_BSP_MAX_EXPORT_BATCH_SIZE, BatchSpanProcessor::DEFAULT_MAX_EXPORT_BATCH_SIZE),
+                );
             case Values::VALUE_SIMPLE:
                 return new SimpleSpanProcessor($exporter);
             case Values::VALUE_NOOP:

--- a/tests/Benchmark/OtlpBench.php
+++ b/tests/Benchmark/OtlpBench.php
@@ -14,6 +14,7 @@ use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
+use OpenTelemetry\SDK\Trace\SpanProcessor\NoopSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use Psr\Http\Client\ClientInterface;
@@ -44,7 +45,7 @@ class OtlpBench
 
     public function setUpNoExporter(): void
     {
-        $processor = new SimpleSpanProcessor();
+        $processor = new NoopSpanProcessor();
         $provider = new TracerProvider($processor, $this->sampler, $this->resource);
         $this->tracer = $provider->getTracer('io.opentelemetry.contrib.php');
     }

--- a/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -297,9 +297,9 @@ class BatchSpanProcessorTest extends MockeryTestCase
 
         $exporter->expects($this->exactly(2))->method('export')->willReturnCallback(function (iterable $batch) use ($processor, &$i) {
             if ($i) {
-                $this->assertCount(5, $batch);
+                $this->assertCount(3, $batch);
             } else {
-                for ($i = 0; $i < 6; $i++) {
+                for ($i = 0; $i < 5; $i++) {
                     $span = $this->createSampledSpanMock();
                     $processor->onStart($span, Context::getCurrent());
                     $processor->onEnd($span);
@@ -312,7 +312,10 @@ class BatchSpanProcessorTest extends MockeryTestCase
         $span = $this->createSampledSpanMock();
         $processor->onStart($span, Context::getCurrent());
         $processor->onEnd($span);
+        $processor->onStart($span, Context::getCurrent());
+        $processor->onEnd($span);
 
+        $processor->forceFlush();
         $processor->forceFlush();
     }
 

--- a/tests/Unit/SDK/Trace/SpanProcessorFactoryTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessorFactoryTest.php
@@ -33,7 +33,7 @@ class SpanProcessorFactoryTest extends TestCase
     {
         $this->setEnvironmentVariable('OTEL_PHP_TRACES_PROCESSOR', $processorName);
         $factory = new SpanProcessorFactory();
-        $this->assertInstanceOf($expected, $factory->fromEnvironment());
+        $this->assertInstanceOf($expected, $factory->fromEnvironment($this->createMock(SpanExporterInterface::class)));
     }
 
     public function processorProvider()


### PR DESCRIPTION
> [Export()](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#exportbatch) will never be called concurrently for the same exporter instance.

This PR calls `::export()` in a synchronous loop to prevent concurrent calls to `::export()`.
Note that this might block the `Span::end()` call that triggered the export longer. The blocking autoflush behavior of `BatchSpanProcessor::onEnd()` can be disabled, spans will then only be flushed on explicit `::forceFlush()` / `::shutdown()` calls.
> [OnEnd()](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onendspan) MUST be called synchronously within the [Span.End() API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#end), therefore it should not block or throw an exception.

Disallowing concurrent export calls means that we have to reintroduce support for concurrent exports by changing the return type of `::export()` to a promise/future-like value - I plan on working on that after this PR is merged.

Alternative to #787, see also https://github.com/open-telemetry/opentelemetry-php/pull/787#discussion_r935643354.