### PR TITLE
config to API, .env support

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,11 +13,6 @@ parameters:
         - tests/TraceContext/W3CTestService
     ignoreErrors:
         -
-            message: "#Call to an undefined method .*#"
-            paths:
-                - tests/Unit/SDK/Common/Configuration/Resolver/PhpIniResolverTest.php
-                - tests/Unit/SDK/Common/Configuration/Resolver/CompositeResolverTest.php
-        -
             message: "#Call to an undefined method .*:allows.*#"
             paths:
                 - tests

--- a/src/API/Configuration/ClassConstantAccessor.php
+++ b/src/API/Configuration/ClassConstantAccessor.php
@@ -2,10 +2,13 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Util;
+namespace OpenTelemetry\API\Configuration;
 
 use LogicException;
 
+/**
+ * @psalm-internal \OpenTelemetry
+ */
 class ClassConstantAccessor
 {
     public static function requireValue(string $className, string $constantName)

--- a/src/API/Configuration/Parser/BooleanParser.php
+++ b/src/API/Configuration/Parser/BooleanParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Parser;
+namespace OpenTelemetry\API\Configuration\Parser;
 
 use InvalidArgumentException;
 

--- a/src/API/Configuration/Parser/ListParser.php
+++ b/src/API/Configuration/Parser/ListParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Parser;
+namespace OpenTelemetry\API\Configuration\Parser;
 
 class ListParser
 {

--- a/src/API/Configuration/Parser/MapParser.php
+++ b/src/API/Configuration/Parser/MapParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Parser;
+namespace OpenTelemetry\API\Configuration\Parser;
 
 use InvalidArgumentException;
 

--- a/src/API/Configuration/Parser/RatioParser.php
+++ b/src/API/Configuration/Parser/RatioParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Parser;
+namespace OpenTelemetry\API\Configuration\Parser;
 
 use InvalidArgumentException;
 use RangeException;

--- a/src/API/Configuration/Resolver/CompositeResolver.php
+++ b/src/API/Configuration/Resolver/CompositeResolver.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Resolver;
-
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+namespace OpenTelemetry\API\Configuration\Resolver;
 
 /**
- * @interal
+ * @psalm-internal \OpenTelemetry\API\Configuration
  */
 class CompositeResolver
 {
@@ -20,6 +18,7 @@ class CompositeResolver
         $instance ??= new self([
             new PhpIniResolver(),
             new EnvironmentResolver(),
+            new DotEnvResolver(),
         ]);
 
         return $instance;
@@ -50,9 +49,7 @@ class CompositeResolver
             }
         }
 
-        return Configuration::isEmpty($default)
-            ? Configuration::getDefault($variableName)
-            : $default;
+        return $default;
     }
 
     public function hasVariable(string $variableName): bool

--- a/src/API/Configuration/Resolver/DotEnvResolver.php
+++ b/src/API/Configuration/Resolver/DotEnvResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Configuration\Resolver;
+
+/**
+ * Resolve variables from a `.env` file
+ * @psalm-internal \OpenTelemetry\API\Configuration
+ */
+class DotEnvResolver implements ResolverInterface
+{
+    private array $values = [];
+
+    public function __construct(string $path = null)
+    {
+        $path ??= getcwd();
+        $filename = "{$path}/.env";
+        if (file_exists($filename)) {
+            $fp = fopen($filename, 'r');
+            while (($buffer = fgets($fp, 4096)) !== false) {
+                if (preg_match('/^ *#.*/', $buffer)) {
+                    continue;
+                }
+                [$key, $value] = $this->split($buffer);
+                if ($key && $value) {
+                    $this->values[$key] = $value;
+                }
+            }
+        }
+    }
+
+    public function retrieveValue(string $variableName)
+    {
+        return $this->values[$variableName];
+    }
+
+    public function hasVariable(string $variableName): bool
+    {
+        return array_key_exists($variableName, $this->values);
+    }
+
+    private function split(string $line): array
+    {
+        $pos = strpos($line, '#'); //start of comment
+        if ($pos !== false) {
+            $line = substr($line, 0, $pos);
+        }
+        $parts = explode('=', $line, 2);
+        if (count($parts) !== 2) {
+            return [false, false];
+        }
+
+        return array_map('trim', $parts);
+    }
+}

--- a/src/API/Configuration/Resolver/EnvironmentResolver.php
+++ b/src/API/Configuration/Resolver/EnvironmentResolver.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Resolver;
+namespace OpenTelemetry\API\Configuration\Resolver;
 
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\API\Configuration;
 
 /**
- * @internal
+ * Resolve variables from environment, via $_SERVER then `getenv()`
+ * @psalm-internal \OpenTelemetry\API\Configuration
  */
 class EnvironmentResolver implements ResolverInterface
 {

--- a/src/API/Configuration/Resolver/PhpIniAccessor.php
+++ b/src/API/Configuration/Resolver/PhpIniAccessor.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Resolver;
+namespace OpenTelemetry\API\Configuration\Resolver;
 
+/**
+ * @internal
+ */
 class PhpIniAccessor
 {
     /**

--- a/src/API/Configuration/Resolver/PhpIniResolver.php
+++ b/src/API/Configuration/Resolver/PhpIniResolver.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Resolver;
+namespace OpenTelemetry\API\Configuration\Resolver;
 
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\API\Configuration;
 
 /**
- * @interal
+ * Resolve variables from php.ini
+ * @internal
  * @psalm-suppress TypeDoesNotContainType
  */
 class PhpIniResolver implements ResolverInterface

--- a/src/API/Configuration/Resolver/ResolverInterface.php
+++ b/src/API/Configuration/Resolver/ResolverInterface.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration\Resolver;
+namespace OpenTelemetry\API\Configuration\Resolver;
 
+/**
+ * @internal
+ */
 interface ResolverInterface
 {
     /**

--- a/src/API/Configuration/VariableTypes.php
+++ b/src/API/Configuration/VariableTypes.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\SDK\Common\Configuration;
+namespace OpenTelemetry\API\Configuration;
 
+/**
+ * @psalm-internal \OpenTelemetry
+ */
 interface VariableTypes
 {
     /**

--- a/src/Contrib/Otlp/LogsExporterFactory.php
+++ b/src/Contrib/Otlp/LogsExporterFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Otlp;
 
 use OpenTelemetry\API\Signals;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Defaults;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;

--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Otlp;
 
 use OpenTelemetry\API\Signals;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Defaults;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;

--- a/src/Contrib/Otlp/SpanExporterFactory.php
+++ b/src/Contrib/Otlp/SpanExporterFactory.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\Contrib\Otlp;
 
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\API\Signals;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Defaults;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;

--- a/src/Contrib/Zipkin/SpanExporterFactory.php
+++ b/src/Contrib/Zipkin/SpanExporterFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\Zipkin;
 
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
 use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;

--- a/src/SDK/Common/Configuration.php
+++ b/src/SDK/Common/Configuration.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common;
+
+use OpenTelemetry\API\Configuration\ClassConstantAccessor;
+use OpenTelemetry\API\Configuration\VariableTypes;
+use OpenTelemetry\SDK\Common\Configuration\Defaults;
+use OpenTelemetry\SDK\Common\Configuration\ValueTypes;
+use UnexpectedValueException;
+
+/**
+ * @psalm-internal \OpenTelemetry
+ */
+class Configuration extends \OpenTelemetry\API\Configuration
+{
+    /**
+     * @override
+     */
+    public static function getDefault(string $key, $default = null)
+    {
+        if ($default !== null) {
+            return $default;
+        }
+
+        return ClassConstantAccessor::getValue(Defaults::class, $key);
+    }
+
+    /**
+     * @override
+     */
+    protected static function validateVariableType(string $variableName, string $type): string
+    {
+        $variableType = self::getType($variableName);
+
+        if ($variableType !== null && $variableType !== $type && $variableType !== VariableTypes::MIXED) {
+            throw new UnexpectedValueException(
+                sprintf('Variable "%s" is not supposed to be of type "%s" but type "%s"', $variableName, $type, $variableType)
+            );
+        }
+
+        return $variableName;
+    }
+
+    /**
+     * @override
+     */
+    public static function getType(string $variableName): ?string
+    {
+        return ClassConstantAccessor::getValue(ValueTypes::class, $variableName);
+    }
+}

--- a/src/SDK/Common/Configuration/ValueTypes.php
+++ b/src/SDK/Common/Configuration/ValueTypes.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Configuration;
 
+use OpenTelemetry\API\Configuration\VariableTypes;
+
 /**
  * Environment variables defined by the OpenTelemetry specification and language specific variables for the PHP SDK.
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md

--- a/src/SDK/Logs/ExporterFactory.php
+++ b/src/SDK/Logs/ExporterFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Logs;
 
 use InvalidArgumentException;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Logs\Exporter\NoopExporter;
 use OpenTelemetry\SDK\Registry;

--- a/src/SDK/Logs/LogRecordLimitsBuilder.php
+++ b/src/SDK/Logs/LogRecordLimitsBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Logs;
 
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use const PHP_INT_MAX;
 

--- a/src/SDK/Logs/LogRecordProcessorFactory.php
+++ b/src/SDK/Logs/LogRecordProcessorFactory.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\SDK\Logs;
 
 use InvalidArgumentException;
 use OpenTelemetry\API\Metrics\MeterProviderInterface;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Configuration\Variables;

--- a/src/SDK/Metrics/MeterProviderFactory.php
+++ b/src/SDK/Metrics/MeterProviderFactory.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\SDK\Metrics;
 
 use InvalidArgumentException;
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilter\AllExemplarFilter;

--- a/src/SDK/Propagation/PropagatorFactory.php
+++ b/src/SDK/Propagation/PropagatorFactory.php
@@ -8,7 +8,7 @@ use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\Context\Propagation\MultiTextMapPropagator;
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Registry;
 

--- a/src/SDK/Resource/Detectors/Environment.php
+++ b/src/SDK/Resource/Detectors/Environment.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Resource\Detectors;
 
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;

--- a/src/SDK/Resource/ResourceInfoFactory.php
+++ b/src/SDK/Resource/ResourceInfoFactory.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\SDK\Resource;
 use function in_array;
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Configuration\Variables as Env;
 use OpenTelemetry\SDK\Registry;

--- a/src/SDK/Sdk.php
+++ b/src/SDK/Sdk.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\SDK;
 use OpenTelemetry\API\Metrics\MeterProviderInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Logs\LoggerProviderInterface;
 

--- a/src/SDK/SdkAutoloader.php
+++ b/src/SDK/SdkAutoloader.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\SDK;
 use InvalidArgumentException;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\Configurator;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Util\ShutdownHandler;
 use OpenTelemetry\SDK\Logs\LoggerProviderFactory;

--- a/src/SDK/Trace/ExporterFactory.php
+++ b/src/SDK/Trace/ExporterFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace;
 
 use InvalidArgumentException;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Registry;
 use RuntimeException;

--- a/src/SDK/Trace/SamplerFactory.php
+++ b/src/SDK/Trace/SamplerFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace;
 
 use InvalidArgumentException;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Configuration\Variables as Env;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;

--- a/src/SDK/Trace/SpanLimitsBuilder.php
+++ b/src/SDK/Trace/SpanLimitsBuilder.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\SDK\Trace;
 
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Attribute\FilteredAttributesFactory;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables as Env;
 use OpenTelemetry\SemConv\TraceAttributes;
 use const PHP_INT_MAX;

--- a/src/SDK/Trace/SpanProcessorFactory.php
+++ b/src/SDK/Trace/SpanProcessorFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace;
 
 use InvalidArgumentException;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Configuration\Variables as Env;
 use OpenTelemetry\SDK\Common\Time\ClockFactory;

--- a/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
@@ -16,7 +16,6 @@ use Psr\Log\LogLevel;
 
 /**
  * @covers \OpenTelemetry\API\Behavior\LogsMessagesTrait
- * @covers \OpenTelemetry\API\Behavior\Logging
  */
 class LogsMessagesTraitTest extends TestCase
 {

--- a/tests/Unit/API/Configuration/Parser/BooleanParserTest.php
+++ b/tests/Unit/API/Configuration/Parser/BooleanParserTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Unit\SDK\Common\Configuration\Parser;
+namespace OpenTelemetry\Tests\Unit\API\Configuration\Parser;
 
 use InvalidArgumentException;
-use OpenTelemetry\SDK\Common\Configuration\Parser\BooleanParser;
+use OpenTelemetry\API\Configuration\Parser\BooleanParser;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Configuration\Parser\BooleanParser
+ * @covers \OpenTelemetry\API\Configuration\Parser\BooleanParser
  */
 class BooleanParserTest extends TestCase
 {

--- a/tests/Unit/API/Configuration/Parser/ListParserTest.php
+++ b/tests/Unit/API/Configuration/Parser/ListParserTest.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Unit\SDK\Common\Configuration\Parser;
+namespace OpenTelemetry\Tests\Unit\API\Configuration\Parser;
 
+use OpenTelemetry\API\Configuration\Parser\ListParser;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Configuration\Parser\ListParser
+ * @covers \OpenTelemetry\API\Configuration\Parser\ListParser
  */
 class ListParserTest extends TestCase
 {
@@ -40,7 +41,7 @@ class ListParserTest extends TestCase
     public function test_comma_separated_list_returns_array(string $value, array $expected): void
     {
         $this->assertSame(
-            \OpenTelemetry\SDK\Common\Configuration\Parser\ListParser::parse($value),
+            ListParser::parse($value),
             $expected
         );
     }

--- a/tests/Unit/API/Configuration/Parser/MapParserTest.php
+++ b/tests/Unit/API/Configuration/Parser/MapParserTest.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Unit\SDK\Common\Configuration\Parser;
+namespace OpenTelemetry\Tests\Unit\API\Configuration\Parser;
 
 use InvalidArgumentException;
+use OpenTelemetry\API\Configuration\Parser\MapParser;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Configuration\Parser\MapParser
+ * @covers \OpenTelemetry\API\Configuration\Parser\MapParser
  */
 class MapParserTest extends TestCase
 {
@@ -46,7 +47,7 @@ class MapParserTest extends TestCase
     public function test_map_values_return_array(string $value, array $expected): void
     {
         $this->assertSame(
-            \OpenTelemetry\SDK\Common\Configuration\Parser\MapParser::parse($value),
+            MapParser::parse($value),
             $expected
         );
     }
@@ -58,7 +59,7 @@ class MapParserTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        \OpenTelemetry\SDK\Common\Configuration\Parser\MapParser::parse($value);
+        MapParser::parse($value);
     }
 
     public function mapValueProvider(): array

--- a/tests/Unit/API/Configuration/Parser/RatioParserTest.php
+++ b/tests/Unit/API/Configuration/Parser/RatioParserTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Unit\SDK\Common\Configuration\Parser;
+namespace OpenTelemetry\Tests\Unit\API\Configuration\Parser;
 
 use InvalidArgumentException;
-use OpenTelemetry\SDK\Common\Configuration\Parser\RatioParser;
+use OpenTelemetry\API\Configuration\Parser\RatioParser;
 use PHPUnit\Framework\TestCase;
 use RangeException;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Configuration\Parser\RatioParser
+ * @covers \OpenTelemetry\API\Configuration\Parser\RatioParser
  */
 class RatioParserTest extends TestCase
 {

--- a/tests/Unit/API/Configuration/Resolver/CompositeResolverTest.php
+++ b/tests/Unit/API/Configuration/Resolver/CompositeResolverTest.php
@@ -2,21 +2,24 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Unit\SDK\Common\Configuration\Resolver;
+namespace OpenTelemetry\Tests\Unit\API\Configuration\Resolver;
 
-use OpenTelemetry\SDK\Common\Configuration\Defaults;
-use OpenTelemetry\SDK\Common\Configuration\Resolver\CompositeResolver;
-use OpenTelemetry\SDK\Common\Configuration\Resolver\ResolverInterface;
-use OpenTelemetry\SDK\Common\Configuration\Variables;
+use OpenTelemetry\API\Configuration\Resolver\CompositeResolver;
+use OpenTelemetry\API\Configuration\Resolver\ResolverInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Configuration\Resolver\CompositeResolver
+ * @covers \OpenTelemetry\API\Configuration\Resolver\CompositeResolver
  * @psalm-suppress UndefinedInterfaceMethod
+ * @psalm-suppress InternalClass
+ * @psalm-suppress InternalMethod
  */
 class CompositeResolverTest extends TestCase
 {
+    /** @var ResolverInterface&MockObject $one */
     private ResolverInterface $one;
+    /** @var ResolverInterface&MockObject $two */
     private ResolverInterface $two;
     private CompositeResolver $resolver;
 
@@ -61,32 +64,5 @@ class CompositeResolverTest extends TestCase
             ->willReturn('foo');
 
         $this->assertSame('foo', $this->resolver->resolve($var));
-    }
-
-    public function test_resolve_uses_default_when_not_empty(): void
-    {
-        $this->one->method('hasVariable')->willReturn(false);
-        $this->two->method('hasVariable')->willReturn(false);
-
-        $this->assertSame('foo', $this->resolver->resolve(Variables::OTEL_EXPORTER_OTLP_PROTOCOL, 'foo'));
-    }
-
-    /**
-     * @dataProvider emptyProvider
-     */
-    public function test_resolve_uses_library_default_when_empty(?string $value): void
-    {
-        $this->one->method('hasVariable')->willReturn(false);
-        $this->two->method('hasVariable')->willReturn(false);
-
-        $this->assertSame(Defaults::OTEL_EXPORTER_OTLP_PROTOCOL, $this->resolver->resolve(Variables::OTEL_EXPORTER_OTLP_PROTOCOL, $value));
-    }
-
-    public function emptyProvider(): array
-    {
-        return [
-            [''],
-            [null],
-        ];
     }
 }

--- a/tests/Unit/API/Configuration/Resolver/DotEnvResolverTest.php
+++ b/tests/Unit/API/Configuration/Resolver/DotEnvResolverTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\API\Configuration\Resolver;
+
+use OpenTelemetry\API\Configuration\Resolver\DotEnvResolver;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\API\Configuration\Resolver\DotEnvResolver
+ * @psalm-suppress InternalClass
+ * @psalm-suppress InternalMethod
+ */
+class DotEnvResolverTest extends TestCase
+{
+    private vfsStreamDirectory $root;
+
+    public function setUp(): void
+    {
+        $content = <<<EOS
+#comment
+FOO=foo #comment
+BAR = bar
+BAZ #invalid
+BAT=key1=value1,key2=value2
+#comment
+EOS;
+
+        $this->root = vfsStream::setup('root', null, ['.env' => $content]);
+    }
+
+    /**
+     * @dataProvider variablesProvider
+     */
+    public function test_dotenv_resolver(string $key, ?string $value, $expected): void
+    {
+        $resolver = new DotEnvResolver($this->root->url());
+        $this->assertSame($expected, $resolver->hasVariable($key));
+        if ($expected) {
+            $this->assertSame($value, $resolver->retrieveValue($key));
+        }
+    }
+
+    public static function variablesProvider(): array
+    {
+        return [
+            ['FOO', 'foo', true],
+            ['BAR', 'bar', true],
+            ['MISSING', null, false],
+            ['BAT', 'key1=value1,key2=value2', true],
+        ];
+    }
+}

--- a/tests/Unit/API/Configuration/Resolver/DotEnvResolverTest.php
+++ b/tests/Unit/API/Configuration/Resolver/DotEnvResolverTest.php
@@ -49,6 +49,7 @@ EOS;
         return [
             ['FOO', 'foo', true],
             ['BAR', 'bar', true],
+            ['BAZ', null, false],
             ['MISSING', null, false],
             ['BAT', 'key1=value1,key2=value2', true],
         ];

--- a/tests/Unit/API/Configuration/Resolver/EnvironmentResolverTest.php
+++ b/tests/Unit/API/Configuration/Resolver/EnvironmentResolverTest.php
@@ -2,14 +2,16 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Unit\SDK\Common\Configuration\Resolver;
+namespace OpenTelemetry\Tests\Unit\API\Configuration\Resolver;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
-use OpenTelemetry\SDK\Common\Configuration\Resolver\EnvironmentResolver;
+use OpenTelemetry\API\Configuration\Resolver\EnvironmentResolver;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Configuration\Resolver\EnvironmentResolver
+ * @covers \OpenTelemetry\API\Configuration\Resolver\EnvironmentResolver
+ * @psalm-suppress InternalClass
+ * @psalm-suppress InternalMethod
  */
 class EnvironmentResolverTest extends TestCase
 {
@@ -88,7 +90,7 @@ class EnvironmentResolverTest extends TestCase
     public function test_retrieve_value_with_injected_value(): void
     {
         $value = 'simple';
-        $variable = 'OTEL_PHP_TRACES_PROCESSOR';
+        $variable = 'FOO_BAR_BAZ';
 
         $this->assertFalse(
             $this->resolver->hasVariable($variable)

--- a/tests/Unit/API/Configuration/Resolver/PhpIniResolverTest.php
+++ b/tests/Unit/API/Configuration/Resolver/PhpIniResolverTest.php
@@ -2,18 +2,20 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Unit\SDK\Common\Configuration\Resolver;
+namespace OpenTelemetry\Tests\Unit\API\Configuration\Resolver;
 
-use OpenTelemetry\SDK\Common\Configuration\Resolver\PhpIniAccessor;
-use OpenTelemetry\SDK\Common\Configuration\Resolver\PhpIniResolver;
+use OpenTelemetry\API\Configuration\Resolver\PhpIniAccessor;
+use OpenTelemetry\API\Configuration\Resolver\PhpIniResolver;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Configuration\Resolver\PhpIniResolver
+ * @covers \OpenTelemetry\API\Configuration\Resolver\PhpIniResolver
  * @psalm-suppress UndefinedMethod
  */
 class PhpIniResolverTest extends TestCase
 {
+    /** @var PhpIniAccessor&MockObject $accessor */
     private PhpIniAccessor $accessor;
     private PhpIniResolver $resolver;
 

--- a/tests/Unit/API/ConfigurationTest.php
+++ b/tests/Unit/API/ConfigurationTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\API;
+
+use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
+use Exception;
+use Generator;
+use OpenTelemetry\API\Configuration;
+use OpenTelemetry\API\Configuration\VariableTypes;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+/**
+ * @covers OpenTelemetry\API\Configuration
+ */
+class ConfigurationTest extends TestCase
+{
+    use EnvironmentVariables;
+
+    private const METHOD_NAMES = [
+        VariableTypes::STRING => ['getString'],
+        VariableTypes::BOOL => ['getBoolean'],
+        VariableTypes::INTEGER => ['getInt'],
+        VariableTypes::FLOAT => ['getFloat'],
+        VariableTypes::RATIO => ['getRatio'],
+        VariableTypes::ENUM => ['getEnum'],
+        VariableTypes::LIST => ['getList'],
+        VariableTypes::MAP => ['getMap'],
+        VariableTypes::MIXED => ['getMixed'],
+    ];
+
+    private const ALLOW_EMPTY = [
+        VariableTypes::LIST,
+        VariableTypes::MAP,
+        VariableTypes::MIXED,
+    ];
+
+    public function tearDown(): void
+    {
+        $this->restoreEnvironmentVariables();
+    }
+
+    public function test_has_variable_from_environment(): void
+    {
+        $this->assertFalse(Configuration::has('FOO_VAR'));
+        $this->setEnvironmentVariable('FOO_VAR', 'FOO');
+        $this->assertTrue(Configuration::has('FOO_VAR'));
+    }
+
+    public function test_integer_get(): void
+    {
+        $this->setEnvironmentVariable('OTEL_FOO', '100');
+        $value = Configuration::getInt('OTEL_FOO', 999);
+        $this->assertSame(100, $value);
+    }
+
+    public function test_integer_failure(): void
+    {
+        $this->setEnvironmentVariable('OTEL_FOO', 'foo');
+        $this->expectException(Exception::class);
+        Configuration::getInt('OTEL_FOO', 99);
+    }
+
+    public function environment_variables_integer_uses_default_if_env_var_not_defined()
+    {
+        $this->assertSame(20, Configuration::getInt('OTEL_FOO', 20));
+    }
+
+    public function test_string_get(): void
+    {
+        $this->setEnvironmentVariable('OTEL_FOO', 'foo');
+        $value = Configuration::getString('OTEL_FOO', 'bar');
+        $this->assertSame('foo', $value);
+    }
+
+    /**
+     * The SDK MUST interpret an empty value of an environment variable the same way as when the variable is unset
+     * @dataProvider emptyProvider
+     */
+    public function test_string_uses_default_when_empty_value(?string $input): void
+    {
+        $this->setEnvironmentVariable('OTEL_FOO', $input);
+        $value = Configuration::getString('OTEL_FOO', 'bar');
+        $this->assertSame('bar', $value);
+    }
+
+    /**
+     * @dataProvider emptyProvider
+     */
+    public function test_int_uses_default_when_empty_value(?string $input): void
+    {
+        $this->setEnvironmentVariable('OTEL_FOO', $input);
+        $value = Configuration::getInt('OTEL_FOO', 99);
+        $this->assertSame(99, $value);
+    }
+
+    /**
+     * @dataProvider emptyProvider
+     */
+    public function test_bool_uses_default_when_empty_value(?string $input): void
+    {
+        $this->setEnvironmentVariable('OTEL_FOO', $input);
+        $value = Configuration::getBoolean('OTEL_FOO', true);
+        $this->assertTrue($value);
+    }
+
+    public function emptyProvider()
+    {
+        return [
+            'no value' => [null],
+            'empty string' => [''],
+        ];
+    }
+
+    /**
+     * @dataProvider booleanProvider
+     */
+    public function test_bool_get(string $input, bool $default, bool $expected): void
+    {
+        $this->setEnvironmentVariable('OTEL_BOOL', $input);
+        $this->assertSame($expected, Configuration::getBoolean('OTEL_BOOL', $default));
+    }
+
+    public function booleanProvider(): array
+    {
+        return [
+            'false' => ['false', true, false],
+            'true' => ['true', false, true],
+            'TRUE' => ['TRUE', false, true],
+            'FALSE' => ['FALSE', true, false],
+        ];
+    }
+
+    public function test_list_get()
+    {
+        $this->setEnvironmentVariable('OTEL_LIST', 'a,b,c');
+        $this->assertSame(['a', 'b', 'c'], Configuration::getList('OTEL_LIST'));
+    }
+
+    public function test_map_get()
+    {
+        $this->setEnvironmentVariable('OTEL_MAP', 'a=b,c=d');
+        $this->assertSame(['a'=>'b', 'c'=>'d'], Configuration::getMap('OTEL_MAP'));
+    }
+
+    public function test_enum_get()
+    {
+        $this->setEnvironmentVariable('OTEL_ENUM', 'foo');
+        $this->assertSame('foo', Configuration::getEnum('OTEL_ENUM'));
+    }
+
+    public function test_ratio_get()
+    {
+        $this->setEnvironmentVariable('OTEL_RATIO', '0.5');
+        $this->assertSame(0.5, Configuration::getRatio('OTEL_RATIO'));
+    }
+
+    public function test_get_type(): void
+    {
+        $this->assertSame('mixed', Configuration::getType('OTEL_FOO'));
+    }
+
+    /**
+     * @dataProvider nonEmptyMethodNameProvider
+     */
+    public function test_no_value_throws_exception(string $methodName)
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        call_user_func([Configuration::class, $methodName], 'FOO_BAR_' . $methodName);
+    }
+
+    public function nonEmptyMethodNameProvider(): Generator
+    {
+        foreach (self::METHOD_NAMES as $varType => $names) {
+            if (in_array($varType, self::ALLOW_EMPTY)) {
+                continue;
+            }
+
+            yield $varType => $names;
+        }
+    }
+
+    public function test_default_ratio_for_non_existent_variable(): void
+    {
+        $value = Configuration::getRatio('not-set', 0);
+        $this->assertSame(0.0, $value);
+    }
+
+    /**
+     * @dataProvider nonStringProvider
+     */
+    public function test_get_non_string_value(string $method, $value): void
+    {
+        $_SERVER['OTEL_FOO'] = $value;
+        $this->assertTrue(Configuration::has('OTEL_FOO'));
+        $this->assertSame($value, call_user_func([Configuration::class, $method], 'OTEL_FOO'));
+    }
+
+    public function nonStringProvider(): array
+    {
+        return [
+            ['getFloat', 3.14159],
+            ['getInt', 22],
+            ['getBoolean', true],
+            ['getRatio', 0.44],
+            ['getMixed', [25, 'green']],
+            ['getList', ['foo', 'bar']],
+            ['getMap', ['key1' => 'val1', 'key2' => 'val2']],
+        ];
+    }
+}

--- a/tests/Unit/SDK/Common/Configuration/ConfigurationTest.php
+++ b/tests/Unit/SDK/Common/Configuration/ConfigurationTest.php
@@ -5,18 +5,16 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\SDK\Common\Configuration;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
-use Exception;
 use Generator;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\API\Configuration\VariableTypes;
+use OpenTelemetry\SDK\Common\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Defaults;
-use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
-use OpenTelemetry\SDK\Common\Configuration\VariableTypes;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Configuration\Configuration
+ * @covers \OpenTelemetry\SDK\Common\Configuration
  */
 class ConfigurationTest extends TestCase
 {
@@ -91,154 +89,9 @@ class ConfigurationTest extends TestCase
         VariableTypes::MIXED => [Variables::OTEL_TRACES_SAMPLER_ARG],
     ];
 
-    private const KNOWN_VALUES = [
-        'log level' => [Variables::OTEL_LOG_LEVEL, KnownValues::OTEL_LOG_LEVEL],
-        'trace sampler' => [Variables::OTEL_TRACES_SAMPLER, KnownValues::OTEL_TRACES_SAMPLER],
-        'trace processor' => [Variables::OTEL_PHP_TRACES_PROCESSOR, KnownValues::OTEL_PHP_TRACES_PROCESSOR],
-    ];
-
     public function tearDown(): void
     {
         $this->restoreEnvironmentVariables();
-    }
-
-    public function test_has_variable_from_environment(): void
-    {
-        $this->assertFalse(Configuration::has('FOO_VAR'));
-        $this->setEnvironmentVariable('FOO_VAR', 'FOO');
-        $this->assertTrue(Configuration::has('FOO_VAR'));
-    }
-
-    public function test_integer_get(): void
-    {
-        $this->setEnvironmentVariable('OTEL_FOO', '100');
-        $value = Configuration::getInt('OTEL_FOO', 999);
-        $this->assertSame(100, $value);
-    }
-
-    public function test_integer_failure(): void
-    {
-        $this->setEnvironmentVariable('OTEL_FOO', 'foo');
-        $this->expectException(Exception::class);
-        Configuration::getInt('OTEL_FOO', 99);
-    }
-
-    public function environment_variables_integer_uses_default_if_env_var_not_defined()
-    {
-        $this->assertSame(20, Configuration::getInt('OTEL_FOO', 20));
-    }
-
-    public function test_string_get(): void
-    {
-        $this->setEnvironmentVariable('OTEL_FOO', 'foo');
-        $value = Configuration::getString('OTEL_FOO', 'bar');
-        $this->assertSame('foo', $value);
-    }
-
-    /**
-     * The SDK MUST interpret an empty value of an environment variable the same way as when the variable is unset
-     * @dataProvider emptyProvider
-     */
-    public function test_string_uses_default_when_empty_value(?string $input): void
-    {
-        $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = Configuration::getString('OTEL_FOO', 'bar');
-        $this->assertSame('bar', $value);
-    }
-
-    /**
-     * @dataProvider emptyProvider
-     */
-    public function test_int_uses_default_when_empty_value(?string $input): void
-    {
-        $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = Configuration::getInt('OTEL_FOO', 99);
-        $this->assertSame(99, $value);
-    }
-
-    /**
-     * @dataProvider emptyProvider
-     */
-    public function test_bool_uses_default_when_empty_value(?string $input): void
-    {
-        $this->setEnvironmentVariable('OTEL_FOO', $input);
-        $value = Configuration::getBoolean('OTEL_FOO', true);
-        $this->assertTrue($value);
-    }
-
-    public function emptyProvider()
-    {
-        return [
-            'no value' => [null],
-            'empty string' => [''],
-        ];
-    }
-
-    /**
-     * @dataProvider booleanProvider
-     */
-    public function test_bool_get(string $input, bool $default, bool $expected)
-    {
-        $this->setEnvironmentVariable('OTEL_BOOL', $input);
-        $this->assertSame($expected, Configuration::getBoolean('OTEL_BOOL', $default));
-    }
-
-    public function booleanProvider()
-    {
-        return [
-            'false' => ['false', true, false],
-            'true' => ['true', false, true],
-            'TRUE' => ['TRUE', false, true],
-            'FALSE' => ['FALSE', true, false],
-        ];
-    }
-
-    public function test_list_get()
-    {
-        $this->setEnvironmentVariable('OTEL_LIST', 'a,b,c');
-        $this->assertSame(['a', 'b', 'c'], Configuration::getList('OTEL_LIST'));
-    }
-
-    public function test_map_get()
-    {
-        $this->setEnvironmentVariable('OTEL_MAP', 'a=b,c=d');
-        $this->assertSame(['a'=>'b', 'c'=>'d'], Configuration::getMap('OTEL_MAP'));
-    }
-
-    public function test_enum_get()
-    {
-        $this->setEnvironmentVariable('OTEL_ENUM', 'foo');
-        $this->assertSame('foo', Configuration::getEnum('OTEL_ENUM'));
-    }
-
-    public function test_ratio_get()
-    {
-        $this->setEnvironmentVariable('OTEL_RATIO', '0.5');
-        $this->assertSame(0.5, Configuration::getRatio('OTEL_RATIO'));
-    }
-
-    /**
-     * @dataProvider userEnvValueProvider
-     */
-    public function test_return_user_env_vars(string $methodName, string $variable, string $value, $result)
-    {
-        $this->setEnvironmentVariable($variable, $value);
-
-        $this->assertSame(
-            $result,
-            call_user_func([Configuration::class, $methodName], $variable)
-        );
-    }
-
-    /**
-     * @dataProvider userValueProvider
-     */
-    public function test_return_user_default_value(string $methodName, string $variable, $defaultValue, $result)
-    {
-        $this->assertSame(
-            $result,
-            call_user_func([Configuration::class, $methodName], $variable, $defaultValue)
-        );
     }
 
     /**
@@ -252,24 +105,17 @@ class ConfigurationTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider nonEmptyMethodNameProvider
-     */
-    public function test_no_value_throws_exception(string $methodName)
+    public function libraryDefaultValueProvider(): Generator
     {
-        $this->expectException(UnexpectedValueException::class);
+        foreach (self::LIBRARY_DEFAULTS as $varType => $values) {
+            [$variable, $result] = $values;
 
-        call_user_func([Configuration::class, $methodName], 'FOO_BAR_' . $methodName);
-    }
-
-    /**
-     * @dataProvider invalidTypeProvider
-     */
-    public function test_invalid_type_throws_exception(string $methodName, string $variable)
-    {
-        $this->expectException(UnexpectedValueException::class);
-
-        call_user_func([Configuration::class, $methodName], $variable);
+            yield $varType => [
+                self::METHOD_NAMES[$varType][0],
+                $variable,
+                $result,
+            ];
+        }
     }
 
     /**
@@ -280,6 +126,57 @@ class ConfigurationTest extends TestCase
         $this->expectException(UnexpectedValueException::class);
 
         call_user_func([Configuration::class, $methodName], $variable);
+    }
+
+    public function noDefaultProvider(): Generator
+    {
+        foreach (self::NO_DEFAULTS as $varType => $values) {
+            if (in_array($varType, self::ALLOW_EMPTY)) {
+                continue;
+            }
+
+            yield $varType => [self::METHOD_NAMES[$varType][0], $values[0]];
+        }
+    }
+
+    /**
+     * @dataProvider defaultValueProvider
+     */
+    public function test_get_default_value(string $varName, $varValue): void
+    {
+        $this->assertSame(
+            $varValue,
+            Configuration::getDefault($varName)
+        );
+    }
+
+    /**
+     * @dataProvider defaultValueProvider
+     */
+    public function test_get_default_value_with_empty_var(string $varName, $varValue): void
+    {
+        $this->setEnvironmentVariable($varName, '');
+
+        $this->assertSame(
+            $varValue,
+            Configuration::getDefault($varName)
+        );
+    }
+
+    public function defaultValueProvider(): array
+    {
+        return self::DEFAULT_VALUES;
+    }
+
+    /**
+     * @dataProvider userValueProvider
+     */
+    public function test_return_user_default_value(string $methodName, string $variable, $defaultValue, $result)
+    {
+        $this->assertSame(
+            $result,
+            call_user_func([Configuration::class, $methodName], $variable, $defaultValue)
+        );
     }
 
     public function userValueProvider(): Generator
@@ -296,6 +193,19 @@ class ConfigurationTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider userEnvValueProvider
+     */
+    public function test_return_user_env_vars(string $methodName, string $variable, string $value, $result)
+    {
+        $this->setEnvironmentVariable($variable, $value);
+
+        $this->assertSame(
+            $result,
+            call_user_func([Configuration::class, $methodName], $variable)
+        );
+    }
+
     public function userEnvValueProvider(): Generator
     {
         foreach (self::USER_ENV_VALUES as $varType => $values) {
@@ -310,28 +220,14 @@ class ConfigurationTest extends TestCase
         }
     }
 
-    public function libraryDefaultValueProvider(): Generator
+    /**
+     * @dataProvider invalidTypeProvider
+     */
+    public function test_invalid_type_throws_exception(string $methodName, string $variable)
     {
-        foreach (self::LIBRARY_DEFAULTS as $varType => $values) {
-            [$variable, $result] = $values;
+        $this->expectException(UnexpectedValueException::class);
 
-            yield $varType => [
-                self::METHOD_NAMES[$varType][0],
-                $variable,
-                $result,
-            ];
-        }
-    }
-
-    public function nonEmptyMethodNameProvider(): Generator
-    {
-        foreach (self::METHOD_NAMES as $varType => $names) {
-            if (in_array($varType, self::ALLOW_EMPTY)) {
-                continue;
-            }
-
-            yield $varType => $names;
-        }
+        call_user_func([Configuration::class, $methodName], $variable);
     }
 
     public function invalidTypeProvider(): Generator
@@ -350,39 +246,6 @@ class ConfigurationTest extends TestCase
                 yield sprintf('%s - %s', $varType, $methodType) => [$methodName, $variableName];
             }
         }
-    }
-
-    public function noDefaultProvider(): Generator
-    {
-        foreach (self::NO_DEFAULTS as $varType => $values) {
-            if (in_array($varType, self::ALLOW_EMPTY)) {
-                continue;
-            }
-
-            yield $varType => [self::METHOD_NAMES[$varType][0], $values[0]];
-        }
-    }
-
-    public function test_default_ratio_for_non_existent_variable(): void
-    {
-        $value = Configuration::getRatio('not-set', 0);
-        $this->assertSame(0.0, $value);
-    }
-
-    /**
-     * @dataProvider knownValuesProvider
-     */
-    public function test_get_known_values(string $varName, array $varValue): void
-    {
-        $this->assertSame(
-            $varValue,
-            Configuration::getKnownValues($varName)
-        );
-    }
-
-    public function knownValuesProvider(): array
-    {
-        return self::KNOWN_VALUES;
     }
 
     public function test_retrieve_value_library_default(): void
@@ -421,58 +284,6 @@ class ConfigurationTest extends TestCase
             'list' => ['OTEL_PROPAGATORS', VariableTypes::LIST],
             'map' => ['OTEL_RESOURCE_ATTRIBUTES', VariableTypes::MAP],
             'mixed' => ['OTEL_TRACES_SAMPLER_ARG', VariableTypes::MIXED],
-        ];
-    }
-
-    /**
-     * @dataProvider defaultValueProvider
-     */
-    public function test_get_default_value_with_empty_var(string $varName, $varValue): void
-    {
-        $this->setEnvironmentVariable($varName, '');
-
-        $this->assertSame(
-            $varValue,
-            Configuration::getDefault($varName)
-        );
-    }
-
-    /**
-     * @dataProvider defaultValueProvider
-     */
-    public function test_get_default_value(string $varName, $varValue): void
-    {
-        $this->assertSame(
-            $varValue,
-            Configuration::getDefault($varName)
-        );
-    }
-
-    public function defaultValueProvider(): array
-    {
-        return self::DEFAULT_VALUES;
-    }
-
-    /**
-     * @dataProvider nonStringProvider
-     */
-    public function test_get_non_string_value(string $method, $value): void
-    {
-        $_SERVER['OTEL_FOO'] = $value;
-        $this->assertTrue(Configuration::has('OTEL_FOO'));
-        $this->assertSame($value, call_user_func([Configuration::class, $method], 'OTEL_FOO'));
-    }
-
-    public function nonStringProvider(): array
-    {
-        return [
-            ['getFloat', 3.14159],
-            ['getInt', 22],
-            ['getBoolean', true],
-            ['getRatio', 0.44],
-            ['getMixed', [25, 'green']],
-            ['getList', ['foo', 'bar']],
-            ['getMap', ['key1' => 'val1', 'key2' => 'val2']],
         ];
     }
 }

--- a/tests/Unit/SDK/Common/Util/ClassConstantAccessorTest.php
+++ b/tests/Unit/SDK/Common/Util/ClassConstantAccessorTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\SDK\Common\Util;
 
 use LogicException;
-use OpenTelemetry\SDK\Common\Util\ClassConstantAccessor;
+use OpenTelemetry\API\Configuration\ClassConstantAccessor;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\SDK\Common\Util\ClassConstantAccessor
+ * @covers \OpenTelemetry\API\Configuration\ClassConstantAccessor
  */
 class ClassConstantAccessorTest extends TestCase
 {


### PR DESCRIPTION
* We have a need in some contrib packages to fetch configuration settings. Move the non-SDK-specific parts of Configuration into the API.
* add the ability to fetch config from .env file