### PR TITLE
drop attributes with non-homogenous array values

### DIFF
--- a/src/API/Trace/SpanInterface.php
+++ b/src/API/Trace/SpanInterface.php
@@ -50,15 +50,18 @@ interface SpanInterface extends ImplicitContextKeyedInterface
 
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.1/specification/trace/api.md#set-attributes
-     * Adding attributes at span creation is preferred to calling SetAttribute later, as samplers can only consider information
+     * Adding attributes at span creation is preferred to calling setAttribute later, as samplers can only consider information
      * already present during span creation
      * @param non-empty-string $key
-     * @param bool|int|float|string|array|null $value Note: the array MUST be homogeneous, i.e. it MUST NOT contain values of different types.
+     * @param bool|int|float|string|array|null $value Note: arrays MUST be homogeneous, i.e. it MUST NOT contain values of different types.
      */
     public function setAttribute(string $key, $value): SpanInterface;
 
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.1/specification/trace/api.md#set-attributes
+     * An attribute with a null key will be dropped, and an attribute with a null value will be dropped but also remove any existing
+     * attribute with the same key.
+     * @param iterable<non-empty-string, bool|int|float|string|array|null> $attributes
      */
     public function setAttributes(iterable $attributes): SpanInterface;
 

--- a/src/SDK/Common/Attribute/AttributesBuilder.php
+++ b/src/SDK/Common/Attribute/AttributesBuilder.php
@@ -118,7 +118,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
      */
     private function isHomogeneous(array $value): bool
     {
-        if ($value === [] || count($value) <= 1) {
+        if (count($value) <= 1) {
             return true;
         }
         $type = gettype($value[0]);

--- a/src/SDK/Common/Attribute/AttributesBuilder.php
+++ b/src/SDK/Common/Attribute/AttributesBuilder.php
@@ -6,19 +6,24 @@ namespace OpenTelemetry\SDK\Common\Attribute;
 
 use function array_key_exists;
 use function count;
+use function gettype;
 use function is_array;
 use function is_string;
 use function mb_substr;
+use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 
 /**
  * @internal
  */
 final class AttributesBuilder implements AttributesBuilderInterface
 {
+    use LogsMessagesTrait;
+
     private array $attributes;
     private ?int $attributeCountLimit;
     private ?int $attributeValueLengthLimit;
     private int $droppedAttributesCount;
+    private const NUMERICS = ['integer', 'double'];
 
     public function __construct(array $attributes, ?int $attributeCountLimit, ?int $attributeValueLengthLimit, int $droppedAttributesCount)
     {
@@ -61,6 +66,11 @@ final class AttributesBuilder implements AttributesBuilderInterface
 
             return;
         }
+        if (is_array($value) && !$this->isHomogeneous($value)) {
+            self::logWarning('attribute with non-homogeneous array values dropped: ' . $offset);
+
+            return;
+        }
         if (count($this->attributes) === $this->attributeCountLimit && !array_key_exists($offset, $this->attributes)) {
             $this->droppedAttributesCount++;
 
@@ -100,5 +110,27 @@ final class AttributesBuilder implements AttributesBuilderInterface
         }
 
         return $value;
+    }
+
+    /**
+     * Test whether an array contains only values of the same type, treating int/double as equivalent.
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/common/README.md#attribute
+     */
+    private function isHomogeneous(array $value): bool
+    {
+        if ($value === [] || count($value) <= 1) {
+            return true;
+        }
+        $type = gettype($value[0]);
+        foreach ($value as $v) {
+            if (in_array(gettype($v), self::NUMERICS) && in_array($type, self::NUMERICS)) {
+                continue;
+            }
+            if (gettype($v) !== $type) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Unit/Contrib/Otlp/SpanConverterTest.php
+++ b/tests/Unit/Contrib/Otlp/SpanConverterTest.php
@@ -117,25 +117,6 @@ class SpanConverterTest extends TestCase
                     ]),
                 ]),
             ],
-            'Array of Randoms' => [
-                ['Answer',42,true,['Nested Array']],
-                new AnyValue([
-                    'array_value' => new ArrayValue([
-                        'values' => [
-                            new AnyValue(['string_value' => 'Answer']),
-                            new AnyValue(['int_value' => '42']),
-                            new AnyValue(['bool_value' => true]),
-                            new AnyValue([
-                                'array_value' => new ArrayValue([
-                                    'values' => [
-                                        new AnyValue(['string_value' => 'Nested Array']),
-                                    ],
-                                ]),
-                            ]),
-                        ],
-                    ]),
-                ]),
-            ],
         ];
     }
 

--- a/tests/Unit/Contrib/Zipkin/ZipkinSpanConverterTest.php
+++ b/tests/Unit/Contrib/Zipkin/ZipkinSpanConverterTest.php
@@ -207,7 +207,6 @@ class ZipkinSpanConverterTest extends TestCase
         $listOfStrings = ['string-1', 'string-2'];
         $listOfNumbers = [1, 2, 3, 3.1415, 42];
         $listOfBooleans = [true, true, false, true];
-        $listOfRandoms = [true, [1, 2, 3], false, 'string-1', 3.1415];
 
         $span = (new SpanData())
             ->setName('tags.test')
@@ -219,13 +218,12 @@ class ZipkinSpanConverterTest extends TestCase
             ->addAttribute('boolean-2', false)
             ->addAttribute('list-of-strings', $listOfStrings)
             ->addAttribute('list-of-numbers', $listOfNumbers)
-            ->addAttribute('list-of-booleans', $listOfBooleans)
-            ->addAttribute('list-of-random', $listOfRandoms);
+            ->addAttribute('list-of-booleans', $listOfBooleans);
 
         $tags = (new SpanConverter())->convert([$span])[0]['tags'];
 
         // Check that we can convert all attributes to tags
-        $this->assertCount(10, $tags);
+        $this->assertCount(9, $tags);
 
         // Tags destined for Zipkin must be pairs of strings
         foreach ($tags as $tagKey => $tagValue) {
@@ -240,14 +238,10 @@ class ZipkinSpanConverterTest extends TestCase
         $this->assertSame('true', $tags['boolean-1']);
         $this->assertSame('false', $tags['boolean-2']);
 
-        // Lists must be casted to strings and joined with a separator
+        // Lists must be cast to strings and joined with a separator
         $this->assertSame(implode(',', $listOfStrings), $tags['list-of-strings']);
         $this->assertSame(implode(',', $listOfNumbers), $tags['list-of-numbers']);
         $this->assertSame('true,true,false,true', $tags['list-of-booleans']);
-
-        // This currently works, but OpenTelemetry\Trace\Span should stop arrays
-        // containing multiple value types from being passed to the Exporter.
-        $this->assertSame('true,1,2,3,false,string-1,3.1415', $tags['list-of-random']);
     }
 
     /**

--- a/tests/Unit/SDK/Common/Attribute/AttributesTest.php
+++ b/tests/Unit/SDK/Common/Attribute/AttributesTest.php
@@ -60,7 +60,6 @@ class AttributesTest extends TestCase
             'array' => [
                 $shortStringValue,
                 $longStringValue,
-                true,
             ],
             'ignored_key' => 'ignored_value',
         ])->build();
@@ -70,7 +69,7 @@ class AttributesTest extends TestCase
         $this->assertEquals($floatValue, $attributes->get('float'));
         $this->assertEquals($shortStringValue, $attributes->get('short_string'));
         $this->assertEquals($longStringTrimmed, $attributes->get('long_string'));
-        $this->assertEquals([$shortStringValue, $longStringTrimmed, true], $attributes->get('array'));
+        $this->assertEquals([$shortStringValue, $longStringTrimmed], $attributes->get('array'));
         $this->assertEquals(6, $attributes->count());
         $this->assertNull($attributes->get('ignored_key'));
     }


### PR DESCRIPTION
* Per spec, arrays MUST contain only the same types. I've allowed for numeric types (integer + double) to be treated as equivalent.
* document span attributes null key/values behaviour

Fixes: #1014