### PR TITLE
Grpc metadata value must be an array

### DIFF
--- a/tests/Unit/Contrib/OtlpGrpc/OTLPGrpcExporterTest.php
+++ b/tests/Unit/Contrib/OtlpGrpc/OTLPGrpcExporterTest.php
@@ -107,7 +107,7 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
 
         $exporter = new Exporter();
 
-        $this->assertEquals(['x-aaa' => 'foo', 'x-bbb' => 'barf'], $exporter->getHeaders());
+        $this->assertEquals(['x-aaa' => ['foo'], 'x-bbb' => ['barf']], $exporter->getHeaders());
     }
 
     public function test_set_header(): void
@@ -116,18 +116,18 @@ class OTLPGrpcExporterTest extends AbstractExporterTest
         $exporter->setHeader('foo', 'bar');
         $headers = $exporter->getHeaders();
         $this->assertArrayHasKey('foo', $headers);
-        $this->assertEquals('bar', $headers['foo']);
+        $this->assertEquals(['bar'], $headers['foo']);
     }
 
     public function test_set_headers_in_constructor(): void
     {
         $exporter = new Exporter('localhost:4317', true, '', 'x-aaa=foo,x-bbb=bar');
 
-        $this->assertEquals(['x-aaa' => 'foo', 'x-bbb' => 'bar'], $exporter->getHeaders());
+        $this->assertEquals(['x-aaa' => ['foo'], 'x-bbb' => ['bar']], $exporter->getHeaders());
 
         $exporter->setHeader('key', 'value');
 
-        $this->assertEquals(['x-aaa' => 'foo', 'x-bbb' => 'bar', 'key' => 'value'], $exporter->getHeaders());
+        $this->assertEquals(['x-aaa' => ['foo'], 'x-bbb' => ['bar'], 'key' => ['value']], $exporter->getHeaders());
     }
 
     private function isInsecure(Exporter $exporter) : bool


### PR DESCRIPTION
It will throw an `InvalidArgumentException` with the message `Bad metadata value given` if the value in metadata is not an array.

The doc:
https://grpc.io/docs/what-is-grpc/core-concepts/#metadata:~:text=and%20the%20values%20are%20typically%20strings

The grpc source code:
https://github.com/grpc/grpc/blob/2d4f3c56001cd1e1f85734b2f7c5ce5f2797c38a/src/php/ext/grpc/call.c#L114
https://github.com/grpc/grpc/blob/2d4f3c56001cd1e1f85734b2f7c5ce5f2797c38a/src/php/ext/grpc/call.c#L340-L342