### PR TITLE
Make protobuf implementation optional

### DIFF
--- a/proto/otel/README.md
+++ b/proto/otel/README.md
@@ -1,1 +1,21 @@
 # OpenTelemetry protobuf files
+
+## Protobuf Runtime library
+
+There exist two protobuf runtime libraries that offer the same set of APIs, allowing developers to choose the one that 
+best suits their needs.
+
+The first and easiest option is to install the Protobuf PHP Runtime Library through composer. This can be the easiest 
+way to get started quickly. Either run `composer require google/protobuf`. Or update your `composer.json` as follows:
+
+```json
+"require": {
+  "google/protobuf": "^v3.3.0"
+}
+```
+
+Alternatively, and the recommended option for production is to install the Protobuf C extension for PHP. The extension
+makes both exporters _significantly_ more performant. This can be easily installed with the following command:
+```sh
+$ sudo pecl install protobuf
+```

--- a/proto/otel/README.md
+++ b/proto/otel/README.md
@@ -6,7 +6,7 @@ There exist two protobuf runtime libraries that offer the same set of APIs, allo
 best suits their needs.
 
 The first and easiest option is to install the Protobuf PHP Runtime Library through composer. This can be the easiest 
-way to get started quickly. Either run `composer require google/protobuf`. Or update your `composer.json` as follows:
+way to get started quickly. Either run `composer require google/protobuf`, or update your `composer.json` as follows:
 
 ```json
 "require": {

--- a/proto/otel/composer.json
+++ b/proto/otel/composer.json
@@ -11,8 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "google/protobuf": "^v3.3.0"
+        "php": "^7.4 || ^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -22,6 +21,7 @@
     },
     "suggest": {
         "ext-protobuf": "For better performance, when dealing with the protobuf format",
+        "google/protobuf": "To get started quickly, install the native protobuf library.",
         "ext-grpc": "To use the gRPC based exporters"
     }
 }

--- a/src/Contrib/Otlp/README.md
+++ b/src/Contrib/Otlp/README.md
@@ -25,7 +25,7 @@ There exist two protobuf runtime libraries that offer the same set of APIs, allo
 best suits their needs.
 
 The first and easiest option is to install the Protobuf PHP Runtime Library through composer. This can be the easiest
-way to get started quickly. Either run `composer require google/protobuf`. Or update your `composer.json` as follows:
+way to get started quickly. Either run `composer require google/protobuf`, or update your `composer.json` as follows:
 
 ```json
 "require": {

--- a/src/Contrib/Otlp/README.md
+++ b/src/Contrib/Otlp/README.md
@@ -18,3 +18,23 @@ $exporter = new \OpenTelemetry\Contrib\Otlp\SpanExporter($transport);
 ## gRPC transport
 
 To export over gRPC, you will need to additionally install the `open-telemetry/exporter-grpc` package.
+
+## Protobuf Runtime library
+
+There exist two protobuf runtime libraries that offer the same set of APIs, allowing developers to choose the one that
+best suits their needs.
+
+The first and easiest option is to install the Protobuf PHP Runtime Library through composer. This can be the easiest
+way to get started quickly. Either run `composer require google/protobuf`. Or update your `composer.json` as follows:
+
+```json
+"require": {
+  "google/protobuf": "^v3.3.0"
+}
+```
+
+Alternatively, and the recommended option for production is to install the Protobuf C extension for PHP. The extension
+makes both exporters _significantly_ more performant. This can be easily installed with the following command:
+```sh
+$ sudo pecl install protobuf
+```


### PR DESCRIPTION
The runtime library will always be installed, certain discussions on the matter in the Protobuf repo and on the CNFC slack led to the idea of making the runtime library optional. From what I understand, the C extension provides the same FQNCs as the runtime implementation. This way, developers can choose more easily to what to bundle with their projects. 

Documentation about installing either the runtime implementation or C extension have been added to the 2 README files for now. Currently there aren't any other checks to check if either of the 2 is installed. Questions:
1. Do we want this?
2. Where and how do we want to implement this? 
    - A `_register.php` like file that checks if either of them (or both) are installed
    - Feature detection in the `src/Contrib/Otlp` code where this is first used
    
My personal preference would be the 2nd option, as that has less runtime impact overall. I would also recommend to not add the extension to the requires section, this would make it harder for (less experienced) developers to get started and/or play around. For me personally, the use of the runtime implementation has been a blessing to get started very quickly and I'm currently installing the C extension in our production environments   