### PR TITLE
fixing default service name

### DIFF
--- a/src/SDK/Resource/Detectors/SdkProvided.php
+++ b/src/SDK/Resource/Detectors/SdkProvided.php
@@ -10,7 +10,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SemConv\ResourceAttributes;
 
 /**
- * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service
+ * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value
  */
 final class SdkProvided implements ResourceDetectorInterface
 {

--- a/src/SDK/Resource/Detectors/SdkProvided.php
+++ b/src/SDK/Resource/Detectors/SdkProvided.php
@@ -10,14 +10,14 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SemConv\ResourceAttributes;
 
 /**
- * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value
+ * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service
  */
 final class SdkProvided implements ResourceDetectorInterface
 {
     public function getResource(): ResourceInfo
     {
         $attributes = [
-            ResourceAttributes::SERVICE_NAME => 'unknown_service',
+            ResourceAttributes::SERVICE_NAME => 'unknown_service:php',
         ];
 
         return ResourceInfo::create(Attributes::create($attributes), ResourceAttributes::SCHEMA_URL);

--- a/tests/Integration/SDK/ResourceInfoFactoryTest.php
+++ b/tests/Integration/SDK/ResourceInfoFactoryTest.php
@@ -46,7 +46,7 @@ class ResourceInfoFactoryTest extends TestCase
 
         $this->assertEquals('opentelemetry', $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_NAME));
         $this->assertEquals('php', $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_LANGUAGE));
-        $this->assertEquals('unknown_service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        $this->assertEquals('unknown_service:php', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
     }
 
     public function test_none_default_resources(): void
@@ -182,6 +182,6 @@ class ResourceInfoFactoryTest extends TestCase
 
         $this->assertEquals('opentelemetry', $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_NAME));
         $this->assertEquals('php', $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_LANGUAGE));
-        $this->assertEquals('unknown_service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        $this->assertEquals('unknown_service:php', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/SdkProvidedTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/SdkProvidedTest.php
@@ -15,10 +15,10 @@ class SdkProvidedTest extends TestCase
 {
     public function test_sdk_provided_get_resource(): void
     {
-        $resouceDetector = new Detectors\SdkProvided();
-        $resource = $resouceDetector->getResource();
+        $resourceDetector = new Detectors\SdkProvided();
+        $resource = $resourceDetector->getResource();
 
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
-        $this->assertSame('unknown_service', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        $this->assertSame('unknown_service:php', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
     }
 }

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -74,7 +74,7 @@ class ResourceInfoFactoryTest extends TestCase
     public function test_resource_service_name_default(): void
     {
         $resource = ResourceInfoFactory::defaultResource();
-        $this->assertEquals('unknown_service', $resource->getAttributes()->get('service.name'));
+        $this->assertEquals('unknown_service:php', $resource->getAttributes()->get('service.name'));
     }
 
     /**


### PR DESCRIPTION
default service name should contain runtime name if available: java just appends ":java" so I did the same.
ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service