### PR TITLE
span status compliance

### DIFF
--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -256,7 +256,18 @@ final class Span extends API\Span implements ReadWriteSpanInterface
             return $this;
         }
 
-        $this->status = StatusData::create($code, $description);
+        // An attempt to set value Unset SHOULD be ignored.
+        if ($code === API\StatusCode::STATUS_UNSET) {
+            return $this;
+        }
+
+        // When span status is set to Ok it SHOULD be considered final and any further attempts to change it SHOULD be ignored.
+        if ($this->status->getCode() === API\StatusCode::STATUS_OK) {
+            return $this;
+        }
+
+        // Description MUST be IGNORED for StatusCode Ok & Unset values.
+        $this->status = StatusData::create($code, ($code === API\StatusCode::STATUS_ERROR) ? $description : null);
 
         return $this;
     }

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -265,9 +265,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         if ($this->status->getCode() === API\StatusCode::STATUS_OK) {
             return $this;
         }
-
-        // Description MUST be IGNORED for StatusCode Ok & Unset values.
-        $this->status = StatusData::create($code, ($code === API\StatusCode::STATUS_ERROR) ? $description : null);
+        $this->status = StatusData::create($code, $description);
 
         return $this;
     }

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -749,9 +749,9 @@ class SpanTest extends MockeryTestCase
     }
 
     /**
+     * @dataProvider statusCodeProvider
      * @group trace-compliance
      * @psalm-param StatusCode::STATUS_* $code
-     * @dataProvider statusCodeProvider
      *
      * When span status is set to Ok it SHOULD be considered final and any further attempts to change it SHOULD be ignored.
      */
@@ -766,6 +766,14 @@ class SpanTest extends MockeryTestCase
         $this->assertSame(API\StatusCode::STATUS_OK, $span->toSpanData()->getStatus()->getCode());
     }
 
+    public function statusCodeProvider(): array
+    {
+        return [
+            [API\StatusCode::STATUS_UNSET],
+            [API\StatusCode::STATUS_ERROR],
+        ];
+    }
+
     /**
      * @group trace-compliance
      */
@@ -774,14 +782,6 @@ class SpanTest extends MockeryTestCase
         $span = $this->createTestRootSpan();
         $span->setStatus(API\StatusCode::STATUS_ERROR);
         $this->assertSame(API\StatusCode::STATUS_ERROR, $span->toSpanData()->getStatus()->getCode());
-    }
-
-    public function statusCodeProvider(): array
-    {
-        return [
-            [API\StatusCode::STATUS_UNSET],
-            [API\StatusCode::STATUS_ERROR],
-        ];
     }
 
     private function createTestRootSpan(): Span


### PR DESCRIPTION
implement spec-compliance for span status:
- Ok is final
- Unset should be ignored
- only Error may have a desription
- Error can be updated to Ok

ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status