### PR TITLE
Split metric collection from metric streams

### DIFF
--- a/src/SDK/Metrics/Data/Exemplar.php
+++ b/src/SDK/Metrics/Data/Exemplar.php
@@ -8,6 +8,11 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 
 final class Exemplar
 {
+
+    /**
+     * @var int|string
+     */
+    private $index;
     /**
      * @var float|int
      * @readonly
@@ -29,15 +34,32 @@ final class Exemplar
      * @readonly
      */
     public ?string $spanId;
+
     /**
+     * @param int|string $index
      * @param float|int $value
      */
-    public function __construct($value, int $timestamp, AttributesInterface $attributes, ?string $traceId, ?string $spanId)
+    public function __construct($index, $value, int $timestamp, AttributesInterface $attributes, ?string $traceId, ?string $spanId)
     {
+        $this->index = $index;
         $this->value = $value;
         $this->timestamp = $timestamp;
         $this->attributes = $attributes;
         $this->traceId = $traceId;
         $this->spanId = $spanId;
+    }
+
+    /**
+     * @param iterable<Exemplar> $exemplars
+     * @return array<list<Exemplar>>
+     */
+    public static function groupByIndex(iterable $exemplars): array
+    {
+        $grouped = [];
+        foreach ($exemplars as $exemplar) {
+            $grouped[$exemplar->index][] = $exemplar;
+        }
+
+        return $grouped;
     }
 }

--- a/src/SDK/Metrics/Exemplar/ExemplarReservoirInterface.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarReservoirInterface.php
@@ -14,11 +14,11 @@ interface ExemplarReservoirInterface
      * @param int|string $index
      * @param float|int $value
      */
-    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp, int $revision): void;
+    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void;
 
     /**
      * @param array<AttributesInterface> $dataPointAttributes
-     * @return array<list<Exemplar>>
+     * @return array<Exemplar>
      */
-    public function collect(array $dataPointAttributes, int $revision, int $limit): array;
+    public function collect(array $dataPointAttributes): array;
 }

--- a/src/SDK/Metrics/Exemplar/FilteredReservoir.php
+++ b/src/SDK/Metrics/Exemplar/FilteredReservoir.php
@@ -18,15 +18,15 @@ final class FilteredReservoir implements ExemplarReservoirInterface
         $this->filter = $filter;
     }
 
-    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp, int $revision): void
+    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         if ($this->filter->accepts($value, $attributes, $context, $timestamp)) {
-            $this->reservoir->offer($index, $value, $attributes, $context, $timestamp, $revision);
+            $this->reservoir->offer($index, $value, $attributes, $context, $timestamp);
         }
     }
 
-    public function collect(array $dataPointAttributes, int $revision, int $limit): array
+    public function collect(array $dataPointAttributes): array
     {
-        return $this->reservoir->collect($dataPointAttributes, $revision, $limit);
+        return $this->reservoir->collect($dataPointAttributes);
     }
 }

--- a/src/SDK/Metrics/Exemplar/FixedSizeReservoir.php
+++ b/src/SDK/Metrics/Exemplar/FixedSizeReservoir.php
@@ -21,19 +21,19 @@ final class FixedSizeReservoir implements ExemplarReservoirInterface
         $this->size = $size;
     }
 
-    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp, int $revision): void
+    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         $bucket = random_int(0, $this->measurements);
         $this->measurements++;
         if ($bucket < $this->size) {
-            $this->storage->store($bucket, $index, $value, $attributes, $context, $timestamp, $revision);
+            $this->storage->store($bucket, $index, $value, $attributes, $context, $timestamp);
         }
     }
 
-    public function collect(array $dataPointAttributes, int $revision, int $limit): array
+    public function collect(array $dataPointAttributes): array
     {
         $this->measurements = 0;
 
-        return $this->storage->collect($dataPointAttributes, $revision, $limit);
+        return $this->storage->collect($dataPointAttributes);
     }
 }

--- a/src/SDK/Metrics/Exemplar/HistogramBucketReservoir.php
+++ b/src/SDK/Metrics/Exemplar/HistogramBucketReservoir.php
@@ -26,16 +26,16 @@ final class HistogramBucketReservoir implements ExemplarReservoirInterface
         $this->boundaries = $boundaries;
     }
 
-    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp, int $revision): void
+    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         $boundariesCount = count($this->boundaries);
         for ($i = 0; $i < $boundariesCount && $this->boundaries[$i] < $value; $i++) {
         }
-        $this->storage->store($i, $index, $value, $attributes, $context, $timestamp, $revision);
+        $this->storage->store($i, $index, $value, $attributes, $context, $timestamp);
     }
 
-    public function collect(array $dataPointAttributes, int $revision, int $limit): array
+    public function collect(array $dataPointAttributes): array
     {
-        return $this->storage->collect($dataPointAttributes, $revision, $limit);
+        return $this->storage->collect($dataPointAttributes);
     }
 }

--- a/src/SDK/Metrics/Exemplar/NoopReservoir.php
+++ b/src/SDK/Metrics/Exemplar/NoopReservoir.php
@@ -9,12 +9,12 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 
 final class NoopReservoir implements ExemplarReservoirInterface
 {
-    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp, int $revision): void
+    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         // no-op
     }
 
-    public function collect(array $dataPointAttributes, int $revision, int $limit): array
+    public function collect(array $dataPointAttributes): array
     {
         return [];
     }

--- a/src/SDK/Metrics/MetricFactory/StreamFactory.php
+++ b/src/SDK/Metrics/MetricFactory/StreamFactory.php
@@ -29,7 +29,6 @@ use OpenTelemetry\SDK\Metrics\Stream\SynchronousMetricCollector;
 use OpenTelemetry\SDK\Metrics\Stream\SynchronousMetricStream;
 use OpenTelemetry\SDK\Metrics\ViewProjection;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
-use function assert;
 use function serialize;
 use function spl_object_id;
 use Throwable;

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSource.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSource.php
@@ -22,18 +22,22 @@ final class StreamMetricSource implements MetricSourceInterface
 
     public function collectionTimestamp(): int
     {
-        return $this->provider->stream->collectionTimestamp();
+        return $this->provider->stream->timestamp();
     }
 
     public function collect(?int $timestamp): Metric
     {
+        if ($timestamp !== null) {
+            $this->provider->stream->push($this->provider->metricCollector->collect($timestamp));
+        }
+
         return new Metric(
             $this->provider->instrumentationLibrary,
             $this->provider->resource,
             $this->provider->view->name,
             $this->provider->view->unit,
             $this->provider->view->description,
-            $this->provider->stream->collect($this->reader, $timestamp),
+            $this->provider->stream->collect($this->reader),
         );
     }
 

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
@@ -9,6 +9,7 @@ use OpenTelemetry\SDK\Metrics\Instrument;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
 use OpenTelemetry\SDK\Metrics\MetricSourceInterface;
 use OpenTelemetry\SDK\Metrics\MetricSourceProviderInterface;
+use OpenTelemetry\SDK\Metrics\Stream\MetricCollectorInterface;
 use OpenTelemetry\SDK\Metrics\Stream\MetricStreamInterface;
 use OpenTelemetry\SDK\Metrics\ViewProjection;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
@@ -38,13 +39,25 @@ final class StreamMetricSourceProvider implements MetricSourceProviderInterface,
      * @readonly
      */
     public MetricStreamInterface $stream;
-    public function __construct(ViewProjection $view, Instrument $instrument, InstrumentationScopeInterface $instrumentationLibrary, ResourceInfo $resource, MetricStreamInterface $stream)
-    {
+    /**
+     * @readonly
+     */
+    public MetricCollectorInterface $metricCollector;
+
+    public function __construct(
+        ViewProjection $view,
+        Instrument $instrument,
+        InstrumentationScopeInterface $instrumentationLibrary,
+        ResourceInfo $resource,
+        MetricStreamInterface $stream,
+        MetricCollectorInterface $metricCollector
+    ) {
         $this->view = $view;
         $this->instrument = $instrument;
         $this->instrumentationLibrary = $instrumentationLibrary;
         $this->resource = $resource;
         $this->stream = $stream;
+        $this->metricCollector = $metricCollector;
     }
 
     public function create($temporality): MetricSourceInterface

--- a/src/SDK/Metrics/Stream/AsynchronousMetricCollector.php
+++ b/src/SDK/Metrics/Stream/AsynchronousMetricCollector.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+use OpenTelemetry\SDK\Common\Attribute\AttributesFactoryInterface;
+use OpenTelemetry\SDK\Metrics\AggregationInterface;
+use OpenTelemetry\SDK\Metrics\AttributeProcessorInterface;
+
+/**
+ * @internal
+ */
+final class AsynchronousMetricCollector implements MetricCollectorInterface
+{
+    private $instrument;
+    private ?AttributeProcessorInterface $attributeProcessor;
+    private AggregationInterface $aggregation;
+    private AttributesFactoryInterface $attributesFactory;
+
+    public function __construct(
+        callable $instrument,
+        ?AttributeProcessorInterface $attributeProcessor,
+        AggregationInterface $aggregation,
+        AttributesFactoryInterface $attributesFactory
+    ) {
+        $this->instrument = $instrument;
+        $this->attributeProcessor = $attributeProcessor;
+        $this->aggregation = $aggregation;
+        $this->attributesFactory = $attributesFactory;
+    }
+
+    public function collect(int $timestamp): Metric
+    {
+        $aggregator = new MetricAggregator($this->attributeProcessor, $this->aggregation);
+        ($this->instrument)(new AsynchronousMetricStreamObserver($aggregator, $this->attributesFactory, $timestamp));
+
+        return $aggregator->collect($timestamp);
+    }
+}

--- a/src/SDK/Metrics/Stream/DeltaStorage.php
+++ b/src/SDK/Metrics/Stream/DeltaStorage.php
@@ -19,7 +19,7 @@ final class DeltaStorage
     public function __construct(AggregationInterface $aggregation)
     {
         $this->aggregation = $aggregation;
-        $this->head = new Delta(new Metric([], [], 0, 0), 0);
+        $this->head = new Delta(new Metric([], [], 0), 0);
 
         /** @phan-suppress-next-line PhanTypeObjectUnsetDeclaredProperty */
         unset($this->head->metric);
@@ -99,13 +99,12 @@ final class DeltaStorage
 
     private function mergeInto(Metric $into, Metric $metric): void
     {
-        assert($into->revision < $metric->revision);
-
         foreach ($metric->summaries as $k => $summary) {
             $into->attributes[$k] ??= $metric->attributes[$k];
             $into->summaries[$k] = isset($into->summaries[$k])
                 ? $this->aggregation->merge($into->summaries[$k], $summary)
                 : $summary;
         }
+        $into->exemplars += $metric->exemplars;
     }
 }

--- a/src/SDK/Metrics/Stream/Metric.php
+++ b/src/SDK/Metrics/Stream/Metric.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Metrics\Stream;
 
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
+use OpenTelemetry\SDK\Metrics\Data\Exemplar;
 
 /**
  * @internal
@@ -23,16 +24,21 @@ final class Metric
      */
     public array $summaries;
     public int $timestamp;
-    public int $revision;
+    /**
+     * @var array<Exemplar>
+     */
+    public array $exemplars;
+
     /**
      * @param array<AttributesInterface> $attributes
      * @param array<T> $summaries
+     * @param array<Exemplar> $exemplars
      */
-    public function __construct(array $attributes, array $summaries, int $timestamp, int $revision)
+    public function __construct(array $attributes, array $summaries, int $timestamp, array $exemplars = [])
     {
         $this->attributes = $attributes;
         $this->summaries = $summaries;
         $this->timestamp = $timestamp;
-        $this->revision = $revision;
+        $this->exemplars = $exemplars;
     }
 }

--- a/src/SDK/Metrics/Stream/MetricCollectorInterface.php
+++ b/src/SDK/Metrics/Stream/MetricCollectorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+/**
+ * @internal
+ */
+interface MetricCollectorInterface
+{
+    public function collect(int $timestamp): Metric;
+}

--- a/src/SDK/Metrics/Stream/MetricStreamInterface.php
+++ b/src/SDK/Metrics/Stream/MetricStreamInterface.php
@@ -20,11 +20,18 @@ interface MetricStreamInterface
     public function temporality();
 
     /**
-     * Returns the last collection timestamp.
+     * Returns the last metric timestamp.
      *
-     * @return int collection timestamp
+     * @return int metric timestamp
      */
-    public function collectionTimestamp(): int;
+    public function timestamp(): int;
+
+    /**
+     * Pushes metric data to the stream.
+     *
+     * @param Metric $metric metric data to push
+     */
+    public function push(Metric $metric): void;
 
     /**
      * Registers a new reader with the given temporality.
@@ -45,9 +52,7 @@ interface MetricStreamInterface
      * Collects metric data for the given reader.
      *
      * @param int $reader reader id
-     * @param int|null $timestamp timestamp for newly collected data, null to
-     *        skip collection of new metric data
      * @return DataInterface metric data
      */
-    public function collect(int $reader, ?int $timestamp): DataInterface;
+    public function collect(int $reader): DataInterface;
 }

--- a/src/SDK/Metrics/Stream/SynchronousMetricCollector.php
+++ b/src/SDK/Metrics/Stream/SynchronousMetricCollector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Metrics\Stream;
+
+/**
+ * @internal
+ */
+final class SynchronousMetricCollector implements MetricCollectorInterface
+{
+    private MetricAggregator $aggregator;
+
+    public function __construct(MetricAggregator $aggregator)
+    {
+        $this->aggregator = $aggregator;
+    }
+
+    public function collect(int $timestamp): Metric
+    {
+        return $this->aggregator->collect($timestamp);
+    }
+}

--- a/tests/Unit/Contrib/Otlp/MetricConverterTest.php
+++ b/tests/Unit/Contrib/Otlp/MetricConverterTest.php
@@ -108,8 +108,8 @@ final class MetricConverterTest extends TestCase
                     null,
                     new Sum([
                         new NumberDataPoint(5, Attributes::create(['foo' => 'bar']), 17, 42, [
-                            new Exemplar(.5, 19, Attributes::create(['key' => 'value']), null, null),
-                            new Exemplar(-3, 37, Attributes::create(['key' => 'other']), '4bf92f3577b34da6a3ce929d0e0e4736', '00f067aa0ba902b7'),
+                            new Exemplar(0, .5, 19, Attributes::create(['key' => 'value']), null, null),
+                            new Exemplar(0, -3, 37, Attributes::create(['key' => 'other']), '4bf92f3577b34da6a3ce929d0e0e4736', '00f067aa0ba902b7'),
                         ]),
                     ], Temporality::DELTA, false)
                 ),
@@ -139,8 +139,8 @@ final class MetricConverterTest extends TestCase
                     null,
                     new Histogram([
                         new HistogramDataPoint(5, 9, -2, 8, [5], [], Attributes::create(['foo' => 'bar']), 17, 42, [
-                            new Exemplar(.5, 19, Attributes::create(['key' => 'value']), null, null),
-                            new Exemplar(-3, 37, Attributes::create(['key' => 'other']), '4bf92f3577b34da6a3ce929d0e0e4736', '00f067aa0ba902b7'),
+                            new Exemplar(0, .5, 19, Attributes::create(['key' => 'value']), null, null),
+                            new Exemplar(0, -3, 37, Attributes::create(['key' => 'other']), '4bf92f3577b34da6a3ce929d0e0e4736', '00f067aa0ba902b7'),
                         ]),
                     ], Temporality::DELTA)
                 ),
@@ -170,8 +170,8 @@ final class MetricConverterTest extends TestCase
                     null,
                     new Gauge([
                         new NumberDataPoint(5, Attributes::create(['foo' => 'bar']), 17, 42, [
-                            new Exemplar(.5, 19, Attributes::create(['key' => 'value']), null, null),
-                            new Exemplar(-3, 37, Attributes::create(['key' => 'other']), '4bf92f3577b34da6a3ce929d0e0e4736', '00f067aa0ba902b7'),
+                            new Exemplar(0, .5, 19, Attributes::create(['key' => 'value']), null, null),
+                            new Exemplar(0, -3, 37, Attributes::create(['key' => 'other']), '4bf92f3577b34da6a3ce929d0e0e4736', '00f067aa0ba902b7'),
                         ]),
                     ])
                 ),

--- a/tests/Unit/SDK/Metrics/Exemplar/FilteredReservoirTest.php
+++ b/tests/Unit/SDK/Metrics/Exemplar/FilteredReservoirTest.php
@@ -29,13 +29,13 @@ final class FilteredReservoirTest extends TestCase
     public function test_all_reservoir_returns_exemplars(): void
     {
         $reservoir = new FilteredReservoir(new FixedSizeReservoir(Attributes::factory(), 4), new AllExemplarFilter());
-        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7, 0);
+        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7);
 
         $this->assertEquals([
             0 => [
-                new Exemplar(5, 7, Attributes::create([]), null, null),
+                new Exemplar(0, 5, 7, Attributes::create([]), null, null),
             ],
-        ], $reservoir->collect([0 => Attributes::create([])], 0, 1));
+        ], Exemplar::groupByIndex($reservoir->collect([0 => Attributes::create([])])));
     }
 
     /**
@@ -44,10 +44,10 @@ final class FilteredReservoirTest extends TestCase
     public function test_none_reservoir_doesnt_return_exemplars(): void
     {
         $reservoir = new FilteredReservoir(new FixedSizeReservoir(Attributes::factory(), 4), new NoneExemplarFilter());
-        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7, 0);
+        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7);
 
         $this->assertEquals([
-        ], $reservoir->collect([0 => Attributes::create([])], 0, 1));
+        ], Exemplar::groupByIndex($reservoir->collect([0 => Attributes::create([])])));
     }
 
     /**
@@ -60,13 +60,13 @@ final class FilteredReservoirTest extends TestCase
         $context = Span::wrap(SpanContext::create('12345678901234567890123456789012', '1234567890123456', SpanContextInterface::TRACE_FLAG_SAMPLED))
             ->storeInContext(Context::getRoot());
 
-        $reservoir->offer(0, 5, Attributes::create([]), $context, 7, 0);
+        $reservoir->offer(0, 5, Attributes::create([]), $context, 7);
 
         $this->assertEquals([
             0 => [
-                new Exemplar(5, 7, Attributes::create([]), '12345678901234567890123456789012', '1234567890123456'),
+                new Exemplar(0, 5, 7, Attributes::create([]), '12345678901234567890123456789012', '1234567890123456'),
             ],
-        ], $reservoir->collect([0 => Attributes::create([])], 0, 1));
+        ], Exemplar::groupByIndex($reservoir->collect([0 => Attributes::create([])])));
     }
 
     /**
@@ -79,9 +79,9 @@ final class FilteredReservoirTest extends TestCase
         $context = Span::wrap(SpanContext::create('12345678901234567890123456789012', '1234567890123456'))
             ->storeInContext(Context::getRoot());
 
-        $reservoir->offer(0, 5, Attributes::create([]), $context, 7, 0);
+        $reservoir->offer(0, 5, Attributes::create([]), $context, 7);
 
         $this->assertEquals([
-        ], $reservoir->collect([0 => Attributes::create([])], 0, 1));
+        ], Exemplar::groupByIndex($reservoir->collect([0 => Attributes::create([])])));
     }
 }

--- a/tests/Unit/SDK/Metrics/Exemplar/FixedSizeReservoirTest.php
+++ b/tests/Unit/SDK/Metrics/Exemplar/FixedSizeReservoirTest.php
@@ -18,12 +18,12 @@ final class FixedSizeReservoirTest extends TestCase
     public function test_reservoir_returns_exemplars(): void
     {
         $reservoir = new FixedSizeReservoir(Attributes::factory(), 4);
-        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7, 0);
+        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7);
 
         $this->assertEquals([
             0 => [
-                new Exemplar(5, 7, Attributes::create([]), null, null),
+                new Exemplar(0, 5, 7, Attributes::create([]), null, null),
             ],
-        ], $reservoir->collect([0 => Attributes::create([])], 0, 1));
+        ], Exemplar::groupByIndex($reservoir->collect([0 => Attributes::create([])])));
     }
 }

--- a/tests/Unit/SDK/Metrics/Exemplar/HistogramBucketReservoirTest.php
+++ b/tests/Unit/SDK/Metrics/Exemplar/HistogramBucketReservoirTest.php
@@ -18,15 +18,15 @@ final class HistogramBucketReservoirTest extends TestCase
     public function test_reservoir_returns_exemplars(): void
     {
         $reservoir = new HistogramBucketReservoir(Attributes::factory(), [0]);
-        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7, 0);
-        $reservoir->offer(0, -5, Attributes::create([]), Context::getRoot(), 8, 0);
-        $reservoir->offer(0, 7, Attributes::create([]), Context::getRoot(), 9, 0);
+        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7);
+        $reservoir->offer(0, -5, Attributes::create([]), Context::getRoot(), 8);
+        $reservoir->offer(0, 7, Attributes::create([]), Context::getRoot(), 9);
 
         $this->assertEquals([
             0 => [
-                new Exemplar(-5, 8, Attributes::create([]), null, null),
-                new Exemplar(7, 9, Attributes::create([]), null, null),
+                new Exemplar(0, -5, 8, Attributes::create([]), null, null),
+                new Exemplar(0, 7, 9, Attributes::create([]), null, null),
             ],
-        ], $reservoir->collect([0 => Attributes::create([])], 0, 1));
+        ], Exemplar::groupByIndex($reservoir->collect([0 => Attributes::create([])])));
     }
 }

--- a/tests/Unit/SDK/Metrics/Exemplar/NoopReservoirTest.php
+++ b/tests/Unit/SDK/Metrics/Exemplar/NoopReservoirTest.php
@@ -17,8 +17,8 @@ final class NoopReservoirTest extends TestCase
     public function test_reservoir_does_not_return_exemplars(): void
     {
         $reservoir = new NoopReservoir();
-        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7, 0);
+        $reservoir->offer(0, 5, Attributes::create([]), Context::getRoot(), 7);
 
-        $this->assertCount(0, $reservoir->collect([0 => Attributes::create([])], 0, 1));
+        $this->assertCount(0, $reservoir->collect([0 => Attributes::create([])]));
     }
 }

--- a/tests/Unit/SDK/Metrics/Stream/DeltaStorageTest.php
+++ b/tests/Unit/SDK/Metrics/Stream/DeltaStorageTest.php
@@ -34,13 +34,12 @@ final class DeltaStorageTest extends TestCase
     {
         $ds = new DeltaStorage(new SumAggregation());
 
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(3)], 0, 0), 0b1);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(3)], 0), 0b1);
 
         $metric = $ds->collect(0);
         $this->assertEquals(new Metric(
             [Attributes::create(['a'])],
             [new SumSummary(3)],
-            0,
             0,
         ), $metric);
     }
@@ -49,15 +48,14 @@ final class DeltaStorageTest extends TestCase
     {
         $ds = new DeltaStorage(new SumAggregation());
 
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(3)], 0, 0), 0b1);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(3)], 0), 0b1);
         $ds->collect(0, true);
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(5)], 1, 1), 0b1);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(5)], 1), 0b1);
         for ($i = 0; $i < 2; $i++) {
             $metric = $ds->collect(0, true);
             $this->assertEquals(new Metric(
                 [Attributes::create(['a'])],
                 [new SumSummary(8)],
-                0,
                 0,
             ), $metric);
         }
@@ -67,7 +65,7 @@ final class DeltaStorageTest extends TestCase
     {
         $ds = new DeltaStorage(new SumAggregation());
 
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(3)], 0, 0), 0b0);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(3)], 0), 0b0);
 
         $this->assertNull($ds->collect(0));
     }
@@ -76,30 +74,27 @@ final class DeltaStorageTest extends TestCase
     {
         $ds = new DeltaStorage(new SumAggregation());
 
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(3)], 0, 0), 0b111);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(3)], 0), 0b111);
         $metric = $ds->collect(0);
         $this->assertEquals(new Metric(
             [Attributes::create(['a'])],
             [new SumSummary(3)],
             0,
-            0,
         ), $metric);
 
-        $ds->add(new Metric([Attributes::create(['a']), Attributes::create(['b'])], [new SumSummary(7), new SumSummary(12)], 1, 1), 0b111);
+        $ds->add(new Metric([Attributes::create(['a']), Attributes::create(['b'])], [new SumSummary(7), new SumSummary(12)], 1), 0b111);
         $metric = $ds->collect(1);
         $this->assertEquals(new Metric(
             [Attributes::create(['a']), Attributes::create(['b'])],
             [new SumSummary(10), new SumSummary(12)],
             0,
-            0,
         ), $metric);
 
-        $ds->add(new Metric([Attributes::create(['a']), Attributes::create(['b'])], [new SumSummary(5), new SumSummary(9)], 2, 2), 0b111);
+        $ds->add(new Metric([Attributes::create(['a']), Attributes::create(['b'])], [new SumSummary(5), new SumSummary(9)], 2), 0b111);
         $metric = $ds->collect(1);
         $this->assertEquals(new Metric(
             [Attributes::create(['a']), Attributes::create(['b'])],
             [new SumSummary(5), new SumSummary(9)],
-            2,
             2,
         ), $metric);
 
@@ -108,7 +103,6 @@ final class DeltaStorageTest extends TestCase
             [Attributes::create(['a']), Attributes::create(['b'])],
             [new SumSummary(12), new SumSummary(21)],
             1,
-            1,
         ), $metric);
 
         $metric = $ds->collect(2);
@@ -116,19 +110,18 @@ final class DeltaStorageTest extends TestCase
             [Attributes::create(['a']), Attributes::create(['b'])],
             [new SumSummary(15), new SumSummary(21)],
             0,
-            0,
         ), $metric);
     }
 
     public function test_storage_keeps_constant_memory_on_one_active_reader(): void
     {
         $ds = new DeltaStorage(new SumAggregation());
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0, 0), 0b11);
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0, 1), 0b11);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0), 0b11);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0), 0b11);
 
         $memory = memory_get_usage();
         for ($i = 0; $i < 10000; $i++) {
-            $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(1)], 0, 2 + $i), 0b11);
+            $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(1)], 0), 0b11);
             $ds->collect(0);
         }
         $this->assertLessThan(2000, memory_get_usage() - $memory);
@@ -140,12 +133,12 @@ final class DeltaStorageTest extends TestCase
     public function test_storage_keeps_constant_memory_on_one_active_retaining_reader(): void
     {
         $ds = new DeltaStorage(new SumAggregation());
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0, 0), 0b01);
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0, 1), 0b11);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0), 0b01);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0), 0b11);
 
         $memory = memory_get_usage();
         for ($i = 0; $i < 10000; $i++) {
-            $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(1)], 0, 2 + $i), 0b11);
+            $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(1)], 0), 0b11);
             $ds->collect(0, true);
         }
         $this->assertLessThan(2000, memory_get_usage() - $memory);
@@ -159,13 +152,13 @@ final class DeltaStorageTest extends TestCase
     public function test_storage_keeps_constant_memory_on_alternating_active_retaining_readers(): void
     {
         $ds = new DeltaStorage(new SumAggregation());
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0, 0), 0b100);
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0, 1), 0b110);
-        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0, 2), 0b111);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0), 0b100);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0), 0b110);
+        $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(0)], 0), 0b111);
 
         $memory = memory_get_usage();
         for ($i = 0; $i < 10000; $i++) {
-            $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(1)], 0, 3 + $i), 0b111);
+            $ds->add(new Metric([Attributes::create(['a'])], [new SumSummary(1)], 0), 0b111);
             $ds->collect($i % 3, true);
         }
         $this->assertLessThan(2000, memory_get_usage() - $memory);

--- a/tests/Unit/SDK/Metrics/Stream/MetricStreamTest.php
+++ b/tests/Unit/SDK/Metrics/Stream/MetricStreamTest.php
@@ -6,17 +6,17 @@ namespace OpenTelemetry\Tests\Unit\SDK\Metrics\Stream;
 
 use function current;
 use function extension_loaded;
-use OpenTelemetry\API\Metrics\ObserverInterface;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Metrics\Aggregation\SumAggregation;
+use OpenTelemetry\SDK\Metrics\Aggregation\SumSummary;
 use OpenTelemetry\SDK\Metrics\AttributeProcessor\FilteredAttributeProcessor;
 use OpenTelemetry\SDK\Metrics\Data;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarReservoirInterface;
 use OpenTelemetry\SDK\Metrics\Stream\AsynchronousMetricStream;
+use OpenTelemetry\SDK\Metrics\Stream\Metric;
 use OpenTelemetry\SDK\Metrics\Stream\MetricAggregator;
-use OpenTelemetry\SDK\Metrics\Stream\StreamWriter;
 use OpenTelemetry\SDK\Metrics\Stream\SynchronousMetricStream;
 use const PHP_INT_SIZE;
 use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
@@ -50,206 +50,178 @@ final class MetricStreamTest extends TestCase
 {
     public function test_asynchronous_single_data_point(): void
     {
-        /** @var int|null $value */
-        $value = null;
-
-        $s = new AsynchronousMetricStream(Attributes::factory(), null, new SumAggregation(), null, function (ObserverInterface $observer) use (&$value): void {
-            $observer->observe($value);
-        }, 3);
+        $s = new AsynchronousMetricStream(new SumAggregation(), 3);
 
         $d = $s->register(Temporality::DELTA);
         $c = $s->register(Temporality::CUMULATIVE);
 
-        $value = 5;
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 5));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create([]), 3, 5),
-        ], Temporality::DELTA, false), $s->collect($d, 5));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create([]), 3, 5),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 5));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
 
-        $value = 7;
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(7)], 8));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(2, Attributes::create([]), 5, 8),
-        ], Temporality::DELTA, false), $s->collect($d, 8));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(7, Attributes::create([]), 3, 8),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 8));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
 
-        $value = 3;
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(3)], 12));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(-4, Attributes::create([]), 8, 12),
-        ], Temporality::DELTA, false), $s->collect($d, 12));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(3, Attributes::create([]), 3, 12),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 12));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
     }
 
     public function test_asynchronous_multiple_data_points(): void
     {
-        /** @var int|null $m */
-        $m = null;
-
-        $s = new AsynchronousMetricStream(Attributes::factory(), null, new SumAggregation(), null, function (ObserverInterface $observer) use (&$m): void {
-            if ($m === 0) {
-                $observer->observe(5, ['status' => 300]);
-                $observer->observe(2, ['status' => 400]);
-            }
-            if ($m === 1) {
-                $observer->observe(2, ['status' => 300]);
-                $observer->observe(7, ['status' => 400]);
-            }
-        }, 3);
+        $s = new AsynchronousMetricStream(new SumAggregation(), 3);
 
         $d = $s->register(Temporality::DELTA);
         $c = $s->register(Temporality::CUMULATIVE);
 
-        $m = 0;
+        $s->push(new Metric([Attributes::create(['status' => 300]), Attributes::create(['status' => 400])], [new SumSummary(5), new SumSummary(2)], 5));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create(['status' => 300]), 3, 5),
             new Data\NumberDataPoint(2, Attributes::create(['status' => 400]), 3, 5),
-        ], Temporality::DELTA, false), $s->collect($d, 5));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create(['status' => 300]), 3, 5),
             new Data\NumberDataPoint(2, Attributes::create(['status' => 400]), 3, 5),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 5));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
 
-        $m = 1;
+        $s->push(new Metric([Attributes::create(['status' => 300]), Attributes::create(['status' => 400])], [new SumSummary(2), new SumSummary(7)], 8));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(-3, Attributes::create(['status' => 300]), 5, 8),
             new Data\NumberDataPoint(5, Attributes::create(['status' => 400]), 5, 8),
-        ], Temporality::DELTA, false), $s->collect($d, 8));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(2, Attributes::create(['status' => 300]), 3, 8),
             new Data\NumberDataPoint(7, Attributes::create(['status' => 400]), 3, 8),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 8));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
     }
 
     public function test_asynchronous_omit_data_point(): void
     {
-        /** @var int|null $value */
-        $value = null;
-
-        $s = new AsynchronousMetricStream(Attributes::factory(), null, new SumAggregation(), null, function (ObserverInterface $observer) use (&$value): void {
-            if ($value !== null) {
-                $observer->observe($value);
-            }
-        }, 3);
+        $s = new AsynchronousMetricStream(new SumAggregation(), 3);
 
         $d = $s->register(Temporality::DELTA);
         $c = $s->register(Temporality::CUMULATIVE);
 
-        $value = 5;
-        $s->collect($d, 5);
-        $s->collect($c, 5);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 5));
+        $s->collect($d);
+        $s->collect($c);
 
-        $value = null;
+        $s->push(new Metric([], [], 7));
         $this->assertEquals(new Data\Sum([
-        ], Temporality::DELTA, false), $s->collect($d, 7));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 7));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
 
-        $value = 3;
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(3)], 12));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(3, Attributes::create([]), 7, 12),
-        ], Temporality::DELTA, false), $s->collect($d, 12));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(3, Attributes::create([]), 3, 12),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 12));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
     }
 
     public function test_synchronous_single_data_point(): void
     {
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
-        $w = new StreamWriter(null, Attributes::factory(), $s->writable());
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
 
         $d = $s->register(Temporality::DELTA);
         $c = $s->register(Temporality::CUMULATIVE);
 
-        $w->record(5, [], null, 4);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 5));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create([]), 3, 5),
-        ], Temporality::DELTA, false), $s->collect($d, 5));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create([]), 3, 5),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 5));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
 
-        $w->record(2, [], null, 7);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(2)], 8));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(2, Attributes::create([]), 5, 8),
-        ], Temporality::DELTA, false), $s->collect($d, 8));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(7, Attributes::create([]), 3, 8),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 8));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
 
-        $w->record(-4, [], null, 9);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(-4)], 12));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(-4, Attributes::create([]), 8, 12),
-        ], Temporality::DELTA, false), $s->collect($d, 12));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(3, Attributes::create([]), 3, 12),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 12));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
     }
 
     public function test_synchronous_multiple_data_points(): void
     {
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
-        $w = new StreamWriter(null, Attributes::factory(), $s->writable());
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
 
         $d = $s->register(Temporality::DELTA);
         $c = $s->register(Temporality::CUMULATIVE);
 
-        $w->record(5, ['status' => 300], null, 4);
-        $w->record(2, ['status' => 400], null, 4);
+        $s->push(new Metric([Attributes::create(['status' => 300]), Attributes::create(['status' => 400])], [new SumSummary(5), new SumSummary(2)], 5));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create(['status' => 300]), 3, 5),
             new Data\NumberDataPoint(2, Attributes::create(['status' => 400]), 3, 5),
-        ], Temporality::DELTA, false), $s->collect($d, 5));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create(['status' => 300]), 3, 5),
             new Data\NumberDataPoint(2, Attributes::create(['status' => 400]), 3, 5),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 5));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
 
-        $w->record(-3, ['status' => 300], null, 7);
-        $w->record(5, ['status' => 400], null, 7);
+        $s->push(new Metric([Attributes::create(['status' => 300]), Attributes::create(['status' => 400])], [new SumSummary(-3), new SumSummary(5)], 8));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(-3, Attributes::create(['status' => 300]), 5, 8),
             new Data\NumberDataPoint(5, Attributes::create(['status' => 400]), 5, 8),
-        ], Temporality::DELTA, false), $s->collect($d, 8));
+        ], Temporality::DELTA, false), $s->collect($d));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(2, Attributes::create(['status' => 300]), 3, 8),
             new Data\NumberDataPoint(7, Attributes::create(['status' => 400]), 3, 8),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 8));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
     }
 
     public function test_asynchronous_temporality(): void
     {
-        $s = new AsynchronousMetricStream(Attributes::factory(), null, new SumAggregation(), null, fn (ObserverInterface $observer) => $observer->observe(1), 3);
+        $s = new AsynchronousMetricStream(new SumAggregation(), 3);
         $this->assertSame(Temporality::CUMULATIVE, $s->temporality());
     }
 
     public function test_synchronous_temporality(): void
     {
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
         $this->assertSame(Temporality::DELTA, $s->temporality());
     }
 
-    public function test_asynchronous_collection_timestamp_returns_last_collection_timestamp(): void
+    public function test_asynchronous_timestamp_returns_last_metric_timestamp(): void
     {
-        $s = new AsynchronousMetricStream(Attributes::factory(), null, new SumAggregation(), null, fn (ObserverInterface $observer) => $observer->observe(1), 3);
-        $this->assertSame(3, $s->collectionTimestamp());
+        $s = new AsynchronousMetricStream(new SumAggregation(), 3);
+        $this->assertSame(3, $s->timestamp());
 
-        $s->collect(0, 5);
-        $this->assertSame(5, $s->collectionTimestamp());
+        $s->push(new Metric([], [], 5));
+        $this->assertSame(5, $s->timestamp());
     }
 
-    public function test_synchronous_collection_timestamp_returns_last_collection_timestamp(): void
+    public function test_synchronous_timestamp_returns_last_metric_timestamp(): void
     {
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
-        $this->assertSame(3, $s->collectionTimestamp());
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
+        $this->assertSame(3, $s->timestamp());
 
-        $s->collect(0, 5);
-        $this->assertSame(5, $s->collectionTimestamp());
+        $s->push(new Metric([], [], 5));
+        $this->assertSame(5, $s->timestamp());
     }
 
     public function test_asynchronous_unregister_removes_reader(): void
@@ -257,73 +229,62 @@ final class MetricStreamTest extends TestCase
         /** @var int|null $value */
         $value = null;
 
-        $s = new AsynchronousMetricStream(Attributes::factory(), null, new SumAggregation(), null, function (ObserverInterface $observer) use (&$value): void {
-            if ($value !== null) {
-                $observer->observe($value);
-            }
-        }, 3);
+        $s = new AsynchronousMetricStream(new SumAggregation(), 3);
 
-        $value = 5;
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 7));
         $d = $s->register(Temporality::DELTA);
-        $s->collect($d, 5);
+        $s->collect($d);
         $s->unregister($d);
 
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 7));
         // Implementation treats unknown reader as cumulative reader
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create([]), 3, 7),
-        ], Temporality::CUMULATIVE, false), $s->collect($d, 7));
+        ], Temporality::CUMULATIVE, false), $s->collect($d));
     }
 
     public function test_synchronous_unregister_removes_reader(): void
     {
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
-        $w = new StreamWriter(null, Attributes::factory(), $s->writable());
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
 
         $c = $s->register(Temporality::CUMULATIVE);
-        $w->record(5, [], null, 4);
-        $s->collect($c, 5);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 5));
+        $s->collect($c);
         $s->unregister($c);
 
-        $w->record(-5, [], null, 6);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(-5)], 7));
         $this->assertEquals(new Data\Sum([
-        ], Temporality::DELTA, false), $s->collect($c, 7));
+        ], Temporality::DELTA, false), $s->collect($c));
     }
 
     public function test_asynchronous_unregister_invalid_does_not_affect_reader(): void
     {
-        /** @var int|null $value */
-        $value = null;
+        $s = new AsynchronousMetricStream(new SumAggregation(), 3);
 
-        $s = new AsynchronousMetricStream(Attributes::factory(), null, new SumAggregation(), null, function (ObserverInterface $observer) use (&$value): void {
-            if ($value !== null) {
-                $observer->observe($value);
-            }
-        }, 3);
-
-        $value = 5;
         $d = $s->register(Temporality::DELTA);
-        $s->collect($d, 5);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 5));
+        $s->collect($d);
         $s->unregister($d + 1);
 
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 7));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(0, Attributes::create([]), 5, 7),
-        ], Temporality::DELTA, false), $s->collect($d, 7));
+        ], Temporality::DELTA, false), $s->collect($d));
     }
 
     public function test_synchronous_unregister_invalid_does_not_affect_reader(): void
     {
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
-        $w = new StreamWriter(null, Attributes::factory(), $s->writable());
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
 
         $c = $s->register(Temporality::CUMULATIVE);
-        $w->record(5, [], null, 4);
-        $s->collect($c, 5);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 5));
+        $s->collect($c);
         $s->unregister($c + 1);
 
-        $w->record(-5, [], null, 6);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(-5)], 7));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(0, Attributes::create([]), 3, 7),
-        ], Temporality::CUMULATIVE, false), $s->collect($c, 7));
+        ], Temporality::CUMULATIVE, false), $s->collect($c));
     }
 
     public function test_synchronous_reader_limit_exceeded_triggers_warning(): void
@@ -332,7 +293,7 @@ final class MetricStreamTest extends TestCase
             $this->markTestSkipped();
         }
 
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
 
         for ($i = 0; $i < (PHP_INT_SIZE << 3) - 1; $i++) {
             $s->register(Temporality::DELTA);
@@ -349,8 +310,7 @@ final class MetricStreamTest extends TestCase
             $this->markTestSkipped();
         }
 
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
-        $w = new StreamWriter(null, Attributes::factory(), $s->writable());
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
 
         for ($i = 0; $i < (PHP_INT_SIZE << 3) - 1; $i++) {
             $s->register(Temporality::DELTA);
@@ -358,9 +318,9 @@ final class MetricStreamTest extends TestCase
 
         $d = @$s->register(Temporality::DELTA);
 
-        $w->record(5, [], null, 4);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 5));
         $this->assertEquals(new Data\Sum([
-        ], Temporality::DELTA, false), $s->collect($d, 5));
+        ], Temporality::DELTA, false), $s->collect($d));
     }
 
     public function test_synchronous_reader_limit_does_not_apply_if_gmp_available(): void
@@ -369,8 +329,7 @@ final class MetricStreamTest extends TestCase
             $this->markTestSkipped();
         }
 
-        $s = new SynchronousMetricStream(null, new SumAggregation(), null, 3);
-        $w = new StreamWriter(null, Attributes::factory(), $s->writable());
+        $s = new SynchronousMetricStream(new SumAggregation(), 3);
 
         for ($i = 0; $i < (PHP_INT_SIZE << 3) - 1; $i++) {
             $s->register(Temporality::DELTA);
@@ -378,10 +337,10 @@ final class MetricStreamTest extends TestCase
 
         $d = $s->register(Temporality::DELTA);
 
-        $w->record(5, [], null, 4);
+        $s->push(new Metric([Attributes::create([])], [new SumSummary(5)], 5));
         $this->assertEquals(new Data\Sum([
             new Data\NumberDataPoint(5, Attributes::create([]), 3, 5),
-        ], Temporality::DELTA, false), $s->collect($d, 5));
+        ], Temporality::DELTA, false), $s->collect($d));
     }
 
     public function test_metric_aggregator_applies_attribute_filter(): void
@@ -398,22 +357,8 @@ final class MetricStreamTest extends TestCase
     public function test_metric_aggregator_forwards_to_exemplar_filter(): void
     {
         $exemplarReservoir = $this->createMock(ExemplarReservoirInterface::class);
-        $exemplarReservoir->expects($this->once())->method('offer')->with($this->anything(), 5, Attributes::create(['foo' => 1]), Context::getRoot(), 3, 0);
+        $exemplarReservoir->expects($this->once())->method('offer')->with($this->anything(), 5, Attributes::create(['foo' => 1]), Context::getRoot(), 3);
         $aggregator = new MetricAggregator(new FilteredAttributeProcessor(Attributes::factory(), ['foo', 'bar']), new SumAggregation(), $exemplarReservoir);
         $aggregator->record(5, Attributes::create(['foo' => 1]), Context::getRoot(), 3);
-    }
-
-    public function test_metric_aggregator_exemplars_provides_current_revision_range(): void
-    {
-        $exemplars = [
-            [new Data\Exemplar(5, 3, Attributes::create([]), null, null)],
-        ];
-        $exemplarReservoir = $this->createMock(ExemplarReservoirInterface::class);
-        $exemplarReservoir->expects($this->once())->method('collect')->with($this->anything(), 0, 1)->willReturn($exemplars);
-        $aggregator = new MetricAggregator(new FilteredAttributeProcessor(Attributes::factory(), ['foo', 'bar']), new SumAggregation(), $exemplarReservoir);
-        $aggregator->record(5, Attributes::create([]), Context::getRoot(), 3);
-        $metric = $aggregator->collect(2);
-
-        $this->assertSame($exemplars, $aggregator->exemplars($metric));
     }
 }


### PR DESCRIPTION
Preparation for multi-instrument callbacks, moves callback invocations out of asynchronous metric streams.