### PR TITLE
handle KeyValue otlp attributes

### DIFF
--- a/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
@@ -16,7 +16,6 @@ use Psr\Log\LogLevel;
 
 /**
  * @covers \OpenTelemetry\API\Behavior\LogsMessagesTrait
- * @covers \OpenTelemetry\API\Behavior\Logging
  */
 class LogsMessagesTraitTest extends TestCase
 {

--- a/tests/Unit/Contrib/Otlp/AttributesConverterTest.php
+++ b/tests/Unit/Contrib/Otlp/AttributesConverterTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\Contrib\Otlp;
+
+use OpenTelemetry\Contrib\Otlp\AttributesConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\Contrib\Otlp\AttributesConverter
+ */
+class AttributesConverterTest extends TestCase
+{
+    /**
+     * @dataProvider basicTypesProvider
+     */
+    public function test_convert_basic_types($value, string $expected): void
+    {
+        $json = AttributesConverter::convertAnyValue($value)->serializeToJsonString();
+        $this->assertJsonStringEqualsJsonString($json, $expected);
+    }
+
+    public static function basicTypesProvider(): array
+    {
+        return [
+            'string' => ['foo', '{"stringValue":"foo"}'],
+            'bool:true' => [true, '{"boolValue":true}'],
+            'bool:false' => [false, '{"boolValue":false}'],
+            'int:zero' => [0, '{"intValue":"0"}'],
+            'int:positive' => [3, '{"intValue":"3"}'],
+            'int:negative' => [-2, '{"intValue":"-2"}'],
+            'float:zero' => [0.0, '{"doubleValue":0.0}'],
+            'float:positive' => [3.14159, '{"doubleValue":3.14159}'],
+            'float:negative' => [-2.7, '{"doubleValue":-2.7}'],
+        ];
+    }
+
+    /**
+     * @dataProvider arrayProvider
+     */
+    public function test_is_simple_array(array $value, bool $expected): void
+    {
+        $this->assertSame($expected, AttributesConverter::isSimpleArray($value));
+    }
+
+    public static function arrayProvider(): array
+    {
+        return [
+            'simple' => [[1,2,3,4], true],
+            'empty' => [[], true],
+            'kv' => [['key' => 'value'], false],
+        ];
+    }
+
+    public function test_homogeneous_array_of_primitives(): void
+    {
+        $expected = '{"arrayValue":{"values":[{"intValue":"1"},{"intValue":"2"},{"intValue":"3"},{"intValue":"4"},{"intValue":"5"}]}}';
+        $json = AttributesConverter::convertAnyValue([1,2,3,4,5])->serializeToJsonString();
+        $this->assertJsonStringEqualsJsonString($json, $expected);
+    }
+
+    public function test_complex_array(): void
+    {
+        $expected = '{"kvlistValue":{"values":[{"key":"nested","value":{"arrayValue":{"values":[{"intValue":"123"},{"stringValue":"abc"},{"kvlistValue":{"values":[{"key":"sub","value":{"stringValue":"val"}}]}}]}}}]}}';
+        $json = AttributesConverter::convertAnyValue(['nested' => [123, 'abc', ['sub'=>'val']]])->serializeToJsonString();
+        $this->assertJsonStringEqualsJsonString($json, $expected);
+    }
+
+    public function test_kv_array_with_array_values(): void
+    {
+        $expected = '{"kvlistValue":{"values":[{"key":"nested","value":{"arrayValue":{"values":[{"intValue":"123"},{"intValue":"456"}]}}}]}}';
+        $json = AttributesConverter::convertAnyValue(['nested' => [123, 456]])->serializeToJsonString();
+        $this->assertJsonStringEqualsJsonString($json, $expected);
+    }
+}


### PR DESCRIPTION
if an array is non-simple (has keys), it should be represented as a KeyValue in the generated protobuf-encoded output.
Since we also need to support simple arrays of primitives, I've added a basic check so that those are still represented as ArrayValue.

Fixes #1076 