### PR TITLE
ignore phpstan false positive on metrics multiobserver

### DIFF
--- a/src/SDK/Metrics/MetricObserver/MultiObserver.php
+++ b/src/SDK/Metrics/MetricObserver/MultiObserver.php
@@ -25,7 +25,7 @@ final class MultiObserver implements MetricObserverInterface
     public function __invoke(ObserverInterface $observer): void
     {
         foreach ($this->callbacks as $token => $callback) {
-            if (isset($this->callbacks[$token])) {
+            if (isset($this->callbacks[$token])) { //@phpstan-ignore-line callbacks can be unregistered during collection
                 $callback($observer);
             }
         }


### PR DESCRIPTION
metrics observer callbacks can be removed mid-flight, so ignore the false positive