### PR TITLE
require protobuf extension for otlp exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Using fibers with non-`CLI` SAPIs may require preloading of bindings. One way to
 
 **The PHP protobuf extension is optional when using either the `OTLPHttp` or `OTLPGrpc` exporters from the Contrib package.**
 
-The protobuf extension makes both exporters more performant. _Note that protobuf 3.20.0+ is required for php 8.1 support_
+The protobuf extension makes both exporters _significantly_ more performant, and we recommend that you do not use the PHP package in production. _Note that protobuf 3.20.0+ is required for php 8.1 support_
 
 ---
 

--- a/src/Contrib/OtlpGrpc/composer.json
+++ b/src/Contrib/OtlpGrpc/composer.json
@@ -14,6 +14,7 @@
     "php": "^7.4 || ^8.0",
     "ext-grpc": "*",
     "ext-protobuf": "*",
+    "grpc/grpc": "*",
     "open-telemetry/exporter-otlp-common": "self.version",
     "open-telemetry/gen-otlp-protobuf": "self.version",
     "open-telemetry/sdk": "self.version"

--- a/src/Contrib/OtlpGrpc/composer.json
+++ b/src/Contrib/OtlpGrpc/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "ext-grpc": "*",
-    "google/protobuf": "^3.3.0",
+    "ext-protobuf": "*",
     "open-telemetry/exporter-otlp-common": "self.version",
     "open-telemetry/gen-otlp-protobuf": "self.version",
     "open-telemetry/sdk": "self.version"
@@ -22,8 +22,5 @@
     "psr-4": {
       "OpenTelemetry\\Contrib\\OtlpGrpc\\": "."
     }
-  },
-  "suggest": {
-    "ext-protobuf": "For more performant grpc exporting"
   }
 }

--- a/src/Contrib/OtlpHttp/composer.json
+++ b/src/Contrib/OtlpHttp/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^7.4 || ^8.0",
-    "google/protobuf": "^3.3.0",
+    "ext-protobuf": "*",
     "open-telemetry/api": "self.version",
     "open-telemetry/exporter-otlp-common": "self.version",
     "open-telemetry/gen-otlp-protobuf": "self.version",
@@ -25,8 +25,5 @@
     "psr-4": {
       "OpenTelemetry\\Contrib\\OtlpHttp\\": "."
     }
-  },
-  "suggest": {
-    "ext-protobuf": "For more performant protobuf exporting"
   }
 }


### PR DESCRIPTION
Per feedback from #811 the protobuf php library performs badly in real-world scenarios, and shouldn't be used. Document this, and switch the exporters to requiring instead of suggesting the extension.