### PR TITLE
Fix incorrect autoload path

### DIFF
--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -30,7 +30,7 @@
             "OpenTelemetry\\SDK\\": "."
         },
         "files": [
-            "src/SDK/Common/Util/functions.php"
+            "Common/Util/functions.php"
         ]
     },
     "suggest": {


### PR DESCRIPTION
`Fatal error: Uncaught Error: Failed opening required 'vendor/composer/../open-telemetry/sdk/src/SDK/Common/Util/functions.php'`