### PR TITLE
update contrib autoloading and gitsplit

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -27,7 +27,7 @@ splits:
   - prefix: "src/Contrib/Otlp"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/exporter-otlp.git"
   - prefix: "src/Contrib/Grpc"
-    target: "https://${GH_TOKEN}@github.com/opentelemetry-php/exporter-otlp-grpc.git"
+    target: "https://${GH_TOKEN}@github.com/opentelemetry-php/transport-grpc.git"
   - prefix: "src/Contrib/Zipkin"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/exporter-zipkin.git"
   - prefix: "src/Contrib/ZipkinToNewrelic"

--- a/src/Contrib/Grpc/README.md
+++ b/src/Contrib/Grpc/README.md
@@ -1,6 +1,6 @@
-# OpenTelemetry gRPC Exporter
+# OpenTelemetry gRPC Transport
 
-OTLP gRPC exporter for OpenTelemetry.
+gRPC transport for OpenTelemetry.
 
 ## Usage
 

--- a/src/Contrib/Grpc/composer.json
+++ b/src/Contrib/Grpc/composer.json
@@ -19,6 +19,9 @@
   "autoload": {
     "psr-4": {
       "OpenTelemetry\\Contrib\\Grpc\\": "."
-    }
+    },
+    "files": [
+      "_register.php"
+    ]
   }
 }

--- a/src/Contrib/Otlp/composer.json
+++ b/src/Contrib/Otlp/composer.json
@@ -25,6 +25,9 @@
   "autoload": {
     "psr-4": {
       "OpenTelemetry\\Contrib\\Otlp\\": "."
-    }
+    },
+    "files": [
+      "_register.php"
+    ]
   }
 }

--- a/src/Contrib/Zipkin/composer.json
+++ b/src/Contrib/Zipkin/composer.json
@@ -21,6 +21,9 @@
   "autoload": {
     "psr-4": {
       "OpenTelemetry\\Contrib\\Zipkin\\": "."
-    }
+    },
+    "files": [
+      "_register.php"
+    ]
   }
 }

--- a/src/Contrib/composer.json
+++ b/src/Contrib/composer.json
@@ -32,7 +32,14 @@
     "autoload": {
         "psr-4": {
             "OpenTelemetry\\Contrib\\": "."
-        }
+        },
+        "files": [
+            "Grpc/_register.php",
+            "Newrelic/_register.php",
+            "Otlp/_register.php",
+            "Zipkin/_register.php"
+
+        ]
     },
     "suggest": {
         "ext-sockets": "To use the Thrift UDP Exporter for the Jaeger Agent"


### PR DESCRIPTION
* match grpc's gitsplit destination repo to match package name: 'transport-grpc'
* set autoload->files for contrib modules which support factory registry