### PR TITLE
adding PushMetricExporterInterface

### DIFF
--- a/examples/metrics/getting_started.php
+++ b/examples/metrics/getting_started.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use OpenTelemetry\API\Metrics\ObserverInterface;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MeterProvider;
-use OpenTelemetry\SDK\Metrics\MetricExporter\ConsoleMetricsExporter;
+use OpenTelemetry\SDK\Metrics\MetricExporter\ConsoleMetricExporter;
 use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 
@@ -18,7 +18,7 @@ require 'vendor/autoload.php';
  */
 
 $reader = new ExportingReader(
-    new ConsoleMetricsExporter(Temporality::DELTA)
+    new ConsoleMetricExporter(Temporality::DELTA)
 );
 
 $meterProvider = MeterProvider::builder()

--- a/examples/metrics/weak-reference-observables.php
+++ b/examples/metrics/weak-reference-observables.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use OpenTelemetry\API\Metrics\ObserverInterface;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MeterProvider;
-use OpenTelemetry\SDK\Metrics\MetricExporter\ConsoleMetricsExporter;
+use OpenTelemetry\SDK\Metrics\MetricExporter\ConsoleMetricExporter;
 use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 
@@ -19,7 +19,7 @@ require 'vendor/autoload.php';
  */
 
 $reader = new ExportingReader(
-    new ConsoleMetricsExporter(Temporality::DELTA)
+    new ConsoleMetricExporter(Temporality::DELTA)
 );
 
 $meterProvider = MeterProvider::builder()

--- a/src/Contrib/Otlp/MetricExporter.php
+++ b/src/Contrib/Otlp/MetricExporter.php
@@ -8,8 +8,8 @@ use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use Opentelemetry\Proto\Collector\Metrics\V1\ExportMetricsServiceResponse;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
-use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
+use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
 use RuntimeException;
 use Throwable;
 
@@ -18,7 +18,7 @@ use Throwable;
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/experimental/serialization/json.md#json-file-serialization
  * @psalm-import-type SUPPORTED_CONTENT_TYPES from ProtobufSerializer
  */
-final class MetricExporter implements MetricExporterInterface
+final class MetricExporter implements PushMetricExporterInterface
 {
     use LogsMessagesTrait;
 

--- a/src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php
+++ b/src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php
@@ -7,15 +7,15 @@ namespace OpenTelemetry\SDK\Metrics\MetricExporter;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 use OpenTelemetry\SDK\Metrics\Data\Metric;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
-use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
+use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 /**
  * Console metrics exporter.
  * Note that the output is human-readable JSON, not compatible with OTLP.
  */
-class ConsoleMetricsExporter implements MetricExporterInterface
+class ConsoleMetricExporter implements PushMetricExporterInterface
 {
     /**
      * @var string|Temporality|null

--- a/src/SDK/Metrics/MetricExporter/ConsoleMetricExporterFactory.php
+++ b/src/SDK/Metrics/MetricExporter/ConsoleMetricExporterFactory.php
@@ -11,6 +11,6 @@ class ConsoleMetricExporterFactory implements MetricExporterFactoryInterface
 {
     public function create(): MetricExporterInterface
     {
-        return new ConsoleMetricsExporter();
+        return new ConsoleMetricExporter();
     }
 }

--- a/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
+++ b/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
@@ -74,9 +74,4 @@ final class InMemoryExporter implements MetricExporterInterface
 
         return true;
     }
-
-    public function forceFlush(): bool
-    {
-        return !$this->closed;
-    }
 }

--- a/src/SDK/Metrics/MetricExporter/NoopMetricExporter.php
+++ b/src/SDK/Metrics/MetricExporter/NoopMetricExporter.php
@@ -30,9 +30,4 @@ class NoopMetricExporter implements MetricExporterInterface
     {
         return true;
     }
-
-    public function forceFlush(): bool
-    {
-        return true;
-    }
 }

--- a/src/SDK/Metrics/MetricExporterInterface.php
+++ b/src/SDK/Metrics/MetricExporterInterface.php
@@ -26,6 +26,4 @@ interface MetricExporterInterface
     public function export(iterable $batch): bool;
 
     public function shutdown(): bool;
-
-    public function forceFlush(): bool;
 }

--- a/src/SDK/Metrics/MetricReader/ExportingReader.php
+++ b/src/SDK/Metrics/MetricReader/ExportingReader.php
@@ -16,6 +16,7 @@ use OpenTelemetry\SDK\Metrics\MetricRegistry\MetricCollectorInterface;
 use OpenTelemetry\SDK\Metrics\MetricSourceInterface;
 use OpenTelemetry\SDK\Metrics\MetricSourceProviderInterface;
 use OpenTelemetry\SDK\Metrics\MetricSourceRegistryInterface;
+use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
 use OpenTelemetry\SDK\Metrics\StalenessHandlerInterface;
 use function spl_object_id;
 
@@ -139,10 +140,13 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
         if ($this->closed) {
             return false;
         }
+        if ($this->exporter instanceof PushMetricExporterInterface) {
+            $collect = $this->doCollect();
+            $forceFlush = $this->exporter->forceFlush();
 
-        $collect = $this->doCollect();
-        $forceFlush = $this->exporter->forceFlush();
+            return $collect && $forceFlush;
+        }
 
-        return $collect && $forceFlush;
+        return true;
     }
 }

--- a/src/SDK/Metrics/PushMetricExporterInterface.php
+++ b/src/SDK/Metrics/PushMetricExporterInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Metrics;
+
+use OpenTelemetry\SDK\Metrics;
+
+interface PushMetricExporterInterface extends Metrics\MetricExporterInterface
+{
+    public function forceFlush(): bool;
+}


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/pull/3563 clarifies the behaviour of forceFlush with push/non-push metric exporters.
Break forceFlush out into a PushMetricExporterInterface, and update ExportingReader to only collect/flush if exporter is a push metric exporter.

Fixes #1086