### PR TITLE
allow setting service name from auto instrumentation context

### DIFF
--- a/src/Contrib/Jaeger/HttpCollectorExporter.php
+++ b/src/Contrib/Jaeger/HttpCollectorExporter.php
@@ -20,7 +20,6 @@ class HttpCollectorExporter implements SpanExporterInterface
 
     public function __construct(
         string $endpointUrl,
-        string $name,
         ClientInterface $client,
         RequestFactoryInterface $requestFactory,
         StreamFactoryInterface $streamFactory
@@ -32,7 +31,6 @@ class HttpCollectorExporter implements SpanExporterInterface
             $client,
             $requestFactory,
             $streamFactory,
-            $name,
             $parsedEndpoint
         );
     }

--- a/src/Contrib/Newrelic/Exporter.php
+++ b/src/Contrib/Newrelic/Exporter.php
@@ -29,19 +29,16 @@ class Exporter implements SpanExporterInterface
     public const DATA_FORMAT_VERSION_DEFAULT = '1';
 
     private TransportInterface $transport;
-    private string $name;
     private string $endpointUrl;
 
     public function __construct(
-        $name,
         TransportInterface $transport,
         string $endpointUrl,
         SpanConverter $spanConverter = null
     ) {
-        $this->name = $name;
         $this->endpointUrl = $endpointUrl;
         $this->transport = $transport;
-        $this->setSpanConverter($spanConverter ?? new SpanConverter($name));
+        $this->setSpanConverter($spanConverter ?? new SpanConverter());
     }
 
     /**
@@ -54,7 +51,7 @@ class Exporter implements SpanExporterInterface
 
     private function convert(iterable $spans): array
     {
-        $commonAttributes = ['attributes' => [ 'service.name' => $this->name,
+        $commonAttributes = ['attributes' => [
             'host' => $this->endpointUrl, ]];
 
         return [[ 'common' => $commonAttributes,

--- a/src/Contrib/Newrelic/SpanExporterFactory.php
+++ b/src/Contrib/Newrelic/SpanExporterFactory.php
@@ -23,6 +23,6 @@ class SpanExporterFactory implements SpanExporterFactoryInterface
             'Data-Format-Version' => $dataFormatVersion,
         ]);
 
-        return new Exporter('newrelic', $transport, $endpointUrl);
+        return new Exporter($transport, $endpointUrl);
     }
 }

--- a/src/Contrib/Zipkin/Exporter.php
+++ b/src/Contrib/Zipkin/Exporter.php
@@ -26,12 +26,11 @@ class Exporter implements SpanExporterInterface
     private TransportInterface $transport;
 
     public function __construct(
-        $name,
         TransportInterface $transport,
         SpanConverterInterface $spanConverter = null
     ) {
         $this->transport = $transport;
-        $this->setSpanConverter($spanConverter ?? new SpanConverter($name));
+        $this->setSpanConverter($spanConverter ?? new SpanConverter());
     }
 
     /**

--- a/src/Contrib/Zipkin/SpanExporterFactory.php
+++ b/src/Contrib/Zipkin/SpanExporterFactory.php
@@ -17,6 +17,6 @@ class SpanExporterFactory implements SpanExporterFactoryInterface
         $endpoint = Configuration::getString(Variables::OTEL_EXPORTER_ZIPKIN_ENDPOINT);
         $transport = PsrTransportFactory::discover()->create($endpoint, 'application/json');
 
-        return new Exporter('zipkin', $transport);
+        return new Exporter($transport);
     }
 }

--- a/src/Contrib/ZipkinToNewrelic/Exporter.php
+++ b/src/Contrib/ZipkinToNewrelic/Exporter.php
@@ -30,16 +30,14 @@ class Exporter implements SpanExporterInterface
     private TransportInterface $transport;
 
     public function __construct(
-        string $name,
         TransportInterface $transport,
         SpanConverter $spanConverter = null
     ) {
         $this->transport = $transport;
-        $this->setSpanConverter($spanConverter ?? new SpanConverter($name));
+        $this->setSpanConverter($spanConverter ?? new SpanConverter());
     }
 
     public static function create(
-        string $name,
         string $endpointUrl,
         string $licenseKey
     ): self {
@@ -49,7 +47,7 @@ class Exporter implements SpanExporterInterface
             'Data-Format-Version' => '2',
         ]);
 
-        return new self($name, $transport);
+        return new self($transport);
     }
 
     /**

--- a/tests/Unit/Contrib/Jaeger/AgentExporterTest.php
+++ b/tests/Unit/Contrib/Jaeger/AgentExporterTest.php
@@ -18,7 +18,7 @@ class AgentExporterTest extends TestCase
 {
     public function test_happy_path()
     {
-        $exporter = new AgentExporter('someServiceName', 'http://127.0.0.1:80');
+        $exporter = new AgentExporter('http://127.0.0.1:80');
 
         $status = $exporter->export([new SpanData()])->await();
 

--- a/tests/Unit/Contrib/Jaeger/JaegerExporterTest.php
+++ b/tests/Unit/Contrib/Jaeger/JaegerExporterTest.php
@@ -13,12 +13,9 @@ use OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter\AbstractExporterTest;
  */
 class JaegerExporterTest extends AbstractExporterTest
 {
-    private const EXPORTER_NAME = 'test.jaeger';
-
     public function createExporterWithTransport(TransportInterface $transport): Exporter
     {
         return new Exporter(
-            self::EXPORTER_NAME,
             $transport
         );
     }

--- a/tests/Unit/Contrib/Jaeger/JaegerHttpCollectorExporterTest.php
+++ b/tests/Unit/Contrib/Jaeger/JaegerHttpCollectorExporterTest.php
@@ -29,7 +29,6 @@ class JaegerHttpCollectorExporterTest extends TestCase
          */
         $exporter = new HttpCollectorExporter(
             'https://hostOfJaegerCollector.com/post',
-            'nameOfThisService',
             $this->getClientInterfaceMock(),
             $this->getRequestFactoryInterfaceMock(),
             $this->getStreamFactoryInterfaceMock()

--- a/tests/Unit/Contrib/Jaeger/JaegerHttpSenderTest.php
+++ b/tests/Unit/Contrib/Jaeger/JaegerHttpSenderTest.php
@@ -10,6 +10,8 @@ use OpenTelemetry\Contrib\Jaeger\HttpSender;
 use OpenTelemetry\Contrib\Jaeger\ParsedEndpointUrl;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+use OpenTelemetry\SemConv\ResourceAttributes;
 use OpenTelemetry\Tests\Unit\Contrib\UsesHttpClientTrait;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +39,6 @@ class JaegerHttpSenderTest extends TestCase
             $this->getClientInterfaceMock(),
             $this->getRequestFactoryInterfaceMock(),
             $this->getStreamFactoryInterfaceMock(),
-            $serviceName,
             $this->createParsedEndpointUrlMock(),
             $mockBatchAdapterFactory
         );
@@ -139,7 +140,10 @@ class JaegerHttpSenderTest extends TestCase
         $interceptedValues = $mockBatchAdapterFactory->getInterceptedValues();
 
         //1st batch
-        $this->assertSame('nameOfThe1stLogicalApp', $interceptedValues[0]['process']->serviceName);
+        $this->assertSame(
+            ResourceInfoFactory::defaultResource()->getAttributes()->get(ResourceAttributes::SERVICE_NAME),
+            $interceptedValues[0]['process']->serviceName
+        );
 
         //2nd batch
         $this->assertSame('nameOfThe2ndLogicalApp', $interceptedValues[1]['process']->serviceName);

--- a/tests/Unit/Contrib/Jaeger/JaegerSpanConverterTest.php
+++ b/tests/Unit/Contrib/Jaeger/JaegerSpanConverterTest.php
@@ -70,7 +70,7 @@ class JaegerSpanConverterTest extends TestCase
                         'telemetry.sdk.language' => 'php',
                         'telemetry.sdk.version' => 'dev',
                         'instance' => 'test-a',
-                        'service.name' => 'unknown_service',
+                        'service.name' => 'unknown_service:php',
                     ])
                 )
             );
@@ -114,7 +114,7 @@ class JaegerSpanConverterTest extends TestCase
         $this->assertSame('test-a', $convertedSpan->tags[11]->vStr);
 
         $this->assertSame('service.name', $convertedSpan->tags[12]->key);
-        $this->assertSame('unknown_service', $convertedSpan->tags[12]->vStr);
+        $this->assertSame('unknown_service:php', $convertedSpan->tags[12]->vStr);
     }
 
     public function test_should_correctly_convert_error_status_to_jaeger_thrift_tags()

--- a/tests/Unit/Contrib/Newrelic/NewrelicExporterTest.php
+++ b/tests/Unit/Contrib/Newrelic/NewrelicExporterTest.php
@@ -13,13 +13,11 @@ use OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter\AbstractExporterTest;
  */
 class NewrelicExporterTest extends AbstractExporterTest
 {
-    protected const EXPORTER_NAME = 'test.newrelic';
     protected const LICENSE_KEY = 'abc123';
 
     public function createExporterWithTransport(TransportInterface $transport): Exporter
     {
         return new Exporter(
-            self::EXPORTER_NAME,
             $transport,
             'http://endpoint.url'
         );

--- a/tests/Unit/Contrib/Newrelic/NewrelicSpanConverterTest.php
+++ b/tests/Unit/Contrib/Newrelic/NewrelicSpanConverterTest.php
@@ -7,6 +7,8 @@ namespace OpenTelemetry\Tests\Unit\Contrib\Newrelic;
 use OpenTelemetry\Contrib\Newrelic\SpanConverter;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+use OpenTelemetry\SemConv\ResourceAttributes;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use PHPUnit\Framework\TestCase;
 
@@ -32,13 +34,16 @@ class NewrelicSpanConverterTest extends TestCase
             ->addEvent('validators.list', Attributes::create(['job' => 'stage.updateTime']), 1505855799433901068)
             ->setHasEnded(true);
 
-        $converter = new SpanConverter('test.name');
+        $converter = new SpanConverter();
         $row = $converter->convert([$span])[0];
 
         $this->assertSame($span->getContext()->getSpanId(), $row['id']);
         $this->assertSame($span->getContext()->getTraceId(), $row['trace.id']);
 
-        $this->assertSame('test.name', $row['attributes']['service.name']);
+        $this->assertSame(
+            ResourceInfoFactory::defaultResource()->getAttributes()->get(ResourceAttributes::SERVICE_NAME),
+            $row['attributes']['service.name']
+        );
         $this->assertSame($span->getName(), $row['attributes']['name']);
         $this->assertNull($row['attributes']['parent.id']);
         $this->assertSame(1505855794194, $row['attributes']['timestamp']);
@@ -73,7 +78,7 @@ class NewrelicSpanConverterTest extends TestCase
             ->addAttribute('list-of-booleans', $listOfBooleans)
             ->addAttribute('list-of-random', $listOfRandoms);
 
-        $attributes = (new SpanConverter('tags.test'))->convert([$span])[0]['attributes'];
+        $attributes = (new SpanConverter())->convert([$span])[0]['attributes'];
 
         // Check that we can convert all attributes to tags
         $this->assertCount(17, $attributes);

--- a/tests/Unit/Contrib/Zipkin/ZipkinExporterTest.php
+++ b/tests/Unit/Contrib/Zipkin/ZipkinExporterTest.php
@@ -14,15 +14,12 @@ use OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter\AbstractExporterTest;
  */
 class ZipkinExporterTest extends AbstractExporterTest
 {
-    protected const EXPORTER_NAME = 'test.zipkin';
-
     /**
      * @psalm-suppress PossiblyInvalidArgument
      */
     public function createExporterWithTransport(TransportInterface $transport): Exporter
     {
         return new Exporter(
-            self::EXPORTER_NAME,
             $transport
         );
     }

--- a/tests/Unit/Contrib/ZipkinToNewrelic/ZipkinToNewrelicExporterTest.php
+++ b/tests/Unit/Contrib/ZipkinToNewrelic/ZipkinToNewrelicExporterTest.php
@@ -14,7 +14,6 @@ use OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter\AbstractExporterTest;
  */
 class ZipkinToNewrelicExporterTest extends AbstractExporterTest
 {
-    protected const EXPORTER_NAME = 'test.zipkinToNR';
     protected const LICENSE_KEY = 'abc123';
 
     /**
@@ -23,7 +22,6 @@ class ZipkinToNewrelicExporterTest extends AbstractExporterTest
     public function createExporterWithTransport(TransportInterface $transport): Exporter
     {
         return new Exporter(
-            self::EXPORTER_NAME,
             $transport
         );
     }


### PR DESCRIPTION
Currently there is no way to set service name from auto instrumentation context for zipkin and newrelic exporters.
We should read that from `OTEL_SERVICE_NAME` or any other configuration settings IMO.