### PR TITLE
refactor: static access for EnvironmentVariablesTrait methods

### DIFF
--- a/src/Contrib/Otlp/ExporterTrait.php
+++ b/src/Contrib/Otlp/ExporterTrait.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Otlp;
 
 use OpenTelemetry\SDK\Behavior\LogsMessagesTrait;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
 use OpenTelemetry\SDK\Trace\Behavior\UsesSpanConverterTrait;
 
 trait ExporterTrait
 {
-    use EnvironmentVariablesTrait;
     use LogsMessagesTrait;
     use UsesSpanConverterTrait;
 }

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -9,9 +9,9 @@ use Grpc\ChannelCredentials;
 use OpenTelemetry\Contrib\Otlp\ExporterTrait;
 use OpenTelemetry\Contrib\Otlp\SpanConverter;
 use Opentelemetry\Proto\Collector\Trace\V1\TraceServiceClient;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Trace\Behavior\SpanExporterTrait;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -47,36 +47,36 @@ class Exporter implements SpanExporterInterface
         TraceServiceClient $client = null
     ) {
         $this->insecure = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE) ?
-            $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE, $insecure) :
-            $this->getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
+            self::getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE, $insecure) :
+            self::getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
 
         if (!empty($certificateFile) || $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_CERTIFICATE)) {
             $this->certificateFile = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) ?
-                    $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) :
-                    $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);
+                    self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) :
+                    self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);
         }
 
         $this->compression = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
-            $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) :
-            $this->getEnumFromEnvironment(
+            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) :
+            self::getEnumFromEnvironment(
                 Env::OTEL_EXPORTER_OTLP_COMPRESSION,
                 $compression ? Values::VALUE_GZIP : Values::VALUE_NONE
             );
 
         $this->timeout = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT) ?
-            $this->getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, $timeout) :
-            $this->getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TIMEOUT, $timeout);
+            self::getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, $timeout) :
+            self::getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TIMEOUT, $timeout);
 
         $this->metadata = self::transformToGrpcMetadata($this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
-            $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS, $headers) :
-            $this->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS, $headers));
+            self::getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS, $headers) :
+            self::getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS, $headers));
 
         $opts = $this->getClientOptions();
 
         $this->client = $client ?? new TraceServiceClient(
             $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) ?
-                $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) :
-                $this->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, $endpointURL),
+                self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) :
+                self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, $endpointURL),
             $opts
         );
     }

--- a/src/Contrib/OtlpGrpc/Exporter.php
+++ b/src/Contrib/OtlpGrpc/Exporter.php
@@ -11,6 +11,7 @@ use OpenTelemetry\Contrib\Otlp\SpanConverter;
 use Opentelemetry\Proto\Collector\Trace\V1\TraceServiceClient;
 use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Trace\Behavior\SpanExporterTrait;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
@@ -46,37 +47,37 @@ class Exporter implements SpanExporterInterface
         int $timeout = 10,
         TraceServiceClient $client = null
     ) {
-        $this->insecure = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE) ?
-            self::getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE, $insecure) :
-            self::getBooleanFromEnvironment(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
+        $this->insecure = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE) ?
+            EnvironmentVariables::getBoolean(Env::OTEL_EXPORTER_OTLP_TRACES_INSECURE, $insecure) :
+            EnvironmentVariables::getBoolean(Env::OTEL_EXPORTER_OTLP_INSECURE, $insecure);
 
-        if (!empty($certificateFile) || $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_CERTIFICATE)) {
-            $this->certificateFile = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) ?
-                    self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) :
-                    self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);
+        if (!empty($certificateFile) || EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_CERTIFICATE)) {
+            $this->certificateFile = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) ?
+                    EnvironmentVariables::getString(Env::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE) :
+                    EnvironmentVariables::getString(Env::OTEL_EXPORTER_OTLP_CERTIFICATE, $certificateFile);
         }
 
-        $this->compression = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
-            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) :
-            self::getEnumFromEnvironment(
+        $this->compression = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
+            EnvironmentVariables::getEnum(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) :
+            EnvironmentVariables::getEnum(
                 Env::OTEL_EXPORTER_OTLP_COMPRESSION,
                 $compression ? Values::VALUE_GZIP : Values::VALUE_NONE
             );
 
-        $this->timeout = $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT) ?
-            self::getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, $timeout) :
-            self::getIntFromEnvironment(Env::OTEL_EXPORTER_OTLP_TIMEOUT, $timeout);
+        $this->timeout = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT) ?
+            EnvironmentVariables::getInt(Env::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, $timeout) :
+            EnvironmentVariables::getInt(Env::OTEL_EXPORTER_OTLP_TIMEOUT, $timeout);
 
-        $this->metadata = self::transformToGrpcMetadata($this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
-            self::getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS, $headers) :
-            self::getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS, $headers));
+        $this->metadata = self::transformToGrpcMetadata(EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
+            EnvironmentVariables::getMap(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS, $headers) :
+            EnvironmentVariables::getMap(Env::OTEL_EXPORTER_OTLP_HEADERS, $headers));
 
         $opts = $this->getClientOptions();
 
         $this->client = $client ?? new TraceServiceClient(
-            $this->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) ?
-                self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) :
-                self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, $endpointURL),
+            EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) ?
+                EnvironmentVariables::getString(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) :
+                EnvironmentVariables::getString(Env::OTEL_EXPORTER_OTLP_ENDPOINT, $endpointURL),
             $opts
         );
     }

--- a/src/Contrib/OtlpHttp/Exporter.php
+++ b/src/Contrib/OtlpHttp/Exporter.php
@@ -9,7 +9,7 @@ use Http\Discovery\Psr18ClientDiscovery;
 use InvalidArgumentException;
 use OpenTelemetry\API\Common\Signal\Signals;
 use OpenTelemetry\Contrib\Otlp\SpanExporter;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
@@ -20,8 +20,6 @@ use function sprintf;
 
 class Exporter
 {
-    use EnvironmentVariablesTrait;
-
     private const DEFAULT_ENDPOINT = 'https://localhost:4318';
     private const DEFAULT_COMPRESSION = 'none';
     private const OTLP_PROTOCOL = 'http/protobuf';
@@ -35,24 +33,24 @@ class Exporter
         TransportFactoryInterface $transportFactory
     ): TransportInterface {
 
-        $endpoint = self::hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
-            ? self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+        $endpoint = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+            ? EnvironmentVariables::getString(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
             : HttpEndpointResolver::create()->resolveToString(
-                self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, self::DEFAULT_ENDPOINT),
+                EnvironmentVariables::getString(Env::OTEL_EXPORTER_OTLP_ENDPOINT, self::DEFAULT_ENDPOINT),
                 Signals::TRACE,
             );
 
-        $headers = self::hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
-            self::getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) :
-            self::getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS);
+        $headers = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
+            EnvironmentVariables::getMap(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) :
+            EnvironmentVariables::getMap(Env::OTEL_EXPORTER_OTLP_HEADERS);
 
-        $compression = self::hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
-            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, self::DEFAULT_COMPRESSION) :
-            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_COMPRESSION, self::DEFAULT_COMPRESSION);
+        $compression = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
+            EnvironmentVariables::getEnum(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, self::DEFAULT_COMPRESSION) :
+            EnvironmentVariables::getEnum(Env::OTEL_EXPORTER_OTLP_COMPRESSION, self::DEFAULT_COMPRESSION);
 
-        $protocol = self::hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) ?
-            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, self::OTLP_PROTOCOL) :
-            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_PROTOCOL, self::OTLP_PROTOCOL);
+        $protocol = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) ?
+            EnvironmentVariables::getEnum(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, self::OTLP_PROTOCOL) :
+            EnvironmentVariables::getEnum(Env::OTEL_EXPORTER_OTLP_PROTOCOL, self::OTLP_PROTOCOL);
 
         if ($protocol !== self::OTLP_PROTOCOL) {
             throw new InvalidArgumentException(sprintf('Invalid OTLP Protocol "%s" specified', $protocol));

--- a/src/Contrib/OtlpHttp/Exporter.php
+++ b/src/Contrib/OtlpHttp/Exporter.php
@@ -32,7 +32,6 @@ class Exporter
     public static function createTransport(
         TransportFactoryInterface $transportFactory
     ): TransportInterface {
-
         $endpoint = EnvironmentVariables::has(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
             ? EnvironmentVariables::getString(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
             : HttpEndpointResolver::create()->resolveToString(

--- a/src/Contrib/OtlpHttp/Exporter.php
+++ b/src/Contrib/OtlpHttp/Exporter.php
@@ -20,6 +20,8 @@ use function sprintf;
 
 class Exporter
 {
+    use EnvironmentVariablesTrait;
+
     private const DEFAULT_ENDPOINT = 'https://localhost:4318';
     private const DEFAULT_COMPRESSION = 'none';
     private const OTLP_PROTOCOL = 'http/protobuf';
@@ -32,28 +34,25 @@ class Exporter
     public static function createTransport(
         TransportFactoryInterface $transportFactory
     ): TransportInterface {
-        $env = new class() {
-            use EnvironmentVariablesTrait;
-        };
 
-        $endpoint = $env->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
-            ? $env->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+        $endpoint = self::hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+            ? self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
             : HttpEndpointResolver::create()->resolveToString(
-                $env->getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, self::DEFAULT_ENDPOINT),
+                self::getStringFromEnvironment(Env::OTEL_EXPORTER_OTLP_ENDPOINT, self::DEFAULT_ENDPOINT),
                 Signals::TRACE,
             );
 
-        $headers = $env->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
-            $env->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) :
-            $env->getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS);
+        $headers = self::hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
+            self::getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_HEADERS) :
+            self::getMapFromEnvironment(Env::OTEL_EXPORTER_OTLP_HEADERS);
 
-        $compression = $env->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
-            $env->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, self::DEFAULT_COMPRESSION) :
-            $env->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_COMPRESSION, self::DEFAULT_COMPRESSION);
+        $compression = self::hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION) ?
+            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, self::DEFAULT_COMPRESSION) :
+            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_COMPRESSION, self::DEFAULT_COMPRESSION);
 
-        $protocol = $env->hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) ?
-            $env->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, self::OTLP_PROTOCOL) :
-            $env->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_PROTOCOL, self::OTLP_PROTOCOL);
+        $protocol = self::hasEnvironmentVariable(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) ?
+            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, self::OTLP_PROTOCOL) :
+            self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_PROTOCOL, self::OTLP_PROTOCOL);
 
         if ($protocol !== self::OTLP_PROTOCOL) {
             throw new InvalidArgumentException(sprintf('Invalid OTLP Protocol "%s" specified', $protocol));

--- a/src/SDK/Common/Environment/EnvironmentVariables.php
+++ b/src/SDK/Common/Environment/EnvironmentVariables.php
@@ -7,47 +7,47 @@ namespace OpenTelemetry\SDK\Common\Environment;
 /**
  * Centralized methods for retrieving environment variables
  */
-trait EnvironmentVariablesTrait
+class EnvironmentVariables
 {
     /**
      * Retrieve an integer value from an environment variable
      */
-    public static function getIntFromEnvironment(string $key, int $default): int
+    public static function getInt(string $key, int $default): int
     {
         return Accessor::getInt($key, (string) $default);
     }
 
-    public static function getStringFromEnvironment(string $key, string $default = ''): string
+    public static function getString(string $key, string $default = ''): string
     {
         return Accessor::getString($key, $default);
     }
 
-    public static function getBooleanFromEnvironment(string $key, bool $default = null): bool
+    public static function getBoolean(string $key, bool $default = null): bool
     {
         return Accessor::getBool($key, is_null($default) ? null : ($default ? 'true' : 'false'));
     }
 
-    public static function getMapFromEnvironment(string $key, string $default = null): array
+    public static function getMap(string $key, string $default = null): array
     {
         return Accessor::getMap($key, $default);
     }
 
-    public static function getListFromEnvironment(string $key, string $default = null): array
+    public static function getList(string $key, string $default = null): array
     {
         return Accessor::getList($key, $default);
     }
 
-    public static function getEnumFromEnvironment(string $key, string $default = null): string
+    public static function getEnum(string $key, string $default = null): string
     {
         return Accessor::getEnum($key, $default);
     }
 
-    public static function getRatioFromEnvironment(string $key, float $default = null): float
+    public static function getRatio(string $key, float $default = null): float
     {
         return Accessor::getRatio($key, $default ? (string) $default : null);
     }
 
-    public static function hasEnvironmentVariable(string $key): bool
+    public static function has(string $key): bool
     {
         return Resolver::hasVariable($key);
     }

--- a/src/SDK/Common/Environment/EnvironmentVariables.php
+++ b/src/SDK/Common/Environment/EnvironmentVariables.php
@@ -24,7 +24,7 @@ class EnvironmentVariables
 
     public static function getBoolean(string $key, bool $default = null): bool
     {
-        return Accessor::getBool($key, is_null($default) ? null : ($default ? 'true' : 'false'));
+        return Accessor::getBool($key, null === $default ? null : ($default ? 'true' : 'false'));
     }
 
     public static function getMap(string $key, string $default = null): array

--- a/src/SDK/Common/Environment/EnvironmentVariablesTrait.php
+++ b/src/SDK/Common/Environment/EnvironmentVariablesTrait.php
@@ -12,42 +12,42 @@ trait EnvironmentVariablesTrait
     /**
      * Retrieve an integer value from an environment variable
      */
-    public function getIntFromEnvironment(string $key, int $default): int
+    public static function getIntFromEnvironment(string $key, int $default): int
     {
         return Accessor::getInt($key, (string) $default);
     }
 
-    public function getStringFromEnvironment(string $key, string $default = ''): string
+    public static function getStringFromEnvironment(string $key, string $default = ''): string
     {
         return Accessor::getString($key, $default);
     }
 
-    public function getBooleanFromEnvironment(string $key, bool $default): bool
+    public static function getBooleanFromEnvironment(string $key, bool $default = null): bool
     {
-        return Accessor::getBool($key, $default ? 'true' : 'false');
+        return Accessor::getBool($key, is_null($default) ? null : ($default ? 'true' : 'false'));
     }
 
-    public function getMapFromEnvironment(string $key, string $default = null): array
+    public static function getMapFromEnvironment(string $key, string $default = null): array
     {
         return Accessor::getMap($key, $default);
     }
 
-    public function getListFromEnvironment(string $key, string $default = null): array
+    public static function getListFromEnvironment(string $key, string $default = null): array
     {
         return Accessor::getList($key, $default);
     }
 
-    public function getEnumFromEnvironment(string $key, string $default = null): string
+    public static function getEnumFromEnvironment(string $key, string $default = null): string
     {
         return Accessor::getEnum($key, $default);
     }
 
-    public function getRatioFromEnvironment(string $key, float $default = null): float
+    public static function getRatioFromEnvironment(string $key, float $default = null): float
     {
         return Accessor::getRatio($key, $default ? (string) $default : null);
     }
 
-    public function hasEnvironmentVariable(string $key): bool
+    public static function hasEnvironmentVariable(string $key): bool
     {
         return Resolver::hasVariable($key);
     }

--- a/src/SDK/Resource/Detectors/Environment.php
+++ b/src/SDK/Resource/Detectors/Environment.php
@@ -20,11 +20,11 @@ final class Environment implements ResourceDetectorInterface
 
     public function getResource(): ResourceInfo
     {
-        $attributes = $this->getMapFromEnvironment(Env::OTEL_RESOURCE_ATTRIBUTES, '');
+        $attributes = self::getMapFromEnvironment(Env::OTEL_RESOURCE_ATTRIBUTES, '');
 
         //@see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration
-        $serviceName = $this->hasEnvironmentVariable(Env::OTEL_SERVICE_NAME) ?
-                       $this->getStringFromEnvironment(Env::OTEL_SERVICE_NAME) :
+        $serviceName = self::hasEnvironmentVariable(Env::OTEL_SERVICE_NAME) ?
+                       self::getStringFromEnvironment(Env::OTEL_SERVICE_NAME) :
                        null;
         if ($serviceName) {
             $attributes[ResourceAttributes::SERVICE_NAME] = $serviceName;

--- a/src/SDK/Resource/Detectors/Environment.php
+++ b/src/SDK/Resource/Detectors/Environment.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Resource\Detectors;
 
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
@@ -16,15 +16,13 @@ use OpenTelemetry\SemConv\ResourceAttributes;
  */
 final class Environment implements ResourceDetectorInterface
 {
-    use EnvironmentVariablesTrait;
-
     public function getResource(): ResourceInfo
     {
-        $attributes = self::getMapFromEnvironment(Env::OTEL_RESOURCE_ATTRIBUTES, '');
+        $attributes = EnvironmentVariables::getMap(Env::OTEL_RESOURCE_ATTRIBUTES, '');
 
         //@see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration
-        $serviceName = self::hasEnvironmentVariable(Env::OTEL_SERVICE_NAME) ?
-                       self::getStringFromEnvironment(Env::OTEL_SERVICE_NAME) :
+        $serviceName = EnvironmentVariables::has(Env::OTEL_SERVICE_NAME) ?
+                       EnvironmentVariables::getString(Env::OTEL_SERVICE_NAME) :
                        null;
         if ($serviceName) {
             $attributes[ResourceAttributes::SERVICE_NAME] = $serviceName;

--- a/src/SDK/Resource/ResourceInfoFactory.php
+++ b/src/SDK/Resource/ResourceInfoFactory.php
@@ -7,14 +7,11 @@ namespace OpenTelemetry\SDK\Resource;
 use function in_array;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Environment\Accessor;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
 use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 
 class ResourceInfoFactory
 {
-    use EnvironmentVariablesTrait;
-
     /**
      * Merges resources into a new one.
      *

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK;
 
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Common\Environment\Variables;
 
 class SDK
 {
-    use EnvironmentVariablesTrait;
-
     public static function isDisabled(): bool
     {
-        return self::getBooleanFromEnvironment(Variables::OTEL_SDK_DISABLED);
+        return EnvironmentVariables::getBoolean(Variables::OTEL_SDK_DISABLED);
     }
 }

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK;
 
-use OpenTelemetry\SDK\Common\Environment\Accessor;
 use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
 use OpenTelemetry\SDK\Common\Environment\Variables;
 
@@ -14,6 +13,6 @@ class SDK
 
     public static function isDisabled(): bool
     {
-        return Accessor::getBool(Variables::OTEL_SDK_DISABLED);
+        return self::getBooleanFromEnvironment(Variables::OTEL_SDK_DISABLED);
     }
 }

--- a/src/SDK/Trace/ExporterFactory.php
+++ b/src/SDK/Trace/ExporterFactory.php
@@ -79,7 +79,7 @@ class ExporterFactory
 
     public function fromEnvironment(): ?SpanExporterInterface
     {
-        $envValue = $this->getStringFromEnvironment(Env::OTEL_TRACES_EXPORTER, '');
+        $envValue = self::getStringFromEnvironment(Env::OTEL_TRACES_EXPORTER, '');
         $exporters = explode(',', $envValue);
         //TODO "The SDK MAY accept a comma-separated list to enable setting multiple exporters"
         if (1 !== count($exporters)) {
@@ -95,9 +95,9 @@ class ExporterFactory
             case 'zipkintonewrelic':
                 throw new InvalidArgumentException(sprintf('Exporter %s cannot be created from environment', $exporter));
             case Values::VALUE_OTLP:
-                $protocol = $this->getEnumFromEnvironment(
+                $protocol = self::getEnumFromEnvironment(
                     Env::OTEL_EXPORTER_OTLP_PROTOCOL,
-                    $this->getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, '')
+                    self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, '')
                 );
                 switch ($protocol) {
                     case Values::VALUE_GRPC:

--- a/src/SDK/Trace/ExporterFactory.php
+++ b/src/SDK/Trace/ExporterFactory.php
@@ -8,14 +8,12 @@ use InvalidArgumentException;
 use OpenTelemetry\SDK\Common\Dsn\DsnInterface;
 use OpenTelemetry\SDK\Common\Dsn\Parser;
 use OpenTelemetry\SDK\Common\Dsn\ParserInterface;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 
 class ExporterFactory
 {
-    use EnvironmentVariablesTrait;
-
     private const KNOWN_EXPORTERS = [
         'console' => '\OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter',
         'memory' => '\OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter',
@@ -79,7 +77,7 @@ class ExporterFactory
 
     public function fromEnvironment(): ?SpanExporterInterface
     {
-        $envValue = self::getStringFromEnvironment(Env::OTEL_TRACES_EXPORTER, '');
+        $envValue = EnvironmentVariables::getString(Env::OTEL_TRACES_EXPORTER, '');
         $exporters = explode(',', $envValue);
         //TODO "The SDK MAY accept a comma-separated list to enable setting multiple exporters"
         if (1 !== count($exporters)) {
@@ -95,9 +93,9 @@ class ExporterFactory
             case 'zipkintonewrelic':
                 throw new InvalidArgumentException(sprintf('Exporter %s cannot be created from environment', $exporter));
             case Values::VALUE_OTLP:
-                $protocol = self::getEnumFromEnvironment(
+                $protocol = EnvironmentVariables::getEnum(
                     Env::OTEL_EXPORTER_OTLP_PROTOCOL,
-                    self::getEnumFromEnvironment(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, '')
+                    EnvironmentVariables::getEnum(Env::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, '')
                 );
                 switch ($protocol) {
                     case Values::VALUE_GRPC:

--- a/src/SDK/Trace/SamplerFactory.php
+++ b/src/SDK/Trace/SamplerFactory.php
@@ -21,10 +21,10 @@ class SamplerFactory
 
     public function fromEnvironment(): SamplerInterface
     {
-        $name = $this->getStringFromEnvironment(Env::OTEL_TRACES_SAMPLER);
+        $name = self::getStringFromEnvironment(Env::OTEL_TRACES_SAMPLER);
 
         if (strpos($name, self::TRACEIDRATIO_PREFIX) !== false) {
-            $arg = $this->getRatioFromEnvironment(Env::OTEL_TRACES_SAMPLER_ARG);
+            $arg = self::getRatioFromEnvironment(Env::OTEL_TRACES_SAMPLER_ARG);
 
             switch ($name) {
                 case Values::VALUE_TRACE_ID_RATIO:

--- a/src/SDK/Trace/SamplerFactory.php
+++ b/src/SDK/Trace/SamplerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace;
 
 use InvalidArgumentException;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
@@ -15,16 +15,14 @@ use OpenTelemetry\SDK\Trace\Sampler\TraceIdRatioBasedSampler;
 
 class SamplerFactory
 {
-    use EnvironmentVariablesTrait;
-
     private const TRACEIDRATIO_PREFIX = 'traceidratio';
 
     public function fromEnvironment(): SamplerInterface
     {
-        $name = self::getStringFromEnvironment(Env::OTEL_TRACES_SAMPLER);
+        $name = EnvironmentVariables::getString(Env::OTEL_TRACES_SAMPLER);
 
         if (strpos($name, self::TRACEIDRATIO_PREFIX) !== false) {
-            $arg = self::getRatioFromEnvironment(Env::OTEL_TRACES_SAMPLER_ARG);
+            $arg = EnvironmentVariables::getRatio(Env::OTEL_TRACES_SAMPLER_ARG);
 
             switch ($name) {
                 case Values::VALUE_TRACE_ID_RATIO:

--- a/src/SDK/Trace/SpanLimitsBuilder.php
+++ b/src/SDK/Trace/SpanLimitsBuilder.php
@@ -6,15 +6,13 @@ namespace OpenTelemetry\SDK\Trace;
 
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Attribute\FilteredAttributesFactory;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SemConv\TraceAttributes;
 use const PHP_INT_MAX;
 
 class SpanLimitsBuilder
 {
-    use EnvironmentVariablesTrait;
-
     /** @var ?int Maximum allowed attribute count per record */
     private ?int $attributeCountLimit = null;
 
@@ -113,17 +111,17 @@ class SpanLimitsBuilder
     public function build(): SpanLimits
     {
         $attributeCountLimit = $this->attributeCountLimit
-            ?: self::getIntFromEnvironment(Env::OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_ATTRIBUTE_COUNT_LIMIT);
+            ?: EnvironmentVariables::getInt(Env::OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_ATTRIBUTE_COUNT_LIMIT);
         $attributeValueLengthLimit = $this->attributeValueLengthLimit
-            ?: self::getIntFromEnvironment(Env::OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, SpanLimits::DEFAULT_SPAN_ATTRIBUTE_LENGTH_LIMIT);
+            ?: EnvironmentVariables::getInt(Env::OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, SpanLimits::DEFAULT_SPAN_ATTRIBUTE_LENGTH_LIMIT);
         $eventCountLimit = $this->eventCountLimit
-            ?: self::getIntFromEnvironment(Env::OTEL_SPAN_EVENT_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_EVENT_COUNT_LIMIT);
+            ?: EnvironmentVariables::getInt(Env::OTEL_SPAN_EVENT_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_EVENT_COUNT_LIMIT);
         $linkCountLimit = $this->linkCountLimit
-            ?: self::getIntFromEnvironment(Env::OTEL_SPAN_LINK_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_LINK_COUNT_LIMIT);
+            ?: EnvironmentVariables::getInt(Env::OTEL_SPAN_LINK_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_LINK_COUNT_LIMIT);
         $attributePerEventCountLimit = $this->attributePerEventCountLimit
-            ?: self::getIntFromEnvironment(Env::OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_EVENT_ATTRIBUTE_COUNT_LIMIT);
+            ?: EnvironmentVariables::getInt(Env::OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_EVENT_ATTRIBUTE_COUNT_LIMIT);
         $attributePerLinkCountLimit = $this->attributePerLinkCountLimit
-            ?: self::getIntFromEnvironment(Env::OTEL_LINK_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_LINK_ATTRIBUTE_COUNT_LIMIT);
+            ?: EnvironmentVariables::getInt(Env::OTEL_LINK_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_LINK_ATTRIBUTE_COUNT_LIMIT);
 
         if ($attributeValueLengthLimit === PHP_INT_MAX) {
             $attributeValueLengthLimit = null;

--- a/src/SDK/Trace/SpanLimitsBuilder.php
+++ b/src/SDK/Trace/SpanLimitsBuilder.php
@@ -113,17 +113,17 @@ class SpanLimitsBuilder
     public function build(): SpanLimits
     {
         $attributeCountLimit = $this->attributeCountLimit
-            ?: $this->getIntFromEnvironment(Env::OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_ATTRIBUTE_COUNT_LIMIT);
+            ?: self::getIntFromEnvironment(Env::OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_ATTRIBUTE_COUNT_LIMIT);
         $attributeValueLengthLimit = $this->attributeValueLengthLimit
-            ?: $this->getIntFromEnvironment(Env::OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, SpanLimits::DEFAULT_SPAN_ATTRIBUTE_LENGTH_LIMIT);
+            ?: self::getIntFromEnvironment(Env::OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, SpanLimits::DEFAULT_SPAN_ATTRIBUTE_LENGTH_LIMIT);
         $eventCountLimit = $this->eventCountLimit
-            ?: $this->getIntFromEnvironment(Env::OTEL_SPAN_EVENT_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_EVENT_COUNT_LIMIT);
+            ?: self::getIntFromEnvironment(Env::OTEL_SPAN_EVENT_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_EVENT_COUNT_LIMIT);
         $linkCountLimit = $this->linkCountLimit
-            ?: $this->getIntFromEnvironment(Env::OTEL_SPAN_LINK_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_LINK_COUNT_LIMIT);
+            ?: self::getIntFromEnvironment(Env::OTEL_SPAN_LINK_COUNT_LIMIT, SpanLimits::DEFAULT_SPAN_LINK_COUNT_LIMIT);
         $attributePerEventCountLimit = $this->attributePerEventCountLimit
-            ?: $this->getIntFromEnvironment(Env::OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_EVENT_ATTRIBUTE_COUNT_LIMIT);
+            ?: self::getIntFromEnvironment(Env::OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_EVENT_ATTRIBUTE_COUNT_LIMIT);
         $attributePerLinkCountLimit = $this->attributePerLinkCountLimit
-            ?: $this->getIntFromEnvironment(Env::OTEL_LINK_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_LINK_ATTRIBUTE_COUNT_LIMIT);
+            ?: self::getIntFromEnvironment(Env::OTEL_LINK_ATTRIBUTE_COUNT_LIMIT, SpanLimits::DEFAULT_LINK_ATTRIBUTE_COUNT_LIMIT);
 
         if ($attributeValueLengthLimit === PHP_INT_MAX) {
             $attributeValueLengthLimit = null;

--- a/src/SDK/Trace/SpanProcessorFactory.php
+++ b/src/SDK/Trace/SpanProcessorFactory.php
@@ -23,16 +23,16 @@ class SpanProcessorFactory
             return new NoopSpanProcessor();
         }
 
-        $name = $this->getEnumFromEnvironment(Env::OTEL_PHP_TRACES_PROCESSOR);
+        $name = self::getEnumFromEnvironment(Env::OTEL_PHP_TRACES_PROCESSOR);
         switch ($name) {
             case Values::VALUE_BATCH:
                 return new BatchSpanProcessor(
                     $exporter,
                     ClockFactory::getDefault(),
-                    $this->getIntFromEnvironment(Env::OTEL_BSP_MAX_QUEUE_SIZE, BatchSpanProcessor::DEFAULT_MAX_QUEUE_SIZE),
-                    $this->getIntFromEnvironment(Env::OTEL_BSP_SCHEDULE_DELAY, BatchSpanProcessor::DEFAULT_SCHEDULE_DELAY),
-                    $this->getIntFromEnvironment(Env::OTEL_BSP_EXPORT_TIMEOUT, BatchSpanProcessor::DEFAULT_EXPORT_TIMEOUT),
-                    $this->getIntFromEnvironment(Env::OTEL_BSP_MAX_EXPORT_BATCH_SIZE, BatchSpanProcessor::DEFAULT_MAX_EXPORT_BATCH_SIZE),
+                    self::getIntFromEnvironment(Env::OTEL_BSP_MAX_QUEUE_SIZE, BatchSpanProcessor::DEFAULT_MAX_QUEUE_SIZE),
+                    self::getIntFromEnvironment(Env::OTEL_BSP_SCHEDULE_DELAY, BatchSpanProcessor::DEFAULT_SCHEDULE_DELAY),
+                    self::getIntFromEnvironment(Env::OTEL_BSP_EXPORT_TIMEOUT, BatchSpanProcessor::DEFAULT_EXPORT_TIMEOUT),
+                    self::getIntFromEnvironment(Env::OTEL_BSP_MAX_EXPORT_BATCH_SIZE, BatchSpanProcessor::DEFAULT_MAX_EXPORT_BATCH_SIZE),
                 );
             case Values::VALUE_SIMPLE:
                 return new SimpleSpanProcessor($exporter);

--- a/src/SDK/Trace/SpanProcessorFactory.php
+++ b/src/SDK/Trace/SpanProcessorFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace;
 
 use InvalidArgumentException;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables;
 use OpenTelemetry\SDK\Common\Environment\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Environment\Variables as Env;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;
@@ -15,24 +15,22 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 
 class SpanProcessorFactory
 {
-    use EnvironmentVariablesTrait;
-
     public function fromEnvironment(?SpanExporterInterface $exporter = null): SpanProcessorInterface
     {
         if ($exporter === null) {
             return new NoopSpanProcessor();
         }
 
-        $name = self::getEnumFromEnvironment(Env::OTEL_PHP_TRACES_PROCESSOR);
+        $name = EnvironmentVariables::getEnum(Env::OTEL_PHP_TRACES_PROCESSOR);
         switch ($name) {
             case Values::VALUE_BATCH:
                 return new BatchSpanProcessor(
                     $exporter,
                     ClockFactory::getDefault(),
-                    self::getIntFromEnvironment(Env::OTEL_BSP_MAX_QUEUE_SIZE, BatchSpanProcessor::DEFAULT_MAX_QUEUE_SIZE),
-                    self::getIntFromEnvironment(Env::OTEL_BSP_SCHEDULE_DELAY, BatchSpanProcessor::DEFAULT_SCHEDULE_DELAY),
-                    self::getIntFromEnvironment(Env::OTEL_BSP_EXPORT_TIMEOUT, BatchSpanProcessor::DEFAULT_EXPORT_TIMEOUT),
-                    self::getIntFromEnvironment(Env::OTEL_BSP_MAX_EXPORT_BATCH_SIZE, BatchSpanProcessor::DEFAULT_MAX_EXPORT_BATCH_SIZE),
+                    EnvironmentVariables::getInt(Env::OTEL_BSP_MAX_QUEUE_SIZE, BatchSpanProcessor::DEFAULT_MAX_QUEUE_SIZE),
+                    EnvironmentVariables::getInt(Env::OTEL_BSP_SCHEDULE_DELAY, BatchSpanProcessor::DEFAULT_SCHEDULE_DELAY),
+                    EnvironmentVariables::getInt(Env::OTEL_BSP_EXPORT_TIMEOUT, BatchSpanProcessor::DEFAULT_EXPORT_TIMEOUT),
+                    EnvironmentVariables::getInt(Env::OTEL_BSP_MAX_EXPORT_BATCH_SIZE, BatchSpanProcessor::DEFAULT_MAX_EXPORT_BATCH_SIZE),
                 );
             case Values::VALUE_SIMPLE:
                 return new SimpleSpanProcessor($exporter);

--- a/tests/Unit/SDK/Common/Environment/EnvironmentVariablesTest.php
+++ b/tests/Unit/SDK/Common/Environment/EnvironmentVariablesTest.php
@@ -6,24 +6,16 @@ namespace OpenTelemetry\Tests\Unit\SDK\Common\Environment;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use Exception;
-use OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait;
+use OpenTelemetry\SDK\Common\Environment\EnvironmentVariables as Env;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Environment\EnvironmentVariablesTrait
+ * @covers \OpenTelemetry\SDK\Common\Environment\EnvironmentVariables
  */
-class EnvironmentVariablesTraitTest extends TestCase
+class EnvironmentVariablesTest extends TestCase
 {
     use EnvironmentVariables;
 
-    private $mock;
-
-    public function setUp(): void
-    {
-        $this->mock = new class() {
-            use EnvironmentVariablesTrait;
-        };
-    }
     public function tearDown(): void
     {
         $this->restoreEnvironmentVariables();
@@ -31,15 +23,15 @@ class EnvironmentVariablesTraitTest extends TestCase
 
     public function test_has_environment_variable(): void
     {
-        $this->assertFalse($this->mock->hasEnvironmentVariable('FOO_VAR'));
+        $this->assertFalse(Env::has('FOO_VAR'));
         $this->setEnvironmentVariable('FOO_VAR', 'FOO');
-        $this->assertTrue($this->mock->hasEnvironmentVariable('FOO_VAR'));
+        $this->assertTrue(Env::has('FOO_VAR'));
     }
 
     public function test_integer_get(): void
     {
         $this->setEnvironmentVariable('OTEL_FOO', '100');
-        $value = $this->mock->getIntFromEnvironment('OTEL_FOO', 999);
+        $value = Env::getInt('OTEL_FOO', 999);
         $this->assertSame(100, $value);
     }
 
@@ -47,18 +39,18 @@ class EnvironmentVariablesTraitTest extends TestCase
     {
         $this->setEnvironmentVariable('OTEL_FOO', 'foo');
         $this->expectException(Exception::class);
-        $this->mock->getIntFromEnvironment('OTEL_FOO', 99);
+        Env::getInt('OTEL_FOO', 99);
     }
 
     public function environment_variables_integer_uses_default_if_env_var_not_defined()
     {
-        $this->assertSame(20, $this->mock->getIntFromEnvironment('OTEL_FOO', 20));
+        $this->assertSame(20, Env::getInt('OTEL_FOO', 20));
     }
 
     public function test_string_get(): void
     {
         $this->setEnvironmentVariable('OTEL_FOO', 'foo');
-        $value = $this->mock->getStringFromEnvironment('OTEL_FOO', 'bar');
+        $value = Env::getString('OTEL_FOO', 'bar');
         $this->assertSame('foo', $value);
     }
 
@@ -69,7 +61,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     public function test_string_uses_default_when_empty_value(?string $input): void
     {
         $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = $this->mock->getStringFromEnvironment('OTEL_FOO', 'bar');
+        $value = Env::getString('OTEL_FOO', 'bar');
         $this->assertSame('bar', $value);
     }
 
@@ -79,7 +71,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     public function test_int_uses_default_when_empty_value(?string $input): void
     {
         $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = $this->mock->getIntFromEnvironment('OTEL_FOO', 99);
+        $value = Env::getInt('OTEL_FOO', 99);
         $this->assertSame(99, $value);
     }
 
@@ -89,7 +81,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     public function test_bool_uses_default_when_empty_value(?string $input): void
     {
         $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = $this->mock->getBooleanFromEnvironment('OTEL_FOO', true);
+        $value = Env::getBoolean('OTEL_FOO', true);
         $this->assertTrue($value);
     }
 
@@ -107,7 +99,7 @@ class EnvironmentVariablesTraitTest extends TestCase
     public function test_bool_get(string $input, bool $default, bool $expected)
     {
         $this->setEnvironmentVariable('OTEL_BOOL', $input);
-        $this->assertSame($expected, $this->mock->getBooleanFromEnvironment('OTEL_BOOL', $default));
+        $this->assertSame($expected, Env::getBoolean('OTEL_BOOL', $default));
     }
 
     public function booleanProvider()
@@ -125,24 +117,24 @@ class EnvironmentVariablesTraitTest extends TestCase
     public function test_list_get()
     {
         $this->setEnvironmentVariable('OTEL_LIST', 'a,b,c');
-        $this->assertSame(['a', 'b', 'c'], $this->mock->getListFromEnvironment('OTEL_LIST'));
+        $this->assertSame(['a', 'b', 'c'], Env::getList('OTEL_LIST'));
     }
 
     public function test_map_get()
     {
         $this->setEnvironmentVariable('OTEL_MAP', 'a=b,c=d');
-        $this->assertSame(['a'=>'b', 'c'=>'d'], $this->mock->getMapFromEnvironment('OTEL_MAP'));
+        $this->assertSame(['a'=>'b', 'c'=>'d'], Env::getMap('OTEL_MAP'));
     }
 
     public function test_enum_get()
     {
         $this->setEnvironmentVariable('OTEL_ENUM', 'foo');
-        $this->assertSame('foo', $this->mock->getEnumFromEnvironment('OTEL_ENUM'));
+        $this->assertSame('foo', Env::getEnum('OTEL_ENUM'));
     }
 
     public function test_ratio_get()
     {
         $this->setEnvironmentVariable('OTEL_RATIO', '0.5');
-        $this->assertSame(0.5, $this->mock->getRatioFromEnvironment('OTEL_RATIO'));
+        $this->assertSame(0.5, Env::getRatio('OTEL_RATIO'));
     }
 }


### PR DESCRIPTION
The `EnvironmentVariablesTrait` provided instance accessor methods with only static calls. This refactors those methods to be static, removing several cases of anonymous class instantiation to provide its functionality.

It's still possible to access static methods through `$this->` so this is also non-breaking to consumers.