### PR TITLE
relax default logging levels

### DIFF
--- a/src/API/Behavior/LogsMessagesTrait.php
+++ b/src/API/Behavior/LogsMessagesTrait.php
@@ -18,11 +18,10 @@ trait LogsMessagesTrait
     {
         switch ($level) {
             case LogLevel::WARNING:
-                return E_USER_WARNING;
             case LogLevel::ERROR:
             case LogLevel::CRITICAL:
             case LogLevel::EMERGENCY:
-                return E_USER_ERROR;
+                return E_USER_WARNING;
             default:
                 return E_USER_NOTICE;
         }


### PR DESCRIPTION
without a psr-3 logger, we use trigger_error. Using this with E_USER_ERROR is fatal, which is not what we want.

Fixes #968 