### PR TITLE
remove 'include context' parameter from logging examples

### DIFF
--- a/examples/logs/features/batch_exporting.php
+++ b/examples/logs/features/batch_exporting.php
@@ -37,7 +37,7 @@ echo 'Span id: ' . $span->getContext()->getSpanId() . PHP_EOL;
 
 //get a logger, and emit a log record from an EventLogger. The active context (trace id + span id) will be
 //attached to the log record
-$logger = $loggerProvider->getLogger('demo', '1.0', 'http://schema.url', true, ['foo' => 'bar']);
+$logger = $loggerProvider->getLogger('demo', '1.0', 'http://schema.url', ['foo' => 'bar']);
 $eventLogger = new EventLogger($logger, 'my-domain');
 
 $record = (new LogRecord(['foo' => 'bar', 'baz' => 'bat', 'msg' => 'hello world']))

--- a/examples/logs/features/monolog-otel-integration.php
+++ b/examples/logs/features/monolog-otel-integration.php
@@ -18,6 +18,8 @@ use Psr\Log\LogLevel;
  * configured from environment, and autoloaded as part of composer where is can be retrieved from `Globals`.
  *
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md#usage
+ *
+ * We have an official monolog handler, @see https://packagist.org/packages/open-telemetry/opentelemetry-logger-monolog
  */
 
 // create env vars before requiring composer
@@ -40,7 +42,7 @@ $otelHandler = new class(LogLevel::INFO) extends AbstractProcessingHandler {
     {
         parent::__construct($level, $bubble);
         $provider ??= Globals::loggerProvider();
-        $this->logger = $provider->getLogger('monolog-demo', null, null, true, ['logging.library' => 'monolog']);
+        $this->logger = $provider->getLogger('monolog-demo', null, null, ['logging.library' => 'monolog']);
     }
 
     protected function write(array $record): void

--- a/examples/logs/getting_started.php
+++ b/examples/logs/getting_started.php
@@ -30,7 +30,7 @@ echo 'Span id: ' . $span->getContext()->getSpanId() . PHP_EOL;
 
 //get a logger, and emit a log record from an EventLogger. The active context (trace id + span id) will be
 //attached to the log record
-$logger = $loggerProvider->getLogger('demo', '1.0', 'http://schema.url', true, ['foo' => 'bar']);
+$logger = $loggerProvider->getLogger('demo', '1.0', 'http://schema.url', ['foo' => 'bar']);
 $eventLogger = new EventLogger($logger, 'my-domain');
 
 $record = (new LogRecord(['foo' => 'bar', 'baz' => 'bat', 'msg' => 'hello world']))


### PR DESCRIPTION
the param was removed from spec, and our API implementation recently, but I missed these examples.