### PR TITLE
fix PHP 7.4 preloading errors

### DIFF
--- a/src/SDK/Common/Dev/Compatibility/BC/AbstractClock.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/AbstractClock.php
@@ -74,4 +74,6 @@ abstract class AbstractClock implements ClockInterface
  * BC class alias
  * @todo: remove in future release. Also in composer.json autoload/files.
  */
-class_alias(AbstractClock::class, 'OpenTelemetry\SDK\AbstractClock');
+if (!class_exists('OpenTelemetry\SDK\AbstractClock', false)) {
+    class_alias(AbstractClock::class, 'OpenTelemetry\SDK\AbstractClock');
+}

--- a/src/SDK/Common/Dev/Compatibility/BC/ClockInterface.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/ClockInterface.php
@@ -13,7 +13,9 @@ interface ClockInterface extends Moved
 /**
  * @codeCoverageIgnoreStart
  */
-class_alias(ClockInterface::class, 'OpenTelemetry\SDK\ClockInterface');
+if (!interface_exists('OpenTelemetry\SDK\ClockInterface', false)) {
+    class_alias(ClockInterface::class, 'OpenTelemetry\SDK\ClockInterface');
+}
 /**
  * @codeCoverageIgnoreEnd
  */

--- a/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibrary.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibrary.php
@@ -49,7 +49,9 @@ final class InstrumentationLibrary implements InstrumentationLibraryInterface
     }
 }
 
-class_alias(InstrumentationLibrary::class, OpenTelemetry_SDK_InstrumentationLibrary);
+if (!class_exists(OpenTelemetry_SDK_InstrumentationLibrary, false)) {
+    class_alias(InstrumentationLibrary::class, OpenTelemetry_SDK_InstrumentationLibrary);
+}
 /**
  * @codeCoverageIgnoreEnd
  */

--- a/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibraryInterface.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/InstrumentationLibraryInterface.php
@@ -13,7 +13,9 @@ interface InstrumentationLibraryInterface extends Moved
 /**
  * @codeCoverageIgnoreStart
  */
-class_alias(InstrumentationLibraryInterface::class, 'OpenTelemetry\SDK\Common\Instrumentation\InstrumentationLibraryInterface');
+if (!interface_exists('OpenTelemetry\SDK\Common\Instrumentation\InstrumentationLibraryInterface', false)) {
+    class_alias(InstrumentationLibraryInterface::class, 'OpenTelemetry\SDK\Common\Instrumentation\InstrumentationLibraryInterface');
+}
 /**
  * @codeCoverageIgnoreEnd
  */

--- a/src/SDK/Common/Dev/Compatibility/BC/LoggerHolder.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/LoggerHolder.php
@@ -25,7 +25,9 @@ final class LoggerHolder
     }
 }
 
-class_alias(LoggerHolder::class, OpenTelemetry_SDK_Common_Log_LoggerHolder);
+if (!class_exists(OpenTelemetry_SDK_Common_Log_LoggerHolder, false)) {
+    class_alias(LoggerHolder::class, OpenTelemetry_SDK_Common_Log_LoggerHolder);
+}
 /**
  * @codeCoverageIgnoreEnd
  */

--- a/src/SDK/Common/Dev/Compatibility/BC/OtlpExporter.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/OtlpExporter.php
@@ -46,6 +46,8 @@ class OtlpExporter implements SpanExporterInterface
     }
 }
 
-class_alias(OtlpExporter::class, 'OpenTelemetry\Contrib\OtlpGrpc\Exporter');
-class_alias(OtlpExporter::class, 'OpenTelemetry\Contrib\OtlpHttp\Exporter');
-class_alias(OtlpExporter::class, 'OpenTelemetry\Contrib\Otlp\Exporter');
+if (!class_exists('OpenTelemetry\Contrib\Otlp\Exporter', false)) {
+    class_alias(OtlpExporter::class, 'OpenTelemetry\Contrib\OtlpGrpc\Exporter');
+    class_alias(OtlpExporter::class, 'OpenTelemetry\Contrib\OtlpHttp\Exporter');
+    class_alias(OtlpExporter::class, 'OpenTelemetry\Contrib\Otlp\Exporter');
+}

--- a/src/SDK/Common/Dev/Compatibility/BC/SystemClock.php
+++ b/src/SDK/Common/Dev/Compatibility/BC/SystemClock.php
@@ -41,7 +41,9 @@ class SystemClock implements ClockInterface
     }
 }
 
-class_alias(SystemClock::class, OpenTelemetry_SDK_SystemClock);
+if (!class_exists(OpenTelemetry_SDK_SystemClock, false)) {
+    class_alias(SystemClock::class, OpenTelemetry_SDK_SystemClock);
+}
 /**
  * @codeCoverageIgnoreEnd
  */


### PR DESCRIPTION
This PR fix `PHP Warning:  Can't preload already declared class ...` errors if PHP preloading is enabled.