### PR TITLE
error log backtrace and OTEL_LOG_LEVEL support

### DIFF
--- a/src/API/Behavior/Internal/Logging.php
+++ b/src/API/Behavior/Internal/Logging.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Behavior\Internal;
+
+use Psr\Log\LogLevel;
+
+/**
+ * Logging utility functions for default (error_log) logging.
+ * This is not part of SDK configuration to avoid creating a dependency on SDK from any package which does logging.
+ * @todo this should be `@internal`, but deptrac is not happy with that.
+ */
+class Logging
+{
+    private const VARIABLE_NAME = 'OTEL_LOG_LEVEL';
+    private const DEFAULT_LEVEL = LogLevel::INFO;
+    private const NONE = 'none';
+    private const LEVELS = [
+        LogLevel::DEBUG,
+        LogLevel::INFO,
+        LogLevel::NOTICE,
+        LogLevel::WARNING,
+        LogLevel::ERROR,
+        LogLevel::CRITICAL,
+        LogLevel::ALERT,
+        LogLevel::EMERGENCY,
+        self::NONE, //highest priority so that nothing is logged
+    ];
+
+    /**
+     * The minimum log level. Messages with lower severity than this will be ignored.
+     */
+    private static ?int $logLevel = null;
+
+    /**
+     * Get level priority from level name
+     */
+    public static function level(string $level): int
+    {
+        $value = array_search($level, self::LEVELS);
+
+        return $value ?: 1; //'info'
+    }
+
+    /**
+     * Get defined OTEL_LOG_LEVEL, or default
+     */
+    public static function logLevel(): int
+    {
+        self::$logLevel ??= self::getLogLevel();
+
+        return self::$logLevel;
+    }
+
+    /**
+     * Map PSR-3 levels to error_log levels.
+     * Note that we should never use higher than E_USER_WARNING so that we do not break user applications.
+     */
+    public static function map(string $level)
+    {
+        switch ($level) {
+            case LogLevel::WARNING:
+            case LogLevel::ERROR:
+            case LogLevel::CRITICAL:
+            case LogLevel::EMERGENCY:
+                return E_USER_WARNING;
+            default:
+                return E_USER_NOTICE;
+        }
+    }
+
+    private static function getLogLevel(): int
+    {
+        $level = array_key_exists(self::VARIABLE_NAME, $_SERVER)
+            ? $_SERVER[self::VARIABLE_NAME]
+            : getenv(self::VARIABLE_NAME);
+        if (!$level) {
+            $level = ini_get(self::VARIABLE_NAME);
+        }
+        if (!$level) {
+            $level = self::DEFAULT_LEVEL;
+        }
+
+        return self::level($level);
+    }
+
+    public static function reset(): void
+    {
+        self::$logLevel = null;
+    }
+}

--- a/src/API/LoggerHolder.php
+++ b/src/API/LoggerHolder.php
@@ -44,7 +44,7 @@ final class LoggerHolder
     }
 
     /**
-     * Disable logging
+     * Disable psr-3 logging
      */
     public static function disable(): void
     {

--- a/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
@@ -8,7 +8,6 @@ use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\API\LoggerHolder;
-use OpenTelemetry\SDK\Common\Configuration\Variables;
 use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -104,7 +103,7 @@ class LogsMessagesTraitTest extends TestCase
     public function test_error_log_with_configured_otel_log_level(string $otelLogLevel, string $method, bool $expected): void
     {
         LoggerHolder::unset();
-        $this->setEnvironmentVariable(Variables::OTEL_LOG_LEVEL, $otelLogLevel);
+        $this->setEnvironmentVariable('OTEL_LOG_LEVEL', $otelLogLevel);
         $instance = $this->createInstance();
         if ($expected === true) {
             $this->expectException(PHPUnitFrameworkException::class);

--- a/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\API\Behavior;
 
+use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\API\LoggerHolder;
+use OpenTelemetry\SDK\Common\Configuration\Variables;
 use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -14,9 +17,12 @@ use Psr\Log\LogLevel;
 
 /**
  * @covers \OpenTelemetry\API\Behavior\LogsMessagesTrait
+ * @covers \OpenTelemetry\API\Behavior\Logging
  */
 class LogsMessagesTraitTest extends TestCase
 {
+    use EnvironmentVariables;
+
     // @var LoggerInterface|MockObject $logger
     protected MockObject $logger;
 
@@ -29,6 +35,7 @@ class LogsMessagesTraitTest extends TestCase
     public function tearDown(): void
     {
         LoggerHolder::unset();
+        $this->restoreEnvironmentVariables();
     }
 
     public function test_defaults_to_trigger_error_with_warning(): void
@@ -39,7 +46,7 @@ class LogsMessagesTraitTest extends TestCase
         $instance = $this->createInstance();
 
         $this->expectException(PHPUnitFrameworkException::class);
-        $this->expectExceptionMessageMatches(sprintf('/%s/', $message));
+        $this->expectExceptionMessageMatches('/LogsMessagesTraitTest->test_defaults_to_trigger_error_with_warning()/');
         $instance->run('logWarning', 'foo', ['exception' => new \Exception($message)]);
     }
 
@@ -53,6 +60,17 @@ class LogsMessagesTraitTest extends TestCase
         $this->expectException(PHPUnitFrameworkException::class);
         $this->expectExceptionMessageMatches(sprintf('/%s/', $message));
         $instance->run('logError', 'foo', ['exception' => new \Exception($message)]);
+    }
+
+    public function test_error_log_without_exception_contains_code_location(): void
+    {
+        LoggerHolder::unset();
+        $this->assertFalse(LoggerHolder::isSet());
+        $instance = $this->createInstance();
+
+        $this->expectException(PHPUnitFrameworkException::class);
+        $this->expectExceptionMessageMatches(sprintf('/%s\(/', addcslashes(__FILE__, '/')));
+        $instance->run('logWarning', 'no exception here');
     }
 
     /**
@@ -80,8 +98,36 @@ class LogsMessagesTraitTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider otelLogLevelProvider
+     */
+    public function test_error_log_with_configured_otel_log_level(string $otelLogLevel, string $method, bool $expected): void
+    {
+        LoggerHolder::unset();
+        $this->setEnvironmentVariable(Variables::OTEL_LOG_LEVEL, $otelLogLevel);
+        $instance = $this->createInstance();
+        if ($expected === true) {
+            $this->expectException(PHPUnitFrameworkException::class);
+        } else {
+            $this->assertTrue(true, 'dummy assertion');
+        }
+        $instance->run($method, 'test message');
+    }
+
+    public static function otelLogLevelProvider(): array
+    {
+        return [
+            ['warning', 'logWarning', true],
+            ['warning', 'logError', true],
+            ['warning', 'logInfo', false],
+            ['none', 'logError', false],
+        ];
+    }
+
     private function createInstance(): object
     {
+        Logging::reset();
+
         return new class() {
             use LogsMessagesTrait;
             //accessor for protected trait methods


### PR DESCRIPTION
* adding a backtrace to the errors reported via error_log (which is the default)
* implement OTEL_LOG_LEVEL, which can be used to control which errors are reported via error_log. Note that this doesn't use configuration code from the SDK, as the usage is in the API (because messages are logged from many packages) and deptrac rightly complains about the dependency on SDK.