### PR TITLE
use a stable released version of psalm

### DIFF
--- a/.github/workflows/psalm-security-analysis.yml
+++ b/.github/workflows/psalm-security-analysis.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:4
+        uses: docker://vimeo/psalm-github-actions:4.23.0 #see https://hub.docker.com/r/vimeo/psalm-github-actions/tags
         with:
           composer_require_dev: true
           composer_ignore_platform_reqs: true

--- a/.github/workflows/psalm-security-analysis.yml
+++ b/.github/workflows/psalm-security-analysis.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:4.23.0 #see https://hub.docker.com/r/vimeo/psalm-github-actions/tags
+        uses: docker://vimeo/psalm-github-actions:4.26.0 #see https://hub.docker.com/r/vimeo/psalm-github-actions/tags
         with:
           composer_require_dev: true
           composer_ignore_platform_reqs: true

--- a/.github/workflows/psalm-security-analysis.yml
+++ b/.github/workflows/psalm-security-analysis.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
+        uses: docker://vimeo/psalm-github-actions:4
         with:
           composer_require_dev: true
           composer_ignore_platform_reqs: true

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "phpunit/phpunit": "^9.3",
         "psalm/plugin-mockery": "^0.9",
         "psalm/plugin-phpunit": "^0.16",
-        "psalm/psalm": "^4.0",
+        "vimeo/psalm": "^4.0",
         "qossmic/deptrac-shim": "^0.22.1",
         "rector/rector": "^0.13.7",
         "symfony/http-client": "^5.2"


### PR DESCRIPTION
master breaks our builds occasionally, so switch to a tagged release. Use v4.26.0 which is the latest stable.