### PR TITLE
decode OTEL_RESOURCE_ATTRIBUTES values

### DIFF
--- a/src/SDK/Resource/Detectors/Environment.php
+++ b/src/SDK/Resource/Detectors/Environment.php
@@ -19,7 +19,7 @@ final class Environment implements ResourceDetectorInterface
     public function getResource(): ResourceInfo
     {
         $attributes = Configuration::has(Variables::OTEL_RESOURCE_ATTRIBUTES)
-            ? Configuration::getMap(Variables::OTEL_RESOURCE_ATTRIBUTES, [])
+            ? self::decode(Configuration::getMap(Variables::OTEL_RESOURCE_ATTRIBUTES, []))
             : [];
 
         //@see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration
@@ -31,5 +31,10 @@ final class Environment implements ResourceDetectorInterface
         }
 
         return ResourceInfo::create(Attributes::create($attributes), ResourceAttributes::SCHEMA_URL);
+    }
+
+    private static function decode(array $attributes): array
+    {
+        return array_map('urldecode', $attributes);
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/EnvironmentTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/EnvironmentTest.php
@@ -52,7 +52,7 @@ class EnvironmentTest extends TestCase
      */
     public function test_environment_get_resource_with_encoded_value(string $value, string $expected): void
     {
-        $key = '_key';
+        $key = 'key';
         $this->setEnvironmentVariable('OTEL_RESOURCE_ATTRIBUTES', sprintf('%s=%s', $key, $value));
 
         $resource = $this->detector->getResource();


### PR DESCRIPTION
per spec, resource attributes coming from environment should be decoded in the same way that they would be if coming from a header

Closes #786 