### PR TITLE
implement retrieve span and trace id as binary

### DIFF
--- a/src/API/Trace/SpanContext.php
+++ b/src/API/Trace/SpanContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Trace;
 
+use function hex2bin;
+
 final class SpanContext implements SpanContextInterface
 {
     private static ?SpanContextInterface $invalidContext = null;
@@ -49,9 +51,9 @@ final class SpanContext implements SpanContextInterface
         return $this->traceId;
     }
 
-    public function getTraceIdBytes(): array
+    public function getTraceIdBinary(): string
     {
-        return $this->toByteArray($this->traceId);
+        return hex2bin($this->traceId);
     }
 
     public function getSpanId(): string
@@ -59,9 +61,9 @@ final class SpanContext implements SpanContextInterface
         return $this->spanId;
     }
 
-    public function getSpanIdBytes(): array
+    public function getSpanIdBinary(): string
     {
-        return $this->toByteArray($this->spanId);
+        return hex2bin($this->spanId);
     }
 
     public function getTraceState(): ?TraceStateInterface
@@ -121,15 +123,5 @@ final class SpanContext implements SpanContextInterface
         }
 
         return self::$invalidContext;
-    }
-
-    private function toByteArray(string $id): array
-    {
-        $bytes = [];
-        for ($i=0; $i<strlen($id); $i += 2) {
-            $bytes[] = base_convert($id[$i] . $id[$i+1], 16, 2);
-        }
-
-        return $bytes;
     }
 }

--- a/src/API/Trace/SpanContext.php
+++ b/src/API/Trace/SpanContext.php
@@ -49,9 +49,19 @@ final class SpanContext implements SpanContextInterface
         return $this->traceId;
     }
 
+    public function getTraceIdBytes(): array
+    {
+        return $this->toByteArray($this->traceId);
+    }
+
     public function getSpanId(): string
     {
         return $this->spanId;
+    }
+
+    public function getSpanIdBytes(): array
+    {
+        return $this->toByteArray($this->spanId);
     }
 
     public function getTraceState(): ?TraceStateInterface
@@ -111,5 +121,15 @@ final class SpanContext implements SpanContextInterface
         }
 
         return self::$invalidContext;
+    }
+
+    private function toByteArray(string $id): array
+    {
+        $bytes = [];
+        for ($i=0; $i<strlen($id); $i += 2) {
+            $bytes[] = base_convert($id[$i] . $id[$i+1], 16, 2);
+        }
+
+        return $bytes;
     }
 }

--- a/src/API/Trace/SpanContextInterface.php
+++ b/src/API/Trace/SpanContextInterface.php
@@ -18,11 +18,11 @@ interface SpanContextInterface
 
     /** @psalm-mutation-free */
     public function getTraceId(): string;
-    public function getTraceIdBytes(): array;
+    public function getTraceIdBinary(): string;
 
     /** @psalm-mutation-free */
     public function getSpanId(): string;
-    public function getSpanIdBytes(): array;
+    public function getSpanIdBinary(): string;
     public function getTraceFlags(): int;
     public function getTraceState(): ?TraceStateInterface;
     public function isValid(): bool;

--- a/src/API/Trace/SpanContextInterface.php
+++ b/src/API/Trace/SpanContextInterface.php
@@ -12,20 +12,17 @@ interface SpanContextInterface
     public const TRACE_FLAG_SAMPLED = 0x01;
     public const TRACE_FLAG_DEFAULT = 0x00;
 
-    /** @todo Implement this in the API layer */
     public static function createFromRemoteParent(string $traceId, string $spanId, int $traceFlags = self::TRACE_FLAG_DEFAULT, ?TraceStateInterface $traceState = null): SpanContextInterface;
-
-    /** @todo Implement this in the API layer */
     public static function getInvalid(): SpanContextInterface;
-
-    /** @todo Implement this in the API layer */
     public static function create(string $traceId, string $spanId, int $traceFlags = self::TRACE_FLAG_DEFAULT, ?TraceStateInterface $traceState = null): SpanContextInterface;
 
     /** @psalm-mutation-free */
     public function getTraceId(): string;
+    public function getTraceIdBytes(): array;
 
     /** @psalm-mutation-free */
     public function getSpanId(): string;
+    public function getSpanIdBytes(): array;
     public function getTraceFlags(): int;
     public function getTraceState(): ?TraceStateInterface;
     public function isValid(): bool;

--- a/src/Contrib/Otlp/SpanConverter.php
+++ b/src/Contrib/Otlp/SpanConverter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\Otlp;
 
-use function hex2bin;
 use OpenTelemetry\API\Trace as API;
 use Opentelemetry\Proto\Collector\Trace\V1\ExportTraceServiceRequest;
 use Opentelemetry\Proto\Common\V1\InstrumentationScope;
@@ -140,11 +139,11 @@ final class SpanConverter
     private function convertSpan(SpanDataInterface $span): Span
     {
         $pSpan = new Span();
-        $pSpan->setTraceId(hex2bin($span->getContext()->getTraceId()));
-        $pSpan->setSpanId(hex2bin($span->getContext()->getSpanId()));
+        $pSpan->setTraceId($span->getContext()->getTraceIdBinary());
+        $pSpan->setSpanId($span->getContext()->getSpanIdBinary());
         $pSpan->setTraceState((string) $span->getContext()->getTraceState());
         if ($span->getParentContext()->isValid()) {
-            $pSpan->setParentSpanId(hex2bin($span->getParentContext()->getSpanId()));
+            $pSpan->setParentSpanId($span->getParentContext()->getSpanIdBinary());
         }
         $pSpan->setName($span->getName());
         $pSpan->setKind($this->convertSpanKind($span->getKind()));
@@ -164,8 +163,8 @@ final class SpanConverter
         foreach ($span->getLinks() as $link) {
             /** @psalm-suppress InvalidArgument */
             $pSpan->getLinks()[] = $pLink = new Link();
-            $pLink->setTraceId(hex2bin($link->getSpanContext()->getTraceId()));
-            $pLink->setSpanId(hex2bin($link->getSpanContext()->getSpanId()));
+            $pLink->setTraceId($link->getSpanContext()->getTraceIdBinary());
+            $pLink->setSpanId($link->getSpanContext()->getSpanIdBinary());
             $pLink->setTraceState((string) $link->getSpanContext()->getTraceState());
             $this->setAttributes($pLink, $link->getAttributes());
         }

--- a/tests/Unit/API/Trace/SpanContextTest.php
+++ b/tests/Unit/API/Trace/SpanContextTest.php
@@ -61,24 +61,20 @@ class SpanContextTest extends TestCase
         $this->assertSame(self::SECOND_TRACE_ID, $this->second->getTraceId());
     }
 
-    public function test_get_trace_id_binary(): void
+    public function test_get_trace_and_span_id_binary(): void
     {
-        $bytes = $this->first->getTraceIdBytes();
-        $this->assertCount(16, $bytes);
-        $this->assertSame('1100001', $bytes[15]);
+        $traceId = '7d9df3359179cfd468fdf360f3e29f1a';
+        $spanId = '7d9df3359179cfd4';
+
+        $spanContext = SpanContext::create($traceId, $spanId);
+        $this->assertSame(hex2bin($traceId), $spanContext->getTraceIdBinary());
+        $this->assertSame(hex2bin($spanId), $spanContext->getSpanIdBinary());
     }
 
     public function test_get_span_id(): void
     {
         $this->assertSame(self::FIRST_SPAN_ID, $this->first->getSpanId());
         $this->assertSame(self::SECOND_SPAN_ID, $this->second->getSpanId());
-    }
-
-    public function test_get_span_id_binary(): void
-    {
-        $bytes = $this->first->getSpanIdBytes();
-        $this->assertCount(8, $bytes);
-        $this->assertSame('1100001', $bytes[7]);
     }
 
     public function test_get_trace_flags(): void

--- a/tests/Unit/API/Trace/SpanContextTest.php
+++ b/tests/Unit/API/Trace/SpanContextTest.php
@@ -61,10 +61,24 @@ class SpanContextTest extends TestCase
         $this->assertSame(self::SECOND_TRACE_ID, $this->second->getTraceId());
     }
 
+    public function test_get_trace_id_binary(): void
+    {
+        $bytes = $this->first->getTraceIdBytes();
+        $this->assertCount(16, $bytes);
+        $this->assertSame('1100001', $bytes[15]);
+    }
+
     public function test_get_span_id(): void
     {
         $this->assertSame(self::FIRST_SPAN_ID, $this->first->getSpanId());
         $this->assertSame(self::SECOND_SPAN_ID, $this->second->getSpanId());
+    }
+
+    public function test_get_span_id_binary(): void
+    {
+        $bytes = $this->first->getSpanIdBytes();
+        $this->assertCount(8, $bytes);
+        $this->assertSame('1100001', $bytes[7]);
     }
 
     public function test_get_trace_flags(): void


### PR DESCRIPTION
per spec, https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#retrieving-the-traceid-and-spanid allow retrieving span and trace id as binary (byte array), using `bin2hex`
Update otlp span converter to use the new methods.