### PR TITLE
refactor attribute validation

### DIFF
--- a/src/SDK/Common/Attribute/AttributeValidator.php
+++ b/src/SDK/Common/Attribute/AttributeValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Attribute;
+
+class AttributeValidator implements AttributeValidatorInterface
+{
+    private const PRIMITIVES = [
+        'string',
+        'integer',
+        'double',
+        'boolean',
+    ];
+    private const NUMERICS = [
+        'double',
+        'integer',
+    ];
+
+    /**
+     * Validate whether a value is a primitive, or a homogeneous array of primitives (treating int/double as equivalent).
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/common/README.md#attribute
+     */
+    public function validate($value): bool
+    {
+        if (is_array($value)) {
+            return $this->validateArray($value);
+        }
+
+        return in_array(gettype($value), self::PRIMITIVES);
+    }
+
+    private function validateArray(array $value): bool
+    {
+        if ($value === []) {
+            return true;
+        }
+        $type = gettype(reset($value));
+        if (!in_array($type, self::PRIMITIVES)) {
+            return false;
+        }
+        foreach ($value as $v) {
+            if (in_array(gettype($v), self::NUMERICS) && in_array($type, self::NUMERICS)) {
+                continue;
+            }
+            if (gettype($v) !== $type) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function getInvalidMessage(): string
+    {
+        return 'attribute with non-primitive or non-homogeneous array of primitives dropped';
+    }
+}

--- a/src/SDK/Common/Attribute/AttributeValidatorInterface.php
+++ b/src/SDK/Common/Attribute/AttributeValidatorInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Attribute;
+
+interface AttributeValidatorInterface
+{
+    public function validate($value): bool;
+    public function getInvalidMessage(): string;
+}

--- a/src/SDK/Common/Attribute/AttributesFactory.php
+++ b/src/SDK/Common/Attribute/AttributesFactory.php
@@ -18,13 +18,14 @@ final class AttributesFactory implements AttributesFactoryInterface
         $this->attributeValueLengthLimit = $attributeValueLengthLimit;
     }
 
-    public function builder(iterable $attributes = []): AttributesBuilderInterface
+    public function builder(iterable $attributes = [], ?AttributeValidatorInterface $attributeValidator = null): AttributesBuilderInterface
     {
         $builder = new AttributesBuilder(
             [],
             $this->attributeCountLimit,
             $this->attributeValueLengthLimit,
             0,
+            $attributeValidator,
         );
         foreach ($attributes as $key => $value) {
             $builder[$key] = $value;

--- a/src/SDK/Common/Attribute/AttributesFactoryInterface.php
+++ b/src/SDK/Common/Attribute/AttributesFactoryInterface.php
@@ -6,5 +6,5 @@ namespace OpenTelemetry\SDK\Common\Attribute;
 
 interface AttributesFactoryInterface
 {
-    public function builder(iterable $attributes = []): AttributesBuilderInterface;
+    public function builder(iterable $attributes = [], ?AttributeValidatorInterface $attributeValidator = null): AttributesBuilderInterface;
 }

--- a/src/SDK/Common/Attribute/FilteredAttributesFactory.php
+++ b/src/SDK/Common/Attribute/FilteredAttributesFactory.php
@@ -21,9 +21,9 @@ final class FilteredAttributesFactory implements AttributesFactoryInterface
         $this->rejectedKeys = $rejectedKeys;
     }
 
-    public function builder(iterable $attributes = []): AttributesBuilderInterface
+    public function builder(iterable $attributes = [], ?AttributeValidatorInterface $attributeValidator = null): AttributesBuilderInterface
     {
-        $builder = new FilteredAttributesBuilder($this->factory->builder(), $this->rejectedKeys);
+        $builder = new FilteredAttributesBuilder($this->factory->builder([], $attributeValidator), $this->rejectedKeys);
         foreach ($attributes as $attribute => $value) {
             $builder[$attribute] = $value;
         }

--- a/src/SDK/Common/Attribute/LogRecordAttributeValidator.php
+++ b/src/SDK/Common/Attribute/LogRecordAttributeValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Attribute;
+
+class LogRecordAttributeValidator implements AttributeValidatorInterface
+{
+    public function validate($value): bool
+    {
+        return true;
+    }
+
+    public function getInvalidMessage(): string
+    {
+        //not required as this validator always returns true
+        return 'unused';
+    }
+}

--- a/src/SDK/Logs/ReadableLogRecord.php
+++ b/src/SDK/Logs/ReadableLogRecord.php
@@ -10,6 +10,7 @@ use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
+use OpenTelemetry\SDK\Common\Attribute\LogRecordAttributeValidator;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 
@@ -43,7 +44,7 @@ class ReadableLogRecord extends LogRecord
         $this->convertedAttributes = $this->loggerSharedState
             ->getLogRecordLimits()
             ->getAttributeFactory()
-            ->builder($logRecord->attributes)
+            ->builder($logRecord->attributes, new LogRecordAttributeValidator())
             ->build();
     }
 

--- a/tests/Unit/SDK/Common/Attribute/AttributeValidatorTest.php
+++ b/tests/Unit/SDK/Common/Attribute/AttributeValidatorTest.php
@@ -68,7 +68,7 @@ class AttributeValidatorTest extends TestCase
         return [
             'empty array' => [[], true],
             'array of strings' => [['one', 'two'], true],
-            'array of int' => [[1, 2], true],
+            'array of ints' => [[1, 2], true],
             'array of double' => [[1.1, 1.2], true],
             'mixed numerics' => [[2, 3.5, PHP_INT_MAX], true],
             'array of bool' => [[true, false], true],

--- a/tests/Unit/SDK/Common/Attribute/AttributeValidatorTest.php
+++ b/tests/Unit/SDK/Common/Attribute/AttributeValidatorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Common\Attribute;
+
+use OpenTelemetry\SDK\Common\Attribute\AttributeValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\SDK\Common\Attribute\AttributeValidator
+ */
+class AttributeValidatorTest extends TestCase
+{
+    private AttributeValidator $validator;
+
+    public function setUp(): void
+    {
+        $this->validator = new AttributeValidator();
+    }
+
+    /**
+     * @dataProvider primitiveProvider
+     */
+    public function test_validate_primitives($value): void
+    {
+        $this->assertTrue($this->validator->validate($value));
+    }
+
+    public static function primitiveProvider(): array
+    {
+        return [
+            'bool true' => [true],
+            'bool false' => [false],
+            'string' => ['hello otel'],
+            'int' => [4],
+            'double' => [3.14159],
+        ];
+    }
+
+    /**
+     * @dataProvider nonPrimitiveProvider
+     */
+    public function test_validate_non_primitives($value): void
+    {
+        $this->assertFalse($this->validator->validate($value));
+    }
+
+    public static function nonPrimitiveProvider(): array
+    {
+        return [
+            'object' => [new \stdClass()],
+            'null' => [null],
+            'resource' => [tmpfile()],
+        ];
+    }
+
+    /**
+     * @dataProvider arrayProvider
+     */
+    public function test_validate_array($value, bool $expected): void
+    {
+        $this->assertSame($expected, $this->validator->validate($value));
+    }
+
+    public static function arrayProvider(): array
+    {
+        return [
+            'empty array' => [[], true],
+            'array of strings' => [['one', 'two'], true],
+            'array of int' => [[1, 2], true],
+            'array of double' => [[1.1, 1.2], true],
+            'mixed numerics' => [[2, 3.5, PHP_INT_MAX], true],
+            'array of bool' => [[true, false], true],
+            'mixed array' => [[true, 'one', 2], false],
+            'complex array' => [['one' => ['one']], false],
+        ];
+    }
+}


### PR DESCRIPTION
moving private method into a testable class, introduce attribute validation class which applies to most attribute. LogRecord attributes are allowed to be complex, so introduce a validator for these which lets everything through.

Fixes #1074 