### PR TITLE
temporality preference from env

### DIFF
--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -11,7 +11,6 @@ use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Otlp\HttpEndpointResolver;
-use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricExporterFactoryInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Registry;
@@ -69,14 +68,16 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
         );
     }
 
-    private function getTemporality(): string
+    private function getTemporality(): ?string
     {
         $value = Configuration::getEnum(Variables::OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE);
         switch (strtolower($value)) {
-            case strtolower(Temporality::CUMULATIVE):
-                return Temporality::CUMULATIVE;
-            case strtolower(Temporality::DELTA):
-                return Temporality::DELTA;
+            case 'cumulative':
+                return 'cumulative';
+            case 'delta':
+                return 'delta';
+            case 'lowmemory':
+                return null;
             default:
                 throw new \UnexpectedValueException('Unknown temporality: ' . $value);
         }

--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -11,6 +11,7 @@ use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Otlp\HttpEndpointResolver;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricExporterFactoryInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Registry;
@@ -68,14 +69,17 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
         );
     }
 
-    private function getTemporality(): ?string
+    /**
+     * @todo return string|Temporality|null (php >= 8.0)
+     */
+    private function getTemporality()
     {
         $value = Configuration::getEnum(Variables::OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE);
         switch (strtolower($value)) {
             case 'cumulative':
-                return 'cumulative';
+                return Temporality::CUMULATIVE;
             case 'delta':
-                return 'delta';
+                return Temporality::DELTA;
             case 'lowmemory':
                 return null;
             default:

--- a/src/SDK/Common/Configuration/Defaults.php
+++ b/src/SDK/Common/Configuration/Defaults.php
@@ -97,6 +97,8 @@ interface Defaults
     public const OTEL_METRICS_EXEMPLAR_FILTER = 'with_sampled_trace';
     public const OTEL_METRIC_EXPORT_INTERVAL = 60000;
     public const OTEL_METRIC_EXPORT_TIMEOUT = 30000;
+    public const OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = 'cumulative';
+    public const OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION = 'explicit_bucket_histogram';
     /**
      * Language Specific Environment Variables
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#language-specific-environment-variables

--- a/src/SDK/Common/Configuration/KnownValues.php
+++ b/src/SDK/Common/Configuration/KnownValues.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Configuration;
 
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use Psr\Log\LogLevel;
 
 /**
@@ -54,6 +55,11 @@ interface KnownValues
     public const VALUE_LOG_NOTICE = LogLevel::NOTICE;
     public const VALUE_LOG_INFO = LogLevel::INFO;
     public const VALUE_LOG_DEBUG = LogLevel::DEBUG;
+    public const VALUE_TEMPORALITY_CUMULATIVE = Temporality::CUMULATIVE;
+    public const VALUE_TEMPORALITY_DELTA = Temporality::DELTA;
+    public const VALUE_TEMPORALITY_LOW_MEMORY = 'LowMemory';
+    public const VALUE_HISTOGRAM_AGGREGATION_EXPLICIT = 'explicit_bucket_histogram';
+    public const VALUE_HISTOGRAM_AGGREGATION_BASE2_EXPONENTIAL = 'base2_exponential_bucket_histogram';
 
     public const VALUES_BOOLEAN = [
         self::VALUE_TRUE,
@@ -69,6 +75,17 @@ interface KnownValues
         self::VALUE_GRPC,
         self::VALUE_HTTP_PROTOBUF,
         self::VALUE_HTTP_JSON,
+    ];
+
+    public const VALUES_TEMPORALITY_PREFERENCE = [
+        self::VALUE_TEMPORALITY_CUMULATIVE,
+        self::VALUE_TEMPORALITY_DELTA,
+        //self::VALUE_TEMPORALITY_LOW_MEMORY, //not implemented
+    ];
+
+    public const VALUES_HISTOGRAM_AGGREGATION = [
+        self::VALUE_HISTOGRAM_AGGREGATION_EXPLICIT,
+        self::VALUE_HISTOGRAM_AGGREGATION_BASE2_EXPONENTIAL,
     ];
 
     /**

--- a/src/SDK/Common/Configuration/KnownValues.php
+++ b/src/SDK/Common/Configuration/KnownValues.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Configuration;
 
-use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use Psr\Log\LogLevel;
 
 /**
@@ -55,9 +54,9 @@ interface KnownValues
     public const VALUE_LOG_NOTICE = LogLevel::NOTICE;
     public const VALUE_LOG_INFO = LogLevel::INFO;
     public const VALUE_LOG_DEBUG = LogLevel::DEBUG;
-    public const VALUE_TEMPORALITY_CUMULATIVE = Temporality::CUMULATIVE;
-    public const VALUE_TEMPORALITY_DELTA = Temporality::DELTA;
-    public const VALUE_TEMPORALITY_LOW_MEMORY = 'LowMemory';
+    public const VALUE_TEMPORALITY_CUMULATIVE = 'cumulative';
+    public const VALUE_TEMPORALITY_DELTA = 'delta';
+    public const VALUE_TEMPORALITY_LOW_MEMORY = 'lowmemory';
     public const VALUE_HISTOGRAM_AGGREGATION_EXPLICIT = 'explicit_bucket_histogram';
     public const VALUE_HISTOGRAM_AGGREGATION_BASE2_EXPONENTIAL = 'base2_exponential_bucket_histogram';
 
@@ -80,7 +79,7 @@ interface KnownValues
     public const VALUES_TEMPORALITY_PREFERENCE = [
         self::VALUE_TEMPORALITY_CUMULATIVE,
         self::VALUE_TEMPORALITY_DELTA,
-        //self::VALUE_TEMPORALITY_LOW_MEMORY, //not implemented
+        self::VALUE_TEMPORALITY_LOW_MEMORY,
     ];
 
     public const VALUES_HISTOGRAM_AGGREGATION = [

--- a/src/SDK/Common/Configuration/ValueTypes.php
+++ b/src/SDK/Common/Configuration/ValueTypes.php
@@ -103,6 +103,8 @@ interface ValueTypes
     public const OTEL_METRICS_EXEMPLAR_FILTER = VariableTypes::ENUM;
     public const OTEL_METRIC_EXPORT_INTERVAL = VariableTypes::INTEGER;
     public const OTEL_METRIC_EXPORT_TIMEOUT = VariableTypes::INTEGER;
+    public const OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = VariableTypes::ENUM;
+    public const OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION = VariableTypes::ENUM;
     /**
      * Language Specific Environment Variables
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#language-specific-environment-variables

--- a/src/SDK/Common/Configuration/Variables.php
+++ b/src/SDK/Common/Configuration/Variables.php
@@ -117,6 +117,8 @@ interface Variables
     public const OTEL_METRICS_EXEMPLAR_FILTER = 'OTEL_METRICS_EXEMPLAR_FILTER';
     public const OTEL_METRIC_EXPORT_INTERVAL = 'OTEL_METRIC_EXPORT_INTERVAL';
     public const OTEL_METRIC_EXPORT_TIMEOUT = 'OTEL_METRIC_EXPORT_TIMEOUT';
+    public const OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = 'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE';
+    public const OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION = 'OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION';
     /**
      * Language Specific Environment Variables
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#language-specific-environment-variables

--- a/src/SDK/Metrics/MeterProviderFactory.php
+++ b/src/SDK/Metrics/MeterProviderFactory.php
@@ -23,6 +23,11 @@ class MeterProviderFactory
 {
     use LogsMessagesTrait;
 
+    /**
+     * @todo https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md#general
+     *       - "The exporter MUST configure the default aggregation on the basis of instrument kind using the
+     *         OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION variable as described below if it is implemented."
+     */
     public function create(): MeterProviderInterface
     {
         if (Sdk::isDisabled()) {
@@ -43,6 +48,7 @@ class MeterProviderFactory
             $exporter = new NoopMetricExporter();
         }
 
+        // @todo "The exporter MUST be paired with a periodic exporting MetricReader"
         $reader = new ExportingReader($exporter);
         $resource = ResourceInfoFactory::defaultResource();
         $exemplarFilter = $this->createExemplarFilter(Configuration::getEnum(Variables::OTEL_METRICS_EXEMPLAR_FILTER));

--- a/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -66,19 +67,19 @@ class MetricExporterFactoryTest extends TestCase
         return [
             'default' => [
                 [],
-                'cumulative',
+                Temporality::CUMULATIVE,
             ],
             'cumulative' => [
                 [
                     'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative',
                 ],
-                'cumulative',
+                Temporality::CUMULATIVE,
             ],
             'delta' => [
                 [
                     'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'delta',
                 ],
-                'delta',
+                Temporality::DELTA,
             ],
             'low memory' => [
                 [
@@ -90,7 +91,7 @@ class MetricExporterFactoryTest extends TestCase
                 [
                     'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative',
                 ],
-                'cumulative',
+                Temporality::CUMULATIVE,
             ],
         ];
     }

--- a/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
@@ -10,7 +10,6 @@ use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
-use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -46,7 +45,7 @@ class MetricExporterFactoryTest extends TestCase
     /**
      * @dataProvider temporalityProvider
      */
-    public function test_create_with_temporality(array $env, string $expected): void
+    public function test_create_with_temporality(array $env, ?string $expected): void
     {
         // @phpstan-ignore-next-line
         $this->transportFactory->method('create')->willReturn($this->transport);
@@ -67,25 +66,31 @@ class MetricExporterFactoryTest extends TestCase
         return [
             'default' => [
                 [],
-                Temporality::CUMULATIVE,
+                'cumulative',
             ],
             'cumulative' => [
                 [
                     'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative',
                 ],
-                Temporality::CUMULATIVE,
+                'cumulative',
             ],
             'delta' => [
                 [
                     'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'delta',
                 ],
-                Temporality::DELTA,
+                'delta',
+            ],
+            'low memory' => [
+                [
+                    'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'lowmemory',
+                ],
+                null,
             ],
             'CuMuLaTiVe (mixed case)' => [
                 [
                     'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative',
                 ],
-                Temporality::CUMULATIVE,
+                'cumulative',
             ],
         ];
     }


### PR DESCRIPTION
Implement OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, which controls the temporality of meters when creating from environment vars. Add OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION to variables, although we do not yet have anything that uses it.