### PR TITLE
fixes and tests for MetricExporterFactory

### DIFF
--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -6,16 +6,26 @@ namespace OpenTelemetry\Contrib\Otlp;
 
 use OpenTelemetry\API\Common\Signal\Signals;
 use OpenTelemetry\SDK\Common\Configuration\Configuration;
-use OpenTelemetry\SDK\Common\Configuration\KnownValues;
+use OpenTelemetry\SDK\Common\Configuration\Defaults;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
+use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
+use OpenTelemetry\SDK\Common\Otlp\HttpEndpointResolver;
 use OpenTelemetry\SDK\Metrics\MetricExporterFactoryInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Registry;
-use UnexpectedValueException;
 
 class MetricExporterFactory implements MetricExporterFactoryInterface
 {
+    private const DEFAULT_COMPRESSION = 'none';
+
+    private ?TransportFactoryInterface $transportFactory;
+
+    public function __construct(?TransportFactoryInterface $transportFactory = null)
+    {
+        $this->transportFactory = $transportFactory;
+    }
+
     /**
      * @psalm-suppress ArgumentTypeCoercion
      */
@@ -28,6 +38,9 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
         return new MetricExporter($this->buildTransport($protocol));
     }
 
+    /**
+     * @psalm-suppress UndefinedClass
+     */
     private function buildTransport(string $protocol): TransportInterface
     {
         /**
@@ -35,32 +48,44 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
          * - OTEL_METRIC_EXPORT_INTERVAL
          * - OTEL_METRIC_EXPORT_TIMEOUT
          */
-        $endpoint = Configuration::has(Variables::OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
-            ? Configuration::getString(Variables::OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
-            : Configuration::getString(Variables::OTEL_EXPORTER_OTLP_ENDPOINT);
+        $endpoint = $this->getEndpoint($protocol);
 
         $headers = Configuration::has(Variables::OTEL_EXPORTER_OTLP_METRICS_HEADERS)
             ? Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_METRICS_HEADERS)
             : Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_HEADERS);
         $headers += OtlpUtil::getUserAgentHeader();
+        $compression = $this->getCompression();
 
-        $factory = Registry::transportFactory($protocol);
-        switch ($protocol) {
-            case KnownValues::VALUE_GRPC:
-                return $factory->create(
-                    $endpoint . OtlpUtil::method(Signals::METRICS),
-                    ContentTypes::PROTOBUF,
-                    $headers
-                );
-            case KnownValues::VALUE_HTTP_PROTOBUF:
-            case KnownValues::VALUE_HTTP_JSON:
-                return $factory->create(
-                    $endpoint,
-                    Protocols::contentType($protocol),
-                    $headers
-                );
-            default:
-                throw new UnexpectedValueException('Unknown otlp protocol: ' . $protocol);
+        $factoryClass = Registry::transportFactory($protocol);
+        $factory = $this->transportFactory ?: new $factoryClass();
+
+        return $factory->create(
+            $endpoint,
+            Protocols::contentType($protocol),
+            $headers,
+            $compression,
+        );
+    }
+
+    private function getCompression(): string
+    {
+        return Configuration::has(Variables::OTEL_EXPORTER_OTLP_METRICS_COMPRESSION) ?
+            Configuration::getEnum(Variables::OTEL_EXPORTER_OTLP_METRICS_COMPRESSION) :
+            Configuration::getEnum(Variables::OTEL_EXPORTER_OTLP_COMPRESSION, self::DEFAULT_COMPRESSION);
+    }
+
+    private function getEndpoint(string $protocol): string
+    {
+        if (Configuration::has(Variables::OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)) {
+            return Configuration::getString(Variables::OTEL_EXPORTER_OTLP_METRICS_ENDPOINT);
         }
+        $endpoint = Configuration::has(Variables::OTEL_EXPORTER_OTLP_ENDPOINT)
+            ? Configuration::getString(Variables::OTEL_EXPORTER_OTLP_ENDPOINT)
+            : Defaults::OTEL_EXPORTER_OTLP_ENDPOINT;
+        if ($protocol === Protocols::GRPC) {
+            return $endpoint . OtlpUtil::method(Signals::METRICS);
+        }
+
+        return HttpEndpointResolver::create()->resolveToString($endpoint, Signals::METRICS);
     }
 }


### PR DESCRIPTION
Fixing grpc path and allowing compression from MetricExporterFactory.
Adding tests for MetricExporterFactory.

Replaces #903 