### PR TITLE
Rename `AbstractSpan` to `Span` for consistent access to static methods

### DIFF
--- a/docs/laravel-quickstart.md
+++ b/docs/laravel-quickstart.md
@@ -129,7 +129,7 @@ the `use` keyword. This is what our list of open-telemetry imported classes shou
  ```php
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Contrib\Jaeger\Exporter as JaegerExporter;
@@ -255,7 +255,7 @@ child span of the rootSpan. We can do the same as follows:
 - Import the required functions on top of the file:
 
 ```php
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 ```
@@ -267,7 +267,7 @@ use OpenTelemetry\SDK\Trace\TracerProvider;
 $tracer = TracerProvider::getDefaultTracer();
 if ($tracer) {
     /** @var Span $span */
-    $span = AbstractSpan::getCurrent();
+    $span = Span::getCurrent();
 
     $span->setAttribute('foo', 'bar');
     $span->setAttribute('Application', 'Laravel');

--- a/src/API/Trace/AbstractSpan.php
+++ b/src/API/Trace/AbstractSpan.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Trace;
+
+use const E_USER_DEPRECATED;
+use function sprintf;
+use function trigger_error;
+
+@trigger_error(sprintf('Using %s is deprecated, use %s instead.', AbstractSpan::class, Span::class), E_USER_DEPRECATED);
+
+/** @deprecated Use {@link \OpenTelemetry\API\Trace\Span} instead. */
+abstract class AbstractSpan extends Span
+{
+}

--- a/src/API/Trace/NonRecordingSpan.php
+++ b/src/API/Trace/NonRecordingSpan.php
@@ -12,7 +12,7 @@ use Throwable;
  * @internal
  * @psalm-internal OpenTelemetry
  */
-final class NonRecordingSpan extends AbstractSpan
+final class NonRecordingSpan extends Span
 {
     private SpanContextInterface $context;
 

--- a/src/API/Trace/NoopSpanBuilder.php
+++ b/src/API/Trace/NoopSpanBuilder.php
@@ -59,9 +59,9 @@ final class NoopSpanBuilder implements SpanBuilderInterface
 
     public function startSpan(): SpanInterface
     {
-        $span = AbstractSpan::fromContext($this->parent ?? $this->contextStorage->current());
+        $span = Span::fromContext($this->parent ?? $this->contextStorage->current());
         if ($span->isRecording()) {
-            $span = AbstractSpan::wrap($span->getContext());
+            $span = Span::wrap($span->getContext());
         }
 
         return $span;

--- a/src/API/Trace/Propagation/TraceContextPropagator.php
+++ b/src/API/Trace/Propagation/TraceContextPropagator.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\API\Trace\Propagation;
 use function count;
 use function explode;
 use function hexdec;
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\API\Trace\TraceState;
@@ -60,7 +60,7 @@ final class TraceContextPropagator implements TextMapPropagatorInterface
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
         $context ??= Context::getCurrent();
-        $spanContext = AbstractSpan::fromContext($context)->getContext();
+        $spanContext = Span::fromContext($context)->getContext();
 
         if (!$spanContext->isValid()) {
             return;
@@ -88,7 +88,7 @@ final class TraceContextPropagator implements TextMapPropagatorInterface
             return $context;
         }
 
-        return $context->withContextValue(AbstractSpan::wrap($spanContext));
+        return $context->withContextValue(Span::wrap($spanContext));
     }
 
     private static function extractImpl($carrier, PropagationGetterInterface $getter): SpanContextInterface

--- a/src/API/Trace/Span.php
+++ b/src/API/Trace/Span.php
@@ -8,7 +8,7 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextKeys;
 use OpenTelemetry\Context\ScopeInterface;
 
-abstract class AbstractSpan implements SpanInterface
+abstract class Span implements SpanInterface
 {
     private static ?self $invalidSpan = null;
 

--- a/src/Extension/Propagator/B3/B3MultiPropagator.php
+++ b/src/Extension/Propagator/B3/B3MultiPropagator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Extension\Propagator\B3;
 
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\Context\Context;
@@ -104,7 +104,7 @@ final class B3MultiPropagator implements TextMapPropagatorInterface
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
         $context ??= Context::getCurrent();
-        $spanContext = AbstractSpan::fromContext($context)->getContext();
+        $spanContext = Span::fromContext($context)->getContext();
 
         if (!$spanContext->isValid()) {
             return;
@@ -132,7 +132,7 @@ final class B3MultiPropagator implements TextMapPropagatorInterface
             return $context;
         }
 
-        return $context->withContextValue(AbstractSpan::wrap($spanContext));
+        return $context->withContextValue(Span::wrap($spanContext));
     }
 
     private static function getSampledValue($carrier, PropagationGetterInterface $getter): ?int

--- a/src/Extension/Propagator/B3/B3SinglePropagator.php
+++ b/src/Extension/Propagator/B3/B3SinglePropagator.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\Extension\Propagator\B3;
 
 use function count;
 use function explode;
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\Context\Context;
@@ -56,7 +56,7 @@ final class B3SinglePropagator implements TextMapPropagatorInterface
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
         $context ??= Context::getCurrent();
-        $spanContext = AbstractSpan::fromContext($context)->getContext();
+        $spanContext = Span::fromContext($context)->getContext();
 
         if (!$spanContext->isValid()) {
             return;
@@ -85,7 +85,7 @@ final class B3SinglePropagator implements TextMapPropagatorInterface
             return $context;
         }
 
-        return $context->withContextValue(AbstractSpan::wrap($spanContext));
+        return $context->withContextValue(Span::wrap($spanContext));
     }
 
     private static function processSampledValue($value): ?int

--- a/src/SDK/Metrics/Exemplar/BucketStorage.php
+++ b/src/SDK/Metrics/Exemplar/BucketStorage.php
@@ -8,7 +8,7 @@ use function array_fill;
 use function assert;
 use function class_exists;
 use function count;
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Common\Attribute\AttributesFactoryInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
@@ -44,7 +44,7 @@ final class BucketStorage
         $exemplar->attributes = $attributes;
         $exemplar->revision = $revision;
 
-        if (class_exists(AbstractSpan::class) && ($spanContext = AbstractSpan::fromContext($context)->getContext())->isValid()) {
+        if (class_exists(Span::class) && ($spanContext = Span::fromContext($context)->getContext())->isValid()) {
             $exemplar->traceId = $spanContext->getTraceId();
             $exemplar->spanId = $spanContext->getSpanId();
         } else {

--- a/src/SDK/Metrics/Exemplar/ExemplarFilter/WithSampledTraceExemplarFilter.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilter/WithSampledTraceExemplarFilter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilter;
 
 use function class_exists;
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
@@ -14,7 +14,7 @@ final class WithSampledTraceExemplarFilter implements ExemplarFilterInterface
 {
     public function accepts($value, AttributesInterface $attributes, Context $context, int $timestamp): bool
     {
-        return class_exists(AbstractSpan::class)
-            && AbstractSpan::fromContext($context)->getContext()->isSampled();
+        return class_exists(Span::class)
+            && Span::fromContext($context)->getContext()->isSampled();
     }
 }

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -15,7 +15,7 @@ use OpenTelemetry\SDK\Common\Time\ClockFactory;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use Throwable;
 
-final class Span extends API\AbstractSpan implements ReadWriteSpanInterface
+final class Span extends API\Span implements ReadWriteSpanInterface
 {
 
     /** @readonly */

--- a/tests/Unit/SDK/Metrics/Exemplar/BucketStorageTest.php
+++ b/tests/Unit/SDK/Metrics/Exemplar/BucketStorageTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics\Exemplar;
 
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
@@ -47,7 +47,7 @@ final class BucketStorageTest extends TestCase
     {
         $storage = new BucketStorage(Attributes::factory());
 
-        $context = AbstractSpan::wrap(SpanContext::create('12345678901234567890123456789012', '1234567890123456'))
+        $context = Span::wrap(SpanContext::create('12345678901234567890123456789012', '1234567890123456'))
             ->storeInContext(Context::getRoot());
 
         $storage->store(0, 0, 5, Attributes::create([]), $context, 7, 0);

--- a/tests/Unit/SDK/Metrics/Exemplar/FilteredReservoirTest.php
+++ b/tests/Unit/SDK/Metrics/Exemplar/FilteredReservoirTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics\Exemplar;
 
-use OpenTelemetry\API\Trace\AbstractSpan;
+use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\Context\Context;
@@ -57,7 +57,7 @@ final class FilteredReservoirTest extends TestCase
     {
         $reservoir = new FilteredReservoir(new FixedSizeReservoir(Attributes::factory(), 4), new WithSampledTraceExemplarFilter());
 
-        $context = AbstractSpan::wrap(SpanContext::create('12345678901234567890123456789012', '1234567890123456', SpanContextInterface::TRACE_FLAG_SAMPLED))
+        $context = Span::wrap(SpanContext::create('12345678901234567890123456789012', '1234567890123456', SpanContextInterface::TRACE_FLAG_SAMPLED))
             ->storeInContext(Context::getRoot());
 
         $reservoir->offer(0, 5, Attributes::create([]), $context, 7, 0);
@@ -76,7 +76,7 @@ final class FilteredReservoirTest extends TestCase
     {
         $reservoir = new FilteredReservoir(new FixedSizeReservoir(Attributes::factory(), 4), new WithSampledTraceExemplarFilter());
 
-        $context = AbstractSpan::wrap(SpanContext::create('12345678901234567890123456789012', '1234567890123456'))
+        $context = Span::wrap(SpanContext::create('12345678901234567890123456789012', '1234567890123456'))
             ->storeInContext(Context::getRoot());
 
         $reservoir->offer(0, 5, Attributes::create([]), $context, 7, 0);


### PR DESCRIPTION
Unifies access to static interface methods. Other API interfaces with static methods have a class without the `Interface` suffix that provides an implementation, e.g.:
`Baggage::getCurrent(): BaggageInterface`
`SpanContext::getInvalid(): SpanContextInterface`

I considered creating a `Span` class that does not implement `SpanInterface` but disliked the idea of splitting the PHPDoc documentation in different classes.