### PR TITLE
fail if no protobuf implementation found

### DIFF
--- a/src/Contrib/Otlp/LogsExporter.php
+++ b/src/Contrib/Otlp/LogsExporter.php
@@ -28,6 +28,9 @@ class LogsExporter implements LogRecordExporterInterface
      */
     public function __construct(TransportInterface $transport)
     {
+        if (!class_exists('\Google\Protobuf\Api')) {
+            throw new RuntimeException('No protobuf implementation found (ext-protobuf or google/protobuf)');
+        }
         $this->transport = $transport;
         $this->serializer = ProtobufSerializer::forTransport($transport);
     }

--- a/src/Contrib/Otlp/LogsExporter.php
+++ b/src/Contrib/Otlp/LogsExporter.php
@@ -11,6 +11,7 @@ use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
 use OpenTelemetry\SDK\Logs\ReadableLogRecord;
+use RuntimeException;
 use Throwable;
 
 /**

--- a/src/Contrib/Otlp/MetricExporter.php
+++ b/src/Contrib/Otlp/MetricExporter.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
+use RuntimeException;
 use Throwable;
 
 /**

--- a/src/Contrib/Otlp/MetricExporter.php
+++ b/src/Contrib/Otlp/MetricExporter.php
@@ -35,6 +35,9 @@ final class MetricExporter implements MetricExporterInterface
      */
     public function __construct(TransportInterface $transport, $temporality = null)
     {
+        if (!class_exists('\Google\Protobuf\Api')) {
+            throw new RuntimeException('No protobuf implementation found (ext-protobuf or google/protobuf)');
+        }
         $this->transport = $transport;
         $this->serializer = ProtobufSerializer::forTransport($transport);
         $this->temporality = $temporality;

--- a/src/Contrib/Otlp/README.md
+++ b/src/Contrib/Otlp/README.md
@@ -22,7 +22,7 @@ To export over gRPC, you will need to additionally install the `open-telemetry/e
 ## Protobuf Runtime library
 
 There exist two protobuf runtime libraries that offer the same set of APIs, allowing developers to choose the one that
-best suits their needs.
+best suits their needs. You must install one of them, in order to use the OTLP exporter.
 
 The first and easiest option is to install the Protobuf PHP Runtime Library through composer. This can be the easiest
 way to get started quickly. Either run `composer require google/protobuf`, or update your `composer.json` as follows:

--- a/src/Contrib/Otlp/SpanExporter.php
+++ b/src/Contrib/Otlp/SpanExporter.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -27,6 +28,9 @@ final class SpanExporter implements SpanExporterInterface
      */
     public function __construct(TransportInterface $transport)
     {
+        if (!class_exists('\Google\Protobuf\Api')) {
+            throw new RuntimeException('No protobuf implementation found (ext-protobuf or google/protobuf)');
+        }
         $this->transport = $transport;
         $this->serializer = ProtobufSerializer::forTransport($transport);
     }


### PR DESCRIPTION
the otlp exporter will fail to export if there is no protobuf implementation (which we have just made optional, to allow users to choose between extension and native). Add a check to the constructor which will throw a runtime exception. If creating the exporter directly, it will be uncaught. If using a factory, it will report a warning and return a no-op exporter.

Fixes #957 