### PR TITLE
Ensure base64 encoded values can be used as headers from env

### DIFF
--- a/src/SDK/Common/Configuration/Parser/MapParser.php
+++ b/src/SDK/Common/Configuration/Parser/MapParser.php
@@ -25,7 +25,7 @@ class MapParser
         foreach (explode(self::VARIABLE_SEPARATOR, $value) as $pair) {
             self::validateKeyValuePair($pair);
 
-            [$key, $value] = explode(self::KEY_VALUE_SEPARATOR, $pair);
+            [$key, $value] = explode(self::KEY_VALUE_SEPARATOR, $pair, 2);
             $result[trim($key)] = trim($value);
         }
 

--- a/tests/Unit/SDK/Common/Configuration/Parser/MapParserTest.php
+++ b/tests/Unit/SDK/Common/Configuration/Parser/MapParserTest.php
@@ -29,6 +29,10 @@ class MapParserTest extends TestCase
             'foo =bar,bar= baz, baz = foo',
             ['foo' => 'bar', 'bar' => 'baz', 'baz' => 'foo'],
         ],
+        'base64 encoded value is split correctly and trailing equals sign is kept in value' => [
+            'Authorization=Basic 1234abc=,bar=baz',
+            ['Authorization' => 'Basic 1234abc=', 'bar' => 'baz'],
+        ]
     ];
 
     private const INVALID_VALUES = [

--- a/tests/Unit/SDK/Common/Configuration/Parser/MapParserTest.php
+++ b/tests/Unit/SDK/Common/Configuration/Parser/MapParserTest.php
@@ -32,7 +32,7 @@ class MapParserTest extends TestCase
         'base64 encoded value is split correctly and trailing equals sign is kept in value' => [
             'Authorization=Basic 1234abc=,bar=baz',
             ['Authorization' => 'Basic 1234abc=', 'bar' => 'baz'],
-        ]
+        ],
     ];
 
     private const INVALID_VALUES = [


### PR DESCRIPTION
This change instructs explode to extract at most 2 parts.

Given an example value of 
```
OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic bla64=
```

The config parser would have created three elements, where only two are required. The trailing `=` in base64 headers would then have been effectively discarded, leading to invalid configuration.