### PR TITLE
adding configuration resolver

### DIFF
--- a/src/API/Globals.php
+++ b/src/API/Globals.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\API;
 use function assert;
 use Closure;
 use const E_USER_WARNING;
+use OpenTelemetry\API\Instrumentation\ConfigurationResolverInterface;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\API\Instrumentation\ContextKeys;
 use OpenTelemetry\API\Logs\LoggerProviderInterface;
@@ -31,17 +32,20 @@ final class Globals
     private MeterProviderInterface $meterProvider;
     private TextMapPropagatorInterface $propagator;
     private LoggerProviderInterface $loggerProvider;
+    private ConfigurationResolverInterface $configurationResolver;
 
     public function __construct(
         TracerProviderInterface $tracerProvider,
         MeterProviderInterface $meterProvider,
         LoggerProviderInterface $loggerProvider,
-        TextMapPropagatorInterface $propagator
+        TextMapPropagatorInterface $propagator,
+        ConfigurationResolverInterface $configurationResolver
     ) {
         $this->tracerProvider = $tracerProvider;
         $this->meterProvider = $meterProvider;
         $this->loggerProvider = $loggerProvider;
         $this->propagator = $propagator;
+        $this->configurationResolver = $configurationResolver;
     }
 
     public static function tracerProvider(): TracerProviderInterface
@@ -62,6 +66,11 @@ final class Globals
     public static function loggerProvider(): LoggerProviderInterface
     {
         return Context::getCurrent()->get(ContextKeys::loggerProvider()) ?? self::globals()->loggerProvider;
+    }
+
+    public static function configurationResolver(): ConfigurationResolverInterface
+    {
+        return Context::getCurrent()->get(ContextKeys::configurationResolver()) ?? self::globals()->configurationResolver;
     }
 
     /**
@@ -104,10 +113,11 @@ final class Globals
         $meterProvider = $context->get(ContextKeys::meterProvider());
         $propagator = $context->get(ContextKeys::propagator());
         $loggerProvider = $context->get(ContextKeys::loggerProvider());
+        $configurationResolver = $context->get(ContextKeys::configurationResolver());
 
-        assert(isset($tracerProvider, $meterProvider, $loggerProvider, $propagator));
+        assert(isset($tracerProvider, $meterProvider, $loggerProvider, $propagator, $configurationResolver));
 
-        return self::$globals = new self($tracerProvider, $meterProvider, $loggerProvider, $propagator);
+        return self::$globals = new self($tracerProvider, $meterProvider, $loggerProvider, $propagator, $configurationResolver);
     }
 
     /**

--- a/src/API/Instrumentation/ConfigurationResolverInterface.php
+++ b/src/API/Instrumentation/ConfigurationResolverInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Instrumentation;
+
+interface ConfigurationResolverInterface
+{
+    public function has(string $name): bool;
+    public function getString(string $name): ?string;
+    public function getBoolean(string $name): ?bool;
+    public function getInt(string $name): ?int;
+    public function getList(string $name): array;
+}

--- a/src/API/Instrumentation/Configurator.php
+++ b/src/API/Instrumentation/Configurator.php
@@ -28,6 +28,7 @@ final class Configurator implements ImplicitContextKeyedInterface
     private ?MeterProviderInterface $meterProvider = null;
     private ?TextMapPropagatorInterface $propagator = null;
     private ?LoggerProviderInterface $loggerProvider = null;
+    private ?ConfigurationResolverInterface $configurationResolver = null;
 
     private function __construct()
     {
@@ -51,6 +52,7 @@ final class Configurator implements ImplicitContextKeyedInterface
             ->withMeterProvider(new NoopMeterProvider())
             ->withPropagator(new NoopTextMapPropagator())
             ->withLoggerProvider(new NoopLoggerProvider())
+            ->withConfigurationResolver(new NoopConfigurationResolver())
         ;
     }
 
@@ -74,6 +76,9 @@ final class Configurator implements ImplicitContextKeyedInterface
         }
         if ($this->loggerProvider !== null) {
             $context = $context->with(ContextKeys::loggerProvider(), $this->loggerProvider);
+        }
+        if ($this->configurationResolver !== null) {
+            $context = $context->with(ContextKeys::configurationResolver(), $this->configurationResolver);
         }
 
         return $context;
@@ -102,10 +107,19 @@ final class Configurator implements ImplicitContextKeyedInterface
 
         return $self;
     }
+
     public function withLoggerProvider(?LoggerProviderInterface $loggerProvider): Configurator
     {
         $self = clone $this;
         $self->loggerProvider = $loggerProvider;
+
+        return $self;
+    }
+
+    public function withConfigurationResolver(?ConfigurationResolverInterface $configurationResolver): Configurator
+    {
+        $self = clone $this;
+        $self->configurationResolver = $configurationResolver;
 
         return $self;
     }

--- a/src/API/Instrumentation/ContextKeys.php
+++ b/src/API/Instrumentation/ContextKeys.php
@@ -55,4 +55,14 @@ final class ContextKeys
 
         return $instance ??= Context::createKey(LoggerProviderInterface::class);
     }
+
+    /**
+     * @return ContextKeyInterface<ConfigurationResolverInterface>
+     */
+    public static function configurationResolver(): ContextKeyInterface
+    {
+        static $instance;
+
+        return $instance ??= Context::createKey(ConfigurationResolverInterface::class);
+    }
 }

--- a/src/API/Instrumentation/NoopConfigurationResolver.php
+++ b/src/API/Instrumentation/NoopConfigurationResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Instrumentation;
+
+class NoopConfigurationResolver implements ConfigurationResolverInterface
+{
+    public function has(string $name): bool
+    {
+        return false;
+    }
+
+    public function getString(string $name): ?string
+    {
+        return null;
+    }
+
+    public function getBoolean(string $name): ?bool
+    {
+        return null;
+    }
+
+    public function getInt(string $name): ?int
+    {
+        return null;
+    }
+
+    public function getList(string $name): array
+    {
+        return [];
+    }
+}

--- a/src/SDK/Common/Configuration/ConfigurationResolver.php
+++ b/src/SDK/Common/Configuration/ConfigurationResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Configuration;
+
+use OpenTelemetry\API\Instrumentation\ConfigurationResolverInterface;
+
+class ConfigurationResolver implements ConfigurationResolverInterface
+{
+    public function has(string $name): bool
+    {
+        return Configuration::has($name);
+    }
+
+    public function getString(string $name): ?string
+    {
+        return Configuration::getString($name);
+    }
+
+    public function getBoolean(string $name): ?bool
+    {
+        return Configuration::getBoolean($name);
+    }
+
+    public function getInt(string $name): ?int
+    {
+        return Configuration::getInt($name);
+    }
+
+    public function getList(string $name): array
+    {
+        return Configuration::getList($name);
+    }
+}

--- a/src/SDK/SdkAutoloader.php
+++ b/src/SDK/SdkAutoloader.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration\ConfigurationResolver;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Util\ShutdownHandler;
 use OpenTelemetry\SDK\Logs\LoggerProviderFactory;
@@ -58,7 +59,9 @@ class SdkAutoloader
                 ->withTracerProvider($tracerProvider)
                 ->withMeterProvider($meterProvider)
                 ->withLoggerProvider($loggerProvider)
-                ->withPropagator($propagator);
+                ->withPropagator($propagator)
+                ->withConfigurationResolver(new ConfigurationResolver())
+                ;
         });
 
         return true;

--- a/tests/Unit/API/Instrumentation/InstrumentationTest.php
+++ b/tests/Unit/API/Instrumentation/InstrumentationTest.php
@@ -6,7 +6,9 @@ namespace OpenTelemetry\Tests\Unit\API\Instrumentation;
 
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Instrumentation\ConfigurationResolverInterface;
 use OpenTelemetry\API\Instrumentation\Configurator;
+use OpenTelemetry\API\Instrumentation\NoopConfigurationResolver;
 use OpenTelemetry\API\Logs\LoggerProviderInterface;
 use OpenTelemetry\API\Logs\NoopLoggerProvider;
 use OpenTelemetry\API\Metrics\MeterInterface;
@@ -29,12 +31,18 @@ use PHPUnit\Framework\TestCase;
  */
 final class InstrumentationTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        Globals::reset();
+    }
+
     public function test_globals_not_configured_returns_noop_instances(): void
     {
         $this->assertInstanceOf(NoopTracerProvider::class, Globals::tracerProvider());
         $this->assertInstanceOf(NoopMeterProvider::class, Globals::meterProvider());
         $this->assertInstanceOf(NoopTextMapPropagator::class, Globals::propagator());
         $this->assertInstanceOf(NoopLoggerProvider::class, Globals::loggerProvider());
+        $this->assertInstanceOf(NoopConfigurationResolver::class, Globals::configurationResolver());
     }
 
     public function test_globals_returns_configured_instances(): void
@@ -43,12 +51,14 @@ final class InstrumentationTest extends TestCase
         $meterProvider = $this->createMock(MeterProviderInterface::class);
         $propagator = $this->createMock(TextMapPropagatorInterface::class);
         $loggerProvider = $this->createMock(LoggerProviderInterface::class);
+        $configurationResolver = $this->createMock(ConfigurationResolverInterface::class);
 
         $scope = Configurator::create()
             ->withTracerProvider($tracerProvider)
             ->withMeterProvider($meterProvider)
             ->withPropagator($propagator)
             ->withLoggerProvider($loggerProvider)
+            ->withConfigurationResolver($configurationResolver)
             ->activate();
 
         try {
@@ -56,6 +66,7 @@ final class InstrumentationTest extends TestCase
             $this->assertSame($meterProvider, Globals::meterProvider());
             $this->assertSame($propagator, Globals::propagator());
             $this->assertSame($loggerProvider, Globals::loggerProvider());
+            $this->assertSame($configurationResolver, Globals::configurationResolver());
         } finally {
             $scope->detach();
         }
@@ -93,5 +104,19 @@ final class InstrumentationTest extends TestCase
         } finally {
             $scope->detach();
         }
+    }
+
+    public function test_initializers(): void
+    {
+        $called = false;
+        $closure = function(Configurator $configurator) use (&$called): Configurator
+        {
+            $called = true;
+            return $configurator;
+        };
+        Globals::registerInitializer($closure);
+        $this->assertFalse($called);
+        Globals::propagator();
+        $this->assertTrue($called);
     }
 }

--- a/tests/Unit/SDK/SdkAutoloaderTest.php
+++ b/tests/Unit/SDK/SdkAutoloaderTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Instrumentation\NoopConfigurationResolver;
 use OpenTelemetry\API\LoggerHolder;
 use OpenTelemetry\API\Logs\NoopLoggerProvider;
 use OpenTelemetry\API\Metrics\Noop\NoopMeterProvider;
@@ -40,6 +41,8 @@ class SdkAutoloaderTest extends TestCase
         $this->assertFalse(SdkAutoloader::autoload());
         $this->assertInstanceOf(NoopMeterProvider::class, Globals::meterProvider());
         $this->assertInstanceOf(NoopTracerProvider::class, Globals::tracerProvider());
+        $this->assertInstanceOf(NoopLoggerProvider::class, Globals::loggerProvider());
+        $this->assertInstanceOf(NoopConfigurationResolver::class, Globals::configurationResolver());
         $this->assertInstanceOf(NoopTextMapPropagator::class, Globals::propagator(), 'propagator not initialized by disabled autoloader');
     }
 
@@ -57,6 +60,7 @@ class SdkAutoloaderTest extends TestCase
         $this->assertNotInstanceOf(NoopTextMapPropagator::class, Globals::propagator());
         $this->assertInstanceOf(NoopMeterProvider::class, Globals::meterProvider());
         $this->assertInstanceOf(NoopTracerProvider::class, Globals::tracerProvider());
+        $this->assertInstanceOf(NoopConfigurationResolver::class, Globals::configurationResolver());
     }
 
     public function test_enabled_by_configuration(): void
@@ -67,5 +71,6 @@ class SdkAutoloaderTest extends TestCase
         $this->assertNotInstanceOf(NoopMeterProvider::class, Globals::meterProvider());
         $this->assertNotInstanceOf(NoopTracerProvider::class, Globals::tracerProvider());
         $this->assertNotInstanceOf(NoopLoggerProvider::class, Globals::loggerProvider());
+        $this->assertNotInstanceOf(NoopConfigurationResolver::class, Globals::configurationResolver());
     }
 }


### PR DESCRIPTION
adding a configuration resolver interface, and api+sdk implementations. the resolver is globally configured. this allows contrib modules to fetch config if an SDK is installed, without directly using the SDK (per spec).

Replaces: #1079 