### PR TITLE
Remove workaround for php GH-8995

### DIFF
--- a/src/SDK/Metrics/ObservableInstrumentTrait.php
+++ b/src/SDK/Metrics/ObservableInstrumentTrait.php
@@ -55,8 +55,8 @@ trait ObservableInstrumentTrait
         $this->referenceCounter->acquire();
 
         $destructor = null;
-        if ($object = $target) {
-            $destructor = $this->destructors[$object] ??= new ObservableCallbackDestructor($this->writer, $this->referenceCounter);
+        if ($target) {
+            $destructor = $this->destructors[$target] ??= new ObservableCallbackDestructor($this->writer, $this->referenceCounter);
             $destructor->callbackIds[$callbackId] = $callbackId;
         }
 


### PR DESCRIPTION
Fixed in PHP 8.1.9 and 8.0.22 (04 Aug 2022), should be fine to remove this now.