### PR TITLE
fixing empty tracestate header handling

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,3 +29,7 @@ parameters:
             message: "#Call to an undefined method .*:shouldHaveReceived.*#"
             paths:
                 - tests
+        -
+            message: "#Call to an undefined method .*:expects.*#"
+            paths:
+                - tests

--- a/src/API/Trace/TraceState.php
+++ b/src/API/Trace/TraceState.php
@@ -30,9 +30,10 @@ class TraceState implements TraceStateInterface
 
     public function __construct(string $rawTracestate = null)
     {
-        if ($rawTracestate !== null) {
-            $this->traceState = $this->parse($rawTracestate);
+        if ($rawTracestate === null || trim($rawTracestate) === '') {
+            return;
         }
+        $this->traceState = $this->parse($rawTracestate);
     }
 
     /**

--- a/tests/Unit/API/Trace/TraceStateTest.php
+++ b/tests/Unit/API/Trace/TraceStateTest.php
@@ -7,18 +7,22 @@ namespace OpenTelemetry\Tests\API\Unit\Trace;
 use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\API\Trace\TraceState;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
+use Psr\Log\LoggerInterface;
 use function str_repeat;
 use function strlen;
 
 /**
  * @covers OpenTelemetry\API\Trace\TraceState
+ * @psalm-suppress UndefinedInterfaceMethod
  */
 class TraceStateTest extends TestCase
 {
+    private LoggerInterface $logger;
+
     public function setUp(): void
     {
-        LoggerHolder::set(new NullLogger());
+        $this->logger = $this->createMock(LoggerInterface::class);
+        LoggerHolder::set($this->logger);
     }
 
     public function test_get_tracestate_value(): void
@@ -26,6 +30,19 @@ class TraceStateTest extends TestCase
         $tracestate = new TraceState('vendor1=value1');
 
         $this->assertSame('value1', $tracestate->get('vendor1'));
+    }
+
+    public function test_get_tracestate_with_empty_string(): void
+    {
+        $this->logger->expects($this->never())->method('log')->with(
+            $this->equalTo('warning'),
+            $this->anything(),
+            $this->anything(),
+        );
+
+        $tracestate = new TraceState('');
+
+        $this->assertSame(0, $tracestate->getListMemberCount());
     }
 
     public function test_with_tracestate_value(): void


### PR DESCRIPTION
if an empty tracestate header was passed, we were emitting a warning (discovered in the demo app after enabling logging). to fix this, check for empty string as well as null.