### PR TITLE
adding http server span context key

### DIFF
--- a/examples/traces/features/http_server_spans.php
+++ b/examples/traces/features/http_server_spans.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use OpenTelemetry\API\Trace\ContextKeys;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\SDK\Common\Log\LoggerHolder;
+use OpenTelemetry\SDK\Trace\TracerProviderFactory;
+use Psr\Log\LogLevel;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+LoggerHolder::set(
+    new Logger('otel-php', [new StreamHandler(STDOUT, LogLevel::DEBUG)])
+);
+
+//putenv('OTEL_EXPORTER_ZIPKIN_ENDPOINT=http://zipkin:9411/api/v2/spans');
+putenv('OTEL_TRACES_EXPORTER=console');
+
+$factory = new TracerProviderFactory('demo');
+$tracerProvider = $factory->create();
+
+$tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
+
+/*
+ * This demonstrates how to store the root span of an HTTP server request so that it can be retrieved later (e.g to update
+ * its name after routing has been performed).
+ * It's possible to have multiple HTTP server requests being processed within the same process, e.g Symfony's sub-request
+ * feature: https://symfony.com/doc/current/components/http_kernel.html#sub-requests
+ * In this example, both the main and sub-request spans are stored in context with the same key. Some other code (perhaps
+ * a post-route event handler) can then retrieve the currently-active "http request span" and update its name based on the
+ * routing results.
+ */
+
+$rootSpan = $tracer->spanBuilder('main')->startSpan();
+$rootScope = $rootSpan->activate();
+Context::storage()->attach(Context::getCurrent()->with(ContextKeys::httpServerSpan(), $rootSpan));
+//main request routing completed, update span's name from routing results
+Context::getCurrent()->get(ContextKeys::httpServerSpan())->updateName('main-route-name');
+
+//sub-request
+$subRequest = $tracer->spanBuilder('sub-request')->startSpan();
+Context::storage()->attach(Context::getCurrent()->with(ContextKeys::httpServerSpan(), $subRequest));
+$subRequestScope = $subRequest->activate();
+//sub-request routing completed, update "sub-request" span's name from routing results
+Context::getCurrent()->get(ContextKeys::httpServerSpan())->updateName('sub-route-name');
+
+$subRequest->end();
+$subRequestScope->detach();
+Context::storage()->scope()->detach(); //sub-request span
+//end sub-request
+
+$tracer->spanBuilder('process-sub-request-results')->startSpan()->end();
+
+$rootSpan->end();
+Context::storage()->scope()->detach(); //main http server scope
+$rootScope->detach(); //main span
+$tracerProvider->shutdown();

--- a/src/API/Trace/ContextKeys.php
+++ b/src/API/Trace/ContextKeys.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Trace;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKeyInterface;
+
+class ContextKeys
+{
+    public static function httpServerSpan(): ContextKeyInterface
+    {
+        static $instance;
+
+        return $instance ??= Context::createKey('http-server-span-key');
+    }
+}


### PR DESCRIPTION
adds a context key to the API to refer to http server spans, and an example of how it can be used