### PR TITLE
default logging to console

### DIFF
--- a/examples/traces/troubleshooting/setting_up_logging.php
+++ b/examples/traces/troubleshooting/setting_up_logging.php
@@ -5,14 +5,14 @@ require __DIR__ . '/../../../vendor/autoload.php';
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
-use OpenTelemetry\SDK\Common\Log\LoggerHolder;
+use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\SDK\Trace\TracerProviderFactory;
 use Psr\Log\LogLevel;
 
 echo 'Starting SettingUpLogging example' . PHP_EOL;
 
-//create a Logger, and register it with library's logger holder. The library will use this logger
-//for all of its internal logging (errors, warnings, etc)
+//By default, opentelemetry's internal logging (errors, warnings, etc) will be sent to PHP's error_log destination.
+//You can instead provide a psr-3 logger to provide greater control of logging output:
 LoggerHolder::set(
     new Logger('otel-php', [new StreamHandler(STDOUT, LogLevel::DEBUG)])
 );

--- a/examples/traces/troubleshooting/setting_up_logging.php
+++ b/examples/traces/troubleshooting/setting_up_logging.php
@@ -11,7 +11,7 @@ use Psr\Log\LogLevel;
 
 echo 'Starting SettingUpLogging example' . PHP_EOL;
 
-//By default, opentelemetry's internal logging (errors, warnings, etc) will be sent to PHP's error_log destination.
+//By default, opentelemetry's internal logging (errors, warnings, etc) will be output to console.
 //You can instead provide a psr-3 logger to provide greater control of logging output:
 LoggerHolder::set(
     new Logger('otel-php', [new StreamHandler(STDOUT, LogLevel::DEBUG)])

--- a/src/API/Behavior/LogsMessagesTrait.php
+++ b/src/API/Behavior/LogsMessagesTrait.php
@@ -14,7 +14,7 @@ trait LogsMessagesTrait
         return in_array($level, [LogLevel::ERROR, LogLevel::WARNING, LogLevel::CRITICAL, LogLevel::EMERGENCY]);
     }
 
-    private static function map(string $level): int
+    private static function map(string $level)
     {
         switch ($level) {
             case LogLevel::WARNING:
@@ -41,7 +41,7 @@ trait LogsMessagesTrait
                 (array_key_exists('exception', $context) && $context['exception'] instanceof \Throwable) ? $context['exception']->getMessage() : '',
                 get_called_class()
             );
-            error_log($message, self::map($level));
+            trigger_error($message, self::map($level));
         }
     }
 

--- a/src/API/Behavior/LogsMessagesTrait.php
+++ b/src/API/Behavior/LogsMessagesTrait.php
@@ -9,10 +9,40 @@ use Psr\Log\LogLevel;
 
 trait LogsMessagesTrait
 {
+    private static function shouldLog(string $level): bool
+    {
+        return in_array($level, [LogLevel::ERROR, LogLevel::WARNING, LogLevel::CRITICAL, LogLevel::EMERGENCY]);
+    }
+
+    private static function map(string $level): int
+    {
+        switch ($level) {
+            case LogLevel::WARNING:
+                return E_USER_WARNING;
+            case LogLevel::ERROR:
+            case LogLevel::CRITICAL:
+            case LogLevel::EMERGENCY:
+                return E_USER_ERROR;
+            default:
+                return E_USER_NOTICE;
+        }
+    }
+
     private static function doLog(string $level, string $message, array $context): void
     {
-        $context['source'] = get_called_class();
-        LoggerHolder::get()->log($level, $message, $context);
+        $logger = LoggerHolder::get();
+        if ($logger !== null) {
+            $context['source'] = get_called_class();
+            $logger->log($level, $message, $context);
+        } elseif (self::shouldLog($level)) {
+            $message = sprintf(
+                '%s: %s in %s',
+                $message,
+                (array_key_exists('exception', $context) && $context['exception'] instanceof \Throwable) ? $context['exception']->getMessage() : '',
+                get_called_class()
+            );
+            error_log($message, self::map($level));
+        }
     }
 
     protected static function logDebug(string $message, array $context = []): void

--- a/src/API/Common/Log/LoggerHolder.php
+++ b/src/API/Common/Log/LoggerHolder.php
@@ -21,13 +21,14 @@ final class LoggerHolder
 
     /**
      * @suppress PhanTypeMismatchReturnNullable
+     * @internal
      */
-    public static function get(): LoggerInterface
+    public static function get(): ?LoggerInterface
     {
-        return self::$logger ?? new NullLogger();
+        return self::$logger;
     }
 
-    public static function set(LoggerInterface $logger): void
+    public static function set(?LoggerInterface $logger): void
     {
         self::$logger = $logger;
     }

--- a/tests/Unit/API/Trace/Propagation/TraceContextPropagatorTest.php
+++ b/tests/Unit/API/Trace/Propagation/TraceContextPropagatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\API\Trace\Propagation;
 
+use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\SpanContextInterface;
@@ -14,6 +15,7 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Trace\Span;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 /**
  * @covers \OpenTelemetry\API\Trace\Propagation\TraceContextPropagator
@@ -32,6 +34,7 @@ class TraceContextPropagatorTest extends TestCase
 
     protected function setUp(): void
     {
+        LoggerHolder::set(new NullLogger());
         $this->traceContextPropagator = TraceContextPropagator::getInstance();
         $this->traceState = (new TraceState())->with('bar', 'baz')->with('foo', 'bar');
     }

--- a/tests/Unit/API/Trace/TraceStateTest.php
+++ b/tests/Unit/API/Trace/TraceStateTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\API\Unit\Trace;
 
+use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\API\Trace\TraceState;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use function str_repeat;
 use function strlen;
 
@@ -14,6 +16,11 @@ use function strlen;
  */
 class TraceStateTest extends TestCase
 {
+    public function setUp(): void
+    {
+        LoggerHolder::set(new NullLogger());
+    }
+
     public function test_get_tracestate_value(): void
     {
         $tracestate = new TraceState('vendor1=value1');

--- a/tests/Unit/SDK/Metrics/MeterProviderFactoryTest.php
+++ b/tests/Unit/SDK/Metrics/MeterProviderFactoryTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace OpenTelemetry\Example\Unit\SDK\Metrics;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
+use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Metrics\MeterProviderFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 /**
  * @covers \OpenTelemetry\SDK\Metrics\MeterProviderFactory
@@ -17,6 +19,11 @@ use PHPUnit\Framework\TestCase;
 class MeterProviderFactoryTest extends TestCase
 {
     use EnvironmentVariables;
+
+    public function setUp(): void
+    {
+        LoggerHolder::set(new NullLogger());
+    }
 
     public function tearDown(): void
     {

--- a/tests/Unit/SDK/Propagation/PropagatorFactoryTest.php
+++ b/tests/Unit/SDK/Propagation/PropagatorFactoryTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK\Propagation;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use OpenTelemetry\API\Baggage\Propagation\BaggagePropagator;
+use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\Context\Propagation\MultiTextMapPropagator;
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
@@ -14,6 +15,7 @@ use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Propagation\PropagatorFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 /**
  * @covers OpenTelemetry\SDK\Propagation\PropagatorFactory
@@ -21,6 +23,11 @@ use PHPUnit\Framework\TestCase;
 class PropagatorFactoryTest extends TestCase
 {
     use EnvironmentVariables;
+
+    public function setUp(): void
+    {
+        LoggerHolder::set(new NullLogger());
+    }
 
     public function tearDown(): void
     {

--- a/tests/Unit/SDK/SdkAutoloaderTest.php
+++ b/tests/Unit/SDK/SdkAutoloaderTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\SDK;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
+use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\SdkAutoloader;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 /**
  * @covers \OpenTelemetry\SDK\SdkAutoloader
@@ -15,6 +17,11 @@ use PHPUnit\Framework\TestCase;
 class SdkAutoloaderTest extends TestCase
 {
     use EnvironmentVariables;
+
+    public function setUp(): void
+    {
+        LoggerHolder::set(new NullLogger());
+    }
 
     public function tearDown(): void
     {

--- a/tests/Unit/SDK/Trace/SpanExporter/AbstractExporterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/AbstractExporterTest.php
@@ -6,12 +6,14 @@ namespace OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;
 use OpenTelemetry\SDK\Common\Future\ErrorFuture;
 use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
+use Psr\Log\NullLogger;
 
 /**
  * @psalm-suppress UndefinedInterfaceMethod
@@ -23,6 +25,7 @@ abstract class AbstractExporterTest extends MockeryTestCase
 
     public function setUp(): void
     {
+        LoggerHolder::set(new NullLogger());
         $this->future = Mockery::mock(FutureInterface::class);
         $this->future->allows([
             'map' => $this->future,

--- a/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -31,6 +31,7 @@ use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use OpenTelemetry\Tests\Unit\SDK\Util\TestClock;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 
 /**
  * @covers \OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor
@@ -41,6 +42,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
 
     protected function setUp(): void
     {
+        LoggerHolder::set(new NullLogger());
         $this->testClock = new TestClock();
 
         ClockFactory::setDefault($this->testClock);

--- a/tests/Unit/SDK/Trace/SpanProcessor/SimpleSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/SimpleSpanProcessorTest.php
@@ -21,6 +21,7 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\Tests\Unit\SDK\Util\SpanData;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 
 /**
  * @covers OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor
@@ -43,6 +44,7 @@ class SimpleSpanProcessorTest extends MockeryTestCase
 
     protected function setUp(): void
     {
+        LoggerHolder::set(new NullLogger());
         $this->readWriteSpan = Mockery::mock(ReadWriteSpanInterface::class);
         $this->readableSpan = Mockery::mock(ReadableSpanInterface::class);
 


### PR DESCRIPTION
Rather than not logging by default, log to console via trigger_error (>= warning), and allow the LoggerHolder mechanism to be used for greater control over logging (including disabling, eg with a NullLogger)
Closes #897