### PR TITLE
Use correct platform identifier for Apple Silicon / M1 docker images

### DIFF
--- a/.github/workflows/publish-otel-php-base-docker-image.yml
+++ b/.github/workflows/publish-otel-php-base-docker-image.yml
@@ -34,5 +34,5 @@ jobs:
           push: true
           file: docker/Dockerfile
           build-args: PHP_VERSION=${{ matrix.php-version }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm/v8
           tags: ghcr.io/open-telemetry/opentelemetry-php/opentelemetry-php-base:${{ matrix.php-version }}


### PR DESCRIPTION
Use correct arm64 platform for building docker images.

My previous PR in #960 used the wrong platform for M1/Apple silicon