### PR TITLE
require google/protobuf (native)

### DIFF
--- a/proto/otel/README.md
+++ b/proto/otel/README.md
@@ -8,20 +8,19 @@
 
 ## Protobuf Runtime library
 
+OTLP exporting requires a [protobuf runtime library](https://github.com/protocolbuffers/protobuf/tree/main/php).
+
 There exist two protobuf runtime libraries that offer the same set of APIs, allowing developers to choose the one that 
 best suits their needs.
 
-The first and easiest option is to install the Protobuf PHP Runtime Library through composer. This can be the easiest 
-way to get started quickly. Either run `composer require google/protobuf`, or update your `composer.json` as follows:
-
-```json
-"require": {
-  "google/protobuf": "^v3.3.0"
-}
-```
+This package requires `google/protobuf`, which is the native implementation. It is easy to install and a good way to get
+started quickly.
 
 Alternatively, and the recommended option for production is to install the Protobuf C extension for PHP. The extension
-makes both exporters _significantly_ more performant. This can be easily installed with the following command:
-```sh
-$ sudo pecl install protobuf
+makes OTLP exporting _significantly_ more performant. The extension can be installed with the following command:
+
+```shell
+pecl install protobuf
 ```
+
+The extension can be installed alongside the native library, and it will be used instead if available.

--- a/proto/otel/composer.json
+++ b/proto/otel/composer.json
@@ -17,7 +17,8 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^7.4 || ^8.0",
+        "google/protobuf": "^3.3.0"
     },
     "autoload": {
         "psr-4": {
@@ -26,8 +27,7 @@
         }
     },
     "suggest": {
-        "ext-protobuf": "For better performance, when dealing with the protobuf format",
-        "google/protobuf": "To get started quickly, install the native protobuf library."
+        "ext-protobuf": "For better performance, when dealing with the protobuf format"
     },
     "extra": {
         "branch-alias": {

--- a/rector.php
+++ b/rector.php
@@ -28,5 +28,6 @@ return static function (RectorConfig $rectorConfig): void {
         \Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector::class,
         \Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector::class,
         \Rector\RemovingStatic\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector::class,
+        \Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector::class,
     ]);
 };

--- a/src/Contrib/Otlp/README.md
+++ b/src/Contrib/Otlp/README.md
@@ -16,10 +16,6 @@ See https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/trace
 
 ## Http transport
 
-To export over HTTP, you will need to provide implementations for [http factory implementation](https://packagist.org/providers/psr/http-factory-implementation) and [async-client-implementation](https://packagist.org/providers/php-http/async-client-implementation).
-
-You will also need to install [php-http/discovery](https://packagist.org/packages/php-http/discovery).
-
 ```php
 $transport = (new \OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory())->create('http://collector:4318');
 $exporter = new \OpenTelemetry\Contrib\Otlp\SpanExporter($transport);
@@ -27,24 +23,18 @@ $exporter = new \OpenTelemetry\Contrib\Otlp\SpanExporter($transport);
 
 ## gRPC transport
 
-To export over gRPC, you will need to additionally install the `open-telemetry/exporter-grpc` package.
+To export over gRPC, you will need to additionally install the `open-telemetry/transport-grpc` package.
 
 ## Protobuf Runtime library
 
-There exist two protobuf runtime libraries that offer the same set of APIs, allowing developers to choose the one that
-best suits their needs. You must install one of them, in order to use the OTLP exporter.
+OTLP exporting requires a [protobuf implementation](https://github.com/protocolbuffers/protobuf/tree/main/php).
 
-The first and easiest option is to install the Protobuf PHP Runtime Library through composer. This can be the easiest
-way to get started quickly. Either run `composer require google/protobuf`, or update your `composer.json` as follows:
+The `open-telemetry/gen-otlp-protobuf` requires the `google/protobuf` native implementation. It's fine for development, but
+not recommended for production usage.
 
-```json
-"require": {
-  "google/protobuf": "^v3.3.0"
-}
-```
+The recommended option for production is to install the Protobuf C extension for PHP. The extension
+makes exporting _significantly_ more performant. This can be easily installed with the following command:
 
-Alternatively, and the recommended option for production is to install the Protobuf C extension for PHP. The extension
-makes both exporters _significantly_ more performant. This can be easily installed with the following command:
-```sh
-$ sudo pecl install protobuf
+```shell
+pecl install protobuf
 ```

--- a/src/Contrib/Otlp/composer.json
+++ b/src/Contrib/Otlp/composer.json
@@ -24,9 +24,6 @@
     "open-telemetry/sdk": "^1.0"
   },
   "suggest": {
-    "php-http/async-client-implementation": "For otlp/http exporting",
-    "php-http/discovery": "For otlp/http exporting",
-    "psr/http-factory-implementation": "For otlp/http exporting"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
We made protobuf implementation optional back in #949 however it seems to be tripping up a number of developers. Since native + extension can be installed at the same time (with extension taking priority), I think that users will be less surprised when starting out if there is a working implementation by default.