### PR TITLE
Fix fiber support not loaded in `open-telemetry/context`

### DIFF
--- a/src/Context/ZendObserverFiber.php
+++ b/src/Context/ZendObserverFiber.php
@@ -3,6 +3,7 @@
 /** @noinspection PhpUndefinedMethodInspection */
 /** @phan-file-suppress PhanUndeclaredClassCatch */
 /** @phan-file-suppress PhanUndeclaredClassMethod */
+/** @phan-file-suppress PhanUndeclaredMethod */
 
 declare(strict_types=1);
 
@@ -17,6 +18,9 @@ use const PHP_VERSION_ID;
 use function sprintf;
 use function trigger_error;
 
+/**
+ * @internal
+ */
 final class ZendObserverFiber
 {
     public static function isEnabled(): bool

--- a/src/Context/ZendObserverFiber.php
+++ b/src/Context/ZendObserverFiber.php
@@ -1,52 +1,61 @@
 <?php
 
-/** @noinspection PhpUndefinedClassInspection */
-/** @noinspection PhpUndefinedNamespaceInspection */
-/** @phan-file-suppress PhanUndeclaredClassReference */
+/** @noinspection PhpUndefinedMethodInspection */
 /** @phan-file-suppress PhanUndeclaredClassCatch */
 /** @phan-file-suppress PhanUndeclaredClassMethod */
-/** @phan-file-suppress PhanUndeclaredMethod */
 
 declare(strict_types=1);
 
 namespace OpenTelemetry\Context;
 
+use function extension_loaded;
 use FFI;
-use FFI\Exception;
+use const FILTER_VALIDATE_BOOLEAN;
+use function filter_var;
+use function is_string;
+use const PHP_VERSION_ID;
+use function sprintf;
+use function trigger_error;
 
-class ZendObserverFiber
+final class ZendObserverFiber
 {
-    protected static $fibers = null;
-
-    public function isEnabled(): bool
+    public static function isEnabled(): bool
     {
-        return (
-            PHP_VERSION_ID >= 80100 &&
-            (in_array(getenv('OTEL_PHP_FIBERS_ENABLED'), ['true', 'on', '1'])) &&
-            class_exists(FFI::class)
-        );
+        $enabled = $_SERVER['OTEL_PHP_FIBERS_ENABLED'] ?? false;
+
+        return is_string($enabled)
+            ? filter_var($enabled, FILTER_VALIDATE_BOOLEAN)
+            : (bool) $enabled;
     }
 
-    /**
-     * @psalm-suppress UndefinedClass
-     */
-    public function init(): bool
+    public static function init(): bool
     {
-        if (null === self::$fibers) {
-            try {
-                $fibers = FFI::scope('OTEL_ZEND_OBSERVER_FIBER');
-            } catch (Exception $e) {
-                try {
-                    $fibers = FFI::load(__DIR__ . '/fiber/zend_observer_fiber.h');
-                } catch (Exception $e) {
-                    return false;
-                }
-            }
-            $fibers->zend_observer_fiber_init_register(fn (int $initializing) => Context::storage()->fork($initializing)); //@phpstan-ignore-line
-            $fibers->zend_observer_fiber_switch_register(fn (int $from, int $to) => Context::storage()->switch($to)); //@phpstan-ignore-line
-            $fibers->zend_observer_fiber_destroy_register(fn (int $destroying) => Context::storage()->destroy($destroying)); //@phpstan-ignore-line
-            self::$fibers = $fibers;
+        static $fibers;
+        if ($fibers) {
+            return true;
         }
+
+        if (PHP_VERSION_ID < 80100 || !extension_loaded('ffi')) {
+            trigger_error('Context: Fiber context switching not supported, requires PHP >= 8.1 and the FFI extension');
+
+            return false;
+        }
+
+        try {
+            $fibers = FFI::scope('OTEL_ZEND_OBSERVER_FIBER');
+        } catch (FFI\Exception $e) {
+            try {
+                $fibers = FFI::load(__DIR__ . '/fiber/zend_observer_fiber.h');
+            } catch (FFI\Exception $e) {
+                trigger_error(sprintf('Context: Fiber context switching not supported, %s', $e->getMessage()));
+
+                return false;
+            }
+        }
+
+        $fibers->zend_observer_fiber_init_register(static fn (int $initializing) => Context::storage()->fork($initializing)); //@phpstan-ignore-line
+        $fibers->zend_observer_fiber_switch_register(static fn (int $from, int $to) => Context::storage()->switch($to)); //@phpstan-ignore-line
+        $fibers->zend_observer_fiber_destroy_register(static fn (int $destroying) => Context::storage()->destroy($destroying)); //@phpstan-ignore-line
 
         return true;
     }

--- a/src/Context/composer.json
+++ b/src/Context/composer.json
@@ -19,7 +19,10 @@
     "autoload": {
         "psr-4": {
             "OpenTelemetry\\Context\\": "."
-        }
+        },
+        "files": [
+            "fiber/initialize_fiber_handler.php"
+        ]
     },
     "suggest": {
         "ext-ffi": "To allow context switching in Fibers"

--- a/src/Context/fiber/initialize_fiber_handler.php
+++ b/src/Context/fiber/initialize_fiber_handler.php
@@ -13,9 +13,7 @@ if (!class_exists(Fiber::class)) {
     return;
 }
 
-$observer = new ZendObserverFiber();
-
-if ($observer->isEnabled() && $observer->init()) {
+if (ZendObserverFiber::isEnabled() && ZendObserverFiber::init()) {
     // ffi fiber support enabled
 } else {
     Context::setStorage(new FiberBoundContextStorage(Context::storage()));

--- a/tests/Integration/Context/Fiber/test_context_switching_ffi_observer.phpt
+++ b/tests/Integration/Context/Fiber/test_context_switching_ffi_observer.phpt
@@ -2,6 +2,8 @@
 Context switches on execution context switch.
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 80100 || !extension_loaded('ffi')) die('skip requires PHP8.1 and FFI'); ?>
+--ENV--
+OTEL_PHP_FIBERS_ENABLED=1
 --FILE--
 <?php
 use OpenTelemetry\Context\Context;

--- a/tests/Integration/Context/Fiber/test_context_switching_ffi_observer_registered_on_startup.phpt
+++ b/tests/Integration/Context/Fiber/test_context_switching_ffi_observer_registered_on_startup.phpt
@@ -2,6 +2,8 @@
 Fiber handler has to be loaded before fibers are used.
 --SKIPIF--
 <?php if (PHP_VERSION_ID < 80100 || !extension_loaded('ffi')) die('skip requires PHP8.1 and FFI'); ?>
+--ENV--
+OTEL_PHP_FIBERS_ENABLED=1
 --FILE--
 <?php
 use OpenTelemetry\Context\Context;

--- a/tests/Integration/Context/Fiber/test_context_switching_not_supported.phpt
+++ b/tests/Integration/Context/Fiber/test_context_switching_not_supported.phpt
@@ -2,8 +2,8 @@
 Context usage in fiber without fiber support triggers warning.
 --SKIPIF--
 <?php if (!class_exists(Fiber::class)) die('skip requires fibers'); ?>
---INI--
-ffi.enable=0
+--ENV--
+OTEL_PHP_FIBERS_ENABLED=0
 --FILE--
 <?php
 use OpenTelemetry\Context\Context;


### PR DESCRIPTION
Adds missing autoload entry for `initialize_fiber_handler.php` and adds logging if `OTEL_PHP_FIBERS_ENABLED` is enabled and initialization of fiber support fails.