### PR TITLE
adding an identification header to export requests

### DIFF
--- a/src/API/Common/Export/Headers.php
+++ b/src/API/Common/Export/Headers.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Common\Export;
+
+class Headers
+{
+    const EXPORTER_HEADER = 'X-Is-Otel-Exporter';
+}

--- a/src/SDK/Common/Export/Http/PsrTransport.php
+++ b/src/SDK/Common/Export/Http/PsrTransport.php
@@ -8,6 +8,7 @@ use function assert;
 use BadMethodCallException;
 use function explode;
 use function in_array;
+use OpenTelemetry\API\Common\Export\Headers;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;
@@ -84,6 +85,7 @@ final class PsrTransport implements TransportInterface
             ->createRequest('POST', $this->endpoint)
             ->withBody($this->streamFactory->createStream($body))
             ->withHeader('Content-Type', $this->contentType)
+            ->withHeader(Headers::EXPORTER_HEADER, 'true')
         ;
         if ($appliedEncodings) {
             $request = $request->withHeader('Content-Encoding', $appliedEncodings);

--- a/tests/Unit/SDK/Common/Export/Http/PsrTransportTest.php
+++ b/tests/Unit/SDK/Common/Export/Http/PsrTransportTest.php
@@ -12,6 +12,7 @@ use function gzdecode;
 use function gzencode;
 use InvalidArgumentException;
 use Nyholm\Psr7\Response;
+use OpenTelemetry\API\Common\Export\Headers;
 use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -71,6 +72,7 @@ final class PsrTransportTest extends TestCase
     {
         $this->client->expects($this->once())->method('sendRequest')->willReturnCallback(function (RequestInterface $request): ResponseInterface {
             $this->assertSame('bar', $request->getHeaderLine('x-foo'));
+            $this->assertTrue($request->hasHeader(Headers::EXPORTER_HEADER), 'contains custom header for identifying exporter requests');
 
             return new Response();
         });


### PR DESCRIPTION
allow other parts of our code (eg auto-instrumentation) to identify whether an http request
is self-generated. use-case: do not auto-instrument our own code.