### PR TITLE
rename span builder parameter

### DIFF
--- a/src/API/Trace/NoopSpanBuilder.php
+++ b/src/API/Trace/NoopSpanBuilder.php
@@ -42,7 +42,7 @@ final class NoopSpanBuilder implements SpanBuilderInterface
         return $this;
     }
 
-    public function setStartTimestamp(int $timestamp): SpanBuilderInterface
+    public function setStartTimestamp(int $timestampNanos): SpanBuilderInterface
     {
         return $this;
     }

--- a/src/API/Trace/SpanBuilderInterface.php
+++ b/src/API/Trace/SpanBuilderInterface.php
@@ -32,7 +32,7 @@ interface SpanBuilderInterface
      *
      * Defaults to the timestamp when {@see SpanBuilderInterface::startSpan} was called if not explicitly set.
      */
-    public function setStartTimestamp(int $timestamp): SpanBuilderInterface;
+    public function setStartTimestamp(int $timestampNanos): SpanBuilderInterface;
 
     /**
      * @psalm-param SpanKind::KIND_* $spanKind

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -116,13 +116,13 @@ final class SpanBuilder implements API\SpanBuilderInterface
     }
 
     /** @inheritDoc */
-    public function setStartTimestamp(int $timestamp): API\SpanBuilderInterface
+    public function setStartTimestamp(int $timestampNanos): API\SpanBuilderInterface
     {
-        if (0 > $timestamp) {
+        if (0 > $timestampNanos) {
             return $this;
         }
 
-        $this->startEpochNanos = $timestamp;
+        $this->startEpochNanos = $timestampNanos;
 
         return $this;
     }


### PR DESCRIPTION
TC feedback suggested to rename param to hint at the type (nano seconds)

Fixes #1016 