### PR TITLE
report dropped counts in non-otel exporters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ smoke-test-exporter-examples: FORCE ## Run (some) exporter smoke test examples
 # Note this does not include every exporter at the moment
 	$(DOCKER_COMPOSE) up -d --remove-orphans
 	$(DC_RUN_PHP) php ./examples/traces/exporters/zipkin.php
-	$(DC_RUN_PHP) php ./examples/traces/parent_span_example.php
+	$(DC_RUN_PHP) php ./examples/traces/features/parent_span_example.php
 # The following examples do not use the DC_RUN_PHP global because they need environment variables.
 	$(DOCKER_COMPOSE) run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/traces/exporters/newrelic.php
 	$(DOCKER_COMPOSE) run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/traces/exporters/zipkin_to_newrelic.php

--- a/examples/traces/features/parent_span_example.php
+++ b/examples/traces/features/parent_span_example.php
@@ -14,8 +14,7 @@ $sampler = new AlwaysOnSampler();
 
 // zipkin exporter
 $zipkinExporter = new ZipkinExporter(
-    $serviceName,
-    PsrTransportFactory::discover()->create('http://zipkin:9411/api/v2/spans')
+    PsrTransportFactory::discover()->create('http://zipkin:9411/api/v2/spans', 'application/json')
 );
 
 $tracerProvider =  new TracerProvider(

--- a/src/Contrib/Newrelic/SpanConverter.php
+++ b/src/Contrib/Newrelic/SpanConverter.php
@@ -17,6 +17,7 @@ class SpanConverter implements SpanConverterInterface
 {
     const STATUS_CODE_TAG_KEY = 'otel.status_code';
     const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
+    const KEY_DROPPED_ATTRIBUTES_COUNT = 'otel.dropped_attributes_count';
 
     private string $defaultServiceName;
 
@@ -69,6 +70,14 @@ class SpanConverter implements SpanConverterInterface
         }
         foreach ($span->getInstrumentationScope()->getAttributes() as $k => $v) {
             $row['attributes'][$k] = $v;
+        }
+
+        $droppedAttributes = $span->getAttributes()->getDroppedAttributesCount()
+            + $span->getInstrumentationScope()->getAttributes()->getDroppedAttributesCount()
+            + $span->getResource()->getAttributes()->getDroppedAttributesCount();
+
+        if ($droppedAttributes > 0) {
+            $row['attributes'][self::KEY_DROPPED_ATTRIBUTES_COUNT] = $droppedAttributes;
         }
 
         /*


### PR DESCRIPTION
per spec, exporters MUST report on dropped attributes/links/events using keys defined in spec

Fixes #427 