### PR TITLE
fixing otlp json trace/span ids

### DIFF
--- a/examples/logs/exporters/otlp_http_json_with_trace.php
+++ b/examples/logs/exporters/otlp_http_json_with_trace.php
@@ -9,21 +9,40 @@ use OpenTelemetry\API\Logs\EventLogger;
 use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\Contrib\Otlp\LogsExporter;
 use OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory;
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
 use Opentelemetry\Proto\Logs\V1\SeverityNumber;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
 use OpenTelemetry\SDK\Logs\LoggerProvider;
 use OpenTelemetry\SDK\Logs\LogRecordLimitsBuilder;
 use OpenTelemetry\SDK\Logs\Processor\SimpleLogsProcessor;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
 use Psr\Log\LogLevel;
 
 require __DIR__ . '/../../../vendor/autoload.php';
+
+/**
+ * This example demonstrates sending logs and traces via OTLP http/json. The logs should contain the trace id
+ * and span id of the active span.
+ */
+
+echo 'Starting OTLP+json with trace example' . PHP_EOL;
 
 LoggerHolder::set(
     new Logger('otel-php', [new StreamHandler(STDOUT, LogLevel::DEBUG)])
 );
 
-$transport = (new OtlpHttpTransportFactory())->create('http://collector:4318/v1/logs', 'application/x-protobuf');
+$transport = (new OtlpHttpTransportFactory())->create('http://collector:4318/v1/logs', 'application/json');
 $exporter = new LogsExporter($transport);
+
+$tracerProvider =  new TracerProvider(
+    new SimpleSpanProcessor(
+        new SpanExporter(
+            (new OtlpHttpTransportFactory())->create('http://collector:4318/v1/traces', 'application/json')
+        )
+    )
+);
+$tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
 
 $loggerProvider = new LoggerProvider(
     new SimpleLogsProcessor(
@@ -34,11 +53,20 @@ $loggerProvider = new LoggerProvider(
     )
 );
 $logger = $loggerProvider->getLogger('demo', '1.0', 'http://schema.url', true, ['foo' => 'bar']);
-$eventLogger = new EventLogger($logger, 'my-domain');
 
 $record = (new LogRecord(['foo' => 'bar', 'baz' => 'bat', 'msg' => 'hello world']))
     ->setSeverityText('INFO')
     ->setTimestamp((new DateTime())->getTimestamp() * LogRecord::NANOS_PER_SECOND)
     ->setSeverityNumber(SeverityNumber::SEVERITY_NUMBER_INFO);
 
-$eventLogger->logEvent('foo', $record);
+$span = $tracer->spanBuilder('root')->startSpan();
+$scope = $span->activate();
+echo 'Trace id: ' . $span->getContext()->getTraceId() . PHP_EOL;
+echo 'Span id: ' . $span->getContext()->getSpanId() . PHP_EOL;
+
+$logger->logRecord($record);
+
+$scope->detach();
+$span->end();
+
+echo 'Finished example' . PHP_EOL;

--- a/examples/logs/exporters/otlp_http_json_with_trace.php
+++ b/examples/logs/exporters/otlp_http_json_with_trace.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use OpenTelemetry\API\Common\Log\LoggerHolder;
-use OpenTelemetry\API\Logs\EventLogger;
 use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\Contrib\Otlp\LogsExporter;
 use OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory;

--- a/examples/traces/exporters/otlp_http_json.php
+++ b/examples/traces/exporters/otlp_http_json.php
@@ -6,27 +6,36 @@ require __DIR__ . '/../../../vendor/autoload.php';
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use OpenTelemetry\API\Common\Log\LoggerHolder;
+use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory;
 use OpenTelemetry\Contrib\Otlp\SpanExporter;
-use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Common\Time\ClockFactory;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 
 LoggerHolder::set(new Logger('otlp-example', [new StreamHandler('php://stderr')]));
 
-$transport = (new OtlpHttpTransportFactory())->create('http://collector:4318/v1/traces', 'application/json');
-$exporter = new SpanExporter($transport);
-
 echo 'Starting OTLP+json example';
 
 $tracerProvider =  new TracerProvider(
-    new SimpleSpanProcessor(
-        $exporter
-    )
+    new BatchSpanProcessor(
+        new SpanExporter(
+            (new OtlpHttpTransportFactory())->create('http://collector:4318/v1/traces', 'application/json')
+        ),
+        ClockFactory::getDefault(),
+    ),
 );
 $tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
 
 $root = $span = $tracer->spanBuilder('root')->startSpan();
+$scope = $root->activate();
+
+$child = $tracer->spanBuilder('child')->startSpan();
+$child->end();
+
+$span->setStatus(StatusCode::STATUS_OK);
 $root->end();
+$scope->detach();
 echo PHP_EOL . 'OTLP+json example complete!  ';
 
 echo PHP_EOL;

--- a/tests/Unit/Contrib/Otlp/ProtobufSerializerTest.php
+++ b/tests/Unit/Contrib/Otlp/ProtobufSerializerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\Contrib\Otlp;
+
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use OpenTelemetry\Contrib\Otlp\ProtobufSerializer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\Contrib\Otlp\ProtobufSerializer
+ */
+class ProtobufSerializerTest extends TestCase
+{
+    private const TRACE_ID = '197b4f650cd4fa2ecb0bbb883908bc72';
+    private const SPAN_ID = '2fb80e00a3df9fd3';
+
+    private SpanContextInterface $context;
+
+    public function setUp(): void
+    {
+        $this->context = SpanContext::create(self::TRACE_ID, self::SPAN_ID);
+    }
+
+    public function test_binary_to_hex(): void
+    {
+        $encodedTraceId = base64_encode($this->context->getTraceIdBinary());
+        $encodedSpanId = base64_encode($this->context->getSpanIdBinary());
+
+        $this->assertSame($this->context->getTraceId(), ProtobufSerializer::base64BinaryToHex($encodedTraceId));
+        $this->assertSame($this->context->getSpanId(), ProtobufSerializer::base64BinaryToHex($encodedSpanId));
+    }
+
+    public function test_fix_json(): void
+    {
+        $input = file_get_contents(__DIR__ . '/fixtures/trace.json');
+        $expected = json_encode(json_decode(file_get_contents(__DIR__ . '/fixtures/trace-expected.json')));
+        $fixed = ProtobufSerializer::fixJsonOutput($input);
+
+        $this->assertJsonStringEqualsJsonString($expected, $fixed);
+    }
+}

--- a/tests/Unit/Contrib/Otlp/fixtures/trace-expected.json
+++ b/tests/Unit/Contrib/Otlp/fixtures/trace-expected.json
@@ -1,0 +1,37 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {},
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "io.opentelemetry.contrib.php"
+          },
+          "spans": [
+            {
+              "traceId": "fba5aa62be94880d3c86360870f68832",
+              "spanId": "51dbb6fa9869efbd",
+              "parentSpanId": "bb78dad25599483c",
+              "name": "child",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1681444402662544763",
+              "endTimeUnixNano": "1681444402662548104",
+              "status": {}
+            },
+            {
+              "traceId": "fba5aa62be94880d3c86360870f68832",
+              "spanId": "bb78dad25599483c",
+              "name": "root",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1681444402662132127",
+              "endTimeUnixNano": "1681444402662704219",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Unit/Contrib/Otlp/fixtures/trace.json
+++ b/tests/Unit/Contrib/Otlp/fixtures/trace.json
@@ -1,0 +1,37 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {},
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "io.opentelemetry.contrib.php"
+          },
+          "spans": [
+            {
+              "traceId": "+6WqYr6UiA08hjYIcPaIMg==",
+              "spanId": "Udu2+php770=",
+              "parentSpanId": "u3ja0lWZSDw=",
+              "name": "child",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1681444402662544763",
+              "endTimeUnixNano": "1681444402662548104",
+              "status": {}
+            },
+            {
+              "traceId": "+6WqYr6UiA08hjYIcPaIMg==",
+              "spanId": "u3ja0lWZSDw=",
+              "name": "root",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1681444402662132127",
+              "endTimeUnixNano": "1681444402662704219",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The encoding applied by protobuf, which works for protobuf-encoded output, isn't what http/json requires. Rather than build a json serializer, this change modifies the almost-correct JSON output generated by protobuf, replacing the base64+binary-encoded trace ids and span ids with their original values.

Fixes #969 