### PR TITLE
readme badges and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,27 @@
 # OpenTelemetry for PHP
 
-See [opentelemetry.io](https://opentelemetry.io/docs/instrumentation/php/) for more information and documentation.
-
 ![CI Build](https://github.com/open-telemetry/opentelemetry-php/workflows/PHP%20QA/badge.svg)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-php/branch/master/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-php)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel--php-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/D03FAB6GN0K)
 
-<details>
-<summary>Table of Contents</summary>
-
-<!-- toc -->
-
-- [Introduction](#introduction)
-  - [Releases](#releases)
-- [Getting started](#getting-started)
-- [Project status](#project-status)
-  - [Specification conformance](#specification-conformance)
-  - [Backwards compatibility](#backwards-compatibility)
-- [Getting started](#getting-started)
-  - [Instrumenting an application](#using-opentelemetry-in-an-application)
-  - [Instrumenting a library](#using-opentelemetry-to-instrument-a-library)
-  - [Trace signals](#trace-signals)
-    - [Auto-instrumentation](#auto-instrumentation)
-    - [Framework instrumentation](#framework-instrumentation)
-    - [Manual instrumentation](#manual-instrumentation)
-    - [Distributed tracing](#distributed-tracing)
-    - [Examples](#trace-examples)
-  - [Metrics signals](#metrics-signals)
-    - [Examples](#metrics-examples)
-  - [Log signals](#log-signals)
-- [Versioning](#versioning)
-- [Contributing](#contributing)
-<!-- tocstop -->
-
-</details>
-
-# Introduction
-
 This is the **[monorepo](https://en.wikipedia.org/wiki/Monorepo)** for the **main** components of [OpenTelemetry](https://opentelemetry.io/) for PHP.
 
-## Releases
+## Documentation
+
+Please read the official documentation: https://opentelemetry.io/docs/instrumentation/php/
+
+## Packages and versions
+
+| Package              | Latest                                                                                                                                                                                                                                                                                                                                                  |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| API                  | [![Latest Stable Version](http://poser.pugx.org/open-telemetry/api/v/stable)](https://packagist.org/packages/open-telemetry/api/) [![Latest Unstable Version](http://poser.pugx.org/open-telemetry/api/v/unstable)](https://packagist.org/packages/open-telemetry/api/)                                                                                 |
+| SDK                  | [![Latest Stable Version](http://poser.pugx.org/open-telemetry/sdk/v/stable)](https://packagist.org/packages/open-telemetry/sdk/) [![Latest Unstable Version](http://poser.pugx.org/open-telemetry/sdk/v/unstable)](https://packagist.org/packages/open-telemetry/sdk/)                                                                                 |
+| Context              | [![Latest Stable Version](http://poser.pugx.org/open-telemetry/context/v/stable)](https://packagist.org/packages/open-telemetry/context/) [![Latest Unstable Version](http://poser.pugx.org/open-telemetry/context/v/unstable)](https://packagist.org/packages/open-telemetry/context/)                                                                 |
+| Semantic Conventions | [![Latest Stable Version](http://poser.pugx.org/open-telemetry/sem-conv/v/stable)](https://packagist.org/packages/open-telemetry/sem-conv/) [![Latest Unstable Version](http://poser.pugx.org/open-telemetry/sem-conv/v/unstable)](https://packagist.org/packages/open-telemetry/sem-conv/)                                                             |
+| OTLP Exporter        | [![Latest Stable Version](http://poser.pugx.org/open-telemetry/exporter-otlp/v/stable)](https://packagist.org/packages/open-telemetry/exporter-otlp/) [![Latest Unstable Version](http://poser.pugx.org/open-telemetry/exporter-otlp/v/unstable)](https://packagist.org/packages/open-telemetry/exporter-otlp/)                                         |
+| gRPC Transport       | [![Latest Stable Version](http://poser.pugx.org/open-telemetry/transport-grpc/v/stable)](https://packagist.org/packages/open-telemetry/transport-grpc/) [![Latest Unstable Version](http://poser.pugx.org/open-telemetry/transport-grpc/v/unstable)](https://packagist.org/packages/open-telemetry/transport-grpc/)                                     |
+| OTLP Protobuf Files  | [![Latest Stable Version](http://poser.pugx.org/open-telemetry/gen-otlp-protobuf/v/stable)](https://packagist.org/packages/open-telemetry/gen-otlp-protobuf/) [![Latest Unstable Version](http://poser.pugx.org/open-telemetry/gen-otlp-protobuf/v/unstable)](https://packagist.org/packages/open-telemetry/gen-otlp-protobuf/)                         |
+| B3 Propagator        | [![Latest Stable Version](http://poser.pugx.org/open-telemetry/extension-propagator-b3/v/stable)](https://packagist.org/packages/open-telemetry/extension-propagator-b3/) [![Latest Unstable Version](http://poser.pugx.org/open-telemetry/extension-propagator-b3/v/unstable)](https://packagist.org/packages/open-telemetry/extension-propagator-b3/) |
 
 Releases for both this repository and [contrib](https://github.com/open-telemetry/opentelemetry-php-contrib) are
 based on read-only [git subtree splits](https://github.com/splitsh/lite) from our monorepo. You should refer to
@@ -48,27 +30,12 @@ based on read-only [git subtree splits](https://github.com/splitsh/lite) from ou
 You can also look at the read-only repositories, which live in the
 [opentelemetry-php](https://github.com/opentelemetry-php) organization.
 
-# Getting Started
+## Contributing
 
-See [Getting Started](https://opentelemetry.io/docs/instrumentation/php/getting-started/)
-
-All OpenTelemetry libraries are distributed via packagist, notably:
-
-- API: [open-telemetry/api](https://packagist.org/packages/open-telemetry/api)
-- SDK: [open-telemetry/sdk](https://packagist.org/packages/open-telemetry/sdk)
-- Context: [open-telemetry/context](https://packagist.org/packages/open-telemetry/context)
-- Semantic Conventions: [open-telemetry/sem-conv](https://packagist.org/packages/open-telemetry/sem-conv)
-- Exporters: [open-telemetry/exporter-*](https://packagist.org/search/?query=open-telemetry&tags=exporter)
-- Extensions: [open-telemetry/extension-*](https://packagist.org/search/?query=open-telemetry&tags=extension)
-- Auto-instrumentation modules: [open-telemetry/opentelemetry-auto-*](https://packagist.org/search/?query=open-telemetry&tags=instrumentation)
-
-The [open-telemetry/opentelemetry-php-instrumentation](https://github.com/open-telemetry/opentelemetry-php-instrumentation) extension can be
-installed to enable auto-instrumentation of PHP code (in conjunction with contrib modules).
-
-The [OpenTelemetry PHP Contrib repository](https://github.com/open-telemetry/opentelemetry-php-contrib/) hosts contributions that are not part of the core
-distribution or components of the library.
+We would love to have you on board, please see our [Development README](./DEVELOPMENT.md) and [Contributing README](./CONTRIBUTING.md).
 
 ## Specification conformance
+
 We attempt to keep the [OpenTelemetry Specification Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/master/spec-compliance-matrix.md) up to date in order to show which features are available and which have not yet been implemented.
 
 If you find an inconsistency in the data in the matrix, please let us know in our slack channel and we'll get it rectified.
@@ -77,106 +44,6 @@ If you find an inconsistency in the data in the matrix, please let us know in ou
 
 See [compatibility readme](src/SDK/Common/Dev/Compatibility/README.md).
 
-# Requirements
-
-See https://opentelemetry.io/docs/php/getting-started#requirements
-
-## Using OpenTelemetry in an Application
-
-Your application should only depend on Interfaces provided by the API package:
-
-```bash
-$ composer require open-telemetry/api
-```
-In the best case you will use [Dependency Inversion](https://en.wikipedia.org/wiki/Dependency_inversion_principle)
-and write an adapter to not depend on the API directly.
-
-Make sure your application works with a dependency on the API only, however to make full use of the library
-you want to install the **SDK** package and an exporter from the **Contrib** packages as well:
-
-```bash
-$ composer require open-telemetry/sdk
-```
-or
-```bash
-$ composer require open-telemetry/sdk open-telemetry/exporter-zipkin
-```
-Make sure any **SDK** or **Contrib** code is set up by your configuration, bootstrap, dependency injection, etc.
-
-## Using OpenTelemetry to instrument a Library
-
-Your library should only depend on Interfaces provided by the API package:
-
-```bash
-$ composer require open-telemetry/api
-```
-
-For development and testing purposes you also want to install **SDK** and **Contrib** packages:
-```bash
-$ composer require --dev open-telemetry/sdk open-telemetry/sdk-contrib
-```
-
-## SDK autoloading
-
-See https://opentelemetry.io/docs/instrumentation/php/sdk#autoloading
-
-See [autoload_sdk.php example](./examples/autoload_sdk.php)
-
-## Configuration
-
-See https://opentelemetry.io/docs/instrumentation/php/sdk#configuration
-
-## Trace signals
-
-### Auto-instrumentation
-
-See https://opentelemetry.io/docs/instrumentation/php/automatic/
-
-### Framework instrumentation
-
-* [Symfony SDK Bundle](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Symfony/)
-
-### Distributed tracing
-
-See https://opentelemetry.io/docs/instrumentation/php/propagation/
-
-See [examples/traces/demo](examples/traces/demo) for a working example.
-
-### Trace examples
-
-You can use the [zipkin](/examples/traces/exporters/zipkin.php) example to test out the reference
-implementations. This example performs a sample trace with a grouping of 5 spans and exports the result
-to a local zipkin or jaeger instance.
-
-If you'd like a no-fuss way to test this out with docker and docker-compose, you can perform the following simple steps:
-
-1) Install the necessary dependencies by running `make install`.
-2) Execute the example trace using `make smoke-test-exporter-examples:`.
-
-Exported spans can be seen in zipkin at [http://127.0.0.1:9411](http://127.0.0.1:9411)
-
-Exported spans can also be seen in jaeger at [http://127.0.0.1:16686](http://127.0.0.1:16686)
-
-## Metrics signals
-
-See https://opentelemetry.io/docs/instrumentation/php/manual/#metrics
-
-### Metrics examples
-
-See [basic example](./examples/metrics/basic.php)
-
-## Log signals
-
-See https://opentelemetry.io/docs/instrumentation/php/manual/#logging
-
-### Logging examples
-
-See [getting started example](./examples/logs/getting_started.php)
-
-# Versioning
+## Versioning
 
 Versioning rationale can be found in the [Versioning Documentation](/docs/versioning.md)
-
-# Contributing
-
-We would love to have you on board, please see our [Development README](./DEVELOPMENT.md) and [Contributing README](./CONTRIBUTING.md).

--- a/proto/otel/README.md
+++ b/proto/otel/README.md
@@ -1,3 +1,8 @@
+[![Source](https://img.shields.io/badge/source-gen--otlp--protobuf-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/proto/otel)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:gen--otlp--protobuf-blue)](https://github.com/opentelemetry-php/gen-otlp-protobuf)
+[![Latest Version](http://poser.pugx.org/open-telemetry/gen-otlp-protobuf/v/unstable)](https://packagist.org/packages/open-telemetry/gen-otlp-protobuf/)
+[![Stable](http://poser.pugx.org/open-telemetry/gen-otlp-protobuf/v/stable)](https://packagist.org/packages/open-telemetry/gen-otlp-protobuf/)
+
 # OpenTelemetry protobuf files
 
 ## Protobuf Runtime library

--- a/proto/otel/README.md
+++ b/proto/otel/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/gen-otlp-protobuf/releases)
 [![Source](https://img.shields.io/badge/source-gen--otlp--protobuf-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/proto/otel)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:gen--otlp--protobuf-blue)](https://github.com/opentelemetry-php/gen-otlp-protobuf)
 [![Latest Version](http://poser.pugx.org/open-telemetry/gen-otlp-protobuf/v/unstable)](https://packagist.org/packages/open-telemetry/gen-otlp-protobuf/)

--- a/src/API/README.md
+++ b/src/API/README.md
@@ -1,1 +1,8 @@
+[![Source](https://img.shields.io/badge/source-api-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/API)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:api-blue)](https://github.com/opentelemetry-php/api)
+[![Latest Version](http://poser.pugx.org/open-telemetry/api/v/unstable)](https://packagist.org/packages/open-telemetry/api/)
+[![Stable](http://poser.pugx.org/open-telemetry/api/v/stable)](https://packagist.org/packages/open-telemetry/api/)
+
 # OpenTelemetry API
+
+Documentation: https://opentelemetry.io/docs/instrumentation/php

--- a/src/API/README.md
+++ b/src/API/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/api/releases)
 [![Source](https://img.shields.io/badge/source-api-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/API)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:api-blue)](https://github.com/opentelemetry-php/api)
 [![Latest Version](http://poser.pugx.org/open-telemetry/api/v/unstable)](https://packagist.org/packages/open-telemetry/api/)

--- a/src/Context/README.md
+++ b/src/Context/README.md
@@ -1,3 +1,8 @@
+[![Source](https://img.shields.io/badge/source-context-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Context)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:context-blue)](https://github.com/opentelemetry-php/context)
+[![Latest Version](http://poser.pugx.org/open-telemetry/context/v/unstable)](https://packagist.org/packages/open-telemetry/context/)
+[![Stable](http://poser.pugx.org/open-telemetry/context/v/stable)](https://packagist.org/packages/open-telemetry/context/)
+
 # OpenTelemetry Context
 
 Immutable execution scoped propagation mechanism, for further details see [opentelemetry-specification][1].

--- a/src/Context/README.md
+++ b/src/Context/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/context/releases)
 [![Source](https://img.shields.io/badge/source-context-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Context)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:context-blue)](https://github.com/opentelemetry-php/context)
 [![Latest Version](http://poser.pugx.org/open-telemetry/context/v/unstable)](https://packagist.org/packages/open-telemetry/context/)

--- a/src/Contrib/Grpc/README.md
+++ b/src/Contrib/Grpc/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/transport-grpc/releases)
 [![Source](https://img.shields.io/badge/source-transport--grpc-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Grpc)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:transport--grpc-blue)](https://github.com/opentelemetry-php/transport-grpc)
 [![Latest Version](http://poser.pugx.org/open-telemetry/transport-grpc/v/unstable)](https://packagist.org/packages/open-telemetry/transport-grpc/)

--- a/src/Contrib/Grpc/README.md
+++ b/src/Contrib/Grpc/README.md
@@ -1,6 +1,19 @@
+[![Source](https://img.shields.io/badge/source-transport--grpc-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Grpc)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:transport--grpc-blue)](https://github.com/opentelemetry-php/transport-grpc)
+[![Latest Version](http://poser.pugx.org/open-telemetry/transport-grpc/v/unstable)](https://packagist.org/packages/open-telemetry/transport-grpc/)
+[![Stable](http://poser.pugx.org/open-telemetry/transport-grpc/v/stable)](https://packagist.org/packages/open-telemetry/transport-grpc/)
+
+
 # OpenTelemetry gRPC Transport
 
 gRPC transport for OpenTelemetry.
+
+This package provides a transport which can be used by `open-telemetry/exporter-otlp` to send protobuf-encoded telemetry
+over gRPC.
+
+## Documentation
+
+https://opentelemetry.io/docs/instrumentation/php/exporters/#otlp
 
 ## Usage
 

--- a/src/Contrib/Otlp/README.md
+++ b/src/Contrib/Otlp/README.md
@@ -1,4 +1,13 @@
+[![Source](https://img.shields.io/badge/source-exporter--otlp-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Otlp)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:exporter--otlp-blue)](https://github.com/opentelemetry-php/exporter-otlp)
+[![Latest Version](http://poser.pugx.org/open-telemetry/exporter-otlp/v/unstable)](https://packagist.org/packages/open-telemetry/exporter-otlp/)
+[![Stable](http://poser.pugx.org/open-telemetry/exporter-otlp/v/stable)](https://packagist.org/packages/open-telemetry/exporter-otlp/)
+
 # OpenTelemetry OTLP exporter
+
+## Documentation
+
+https://opentelemetry.io/docs/instrumentation/php/exporters/#otlp
 
 ## Usage
 

--- a/src/Contrib/Otlp/README.md
+++ b/src/Contrib/Otlp/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/exporter-otlp/releases)
 [![Source](https://img.shields.io/badge/source-exporter--otlp-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Otlp)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:exporter--otlp-blue)](https://github.com/opentelemetry-php/exporter-otlp)
 [![Latest Version](http://poser.pugx.org/open-telemetry/exporter-otlp/v/unstable)](https://packagist.org/packages/open-telemetry/exporter-otlp/)

--- a/src/Contrib/Zipkin/README.md
+++ b/src/Contrib/Zipkin/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/exporter-zipkin/releases)
 [![Source](https://img.shields.io/badge/source-exporter--zipkin-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Zipkin)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:exporter--zipkin-blue)](https://github.com/opentelemetry-php/exporter-zipkin)
 [![Latest Version](http://poser.pugx.org/open-telemetry/exporter-zipkin/v/unstable)](https://packagist.org/packages/open-telemetry/exporter-zipkin/)

--- a/src/Contrib/Zipkin/README.md
+++ b/src/Contrib/Zipkin/README.md
@@ -1,6 +1,15 @@
+[![Source](https://img.shields.io/badge/source-exporter--zipkin-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Zipkin)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:exporter--zipkin-blue)](https://github.com/opentelemetry-php/exporter-zipkin)
+[![Latest Version](http://poser.pugx.org/open-telemetry/exporter-zipkin/v/unstable)](https://packagist.org/packages/open-telemetry/exporter-zipkin/)
+[![Stable](http://poser.pugx.org/open-telemetry/exporter-zipkin/v/stable)](https://packagist.org/packages/open-telemetry/exporter-zipkin/)
+
 # OpenTelemetry Zipkin Exporter
 
 Zipkin exporter for OpenTelemetry.
+
+## Documentation
+
+https://opentelemetry.io/docs/instrumentation/php/exporters/#zipkin
 
 ## Usage
 

--- a/src/Extension/Propagator/B3/README.md
+++ b/src/Extension/Propagator/B3/README.md
@@ -1,3 +1,8 @@
+[![Source](https://img.shields.io/badge/source-extension--propagator--b3-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Extension/Propagator/B3)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:extension--propagator--b3-blue)](https://github.com/opentelemetry-php/extension-propagator-b3)
+[![Latest Version](http://poser.pugx.org/open-telemetry/extension-propagator-b3/v/unstable)](https://packagist.org/packages/open-telemetry/extension-propagator-b3/)
+[![Stable](http://poser.pugx.org/open-telemetry/extension-propagator-b3/v/stable)](https://packagist.org/packages/open-telemetry/extension-propagator-b3/)
+
 # OpenTelemetry Extension
 ### B3 Propagator
 

--- a/src/Extension/Propagator/B3/README.md
+++ b/src/Extension/Propagator/B3/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/extension-propagator-b3/releases)
 [![Source](https://img.shields.io/badge/source-extension--propagator--b3-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Extension/Propagator/B3)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:extension--propagator--b3-blue)](https://github.com/opentelemetry-php/extension-propagator-b3)
 [![Latest Version](http://poser.pugx.org/open-telemetry/extension-propagator-b3/v/unstable)](https://packagist.org/packages/open-telemetry/extension-propagator-b3/)

--- a/src/SDK/README.md
+++ b/src/SDK/README.md
@@ -1,6 +1,15 @@
+[![Source](https://img.shields.io/badge/source-sdk-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/SDK)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:sdk-blue)](https://github.com/opentelemetry-php/sdk)
+[![Latest Version](http://poser.pugx.org/open-telemetry/sdk/v/unstable)](https://packagist.org/packages/open-telemetry/sdk/)
+[![Stable](http://poser.pugx.org/open-telemetry/sdk/v/stable)](https://packagist.org/packages/open-telemetry/sdk/)
+
 # OpenTelemetry SDK
 
 The OpenTelemetry PHP SDK implements the API, and should be used in conjunction with contributed exporter(s) to generate and export telemetry.
+
+## Documentation
+
+https://opentelemetry.io/docs/instrumentation/php/sdk/
 
 ## Getting started
 

--- a/src/SDK/README.md
+++ b/src/SDK/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/sdk/releases)
 [![Source](https://img.shields.io/badge/source-sdk-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/SDK)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:sdk-blue)](https://github.com/opentelemetry-php/sdk)
 [![Latest Version](http://poser.pugx.org/open-telemetry/sdk/v/unstable)](https://packagist.org/packages/open-telemetry/sdk/)

--- a/src/SemConv/README.md
+++ b/src/SemConv/README.md
@@ -1,3 +1,8 @@
+[![Source](https://img.shields.io/badge/source-sem--conv-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/SemConv)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:sem--conv-blue)](https://github.com/opentelemetry-php/sem-conv)
+[![Latest Version](http://poser.pugx.org/open-telemetry/sem-conv/v/unstable)](https://packagist.org/packages/open-telemetry/sem-conv/)
+[![Stable](http://poser.pugx.org/open-telemetry/sem-conv/v/stable)](https://packagist.org/packages/open-telemetry/sem-conv/)
+
 # OpenTelemetry Semantic Conventions
 
 Common semantic conventions used by OpenTelemetry implementations across all languages.

--- a/src/SemConv/README.md
+++ b/src/SemConv/README.md
@@ -1,3 +1,4 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/sem-conv/releases)
 [![Source](https://img.shields.io/badge/source-sem--conv-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/SemConv)
 [![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:sem--conv-blue)](https://github.com/opentelemetry-php/sem-conv)
 [![Latest Version](http://poser.pugx.org/open-telemetry/sem-conv/v/unstable)](https://packagist.org/packages/open-telemetry/sem-conv/)


### PR DESCRIPTION
* adding badges to the various readme files to make more obvious the current versions
* list all packages and versions in main readme
* remove old README documentation (excluding development-specific), and direct users to opentelemetry.io
* link to opentelemetry.io where possible in package readme