### PR TITLE
Add support for concurrent exports

### DIFF
--- a/src/SDK/Common/Future/CompletedFuture.php
+++ b/src/SDK/Common/Future/CompletedFuture.php
@@ -21,7 +21,7 @@ final class CompletedFuture implements FutureInterface
         $this->value = $value;
     }
 
-    public function await(?CancellationInterface $cancellation = null)
+    public function await()
     {
         return $this->value;
     }

--- a/src/SDK/Common/Future/CompletedFuture.php
+++ b/src/SDK/Common/Future/CompletedFuture.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Future;
+
+/**
+ * @template T
+ * @template-implements FutureInterface<T>
+ */
+final class CompletedFuture implements FutureInterface
+{
+    /** @var T */
+    private $value;
+
+    /**
+     * @param T $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function await(?CancellationInterface $cancellation = null)
+    {
+        return $this->value;
+    }
+}

--- a/src/SDK/Common/Future/FutureInterface.php
+++ b/src/SDK/Common/Future/FutureInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Future;
+
+/**
+ * @template T
+ */
+interface FutureInterface
+{
+    /**
+     * @psalm-return T
+     */
+    public function await(?CancellationInterface $cancellation = null);
+}

--- a/src/SDK/Common/Future/FutureInterface.php
+++ b/src/SDK/Common/Future/FutureInterface.php
@@ -12,5 +12,5 @@ interface FutureInterface
     /**
      * @psalm-return T
      */
-    public function await(?CancellationInterface $cancellation = null);
+    public function await();
 }

--- a/src/SDK/Trace/Behavior/SpanExporterDecoratorTrait.php
+++ b/src/SDK/Trace/Behavior/SpanExporterDecoratorTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace\Behavior;
 
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
+use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
@@ -14,16 +15,15 @@ trait SpanExporterDecoratorTrait
 
     /**
      * @param iterable<SpanDataInterface> $spans
-     * @return int
-     * @psalm-return SpanExporterInterface::STATUS_*
+     * @return FutureInterface<int>
      */
-    public function export(iterable $spans, ?CancellationInterface $cancellation = null): int
+    public function export(iterable $spans, ?CancellationInterface $cancellation = null): FutureInterface
     {
         $response = $this->decorated->export(
             $this->beforeExport($spans),
             $cancellation,
         );
-        $this->afterExport($spans, $response);
+        $this->afterExport($spans, $response->await());
 
         return $response;
     }

--- a/src/SDK/Trace/Behavior/SpanExporterTrait.php
+++ b/src/SDK/Trace/Behavior/SpanExporterTrait.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace\Behavior;
 
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
+use OpenTelemetry\SDK\Common\Future\CompletedFuture;
+use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
@@ -29,19 +31,16 @@ trait SpanExporterTrait
     abstract public static function fromConnectionString(string $endpointUrl, string $name, string $args);
 
     /**
-     * @param iterable<SpanDataInterface> $spans Batch of spans to export
-     *
-     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#exportbatch
-     *
-     * @psalm-return SpanExporterInterface::STATUS_*
+     * @param iterable<SpanDataInterface> $spans
+     * @return FutureInterface<int>
      */
-    public function export(iterable $spans, ?CancellationInterface $cancellation = null): int
+    public function export(iterable $spans, ?CancellationInterface $cancellation = null): FutureInterface
     {
         if (!$this->running) {
-            return SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE;
+            return new CompletedFuture(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE);
         }
 
-        return $this->doExport($spans); /** @phpstan-ignore-line */
+        return new CompletedFuture($this->doExport($spans)); /** @phpstan-ignore-line */
     }
 
     /**

--- a/src/SDK/Trace/SpanExporterInterface.php
+++ b/src/SDK/Trace/SpanExporterInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace;
 
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
+use OpenTelemetry\SDK\Common\Future\FutureInterface;
 
 /**
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#span-exporter
@@ -25,9 +26,9 @@ interface SpanExporterInterface
      *
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#exportbatch
      *
-     * @psalm-return SpanExporterInterface::STATUS_*
+     * @psalm-return FutureInterface<int>
      */
-    public function export(iterable $spans, ?CancellationInterface $cancellation = null): int;
+    public function export(iterable $spans, ?CancellationInterface $cancellation = null): FutureInterface;
 
     /** @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#shutdown-2 */
     public function shutdown(?CancellationInterface $cancellation = null): bool;

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -105,7 +105,7 @@ class BatchSpanProcessor implements SpanProcessorInterface
             return true;
         }
 
-        $this->exporter->export($this->queue);
+        $this->exporter->export($this->queue)->await();
         $this->queue = [];
         $this->stopwatch->reset();
         $this->exporter->forceFlush();

--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -37,7 +37,7 @@ class SimpleSpanProcessor implements SpanProcessorInterface
         }
 
         if (null !== $this->exporter) {
-            $this->exporter->export([$span->toSpanData()]);
+            $this->exporter->export([$span->toSpanData()])->await();
         }
     }
 

--- a/tests/Unit/Contrib/AbstractHttpExporterTest.php
+++ b/tests/Unit/Contrib/AbstractHttpExporterTest.php
@@ -53,7 +53,7 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
             $expected,
             $this->createExporter()->export([
                 $this->createMock(SpanData::class),
-            ])
+            ])->await(),
         );
     }
 
@@ -107,7 +107,7 @@ abstract class AbstractHttpExporterTest extends AbstractExporterTest
             $expected,
             $this->createExporter()->export([
                 $this->createMock(SpanData::class),
-            ])
+            ])->await(),
         );
     }
 

--- a/tests/Unit/Contrib/AgentExporterTest.php
+++ b/tests/Unit/Contrib/AgentExporterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Contrib\Unit;
+namespace OpenTelemetry\Tests\Unit\Contrib;
 
 use OpenTelemetry\Contrib\Jaeger\AgentExporter;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
@@ -10,10 +10,10 @@ use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers OpenTelemetry\Contrib\Jaeger\AgentExporter
- * @covers OpenTelemetry\Contrib\Jaeger\JaegerTransport
- * @covers OpenTelemetry\Contrib\Jaeger\ThriftUdpTransport
- * @covers OpenTelemetry\Contrib\Jaeger\ParsedEndpointUrl
+ * @covers \OpenTelemetry\Contrib\Jaeger\AgentExporter
+ * @covers \OpenTelemetry\Contrib\Jaeger\JaegerTransport
+ * @covers \OpenTelemetry\Contrib\Jaeger\ThriftUdpTransport
+ * @covers \OpenTelemetry\Contrib\Jaeger\ParsedEndpointUrl
  */
 class AgentExporterTest extends TestCase
 {
@@ -24,7 +24,7 @@ class AgentExporterTest extends TestCase
             'someServiceName',
         );
 
-        $status = $exporter->export([new SpanData()]);
+        $status = $exporter->export([new SpanData()])->await();
 
         $this->assertSame(SpanExporterInterface::STATUS_SUCCESS, $status);
 

--- a/tests/Unit/Contrib/JaegerHttpCollectorExporterTest.php
+++ b/tests/Unit/Contrib/JaegerHttpCollectorExporterTest.php
@@ -10,12 +10,12 @@ use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers OpenTelemetry\Contrib\Jaeger\HttpCollectorExporter
- * @covers OpenTelemetry\Contrib\Jaeger\HttpSender
- * @covers OpenTelemetry\Contrib\Jaeger\ThriftHttpTransport
- * @covers OpenTelemetry\Contrib\Jaeger\ParsedEndpointUrl
- * @covers OpenTelemetry\Contrib\Jaeger\BatchAdapter\BatchAdapter
- * @covers OpenTelemetry\Contrib\Jaeger\BatchAdapter\BatchAdapterFactory
+ * @covers \OpenTelemetry\Contrib\Jaeger\HttpCollectorExporter
+ * @covers \OpenTelemetry\Contrib\Jaeger\HttpSender
+ * @covers \OpenTelemetry\Contrib\Jaeger\ThriftHttpTransport
+ * @covers \OpenTelemetry\Contrib\Jaeger\ParsedEndpointUrl
+ * @covers \OpenTelemetry\Contrib\Jaeger\BatchAdapter\BatchAdapter
+ * @covers \OpenTelemetry\Contrib\Jaeger\BatchAdapter\BatchAdapterFactory
  *
  */
 class JaegerHttpCollectorExporterTest extends TestCase
@@ -35,7 +35,7 @@ class JaegerHttpCollectorExporterTest extends TestCase
             $this->getStreamFactoryInterfaceMock()
         );
 
-        $status = $exporter->export([new SpanData()]);
+        $status = $exporter->export([new SpanData()])->await();
 
         $this->assertSame(SpanExporterInterface::STATUS_SUCCESS, $status);
     }

--- a/tests/Unit/Contrib/OTLPGrpcExporterTest.php
+++ b/tests/Unit/Contrib/OTLPGrpcExporterTest.php
@@ -16,7 +16,7 @@ use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use org\bovigo\vfs\vfsStream;
 
 /**
- * @covers OpenTelemetry\Contrib\OtlpGrpc\Exporter
+ * @covers \OpenTelemetry\Contrib\OtlpGrpc\Exporter
  */
 class OTLPGrpcExporterTest extends AbstractExporterTest
 {
@@ -55,7 +55,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
             ])
         );
 
-        $exporterStatusCode = $exporter->export([new SpanData()]);
+        $exporterStatusCode = $exporter->export([new SpanData()])->await();
 
         $this->assertSame(SpanExporterInterface::STATUS_SUCCESS, $exporterStatusCode);
     }
@@ -80,14 +80,14 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
             ])
         );
 
-        $exporterStatusCode = $exporter->export([new SpanData()]);
+        $exporterStatusCode = $exporter->export([new SpanData()])->await();
 
         $this->assertSame(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE, $exporterStatusCode);
     }
 
     public function test_exporter_grpc_responds_as_unavailable(): void
     {
-        $this->assertEquals(SpanExporterInterface::STATUS_FAILED_RETRYABLE, (new Exporter())->export([new SpanData()]));
+        $this->assertEquals(SpanExporterInterface::STATUS_FAILED_RETRYABLE, (new Exporter())->export([new SpanData()])->await());
     }
 
     public function test_set_headers_with_environment_variables(): void

--- a/tests/Unit/Contrib/OTLPHttpExporterTest.php
+++ b/tests/Unit/Contrib/OTLPHttpExporterTest.php
@@ -21,7 +21,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
 
 /**
- * @covers OpenTelemetry\Contrib\OtlpHttp\Exporter
+ * @covers \OpenTelemetry\Contrib\OtlpHttp\Exporter
  */
 class OTLPHttpExporterTest extends AbstractExporterTest
 {
@@ -59,7 +59,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
 
         $this->assertEquals(
             $expected,
-            $exporter->export([new SpanData()])
+            $exporter->export([new SpanData()])->await(),
         );
     }
 
@@ -90,7 +90,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
 
         $this->assertEquals(
             $expected,
-            $exporter->export([new SpanData()])
+            $exporter->export([new SpanData()])->await(),
         );
     }
 
@@ -129,7 +129,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
         $client = new Client(['handler' => $stack]);
         $exporter = new Exporter($client, new HttpFactory(), new HttpFactory());
 
-        $exporter->export([new SpanData()]);
+        $exporter->export([new SpanData()])->await();
 
         $request = $container[0]['request'];
 
@@ -164,7 +164,7 @@ class OTLPHttpExporterTest extends AbstractExporterTest
                 $this->getClientInterfaceMock(),
                 $this->getRequestFactoryInterfaceMock(),
                 $this->getStreamFactoryInterfaceMock()
-            ))->export([])
+            ))->export([])->await(),
         );
     }
 

--- a/tests/Unit/SDK/Trace/SpanExporter/AbstractExporterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/AbstractExporterTest.php
@@ -38,6 +38,6 @@ abstract class AbstractExporterTest extends TestCase
         $span = $this->createMock(SpanData::class);
         $exporter->shutdown();
 
-        $this->assertSame(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE, $exporter->export([$span]));
+        $this->assertSame(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE, $exporter->export([$span])->await());
     }
 }

--- a/tests/Unit/SDK/Trace/SpanExporter/ConsoleSpanExporterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/ConsoleSpanExporterTest.php
@@ -10,7 +10,7 @@ use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
 /**
- * @covers OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter
+ * @covers \OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter
  */
 class ConsoleSpanExporterTest extends AbstractExporterTest
 {
@@ -64,7 +64,7 @@ class ConsoleSpanExporterTest extends AbstractExporterTest
             SpanExporterInterface::STATUS_SUCCESS,
             (new ConsoleSpanExporter($converter))->export([
                 $this->createMock(SpanDataInterface::class),
-            ])
+            ])->await(),
         );
 
         ob_end_clean();
@@ -84,7 +84,7 @@ class ConsoleSpanExporterTest extends AbstractExporterTest
             SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE,
             (new ConsoleSpanExporter($converter))->export([
                 $this->createMock(SpanDataInterface::class),
-            ])
+            ])->await(),
         );
 
         ob_end_clean();
@@ -108,7 +108,7 @@ class ConsoleSpanExporterTest extends AbstractExporterTest
 
         (new ConsoleSpanExporter($converter))->export([
             $this->createMock(SpanDataInterface::class),
-        ]);
+        ])->await();
     }
 
     public function test_from_connection_string(): void

--- a/tests/Unit/SDK/Trace/SpanExporter/LoggerDecoratorTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/LoggerDecoratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter;
 
+use OpenTelemetry\SDK\Common\Future\CompletedFuture;
 use OpenTelemetry\SDK\Trace\SpanExporter\LoggerDecorator;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -11,7 +12,7 @@ use Psr\Log\LogLevel;
 use RuntimeException;
 
 /**
- * @covers OpenTelemetry\SDK\Trace\SpanExporter\LoggerDecorator
+ * @covers \OpenTelemetry\SDK\Trace\SpanExporter\LoggerDecorator
  */
 class LoggerDecoratorTest extends AbstractLoggerAwareTest
 {
@@ -66,7 +67,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
         $this->getSpanExporterInterfaceMock()
             ->expects($this->once())
             ->method('export')
-            ->willReturn(SpanExporterInterface::STATUS_SUCCESS);
+            ->willReturn(new CompletedFuture(SpanExporterInterface::STATUS_SUCCESS));
 
         $this->getLoggerInterfaceMock()
             ->expects($this->once())
@@ -76,7 +77,8 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
         $this->createLoggerDecorator()
             ->export(
                 $this->createSpanMocks()
-            );
+            )
+            ->await();
     }
 
     /**
@@ -88,7 +90,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
         $this->getSpanExporterInterfaceMock()
             ->expects($this->once())
             ->method('export')
-            ->willReturn(SpanExporterInterface::STATUS_FAILED_RETRYABLE);
+            ->willReturn(new CompletedFuture(SpanExporterInterface::STATUS_FAILED_RETRYABLE));
 
         $this->getLoggerInterfaceMock()
             ->expects($this->once())
@@ -98,7 +100,8 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
         $this->createLoggerDecorator()
             ->export(
                 $this->createSpanMocks()
-            );
+            )
+            ->await();
     }
 
     /**
@@ -110,7 +113,7 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
         $this->getSpanExporterInterfaceMock()
             ->expects($this->once())
             ->method('export')
-            ->willReturn(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE);
+            ->willReturn(new CompletedFuture(SpanExporterInterface::STATUS_FAILED_NOT_RETRYABLE));
 
         $this->getLoggerInterfaceMock()
             ->expects($this->once())
@@ -120,7 +123,8 @@ class LoggerDecoratorTest extends AbstractLoggerAwareTest
         $this->createLoggerDecorator()
             ->export(
                 $this->createSpanMocks()
-            );
+            )
+            ->await();
     }
 
     /**

--- a/tests/Unit/SDK/Trace/SpanExporter/LoggerExporterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/LoggerExporterTest.php
@@ -9,7 +9,7 @@ use OpenTelemetry\SDK\Trace\SpanExporter\LoggerExporter;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
 /**
- * @covers OpenTelemetry\SDK\Trace\SpanExporter\LoggerExporter
+ * @covers \OpenTelemetry\SDK\Trace\SpanExporter\LoggerExporter
  */
 class LoggerExporterTest extends AbstractExporterTest
 {
@@ -53,6 +53,7 @@ class LoggerExporterTest extends AbstractExporterTest
                 ->export(
                     $this->createSpanMocks()
                 )
+                ->await(),
         );
     }
 
@@ -72,6 +73,7 @@ class LoggerExporterTest extends AbstractExporterTest
             SpanExporterInterface::STATUS_SUCCESS,
             $this->createLoggerExporter(LoggerExporter::GRANULARITY_SPAN)
                 ->export($spans)
+                ->await(),
         );
     }
 
@@ -91,6 +93,7 @@ class LoggerExporterTest extends AbstractExporterTest
                 ->export(
                     $this->createSpanMocks()
                 )
+                ->await(),
         );
     }
 

--- a/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -10,6 +10,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Future\CompletedFuture;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;
 use OpenTelemetry\SDK\Common\Time\ClockInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
@@ -173,7 +174,8 @@ class BatchSpanProcessorTest extends MockeryTestCase
                         return true;
                     }
                 )
-            );
+            )
+            ->andReturn(new CompletedFuture(0));
 
         /** @var SpanExporterInterface $exporter */
         $processor = new BatchSpanProcessor(
@@ -275,7 +277,8 @@ class BatchSpanProcessorTest extends MockeryTestCase
                         return true;
                     }
                 )
-            );
+            )
+            ->andReturn(new CompletedFuture(0));
 
         $batchProcessor = new BatchSpanProcessor($exporter, $this->testClock);
         foreach ([$sampledSpan, $nonSampledSpan] as $span) {
@@ -305,7 +308,8 @@ class BatchSpanProcessorTest extends MockeryTestCase
                         return true;
                     }
                 )
-            );
+            )
+            ->andReturn(new CompletedFuture(0));
 
         $processor = new BatchSpanProcessor(
             $exporter,

--- a/tests/Unit/SDK/Trace/SpanProcessor/SimpleSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/SimpleSpanProcessorTest.php
@@ -10,6 +10,7 @@ use Mockery\MockInterface;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Future\CompletedFuture;
 use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
@@ -17,7 +18,7 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 
 /**
- * @covers OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor
+ * @covers \OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor
  */
 class SimpleSpanProcessorTest extends MockeryTestCase
 {
@@ -63,7 +64,7 @@ class SimpleSpanProcessorTest extends MockeryTestCase
         $spanData = new SpanData();
         $this->readableSpan->expects('getContext')->andReturn($this->sampledSpanContext);
         $this->readableSpan->expects('toSpanData')->andReturn($spanData);
-        $this->spanExporter->expects('export')->with([$spanData]);
+        $this->spanExporter->expects('export')->with([$spanData])->andReturn(new CompletedFuture(0));
         $this->simpleSpanProcessor->onEnd($this->readableSpan);
     }
 


### PR DESCRIPTION
Related to #788. 

> The return of [Export()](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#exportbatch) is implementation specific. In what is idiomatic for the language the Exporter must send an ExportResult to the Processor. ExportResult has values of either Success or Failure
