### PR TITLE
Guard against ZTS builds

### DIFF
--- a/src/Context/ZendObserverFiber.php
+++ b/src/Context/ZendObserverFiber.php
@@ -15,6 +15,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 use function filter_var;
 use function is_string;
 use const PHP_VERSION_ID;
+use const PHP_ZTS;
 use function sprintf;
 use function trigger_error;
 
@@ -39,8 +40,8 @@ final class ZendObserverFiber
             return true;
         }
 
-        if (PHP_VERSION_ID < 80100 || !extension_loaded('ffi')) {
-            trigger_error('Context: Fiber context switching not supported, requires PHP >= 8.1 and the FFI extension');
+        if (!PHP_ZTS || PHP_VERSION_ID < 80100 || !extension_loaded('ffi')) {
+            trigger_error('Context: Fiber context switching not supported, requires PHP >= 8.1, NTS build, and the FFI extension');
 
             return false;
         }


### PR DESCRIPTION
Registering fiber observers at PHP runtime is something that exists outside of the model, but should work well enough in practice in NTS builds. However, for ZTS builds this is just entirely unsafe.

# Important

I have not run this code, and it may need massaging. I noticed this issue while browsing the code, and felt like opening a PR was better than an issue, but I haven't ran tests or anything to make sure I didn't make some silly mistake.