### PR TITLE
document that examplars are not stable

### DIFF
--- a/src/SDK/Metrics/Exemplar/ExemplarFilter/AllExemplarFilter.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilter/AllExemplarFilter.php
@@ -8,6 +8,10 @@ use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
 
+/**
+ * The exemplar spec is not yet stable, and can change at any time.
+ * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplar
+ */
 final class AllExemplarFilter implements ExemplarFilterInterface
 {
     public function accepts($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): bool

--- a/src/SDK/Metrics/Exemplar/ExemplarFilter/NoneExemplarFilter.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilter/NoneExemplarFilter.php
@@ -8,6 +8,10 @@ use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
 
+/**
+ * The exemplar spec is not yet stable, and can change at any time.
+ * see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplar
+ */
 final class NoneExemplarFilter implements ExemplarFilterInterface
 {
     public function accepts($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): bool

--- a/src/SDK/Metrics/Exemplar/ExemplarFilter/WithSampledTraceExemplarFilter.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilter/WithSampledTraceExemplarFilter.php
@@ -9,6 +9,10 @@ use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
 
+/**
+ * The exemplar spec is not yet stable, and can change at any time.
+ * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplar
+ */
 final class WithSampledTraceExemplarFilter implements ExemplarFilterInterface
 {
     public function accepts($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): bool

--- a/src/SDK/Metrics/Exemplar/ExemplarFilterInterface.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilterInterface.php
@@ -7,6 +7,10 @@ namespace OpenTelemetry\SDK\Metrics\Exemplar;
 use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 
+/**
+ * The exemplar spec is not yet stable, and can change at any time.
+ * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplar
+ */
 interface ExemplarFilterInterface
 {
     /**

--- a/src/SDK/Metrics/Exemplar/FilteredReservoir.php
+++ b/src/SDK/Metrics/Exemplar/FilteredReservoir.php
@@ -7,6 +7,10 @@ namespace OpenTelemetry\SDK\Metrics\Exemplar;
 use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 
+/**
+ * The exemplar spec is not yet stable, and can change at any time.
+ * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplar
+ */
 final class FilteredReservoir implements ExemplarReservoirInterface
 {
     private ExemplarReservoirInterface $reservoir;


### PR DESCRIPTION
noted in TC review. Java moved their examplar code into an internal package, and documented that it may change. We don't have an internal package, so document the warning in a few places.

Fixes: #1088 