### PR TITLE
fixing homogenous check for attributes with non-numeric keys

### DIFF
--- a/src/SDK/Common/Attribute/AttributesBuilder.php
+++ b/src/SDK/Common/Attribute/AttributesBuilder.php
@@ -121,7 +121,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
         if (count($value) <= 1) {
             return true;
         }
-        $type = gettype($value[0]);
+        $type = gettype(reset($value));
         foreach ($value as $v) {
             if (in_array(gettype($v), self::NUMERICS) && in_array($type, self::NUMERICS)) {
                 continue;

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -514,6 +514,7 @@ class SpanTest extends MockeryTestCase
             [['foo', false]],
             [['foo', 'bar', 3]],
             [[5, 3.14, true]],
+            [['one' => 1, 'two' => true]],
         ];
     }
 
@@ -535,6 +536,7 @@ class SpanTest extends MockeryTestCase
             'int and double' => [[3, 3.14159]],
             'integers' => [[3, 1, 5]],
             'doubles' => [[1.25, 3.11]],
+            'strings with non-numeric keys' => [['foo' => 'foo', 'bar' => 'bar']],
         ];
     }
 


### PR DESCRIPTION
use reset() instead of trying to get zero array key