### PR TITLE
fixing phpunit 9.6 deprecations

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -376,7 +376,6 @@ return [
         'vendor/php-http',
         'vendor/phan/phan/src/Phan',
         'vendor/phpunit/phpunit/src',
-        'vendor/promphp/prometheus_client_php/src',
         'vendor/google/protobuf/src',
     ],
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "sort-packages": true,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
+            "php-http/discovery": true,
             "symfony/runtime": true
         }
     },
@@ -90,7 +91,7 @@
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-mockery": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": "^9.6",
         "psalm/plugin-mockery": "^0.9",
         "psalm/plugin-phpunit": "^0.18",
         "psalm/psalm": "^4.0",

--- a/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\API\Behavior;
 
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\API\Common\Log\LoggerHolder;
+use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -37,8 +38,8 @@ class LogsMessagesTraitTest extends TestCase
         $this->assertFalse(LoggerHolder::isSet());
         $instance = $this->createInstance();
 
-        $this->expectWarning();
-        $this->expectWarningMessageMatches(sprintf('/%s/', $message));
+        $this->expectException(PHPUnitFrameworkException::class);
+        $this->expectExceptionMessageMatches(sprintf('/%s/', $message));
         $instance->run('logWarning', 'foo', ['exception' => new \Exception($message)]);
     }
 
@@ -49,8 +50,8 @@ class LogsMessagesTraitTest extends TestCase
         $this->assertFalse(LoggerHolder::isSet());
         $instance = $this->createInstance();
 
-        $this->expectError();
-        $this->expectErrorMessageMatches(sprintf('/%s/', $message));
+        $this->expectException(PHPUnitFrameworkException::class);
+        $this->expectExceptionMessageMatches(sprintf('/%s/', $message));
         $instance->run('logError', 'foo', ['exception' => new \Exception($message)]);
     }
 

--- a/tests/Unit/Context/DebugScopeTest.php
+++ b/tests/Unit/Context/DebugScopeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\Context;
 
 use OpenTelemetry\Context\Context;
+use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,8 +19,8 @@ final class DebugScopeTest extends TestCase
 
         $scope1->detach();
 
-        $this->expectNotice();
-        $this->expectNoticeMessage('already detached');
+        $this->expectException(PHPUnitFrameworkException::class);
+        $this->expectExceptionMessage('already detached');
         $scope1->detach();
     }
 
@@ -29,8 +30,8 @@ final class DebugScopeTest extends TestCase
         $scope2 = Context::getCurrent()->activate();
 
         try {
-            $this->expectNotice();
-            $this->expectNoticeMessage('another scope');
+            $this->expectException(PHPUnitFrameworkException::class);
+            $this->expectExceptionMessage('another scope');
             $scope1->detach();
         } finally {
             $scope2->detach();
@@ -45,8 +46,8 @@ final class DebugScopeTest extends TestCase
         Context::storage()->switch(1);
 
         try {
-            $this->expectNotice();
-            $this->expectNoticeMessage('different execution context');
+            $this->expectException(PHPUnitFrameworkException::class);
+            $this->expectExceptionMessage('different execution context');
             $scope1->detach();
         } finally {
             Context::storage()->switch(0);
@@ -57,8 +58,8 @@ final class DebugScopeTest extends TestCase
     public function test_missing_scope_detach(): void
     {
         try {
-            $this->expectNotice();
-            $this->expectNoticeMessage('missing call');
+            $this->expectException(PHPUnitFrameworkException::class);
+            $this->expectExceptionMessage('missing call');
             Context::getCurrent()->activate();
         } finally {
             /** @psalm-suppress PossiblyNullReference */

--- a/tests/Unit/SDK/Common/Dev/Compatibility/UtilTest.php
+++ b/tests/Unit/SDK/Common/Dev/Compatibility/UtilTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK\Common\Dev\Compatibility;
 
 use Generator;
 use OpenTelemetry\SDK\Common\Dev\Compatibility\Util;
+use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -41,11 +42,11 @@ class UtilTest extends TestCase
     /**
      * @dataProvider errorLevelProvider
      */
-    public function test_trigger_class_deprecation_notice(int $level, string $expectedError): void
+    public function test_trigger_class_deprecation_notice(int $level): void
     {
         Util::setErrorLevel($level);
 
-        $this->{$expectedError}();
+        $this->expectException(PHPUnitFrameworkException::class);
 
         Util::triggerClassDeprecationNotice(Util::class, self::class);
     }
@@ -53,11 +54,11 @@ class UtilTest extends TestCase
     /**
      * @dataProvider errorLevelProvider
      */
-    public function test_trigger_method_deprecation_notice_without_class(int $level, string $expectedError): void
+    public function test_trigger_method_deprecation_notice_without_class(int $level): void
     {
         Util::setErrorLevel($level);
 
-        $this->{$expectedError}();
+        $this->expectException(PHPUnitFrameworkException::class);
 
         Util::triggerMethodDeprecationNotice(Util::class, __METHOD__);
     }
@@ -65,21 +66,21 @@ class UtilTest extends TestCase
     /**
      * @dataProvider errorLevelProvider
      */
-    public function test_trigger_method_deprecation_notice_with_class(int $level, string $expectedError): void
+    public function test_trigger_method_deprecation_notice_with_class(int $level): void
     {
         Util::setErrorLevel($level);
 
-        $this->{$expectedError}();
+        $this->expectException(PHPUnitFrameworkException::class);
 
         Util::triggerMethodDeprecationNotice(Util::class, 'foo', self::class);
     }
 
     public function errorLevelProvider(): Generator
     {
-        yield [E_USER_DEPRECATED, 'expectDeprecation'];
-        yield [E_USER_NOTICE, 'expectNotice'];
-        yield [E_USER_WARNING, 'expectWarning'];
-        yield [E_USER_ERROR, 'expectError'];
+        yield [E_USER_DEPRECATED];
+        yield [E_USER_NOTICE];
+        yield [E_USER_WARNING];
+        yield [E_USER_ERROR];
     }
 
     public function test_turn_errors_off(): void

--- a/tests/Unit/SDK/FactoryRegistryTest.php
+++ b/tests/Unit/SDK/FactoryRegistryTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporterFactoryInterface;
 use OpenTelemetry\SDK\Registry;
 use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;
+use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -79,7 +80,7 @@ class FactoryRegistryTest extends TestCase
      */
     public function test_register_invalid_transport_factory($factory): void
     {
-        $this->expectWarning();
+        $this->expectException(PHPUnitFrameworkException::class);
         Registry::registerTransportFactory('http', $factory, true);
     }
 
@@ -88,7 +89,7 @@ class FactoryRegistryTest extends TestCase
      */
     public function test_register_invalid_span_exporter_factory($factory): void
     {
-        $this->expectWarning();
+        $this->expectException(PHPUnitFrameworkException::class);
         Registry::registerSpanExporterFactory('foo', $factory, true);
     }
 
@@ -97,7 +98,7 @@ class FactoryRegistryTest extends TestCase
      */
     public function test_register_invalid_metric_exporter_factory($factory): void
     {
-        $this->expectWarning();
+        $this->expectException(PHPUnitFrameworkException::class);
         Registry::registerMetricExporterFactory('foo', $factory, true);
     }
 

--- a/tests/Unit/SDK/Metrics/Stream/MetricStreamTest.php
+++ b/tests/Unit/SDK/Metrics/Stream/MetricStreamTest.php
@@ -19,6 +19,7 @@ use OpenTelemetry\SDK\Metrics\Stream\MetricAggregator;
 use OpenTelemetry\SDK\Metrics\Stream\StreamWriter;
 use OpenTelemetry\SDK\Metrics\Stream\SynchronousMetricStream;
 use const PHP_INT_SIZE;
+use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -337,8 +338,8 @@ final class MetricStreamTest extends TestCase
             $s->register(Temporality::DELTA);
         }
 
-        $this->expectWarning();
-        $this->expectWarningMessageMatches('/^GMP extension required to register over \d++ readers$/');
+        $this->expectException(PHPUnitFrameworkException::class);
+        $this->expectExceptionMessageMatches('/^GMP extension required to register over \d++ readers$/');
         $s->register(Temporality::DELTA);
     }
 


### PR DESCRIPTION
phpunit v9.6 introduces a bunch of deprecations for things that will break in v10. This fixes the tests that are currently complaining.
Since PHPUnit v10 requires php 8.1+, it will be some time before we can upgrade

Closes #921 