### PR TITLE
adding console metric exporter

### DIFF
--- a/examples/metrics/exporters/console_from_factory.php
+++ b/examples/metrics/exporters/console_from_factory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenTelemetry\SDK\Metrics\MeterProviderFactory;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+/**
+ * Create a console exporter from environment variables, and generate a histogram.
+ */
+
+putenv('OTEL_METRICS_EXPORTER=console');
+
+$meterProvider = (new MeterProviderFactory())->create();
+
+$meter = $meterProvider->getMeter('io.opentelemetry.contrib.php');
+$hist = $meter ->createHistogram('example', 'bytes', 'The number of bytes received.');
+for ($i=0; $i<=5000; $i++) {
+    $hist->record(rand(0, 1024));
+}
+
+$meterProvider->shutdown();

--- a/examples/metrics/exporters/otlp_grpc.php
+++ b/examples/metrics/exporters/otlp_grpc.php
@@ -20,7 +20,6 @@ $reader = new ExportingReader(
     new MetricExporter(
         (new GrpcTransportFactory())->create('http://collector:4317' . OtlpUtil::method(Signals::METRICS))
     ),
-    $clock
 );
 
 $metricsGenerator = new ExampleMetricsGenerator($reader, $clock);

--- a/examples/metrics/exporters/otlp_http.php
+++ b/examples/metrics/exporters/otlp_http.php
@@ -15,7 +15,6 @@ $reader = new ExportingReader(
     new MetricExporter(
         PsrTransportFactory::discover()->create('http://collector:4318/v1/metrics', \OpenTelemetry\Contrib\Otlp\ContentTypes::JSON)
     ),
-    $clock
 );
 
 $metricsGenerator = new ExampleMetricsGenerator($reader, $clock);

--- a/examples/metrics/exporters/stream.php
+++ b/examples/metrics/exporters/stream.php
@@ -15,7 +15,6 @@ $reader = new ExportingReader(
     new MetricExporter(
         new StreamTransport(STDOUT, 'application/x-ndjson')
     ),
-    $clock
 );
 
 $metricsGenerator = new ExampleMetricsGenerator($reader, $clock);

--- a/src/Contrib/Otlp/ConsoleMetricExporterFactory.php
+++ b/src/Contrib/Otlp/ConsoleMetricExporterFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Otlp;
+
+use OpenTelemetry\SDK\Metrics\MetricExporterFactoryInterface;
+use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
+use OpenTelemetry\SDK\Registry;
+
+class ConsoleMetricExporterFactory implements MetricExporterFactoryInterface
+{
+    public function create(): MetricExporterInterface
+    {
+        $transport = Registry::transportFactory('stream')->create('php://stdout', 'application/x-ndjson');
+
+        return new MetricExporter($transport);
+    }
+}

--- a/src/Contrib/Otlp/_register.php
+++ b/src/Contrib/Otlp/_register.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 \OpenTelemetry\SDK\Registry::registerSpanExporterFactory('otlp', \OpenTelemetry\Contrib\Otlp\SpanExporterFactory::class);
 \OpenTelemetry\SDK\Registry::registerMetricExporterFactory('otlp', \OpenTelemetry\Contrib\Otlp\MetricExporterFactory::class);
+\OpenTelemetry\SDK\Registry::registerMetricExporterFactory('console', \OpenTelemetry\Contrib\Otlp\ConsoleMetricExporterFactory::class);
 
 \OpenTelemetry\SDK\Registry::registerTransportFactory('http', \OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory::class);
 

--- a/tests/Unit/Contrib/Otlp/ConsoleMetricExporterFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/ConsoleMetricExporterFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\Contrib\Otlp;
+
+use OpenTelemetry\Contrib\Otlp\ConsoleMetricExporterFactory;
+use OpenTelemetry\Contrib\Otlp\MetricExporter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\Contrib\Otlp\ConsoleMetricExporterFactory
+ */
+class ConsoleMetricExporterFactoryTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $exporter = (new ConsoleMetricExporterFactory())->create();
+        $this->assertInstanceOf(MetricExporter::class, $exporter);
+    }
+}


### PR DESCRIPTION
allow the existing metric exporter to be created from env vars, by creating a factory and registering it against 'console'. Now, `OTEL_METRICS_EXPORTER=console` will create a metrics provider with console output. Note that it lives in contrib/otlp, since it uses the existing otlp converters.