### PR TITLE
resolve deptrac baseline

### DIFF
--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -1,4 +1,2 @@
 deptrac:
   skip_violations:
-    OpenTelemetry\SDK\Trace\Span:
-      - OpenTelemetry\API\Trace\NonRecordingSpan

--- a/src/API/Trace/NonRecordingSpan.php
+++ b/src/API/Trace/NonRecordingSpan.php
@@ -9,7 +9,6 @@ use Throwable;
 /**
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.1/specification/trace/api.md#wrapping-a-spancontext-in-a-span
  *
- * @internal
  * @psalm-internal OpenTelemetry
  */
 final class NonRecordingSpan extends Span

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\OtlpGrpc;
 
-use grpc;
+use Grpc;
 use Grpc\ChannelCredentials;
 use OpenTelemetry\Contrib\Otlp\ExporterTrait;
 use OpenTelemetry\Contrib\Otlp\SpanConverter;

--- a/src/SDK/Resource/Detectors/Process.php
+++ b/src/SDK/Resource/Detectors/Process.php
@@ -22,6 +22,9 @@ final class Process implements ResourceDetectorInterface
         $attributes = [];
         $attributes[ResourceAttributes::PROCESS_PID] = getmypid();
         $attributes[ResourceAttributes::PROCESS_EXECUTABLE_PATH] = PHP_BINARY;
+        /**
+         * @psalm-suppress PossiblyUndefinedArrayOffset
+         */
         if ($_SERVER['argv'] ?? null) {
             $attributes[ResourceAttributes::PROCESS_COMMAND] = $_SERVER['argv'][0];
             $attributes[ResourceAttributes::PROCESS_COMMAND_ARGS] = $_SERVER['argv'];


### PR DESCRIPTION
Nevay found that an @internal annotation in NonRecordingSpan was the cause of the violation, so remove it.

Closes #718 