### PR TITLE
deprecate sdk/common/dsn

### DIFF
--- a/src/SDK/Common/Dsn/Dsn.php
+++ b/src/SDK/Common/Dsn/Dsn.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\SDK\Common\Dsn;
 
 /**
  * @deprecated
+ * @phan-suppress PhanDeprecatedInterface
  */
 class Dsn implements DsnInterface
 {
@@ -40,6 +41,9 @@ class Dsn implements DsnInterface
         $this->password = $password;
     }
 
+    /**
+     * @phan-suppress PhanDeprecatedClass
+     */
     public static function create(
         string $type,
         string $scheme,

--- a/src/SDK/Common/Dsn/Dsn.php
+++ b/src/SDK/Common/Dsn/Dsn.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Dsn;
 
+/**
+ * @deprecated
+ */
 class Dsn implements DsnInterface
 {
     private string $type;

--- a/src/SDK/Common/Dsn/DsnInterface.php
+++ b/src/SDK/Common/Dsn/DsnInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Dsn;
 
+/**
+ * @deprecated
+ */
 interface DsnInterface
 {
     /** @var string  */

--- a/src/SDK/Common/Dsn/Factory.php
+++ b/src/SDK/Common/Dsn/Factory.php
@@ -7,7 +7,8 @@ namespace OpenTelemetry\SDK\Common\Dsn;
 use InvalidArgumentException;
 
 /**
- * @deprecated
+ * @phan-suppress PhanDeprecatedInterface
+ * @phan-suppress PhanDeprecatedClass
  */
 final class Factory implements FactoryInterface
 {
@@ -32,6 +33,7 @@ final class Factory implements FactoryInterface
 
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
+     * @phan-suppress PhanDeprecatedClass
      */
     #[\ReturnTypeWillChange]
     public function fromArray(array $dsn): Dsn

--- a/src/SDK/Common/Dsn/Factory.php
+++ b/src/SDK/Common/Dsn/Factory.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\SDK\Common\Dsn;
 
 use InvalidArgumentException;
 
+/**
+ * @deprecated
+ */
 final class Factory implements FactoryInterface
 {
     /** @var array  */

--- a/src/SDK/Common/Dsn/FactoryInterface.php
+++ b/src/SDK/Common/Dsn/FactoryInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Dsn;
 
+/**
+ * @deprecated
+ */
 interface FactoryInterface
 {
     public function fromArray(array $dsn): DsnInterface;

--- a/src/SDK/Common/Dsn/Parser.php
+++ b/src/SDK/Common/Dsn/Parser.php
@@ -8,6 +8,8 @@ use InvalidArgumentException;
 
 /**
  * @deprecated
+ * @phan-suppress PhanDeprecatedInterface
+ * @phan-suppress PhanDeprecatedClass
  */
 class Parser implements ParserInterface
 {
@@ -22,6 +24,9 @@ class Parser implements ParserInterface
         $this->factory = $factory ?? Factory::create();
     }
 
+    /**
+     * @phan-suppress PhanDeprecatedClass
+     */
     public static function create(FactoryInterface $factory = null): self
     {
         return new self($factory);

--- a/src/SDK/Common/Dsn/Parser.php
+++ b/src/SDK/Common/Dsn/Parser.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\SDK\Common\Dsn;
 
 use InvalidArgumentException;
 
+/**
+ * @deprecated
+ */
 class Parser implements ParserInterface
 {
     private const QUERY_ATTRIBUTE = 'query';

--- a/src/SDK/Common/Dsn/ParserInterface.php
+++ b/src/SDK/Common/Dsn/ParserInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Dsn;
 
+/**
+ * @deprecated
+ */
 interface ParserInterface
 {
     public function parse(string $dsn): DsnInterface;


### PR DESCRIPTION
I can't find any usage of these classes anywhere in main or contrib repo. rather than delete, lets deprecate and remove closer to release candidate