### PR TITLE
disallow non-standard boolean config values

### DIFF
--- a/src/SDK/Common/Configuration/KnownValues.php
+++ b/src/SDK/Common/Configuration/KnownValues.php
@@ -60,10 +60,6 @@ interface KnownValues
     public const VALUES_BOOLEAN = [
         self::VALUE_TRUE,
         self::VALUE_FALSE,
-        self::VALUE_ON,
-        self::VALUE_OFF,
-        self::VALUE_1,
-        self::VALUE_0,
     ];
 
     public const VALUES_COMPRESSION= [

--- a/src/SDK/Common/Configuration/Parser/BooleanParser.php
+++ b/src/SDK/Common/Configuration/Parser/BooleanParser.php
@@ -8,17 +8,8 @@ use InvalidArgumentException;
 
 class BooleanParser
 {
-    private const TRUTHY_VALUES = [
-        'true',
-        'on',
-        '1',
-    ];
-
-    private const FALSY_VALUES = [
-        'false',
-        'off',
-        '0',
-    ];
+    private const TRUE_VALUE = 'true';
+    private const FALSE_VALUE = 'false';
 
     /**
      * @param string|bool $value
@@ -28,11 +19,11 @@ class BooleanParser
         if (is_bool($value)) {
             return $value;
         }
-        if (in_array(strtolower($value), self::TRUTHY_VALUES)) {
+        if (strtolower($value) === self::TRUE_VALUE) {
             return true;
         }
 
-        if (in_array(strtolower($value), self::FALSY_VALUES)) {
+        if (strtolower($value) === self::FALSE_VALUE) {
             return false;
         }
 

--- a/tests/Unit/SDK/Common/Configuration/ConfigurationTest.php
+++ b/tests/Unit/SDK/Common/Configuration/ConfigurationTest.php
@@ -188,8 +188,6 @@ class ConfigurationTest extends TestCase
         return [
             'false' => ['false', true, false],
             'true' => ['true', false, true],
-            'truthy' => ['1', false, true],
-            'falsey' => ['0', true, false],
             'TRUE' => ['TRUE', false, true],
             'FALSE' => ['FALSE', true, false],
         ];

--- a/tests/Unit/SDK/Common/Configuration/Parser/BooleanParserTest.php
+++ b/tests/Unit/SDK/Common/Configuration/Parser/BooleanParserTest.php
@@ -16,23 +16,30 @@ class BooleanParserTest extends TestCase
     private const TRUTHY_VALUES = [
         'bool uppercase' => ['TRUE'],
         'bool lowercase' => ['true'],
-        'state uppercase' => ['ON'],
-        'state lowercase' => ['on'],
-        'int' => ['1'],
+        'bool mixed case' => ['True'],
     ];
 
     private const FALSY_VALUES = [
         'bool uppercase' => ['FALSE'],
         'bool lowercase' => ['false'],
-        'state uppercase' => ['OFF'],
-        'state lowercase' => ['off'],
-        'int' => ['0'],
+        'bool mixed case' => ['False'],
     ];
 
     private const NON_BOOLEAN_VALUES = [
         'string' => ['Foo'],
         'int' => ['42'],
         'float' => ['0.5'],
+    ];
+
+    private const DISALLOWED_BOOLEAN_VALUES = [
+        ['ON'],
+        ['on'],
+        ['On'],
+        ['1'],
+        ['OFF'],
+        ['off'],
+        ['Off'],
+        ['0'],
     ];
 
     /**
@@ -53,6 +60,20 @@ class BooleanParserTest extends TestCase
         $this->assertFalse(
             BooleanParser::parse($value)
         );
+    }
+
+    /**
+     * @dataProvider disallowedBooleanProvider
+     */
+    public function test_disallowed_boolean_type_values_throw_exception(string $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        BooleanParser::parse($value);
+    }
+
+    public function disallowedBooleanProvider(): array
+    {
+        return self::DISALLOWED_BOOLEAN_VALUES;
     }
 
     /**

--- a/tests/Unit/SDK/SdkTest.php
+++ b/tests/Unit/SDK/SdkTest.php
@@ -41,9 +41,7 @@ class SdkTest extends TestCase
     {
         return [
             ['true', true],
-            ['1', true],
             ['false', false],
-            ['0', false],
         ];
     }
 


### PR DESCRIPTION
per spec, only 'true' and 'false' are valid boolean values. anything else should be interpreted as false and a warning emitted.

Closes #861 