### PR TITLE
document exporters as installable packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ All OpenTelemetry libraries are distributed via packagist, notably:
 - SDK: [open-telemetry/sdk](https://packagist.org/packages/open-telemetry/sdk)
 - Semantic Conventions: [open-telemetry/sem-conv](https://packagist.org/packages/open-telemetry/sem-conv)
 - Context: [open-telemetry/context](https://packagist.org/packages/open-telemetry/context)
-- Exporters: [open-telemetry/exporter-*](https://packagist.org/search/?query=open--telemetry&tags=exporter)
+- Exporters: [open-telemetry/exporter-*](https://packagist.org/search/?query=open-telemetry&tags=exporter)
 - Contrib: [open-telemetry/sdk-contrib](https://packagist.org/packages/open-telemetry/sdk-contrib)
 - Extensions: [open-telemetry/extension-*](https://packagist.org/search/?query=open-telemetry&tags=extension)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All OpenTelemetry libraries are distributed via packagist, notably:
 - SDK: [open-telemetry/sdk](https://packagist.org/packages/open-telemetry/sdk)
 - Semantic Conventions: [open-telemetry/sem-conv](https://packagist.org/packages/open-telemetry/sem-conv)
 - Context: [open-telemetry/context](https://packagist.org/packages/open-telemetry/context)
+- Exporters: [open-telemetry/exporter-*](https://packagist.org/search/?query=open--telemetry&tags=exporter)
 - Contrib: [open-telemetry/sdk-contrib](https://packagist.org/packages/open-telemetry/sdk-contrib)
 - Extensions: [open-telemetry/extension-*](https://packagist.org/search/?query=open-telemetry&tags=extension)
 

--- a/src/Contrib/OtlpGrpc/composer.json
+++ b/src/Contrib/OtlpGrpc/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "open-telemetry/exporter-otlp-grpc",
   "description": "GRPC exporter for OpenTelemetry PHP.",
-  "keywords": ["opentelemetry", "otel", "tracing", "apm", "otlp", "grpc", "protobuf"],
+  "keywords": ["opentelemetry", "otel", "tracing", "contrib", "exporter", "otlp", "grpc", "protobuf"],
   "type": "library",
   "license": "Apache-2.0",
   "authors": [

--- a/src/Contrib/OtlpHttp/composer.json
+++ b/src/Contrib/OtlpHttp/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "open-telemetry/exporter-otlp-http",
   "description": "HTTP/protobuf exporter for OpenTelemetry PHP.",
-  "keywords": ["opentelemetry", "otel", "tracing", "metrics", "otlp", "protobuf", "http"],
+  "keywords": ["opentelemetry", "otel", "tracing", "metrics", "exporter", "contrib", "otlp", "protobuf", "http"],
   "type": "library",
   "license": "Apache-2.0",
   "authors": [


### PR DESCRIPTION
Exporters can be individually installed via packagist now, so link to them. Also add the `exporter` tag to some exporters that were missed, so they can be found more easily.