### PR TITLE
do not export empty metrics

### DIFF
--- a/src/SDK/Metrics/MetricReader/ExportingReader.php
+++ b/src/SDK/Metrics/MetricReader/ExportingReader.php
@@ -70,6 +70,10 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
             $metrics[] = $source->collect($timestamp);
         }
 
+        if ($metrics === []) {
+            return true;
+        }
+
         return $this->exporter->export($metrics);
     }
 

--- a/tests/Unit/SDK/Metrics/MeterProviderTest.php
+++ b/tests/Unit/SDK/Metrics/MeterProviderTest.php
@@ -94,7 +94,6 @@ final class MeterProviderTest extends TestCase
             ClockFactory::getDefault(),
             Attributes::factory(),
             new InstrumentationScopeFactory(Attributes::factory()),
-            /** @phpstan-ignore-next-line */
             [$metricReader->reveal()],
             new CriteriaViewRegistry(),
             null,
@@ -123,7 +122,6 @@ final class MeterProviderTest extends TestCase
             ClockFactory::getDefault(),
             Attributes::factory(),
             new InstrumentationScopeFactory(Attributes::factory()),
-            /** @phpstan-ignore-next-line */
             [$metricReader->reveal()],
             new CriteriaViewRegistry(),
             null,


### PR DESCRIPTION
If no metrics have been generated, do not send an empty export request (except via forceFlush())

Closes #905