### PR TITLE
Add `trace` convenience function that encapsulates `try-catch-finally` boilerplate code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         },
         "files": [
             "src/Context/fiber/initialize_fiber_handler.php",
+            "src/API/Trace/functions.php",
             "src/SDK/Common/Dev/Compatibility/_load.php",
             "src/SDK/Common/Util/functions.php"
         ]

--- a/src/API/Trace/functions.php
+++ b/src/API/Trace/functions.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Trace;
+
+use Closure;
+use OpenTelemetry\SemConv\TraceAttributes;
+use Throwable;
+
+/**
+ * Executes the given closure within the provided span.
+ *
+ * The span will be ended.
+ *
+ * @template R
+ * @param SpanInterface $span span to enclose the closure with
+ * @param Closure(...): R $closure closure to invoke
+ * @param array $args arguments to provide to the closure
+ * @return R result of the closure invocation
+ *
+ * @phpstan-ignore-next-line
+ */
+function trace(SpanInterface $span, Closure $closure, array $args = [])
+{
+    $s = $span;
+    $c = $closure;
+    $a = $args;
+    unset($span, $closure, $args);
+
+    $scope = $s->activate();
+
+    try {
+        return $c(...$a, ...($a = []));
+    } catch (Throwable $e) {
+        $s->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+        $s->recordException($e, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+
+        throw $e;
+    } finally {
+        $scope->detach();
+        $s->end();
+    }
+}

--- a/src/API/Trace/functions.php
+++ b/src/API/Trace/functions.php
@@ -16,12 +16,12 @@ use Throwable;
  * @template R
  * @param SpanInterface $span span to enclose the closure with
  * @param Closure(...): R $closure closure to invoke
- * @param array $args arguments to provide to the closure
+ * @param iterable<int|string, mixed> $args arguments to provide to the closure
  * @return R result of the closure invocation
  *
  * @phpstan-ignore-next-line
  */
-function trace(SpanInterface $span, Closure $closure, array $args = [])
+function trace(SpanInterface $span, Closure $closure, iterable $args = [])
 {
     $s = $span;
     $c = $closure;
@@ -31,6 +31,7 @@ function trace(SpanInterface $span, Closure $closure, array $args = [])
     $scope = $s->activate();
 
     try {
+        /** @psalm-suppress InvalidArgument */
         return $c(...$a, ...($a = []));
     } catch (Throwable $e) {
         $s->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());

--- a/src/API/composer.json
+++ b/src/API/composer.json
@@ -23,6 +23,9 @@
     "autoload": {
         "psr-4": {
             "OpenTelemetry\\API\\": "."
-        }
+        },
+        "files": [
+            "Trace/functions.php"
+        ]
     }
 }

--- a/tests/Unit/API/Trace/TraceTest.php
+++ b/tests/Unit/API/Trace/TraceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\API\Trace;
+
+use Exception;
+use OpenTelemetry\API\Trace\NonRecordingSpan;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanInterface;
+use OpenTelemetry\API\Trace\StatusCode;
+use function OpenTelemetry\API\Trace\trace;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+use WeakReference;
+
+/**
+ * @covers \OpenTelemetry\API\Trace\trace
+ */
+final class TraceTest extends TestCase
+{
+    public function test_runs_with_provided_span(): void
+    {
+        $span = new NonRecordingSpan(SpanContext::getInvalid());
+
+        trace($span, fn () => $this->assertSame($span, Span::getCurrent()));
+    }
+
+    public function test_restores_previous_span(): void
+    {
+        $span = new NonRecordingSpan(SpanContext::getInvalid());
+        $scope = $span->activate();
+
+        try {
+            trace(Span::getInvalid(), fn () => null);
+
+            $this->assertSame($span, Span::getCurrent());
+        } finally {
+            $scope->detach();
+        }
+    }
+
+    public function test_returns_closure_result(): void
+    {
+        $this->assertSame(42, trace(Span::getInvalid(), fn () => 42));
+    }
+
+    public function test_provides_args_to_closure(): void
+    {
+        trace(Span::getInvalid(), fn ($a) => $this->assertSame(42, $a), [42]);
+    }
+
+    public function test_ends_span(): void
+    {
+        $span = $this->createMock(SpanInterface::class);
+        $span->expects($this->once())->method('end');
+
+        trace($span, fn () => null);
+    }
+
+    public function test_rethrows_exception(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        trace(Span::getInvalid(), function (): void {
+            throw new RuntimeException();
+        });
+    }
+
+    public function test_records_exception(): void
+    {
+        $span = $this->createMock(SpanInterface::class);
+        $span->expects($this->once())->method('setStatus')->with(StatusCode::STATUS_ERROR);
+        $span->expects($this->once())->method('recordException');
+
+        try {
+            trace($span, function (): void {
+                throw new RuntimeException();
+            });
+        } catch (RuntimeException $e) {
+        }
+    }
+
+    public function test_ends_span_on_exception(): void
+    {
+        $span = $this->createMock(SpanInterface::class);
+        $span->expects($this->once())->method('end');
+
+        try {
+            trace($span, function (): void {
+                throw new RuntimeException();
+            });
+        } catch (RuntimeException $e) {
+        }
+    }
+
+    public function test_exception_does_not_leak_closure_reference(): void
+    {
+        $c = static function (): void {
+            throw new RuntimeException();
+        };
+        $r = WeakReference::create($c);
+
+        try {
+            trace(Span::getInvalid(), $c);
+        } catch (Exception $e) {
+            $c = null;
+            $this->assertNull($r->get());
+        }
+    }
+
+    public function test_does_not_keep_argument_references(): void
+    {
+        trace(Span::getInvalid(), function (object $o): void {
+            $r = WeakReference::create($o);
+            $o = null;
+
+            $this->assertNull($r->get());
+        }, [new stdClass()]);
+    }
+}


### PR DESCRIPTION
Encapsulates the `try-catch-finally` boilerplate code, especially useful for decorators.
```php
$span = $this->tracer
    ->spanBuilder('example')
    ->startSpan();
return trace($span, $decorated->method(...), func_get_args());
```