### PR TITLE
fix: fiber observers by FFI are not safe on ZTS

### DIFF
--- a/src/Context/README.md
+++ b/src/Context/README.md
@@ -35,7 +35,7 @@ It is recommended to use a `try-finally` statement after `::activate()` to ensur
 
 ### Fiber support
 
-Requires `PHP >= 8.1`, `ext-ffi` and setting the environment variable `OTEL_PHP_FIBERS_ENABLED` to a truthy value. Additionally `vendor/autoload.php` has to be preloaded for non-CLI SAPIs if [`ffi.enable`](https://www.php.net/manual/en/ffi.configuration.php#ini.ffi.enable) is set to `preload`.
+Requires `PHP >= 8.1`, an NTS build, `ext-ffi`, and setting the environment variable `OTEL_PHP_FIBERS_ENABLED` to a truthy value. Additionally `vendor/autoload.php` has to be preloaded for non-CLI SAPIs if [`ffi.enable`](https://www.php.net/manual/en/ffi.configuration.php#ini.ffi.enable) is set to `preload`.
 
 ### Event loops
 

--- a/src/Context/ZendObserverFiber.php
+++ b/src/Context/ZendObserverFiber.php
@@ -15,6 +15,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 use function filter_var;
 use function is_string;
 use const PHP_VERSION_ID;
+use const PHP_ZTS;
 use function sprintf;
 use function trigger_error;
 
@@ -39,8 +40,8 @@ final class ZendObserverFiber
             return true;
         }
 
-        if (PHP_VERSION_ID < 80100 || !extension_loaded('ffi')) {
-            trigger_error('Context: Fiber context switching not supported, requires PHP >= 8.1 and the FFI extension');
+        if (PHP_ZTS || PHP_VERSION_ID < 80100 || !extension_loaded('ffi')) {
+            trigger_error('Context: Fiber context switching not supported, requires PHP >= 8.1, an NTS build, and the FFI extension');
 
             return false;
         }


### PR DESCRIPTION
They aren't _truly_ safe on NTS builds either, as the functions used are only expected to be set at certain times of the lifecycle, but in practice it's safe enough on NTS.

However, for ZTS, these APIs are not safe to call at runtime at all.

I haven't tested these changes. I simply saw this issue while reading the code and thought I'd offer a starting point by opening a PR instead of just an issue.