### PR TITLE
fix stream transport factory creation

### DIFF
--- a/src/SDK/Common/Export/Stream/StreamTransportFactory.php
+++ b/src/SDK/Common/Export/Stream/StreamTransportFactory.php
@@ -97,6 +97,8 @@ final class StreamTransportFactory implements TransportFactoryInterface
         if (!$stream) {
             throw new LogicException(sprintf('Failed opening stream "%s"', $endpoint));
         }
+
+        return $stream;
     }
 
     private static function createHeaderArray(string $contentType, array $headers): array

--- a/tests/Unit/SDK/Common/Export/Stream/StreamTransportFactoryTest.php
+++ b/tests/Unit/SDK/Common/Export/Stream/StreamTransportFactoryTest.php
@@ -6,7 +6,6 @@ namespace OpenTelemetry\Example\Unit\SDK\Common\Export\Stream;
 
 use OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory;
 use PHPUnit\Framework\TestCase;
-use ReflectionObject;
 
 /**
  * @covers \OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory

--- a/tests/Unit/SDK/Common/Export/Stream/StreamTransportFactoryTest.php
+++ b/tests/Unit/SDK/Common/Export/Stream/StreamTransportFactoryTest.php
@@ -17,10 +17,7 @@ class StreamTransportFactoryTest extends TestCase
     {
         $factory = new StreamTransportFactory();
         $transport = $factory->create('php://stdout', 'a');
-        $reflection = new ReflectionObject($transport);
-        $property = $reflection->getProperty('stream');
-        $property->setAccessible(true);
-
-        $this->assertIsResource($property->getValue($transport));
+        $this->expectOutputString('payload');
+        $transport->send('payload')->await();
     }
 }

--- a/tests/Unit/SDK/Common/Export/Stream/StreamTransportFactoryTest.php
+++ b/tests/Unit/SDK/Common/Export/Stream/StreamTransportFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Example\Unit\SDK\Common\Export\Stream;
+
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory;
+use PHPUnit\Framework\TestCase;
+use ReflectionObject;
+
+/**
+ * @covers \OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory
+ */
+class StreamTransportFactoryTest extends TestCase
+{
+    public function test_creates_stream(): void
+    {
+        $factory = new StreamTransportFactory();
+        $transport = $factory->create('php://stdout', 'a');
+        $reflection = new ReflectionObject($transport);
+        $property = $reflection->getProperty('stream');
+        $property->setAccessible(true);
+
+        $this->assertIsResource($property->getValue($transport));
+    }
+}

--- a/tests/Unit/SDK/Common/Export/Stream/StreamTransportFactoryTest.php
+++ b/tests/Unit/SDK/Common/Export/Stream/StreamTransportFactoryTest.php
@@ -15,7 +15,7 @@ class StreamTransportFactoryTest extends TestCase
     public function test_creates_stream(): void
     {
         $factory = new StreamTransportFactory();
-        $transport = $factory->create('php://stdout', 'a');
+        $transport = $factory->create('php://output', 'a');
         $this->expectOutputString('payload');
         $transport->send('payload')->await();
     }


### PR DESCRIPTION
when creating a stream from an endpoint string, the factory wasn't returning the stream. fix and add tests.