### PR TITLE
update semconv to 1.22.0

### DIFF
--- a/script/semantic-conventions/templates/resource_deprecations.php.partial
+++ b/script/semantic-conventions/templates/resource_deprecations.php.partial
@@ -1,9 +1,19 @@
     /**
-     * @deprecated
+     * @deprecated Use USER_AGENT_ORIGINAL
      */
     public const BROWSER_USER_AGENT = 'browser.user_agent';
 
     /**
-     * @deprecated
+     * @deprecated Use CLOUD_RESOURCE_ID
      */
     public const FAAS_ID = 'faas.id';
+
+    /**
+     * @deprecated Use TELEMETRY_DISTRO_VERSION
+     */
+    public const TELEMETRY_AUTO_VERSION = 'telemetry.auto.version';
+
+    /**
+     * @deprecated Use CONTAINER_IMAGE_TAGS
+     */
+    public const CONTAINER_IMAGE_TAG = 'container.image.tag';

--- a/src/SDK/Resource/Detectors/Sdk.php
+++ b/src/SDK/Resource/Detectors/Sdk.php
@@ -44,7 +44,8 @@ final class Sdk implements ResourceDetectorInterface
         }
 
         if (extension_loaded('opentelemetry')) {
-            $attributes[ResourceAttributes::TELEMETRY_AUTO_VERSION] = phpversion('opentelemetry');
+            $attributes[ResourceAttributes::TELEMETRY_DISTRO_NAME] = 'opentelemetry-php-instrumentation';
+            $attributes[ResourceAttributes::TELEMETRY_DISTRO_VERSION] = phpversion('opentelemetry');
         }
 
         return ResourceInfo::create(Attributes::create($attributes), ResourceAttributes::SCHEMA_URL);

--- a/src/SemConv/ResourceAttributes.php
+++ b/src/SemConv/ResourceAttributes.php
@@ -11,7 +11,15 @@ interface ResourceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.19.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.22.0';
+
+    /**
+     * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found here.
+     *
+     * @example 33
+     * @example 32
+     */
+    public const ANDROID_OS_API_LEVEL = 'android.os.api_level';
 
     /**
      * Array of brand name and version separated by a space.
@@ -23,25 +31,6 @@ interface ResourceAttributes
      * @example Chrome 99
      */
     public const BROWSER_BRANDS = 'browser.brands';
-
-    /**
-     * The platform on which the browser is running.
-     *
-     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
-     * The list of possible values is defined in the W3C User-Agent Client Hints specification. Note that some (but not all) of these values can overlap with values in the `os.type` and `os.name` attributes. However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
-     *
-     * @example Windows
-     * @example macOS
-     * @example Android
-     */
-    public const BROWSER_PLATFORM = 'browser.platform';
-
-    /**
-     * A boolean that is true if the browser is running on a mobile device.
-     *
-     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.mobile`). If unavailable, this attribute SHOULD be left unset.
-     */
-    public const BROWSER_MOBILE = 'browser.mobile';
 
     /**
      * Preferred language of the user using the browser.
@@ -56,6 +45,25 @@ interface ResourceAttributes
     public const BROWSER_LANGUAGE = 'browser.language';
 
     /**
+     * A boolean that is true if the browser is running on a mobile device.
+     *
+     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.mobile`). If unavailable, this attribute SHOULD be left unset.
+     */
+    public const BROWSER_MOBILE = 'browser.mobile';
+
+    /**
+     * The platform on which the browser is running.
+     *
+     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
+     * The list of possible values is defined in the W3C User-Agent Client Hints specification. Note that some (but not all) of these values can overlap with values in the `os.type` and `os.name` attributes. However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
+     *
+     * @example Windows
+     * @example macOS
+     * @example Android
+     */
+    public const BROWSER_PLATFORM = 'browser.platform';
+
+    /**
      * Full user-agent string provided by the browser.
      *
      * The user-agent value SHOULD be provided only from browsers that do not have a mechanism to retrieve brands and platform individually from the User-Agent Client Hints API. To retrieve the value, the legacy `navigator.userAgent` API can be used.
@@ -65,17 +73,33 @@ interface ResourceAttributes
     public const USER_AGENT_ORIGINAL = 'user_agent.original';
 
     /**
-     * Name of the cloud provider.
-     */
-    public const CLOUD_PROVIDER = 'cloud.provider';
-
-    /**
      * The cloud account ID the resource is assigned to.
      *
      * @example 111111111111
      * @example opentelemetry
      */
     public const CLOUD_ACCOUNT_ID = 'cloud.account.id';
+
+    /**
+     * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
+     *
+     * Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
+     *
+     * @example us-east-1c
+     */
+    public const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
+
+    /**
+     * The cloud platform in use.
+     *
+     * The prefix of the service SHOULD match the one specified in `cloud.provider`.
+     */
+    public const CLOUD_PLATFORM = 'cloud.platform';
+
+    /**
+     * Name of the cloud provider.
+     */
+    public const CLOUD_PROVIDER = 'cloud.provider';
 
     /**
      * The geographical region the resource is running.
@@ -113,20 +137,11 @@ interface ResourceAttributes
     public const CLOUD_RESOURCE_ID = 'cloud.resource_id';
 
     /**
-     * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
+     * The ARN of an ECS cluster.
      *
-     * Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
-     *
-     * @example us-east-1c
+     * @example arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
      */
-    public const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
-
-    /**
-     * The cloud platform in use.
-     *
-     * The prefix of the service SHOULD match the one specified in `cloud.provider`.
-     */
-    public const CLOUD_PLATFORM = 'cloud.platform';
+    public const AWS_ECS_CLUSTER_ARN = 'aws.ecs.cluster.arn';
 
     /**
      * The Amazon Resource Name (ARN) of an ECS container instance.
@@ -134,13 +149,6 @@ interface ResourceAttributes
      * @example arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9
      */
     public const AWS_ECS_CONTAINER_ARN = 'aws.ecs.container.arn';
-
-    /**
-     * The ARN of an ECS cluster.
-     *
-     * @example arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
-     */
-    public const AWS_ECS_CLUSTER_ARN = 'aws.ecs.cluster.arn';
 
     /**
      * The launch type for an ECS task.
@@ -177,16 +185,6 @@ interface ResourceAttributes
     public const AWS_EKS_CLUSTER_ARN = 'aws.eks.cluster.arn';
 
     /**
-     * The name(s) of the AWS log group(s) an application is writing to.
-     *
-     * Multiple log groups must be supported for cases like multi-container applications, where a single application has sidecar containers, and each write to their own log group.
-     *
-     * @example /aws/lambda/my-function
-     * @example opentelemetry-service
-     */
-    public const AWS_LOG_GROUP_NAMES = 'aws.log.group.names';
-
-    /**
      * The Amazon Resource Name(s) (ARN) of the AWS log group(s).
      *
      * See the log group ARN format documentation.
@@ -196,11 +194,14 @@ interface ResourceAttributes
     public const AWS_LOG_GROUP_ARNS = 'aws.log.group.arns';
 
     /**
-     * The name(s) of the AWS log stream(s) an application is writing to.
+     * The name(s) of the AWS log group(s) an application is writing to.
      *
-     * @example logs/main/10838bed-421f-43ef-870a-f43feacbbb5b
+     * Multiple log groups must be supported for cases like multi-container applications, where a single application has sidecar containers, and each write to their own log group.
+     *
+     * @example /aws/lambda/my-function
+     * @example opentelemetry-service
      */
-    public const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
+    public const AWS_LOG_GROUP_NAMES = 'aws.log.group.names';
 
     /**
      * The ARN(s) of the AWS log stream(s).
@@ -212,18 +213,42 @@ interface ResourceAttributes
     public const AWS_LOG_STREAM_ARNS = 'aws.log.stream.arns';
 
     /**
-     * Time and date the release was created.
+     * The name(s) of the AWS log stream(s) an application is writing to.
      *
-     * @example 2022-10-23T18:00:42Z
+     * @example logs/main/10838bed-421f-43ef-870a-f43feacbbb5b
      */
-    public const HEROKU_RELEASE_CREATION_TIMESTAMP = 'heroku.release.creation_timestamp';
+    public const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
 
     /**
-     * Commit hash for the current release.
+     * The name of the Cloud Run execution being run for the Job, as set by the `CLOUD_RUN_EXECUTION` environment variable.
      *
-     * @example e6134959463efd8966b20e75b913cafe3f5ec
+     * @example job-name-xxxx
+     * @example sample-job-mdw84
      */
-    public const HEROKU_RELEASE_COMMIT = 'heroku.release.commit';
+    public const GCP_CLOUD_RUN_JOB_EXECUTION = 'gcp.cloud_run.job.execution';
+
+    /**
+     * The index for a task within an execution as provided by the `CLOUD_RUN_TASK_INDEX` environment variable.
+     *
+     * @example 1
+     */
+    public const GCP_CLOUD_RUN_JOB_TASK_INDEX = 'gcp.cloud_run.job.task_index';
+
+    /**
+     * The hostname of a GCE instance. This is the full value of the default or custom hostname.
+     *
+     * @example my-host1234.example.com
+     * @example sample-vm.us-west1-b.c.my-project.internal
+     */
+    public const GCP_GCE_INSTANCE_HOSTNAME = 'gcp.gce.instance.hostname';
+
+    /**
+     * The instance name of a GCE instance. This is the value provided by `host.name`, the visible name of the instance in the Cloud Console UI, and the prefix for the default hostname of the instance as defined by the default internal DNS name.
+     *
+     * @example instance-1
+     * @example my-vm-name
+     */
+    public const GCP_GCE_INSTANCE_NAME = 'gcp.gce.instance.name';
 
     /**
      * Unique identifier for the application.
@@ -233,11 +258,41 @@ interface ResourceAttributes
     public const HEROKU_APP_ID = 'heroku.app.id';
 
     /**
-     * Container name used by container runtime.
+     * Commit hash for the current release.
      *
-     * @example opentelemetry-autoconf
+     * @example e6134959463efd8966b20e75b913cafe3f5ec
      */
-    public const CONTAINER_NAME = 'container.name';
+    public const HEROKU_RELEASE_COMMIT = 'heroku.release.commit';
+
+    /**
+     * Time and date the release was created.
+     *
+     * @example 2022-10-23T18:00:42Z
+     */
+    public const HEROKU_RELEASE_CREATION_TIMESTAMP = 'heroku.release.creation_timestamp';
+
+    /**
+     * The command used to run the container (i.e. the command name).
+     *
+     * If using embedded credentials or sensitive data, it is recommended to remove them to prevent potential leakage.
+     *
+     * @example otelcontribcol
+     */
+    public const CONTAINER_COMMAND = 'container.command';
+
+    /**
+     * All the command arguments (including the command/executable itself) run by the container. [2].
+     *
+     * @example otelcontribcol, --config, config.yaml
+     */
+    public const CONTAINER_COMMAND_ARGS = 'container.command_args';
+
+    /**
+     * The full command run by the container as a single string representing the full command. [2].
+     *
+     * @example otelcontribcol --config config.yaml
+     */
+    public const CONTAINER_COMMAND_LINE = 'container.command_line';
 
     /**
      * Container ID. Usually a UUID, as for example used to identify Docker containers. The UUID might be abbreviated.
@@ -247,13 +302,15 @@ interface ResourceAttributes
     public const CONTAINER_ID = 'container.id';
 
     /**
-     * The container runtime managing this container.
+     * Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
      *
-     * @example docker
-     * @example containerd
-     * @example rkt
+     * Docker defines a sha256 of the image id; `container.image.id` corresponds to the `Image` field from the Docker container inspect API endpoint.
+     * K8s defines a link to the container registry repository with digest `"imageID": "registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625"`.
+     * The ID is assinged by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
+     *
+     * @example sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f
      */
-    public const CONTAINER_RUNTIME = 'container.runtime';
+    public const CONTAINER_IMAGE_ID = 'container.image.id';
 
     /**
      * Name of the image the container was built on.
@@ -263,11 +320,38 @@ interface ResourceAttributes
     public const CONTAINER_IMAGE_NAME = 'container.image.name';
 
     /**
-     * Container image tag.
+     * Repo digests of the container image as provided by the container runtime.
      *
-     * @example 0.1
+     * Docker and CRI report those under the `RepoDigests` field.
+     *
+     * @example example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb
+     * @example internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578
      */
-    public const CONTAINER_IMAGE_TAG = 'container.image.tag';
+    public const CONTAINER_IMAGE_REPO_DIGESTS = 'container.image.repo_digests';
+
+    /**
+     * Container image tags. An example can be found in Docker Image Inspect. Should be only the `<tag>` section of the full name for example from `registry.example.com/my-org/my-image:<tag>`.
+     *
+     * @example v1.27.1
+     * @example 3.5.7-0
+     */
+    public const CONTAINER_IMAGE_TAGS = 'container.image.tags';
+
+    /**
+     * Container name used by container runtime.
+     *
+     * @example opentelemetry-autoconf
+     */
+    public const CONTAINER_NAME = 'container.name';
+
+    /**
+     * The container runtime managing this container.
+     *
+     * @example docker
+     * @example containerd
+     * @example rkt
+     */
+    public const CONTAINER_RUNTIME = 'container.runtime';
 
     /**
      * Name of the deployment environment (aka deployment tier).
@@ -285,6 +369,16 @@ interface ResourceAttributes
      * @example 2ab2916d-a51f-4ac8-80ee-45ac31a28092
      */
     public const DEVICE_ID = 'device.id';
+
+    /**
+     * The name of the device manufacturer.
+     *
+     * The Android OS provides this field via Build. iOS apps SHOULD hardcode the value `Apple`.
+     *
+     * @example Apple
+     * @example Samsung
+     */
+    public const DEVICE_MANUFACTURER = 'device.manufacturer';
 
     /**
      * The model identifier for the device.
@@ -307,14 +401,24 @@ interface ResourceAttributes
     public const DEVICE_MODEL_NAME = 'device.model.name';
 
     /**
-     * The name of the device manufacturer.
+     * The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version.
      *
-     * The Android OS provides this field via Build. iOS apps SHOULD hardcode the value `Apple`.
+     * <ul>
+     * <li><strong>AWS Lambda:</strong> Use the (full) log stream name.</li>
+     * </ul>
      *
-     * @example Apple
-     * @example Samsung
+     * @example 2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de
      */
-    public const DEVICE_MANUFACTURER = 'device.manufacturer';
+    public const FAAS_INSTANCE = 'faas.instance';
+
+    /**
+     * The amount of memory available to the serverless function converted to Bytes.
+     *
+     * It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
+     *
+     * @example 134217728
+     */
+    public const FAAS_MAX_MEMORY = 'faas.max_memory';
 
     /**
      * The name of the single function that this runtime instance executes.
@@ -345,7 +449,7 @@ interface ResourceAttributes
      * Depending on the cloud provider and platform, use:<ul>
      * <li><strong>AWS Lambda:</strong> The function version
      * (an integer represented as a decimal string).</li>
-     * <li><strong>Google Cloud Run:</strong> The revision
+     * <li><strong>Google Cloud Run (Services):</strong> The revision
      * (i.e., the function name plus the revision suffix).</li>
      * <li><strong>Google Cloud Functions:</strong> The value of the
      * `K_REVISION` environment variable.</li>
@@ -358,24 +462,9 @@ interface ResourceAttributes
     public const FAAS_VERSION = 'faas.version';
 
     /**
-     * The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version.
-     *
-     * <ul>
-     * <li><strong>AWS Lambda:</strong> Use the (full) log stream name.</li>
-     * </ul>
-     *
-     * @example 2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de
+     * The CPU architecture the host system is running on.
      */
-    public const FAAS_INSTANCE = 'faas.instance';
-
-    /**
-     * The amount of memory available to the serverless function converted to Bytes.
-     *
-     * It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
-     *
-     * @example 134217728
-     */
-    public const FAAS_MAX_MEMORY = 'faas.max_memory';
+    public const HOST_ARCH = 'host.arch';
 
     /**
      * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system.
@@ -383,6 +472,38 @@ interface ResourceAttributes
      * @example fdbf79e8af94cb7f9e8df36789187052
      */
     public const HOST_ID = 'host.id';
+
+    /**
+     * VM image ID or host OS image ID. For Cloud, this value is from the provider.
+     *
+     * @example ami-07b06b442921831e5
+     */
+    public const HOST_IMAGE_ID = 'host.image.id';
+
+    /**
+     * Name of the VM image or OS install the host was instantiated from.
+     *
+     * @example infra-ami-eks-worker-node-7d4ec78312
+     * @example CentOS-8-x86_64-1905
+     */
+    public const HOST_IMAGE_NAME = 'host.image.name';
+
+    /**
+     * The version string of the VM image or host OS as defined in Version Attributes.
+     *
+     * @example 0.1
+     */
+    public const HOST_IMAGE_VERSION = 'host.image.version';
+
+    /**
+     * Available IP addresses of the host, excluding loopback interfaces.
+     *
+     * IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses MUST be specified in the RFC 5952 format.
+     *
+     * @example 192.168.1.140
+     * @example fe80::abc2:4a28:737a:609e
+     */
+    public const HOST_IP = 'host.ip';
 
     /**
      * Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
@@ -399,31 +520,48 @@ interface ResourceAttributes
     public const HOST_TYPE = 'host.type';
 
     /**
-     * The CPU architecture the host system is running on.
+     * The amount of level 2 memory cache available to the processor (in Bytes).
+     *
+     * @example 12288000
      */
-    public const HOST_ARCH = 'host.arch';
+    public const HOST_CPU_CACHE_L2_SIZE = 'host.cpu.cache.l2.size';
 
     /**
-     * Name of the VM image or OS install the host was instantiated from.
+     * Numeric value specifying the family or generation of the CPU.
      *
-     * @example infra-ami-eks-worker-node-7d4ec78312
-     * @example CentOS-8-x86_64-1905
+     * @example 6
      */
-    public const HOST_IMAGE_NAME = 'host.image.name';
+    public const HOST_CPU_FAMILY = 'host.cpu.family';
 
     /**
-     * VM image ID. For Cloud, this value is from the provider.
+     * Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family.
      *
-     * @example ami-07b06b442921831e5
+     * @example 6
      */
-    public const HOST_IMAGE_ID = 'host.image.id';
+    public const HOST_CPU_MODEL_ID = 'host.cpu.model.id';
 
     /**
-     * The version string of the VM image as defined in Version Attributes.
+     * Model designation of the processor.
      *
-     * @example 0.1
+     * @example 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
      */
-    public const HOST_IMAGE_VERSION = 'host.image.version';
+    public const HOST_CPU_MODEL_NAME = 'host.cpu.model.name';
+
+    /**
+     * Stepping or core revisions.
+     *
+     * @example 1
+     */
+    public const HOST_CPU_STEPPING = 'host.cpu.stepping';
+
+    /**
+     * Processor manufacturer identifier. A maximum 12-character string.
+     *
+     * CPUID command returns the vendor ID string in EBX, EDX and ECX registers. Writing these to memory in this order results in a 12-character string.
+     *
+     * @example GenuineIntel
+     */
+    public const HOST_CPU_VENDOR_ID = 'host.cpu.vendor.id';
 
     /**
      * The name of the cluster.
@@ -431,6 +569,31 @@ interface ResourceAttributes
      * @example opentelemetry-cluster
      */
     public const K8S_CLUSTER_NAME = 'k8s.cluster.name';
+
+    /**
+     * A pseudo-ID for the cluster, set to the UID of the `kube-system` namespace.
+     *
+     * K8s does not have support for obtaining a cluster ID. If this is ever
+     * added, we will recommend collecting the `k8s.cluster.uid` through the
+     * official APIs. In the meantime, we are able to use the `uid` of the
+     * `kube-system` namespace as a proxy for cluster ID. Read on for the
+     * rationale.Every object created in a K8s cluster is assigned a distinct UID. The
+     * `kube-system` namespace is used by Kubernetes itself and will exist
+     * for the lifetime of the cluster. Using the `uid` of the `kube-system`
+     * namespace is a reasonable proxy for the K8s ClusterID as it will only
+     * change if the cluster is rebuilt. Furthermore, Kubernetes UIDs are
+     * UUIDs as standardized by
+     * ISO/IEC 9834-8 and ITU-T X.667.
+     * Which states:<blockquote>
+     * If generated according to one of the mechanisms defined in Rec.</blockquote>
+     * ITU-T X.667 | ISO/IEC 9834-8, a UUID is either guaranteed to be
+     *   different from all other UUIDs generated before 3603 A.D., or is
+     *   extremely likely to be different (depending on the mechanism chosen).Therefore, UIDs between clusters should be extremely unlikely to
+     * conflict.
+     *
+     * @example 218fc5a9-a5f1-4b54-aa05-46717d0ab26d
+     */
+    public const K8S_CLUSTER_UID = 'k8s.cluster.uid';
 
     /**
      * The name of the Node.
@@ -454,18 +617,18 @@ interface ResourceAttributes
     public const K8S_NAMESPACE_NAME = 'k8s.namespace.name';
 
     /**
-     * The UID of the Pod.
-     *
-     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
-     */
-    public const K8S_POD_UID = 'k8s.pod.uid';
-
-    /**
      * The name of the Pod.
      *
      * @example opentelemetry-pod-autoconf
      */
     public const K8S_POD_NAME = 'k8s.pod.name';
+
+    /**
+     * The UID of the Pod.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_POD_UID = 'k8s.pod.uid';
 
     /**
      * The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`).
@@ -482,13 +645,6 @@ interface ResourceAttributes
     public const K8S_CONTAINER_RESTART_COUNT = 'k8s.container.restart_count';
 
     /**
-     * The UID of the ReplicaSet.
-     *
-     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
-     */
-    public const K8S_REPLICASET_UID = 'k8s.replicaset.uid';
-
-    /**
      * The name of the ReplicaSet.
      *
      * @example opentelemetry
@@ -496,11 +652,11 @@ interface ResourceAttributes
     public const K8S_REPLICASET_NAME = 'k8s.replicaset.name';
 
     /**
-     * The UID of the Deployment.
+     * The UID of the ReplicaSet.
      *
      * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
      */
-    public const K8S_DEPLOYMENT_UID = 'k8s.deployment.uid';
+    public const K8S_REPLICASET_UID = 'k8s.replicaset.uid';
 
     /**
      * The name of the Deployment.
@@ -510,11 +666,11 @@ interface ResourceAttributes
     public const K8S_DEPLOYMENT_NAME = 'k8s.deployment.name';
 
     /**
-     * The UID of the StatefulSet.
+     * The UID of the Deployment.
      *
      * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
      */
-    public const K8S_STATEFULSET_UID = 'k8s.statefulset.uid';
+    public const K8S_DEPLOYMENT_UID = 'k8s.deployment.uid';
 
     /**
      * The name of the StatefulSet.
@@ -524,11 +680,11 @@ interface ResourceAttributes
     public const K8S_STATEFULSET_NAME = 'k8s.statefulset.name';
 
     /**
-     * The UID of the DaemonSet.
+     * The UID of the StatefulSet.
      *
      * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
      */
-    public const K8S_DAEMONSET_UID = 'k8s.daemonset.uid';
+    public const K8S_STATEFULSET_UID = 'k8s.statefulset.uid';
 
     /**
      * The name of the DaemonSet.
@@ -538,11 +694,11 @@ interface ResourceAttributes
     public const K8S_DAEMONSET_NAME = 'k8s.daemonset.name';
 
     /**
-     * The UID of the Job.
+     * The UID of the DaemonSet.
      *
      * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
      */
-    public const K8S_JOB_UID = 'k8s.job.uid';
+    public const K8S_DAEMONSET_UID = 'k8s.daemonset.uid';
 
     /**
      * The name of the Job.
@@ -552,11 +708,11 @@ interface ResourceAttributes
     public const K8S_JOB_NAME = 'k8s.job.name';
 
     /**
-     * The UID of the CronJob.
+     * The UID of the Job.
      *
      * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
      */
-    public const K8S_CRONJOB_UID = 'k8s.cronjob.uid';
+    public const K8S_JOB_UID = 'k8s.job.uid';
 
     /**
      * The name of the CronJob.
@@ -566,9 +722,30 @@ interface ResourceAttributes
     public const K8S_CRONJOB_NAME = 'k8s.cronjob.name';
 
     /**
-     * The operating system type.
+     * The UID of the CronJob.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
      */
-    public const OS_TYPE = 'os.type';
+    public const K8S_CRONJOB_UID = 'k8s.cronjob.uid';
+
+    /**
+     * The digest of the OCI image manifest. For container images specifically is the digest by which the container image is known.
+     *
+     * Follows OCI Image Manifest Specification, and specifically the Digest property.
+     * An example can be found in Example Image Manifest.
+     *
+     * @example sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4
+     */
+    public const OCI_MANIFEST_DIGEST = 'oci.manifest.digest';
+
+    /**
+     * Unique identifier for a particular build or compilation of the operating system.
+     *
+     * @example TQ3C.230805.001.B2
+     * @example 20E247
+     * @example 22621
+     */
+    public const OS_BUILD_ID = 'os.build_id';
 
     /**
      * Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands.
@@ -588,6 +765,11 @@ interface ResourceAttributes
     public const OS_NAME = 'os.name';
 
     /**
+     * The operating system type.
+     */
+    public const OS_TYPE = 'os.type';
+
+    /**
      * The version string of the operating system as defined in Version Attributes.
      *
      * @example 14.2.1
@@ -596,18 +778,26 @@ interface ResourceAttributes
     public const OS_VERSION = 'os.version';
 
     /**
-     * Process identifier (PID).
+     * The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
      *
-     * @example 1234
+     * @example cmd/otelcol
      */
-    public const PROCESS_PID = 'process.pid';
+    public const PROCESS_COMMAND = 'process.command';
 
     /**
-     * Parent Process identifier (PID).
+     * All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`.
      *
-     * @example 111
+     * @example cmd/otecol
+     * @example --config=config.yaml
      */
-    public const PROCESS_PARENT_PID = 'process.parent_pid';
+    public const PROCESS_COMMAND_ARGS = 'process.command_args';
+
+    /**
+     * The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead.
+     *
+     * @example C:\cmd\otecol --config="my directory\config.yaml"
+     */
+    public const PROCESS_COMMAND_LINE = 'process.command_line';
 
     /**
      * The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
@@ -624,33 +814,32 @@ interface ResourceAttributes
     public const PROCESS_EXECUTABLE_PATH = 'process.executable.path';
 
     /**
-     * The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
-     *
-     * @example cmd/otelcol
-     */
-    public const PROCESS_COMMAND = 'process.command';
-
-    /**
-     * The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead.
-     *
-     * @example C:\cmd\otecol --config="my directory\config.yaml"
-     */
-    public const PROCESS_COMMAND_LINE = 'process.command_line';
-
-    /**
-     * All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`.
-     *
-     * @example cmd/otecol
-     * @example --config=config.yaml
-     */
-    public const PROCESS_COMMAND_ARGS = 'process.command_args';
-
-    /**
      * The username of the user that owns the process.
      *
      * @example root
      */
     public const PROCESS_OWNER = 'process.owner';
+
+    /**
+     * Parent Process identifier (PID).
+     *
+     * @example 111
+     */
+    public const PROCESS_PARENT_PID = 'process.parent_pid';
+
+    /**
+     * Process identifier (PID).
+     *
+     * @example 1234
+     */
+    public const PROCESS_PID = 'process.pid';
+
+    /**
+     * An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
+     *
+     * @example Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0
+     */
+    public const PROCESS_RUNTIME_DESCRIPTION = 'process.runtime.description';
 
     /**
      * The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler.
@@ -667,13 +856,6 @@ interface ResourceAttributes
     public const PROCESS_RUNTIME_VERSION = 'process.runtime.version';
 
     /**
-     * An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
-     *
-     * @example Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0
-     */
-    public const PROCESS_RUNTIME_DESCRIPTION = 'process.runtime.description';
-
-    /**
      * Logical name of the service.
      *
      * MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with `process.executable.name`, e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
@@ -681,6 +863,24 @@ interface ResourceAttributes
      * @example shoppingcart
      */
     public const SERVICE_NAME = 'service.name';
+
+    /**
+     * The version string of the service API or implementation. The format is not defined by these conventions.
+     *
+     * @example 2.0.0
+     * @example a01dbef8a
+     */
+    public const SERVICE_VERSION = 'service.version';
+
+    /**
+     * The string ID of the service instance.
+     *
+     * MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
+     *
+     * @example my-k8s-pod-deployment-1
+     * @example 627cc493-f310-47de-96bd-71410b7dec09
+     */
+    public const SERVICE_INSTANCE_ID = 'service.instance.id';
 
     /**
      * A namespace for `service.name`.
@@ -692,32 +892,23 @@ interface ResourceAttributes
     public const SERVICE_NAMESPACE = 'service.namespace';
 
     /**
-     * The string ID of the service instance.
-     *
-     * MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
-     *
-     * @example 627cc493-f310-47de-96bd-71410b7dec09
+     * The language of the telemetry SDK.
      */
-    public const SERVICE_INSTANCE_ID = 'service.instance.id';
-
-    /**
-     * The version string of the service API or implementation.
-     *
-     * @example 2.0.0
-     */
-    public const SERVICE_VERSION = 'service.version';
+    public const TELEMETRY_SDK_LANGUAGE = 'telemetry.sdk.language';
 
     /**
      * The name of the telemetry SDK as defined above.
      *
+     * The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`.
+     * If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the
+     * `telemetry.sdk.name` attribute to the fully-qualified class or module name of this SDK's main entry point
+     * or another suitable identifier depending on the language.
+     * The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
+     * All custom identifiers SHOULD be stable across different versions of an implementation.
+     *
      * @example opentelemetry
      */
     public const TELEMETRY_SDK_NAME = 'telemetry.sdk.name';
-
-    /**
-     * The language of the telemetry SDK.
-     */
-    public const TELEMETRY_SDK_LANGUAGE = 'telemetry.sdk.language';
 
     /**
      * The version string of the telemetry SDK.
@@ -727,11 +918,28 @@ interface ResourceAttributes
     public const TELEMETRY_SDK_VERSION = 'telemetry.sdk.version';
 
     /**
-     * The version string of the auto instrumentation agent, if used.
+     * The name of the auto instrumentation agent or distribution, if used.
+     *
+     * Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
+     * a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
+     *
+     * @example parts-unlimited-java
+     */
+    public const TELEMETRY_DISTRO_NAME = 'telemetry.distro.name';
+
+    /**
+     * The version string of the auto instrumentation agent or distribution, if used.
      *
      * @example 1.2.3
      */
-    public const TELEMETRY_AUTO_VERSION = 'telemetry.auto.version';
+    public const TELEMETRY_DISTRO_VERSION = 'telemetry.distro.version';
+
+    /**
+     * Additional description of the web engine (e.g. detailed version and edition information).
+     *
+     * @example WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final
+     */
+    public const WEBENGINE_DESCRIPTION = 'webengine.description';
 
     /**
      * The name of the web engine.
@@ -746,13 +954,6 @@ interface ResourceAttributes
      * @example 21.0.0
      */
     public const WEBENGINE_VERSION = 'webengine.version';
-
-    /**
-     * Additional description of the web engine (e.g. detailed version and edition information).
-     *
-     * @example WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final
-     */
-    public const WEBENGINE_DESCRIPTION = 'webengine.description';
 
     /**
      * The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
@@ -785,12 +986,22 @@ interface ResourceAttributes
     public const OTEL_LIBRARY_VERSION = 'otel.library.version';
 
     /**
-     * @deprecated
+     * @deprecated Use USER_AGENT_ORIGINAL
      */
     public const BROWSER_USER_AGENT = 'browser.user_agent';
 
     /**
-     * @deprecated
+     * @deprecated Use CLOUD_RESOURCE_ID
      */
     public const FAAS_ID = 'faas.id';
+
+    /**
+     * @deprecated Use TELEMETRY_DISTRO_VERSION
+     */
+    public const TELEMETRY_AUTO_VERSION = 'telemetry.auto.version';
+
+    /**
+     * @deprecated Use CONTAINER_IMAGE_TAGS
+     */
+    public const CONTAINER_IMAGE_TAG = 'container.image.tag';
 }

--- a/src/SemConv/TraceAttributes.php
+++ b/src/SemConv/TraceAttributes.php
@@ -11,15 +11,164 @@ interface TraceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.19.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.22.0';
 
     /**
-     * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+     * Client address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name.
      *
-     * @example java.net.ConnectException
-     * @example OSError
+     * When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries (e.g. proxies) if it's available.
+     *
+     * @example client.example.com
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
      */
-    public const EXCEPTION_TYPE = 'exception.type';
+    public const CLIENT_ADDRESS = 'client.address';
+
+    /**
+     * Client port number.
+     *
+     * When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries (e.g. proxies) if it's available.
+     *
+     * @example 65123
+     */
+    public const CLIENT_PORT = 'client.port';
+
+    /**
+     * Deprecated, use `server.address`.
+     *
+     * @deprecated Deprecated, use `server.address`..
+     * @example example.com
+     */
+    public const NET_HOST_NAME = 'net.host.name';
+
+    /**
+     * Deprecated, use `server.port`.
+     *
+     * @deprecated Deprecated, use `server.port`..
+     * @example 8080
+     */
+    public const NET_HOST_PORT = 'net.host.port';
+
+    /**
+     * Deprecated, use `server.address` on client spans and `client.address` on server spans.
+     *
+     * @deprecated Deprecated, use `server.address` on client spans and `client.address` on server spans..
+     * @example example.com
+     */
+    public const NET_PEER_NAME = 'net.peer.name';
+
+    /**
+     * Deprecated, use `server.port` on client spans and `client.port` on server spans.
+     *
+     * @deprecated Deprecated, use `server.port` on client spans and `client.port` on server spans..
+     * @example 8080
+     */
+    public const NET_PEER_PORT = 'net.peer.port';
+
+    /**
+     * Deprecated, use `network.protocol.name`.
+     *
+     * @deprecated Deprecated, use `network.protocol.name`..
+     * @example amqp
+     * @example http
+     * @example mqtt
+     */
+    public const NET_PROTOCOL_NAME = 'net.protocol.name';
+
+    /**
+     * Deprecated, use `network.protocol.version`.
+     *
+     * @deprecated Deprecated, use `network.protocol.version`..
+     * @example 3.1.1
+     */
+    public const NET_PROTOCOL_VERSION = 'net.protocol.version';
+
+    /**
+     * Deprecated, use `network.transport` and `network.type`.
+     */
+    public const NET_SOCK_FAMILY = 'net.sock.family';
+
+    /**
+     * Deprecated, use `network.local.address`.
+     *
+     * @deprecated Deprecated, use `network.local.address`..
+     * @example /var/my.sock
+     */
+    public const NET_SOCK_HOST_ADDR = 'net.sock.host.addr';
+
+    /**
+     * Deprecated, use `network.local.port`.
+     *
+     * @deprecated Deprecated, use `network.local.port`..
+     * @example 8080
+     */
+    public const NET_SOCK_HOST_PORT = 'net.sock.host.port';
+
+    /**
+     * Deprecated, use `network.peer.address`.
+     *
+     * @deprecated Deprecated, use `network.peer.address`..
+     * @example 192.168.0.1
+     */
+    public const NET_SOCK_PEER_ADDR = 'net.sock.peer.addr';
+
+    /**
+     * Deprecated, no replacement at this time.
+     *
+     * @deprecated Deprecated, no replacement at this time..
+     * @example /var/my.sock
+     */
+    public const NET_SOCK_PEER_NAME = 'net.sock.peer.name';
+
+    /**
+     * Deprecated, use `network.peer.port`.
+     *
+     * @deprecated Deprecated, use `network.peer.port`..
+     * @example 65531
+     */
+    public const NET_SOCK_PEER_PORT = 'net.sock.peer.port';
+
+    /**
+     * Deprecated, use `network.transport`.
+     */
+    public const NET_TRANSPORT = 'net.transport';
+
+    /**
+     * Destination address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name.
+     *
+     * When observed from the source side, and when communicating through an intermediary, `destination.address` SHOULD represent the destination address behind any intermediaries (e.g. proxies) if it's available.
+     *
+     * @example destination.example.com
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
+     */
+    public const DESTINATION_ADDRESS = 'destination.address';
+
+    /**
+     * Destination port number.
+     *
+     * @example 3389
+     * @example 2888
+     */
+    public const DESTINATION_PORT = 'destination.port';
+
+    /**
+     * Describes a class of error the operation ended with.
+     *
+     * The `error.type` SHOULD be predictable and SHOULD have low cardinality.
+     * Instrumentations SHOULD document the list of errors they report.The cardinality of `error.type` within one instrumentation library SHOULD be low, but
+     * telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+     * should be prepared for `error.type` to have high cardinality at query time, when no
+     * additional filters are applied.If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.If a specific domain defines its own set of error codes (such as HTTP or gRPC status codes),
+     * it's RECOMMENDED to use a domain-specific attribute and also set `error.type` to capture
+     * all errors, regardless of whether they are defined within the domain-specific set or not.
+     *
+     * @example timeout
+     * @example java.net.UnknownHostException
+     * @example server_certificate_invalid
+     * @example 500
+     */
+    public const ERROR_TYPE = 'error.type';
 
     /**
      * The exception message.
@@ -37,25 +186,171 @@ interface TraceAttributes
     public const EXCEPTION_STACKTRACE = 'exception.stacktrace';
 
     /**
+     * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+     *
+     * @example java.net.ConnectException
+     * @example OSError
+     */
+    public const EXCEPTION_TYPE = 'exception.type';
+
+    /**
+     * The name of the invoked function.
+     *
+     * SHOULD be equal to the `faas.name` resource attribute of the invoked function.
+     *
+     * @example my-function
+     */
+    public const FAAS_INVOKED_NAME = 'faas.invoked_name';
+
+    /**
+     * The cloud provider of the invoked function.
+     *
+     * SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
+     */
+    public const FAAS_INVOKED_PROVIDER = 'faas.invoked_provider';
+
+    /**
+     * The cloud region of the invoked function.
+     *
+     * SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
+     *
+     * @example eu-central-1
+     */
+    public const FAAS_INVOKED_REGION = 'faas.invoked_region';
+
+    /**
+     * Type of the trigger which caused this function invocation.
+     */
+    public const FAAS_TRIGGER = 'faas.trigger';
+
+    /**
+     * The `service.name` of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
+     *
+     * @example AuthTokenCache
+     */
+    public const PEER_SERVICE = 'peer.service';
+
+    /**
+     * Username or client_id extracted from the access token or Authorization header in the inbound request from outside the system.
+     *
+     * @example username
+     */
+    public const ENDUSER_ID = 'enduser.id';
+
+    /**
+     * Actual/assumed role the client is making the request under extracted from token or application security context.
+     *
+     * @example admin
+     */
+    public const ENDUSER_ROLE = 'enduser.role';
+
+    /**
+     * Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
+     *
+     * @example read:message, write:files
+     */
+    public const ENDUSER_SCOPE = 'enduser.scope';
+
+    /**
+     * Whether the thread is daemon or not.
+     */
+    public const THREAD_DAEMON = 'thread.daemon';
+
+    /**
+     * Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
+     *
+     * @example 42
+     */
+    public const THREAD_ID = 'thread.id';
+
+    /**
+     * Current thread name.
+     *
+     * @example main
+     */
+    public const THREAD_NAME = 'thread.name';
+
+    /**
+     * The column number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
+     *
+     * @example 16
+     */
+    public const CODE_COLUMN = 'code.column';
+
+    /**
+     * The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
+     *
+     * @example /usr/local/MyApplication/content_root/app/index.php
+     */
+    public const CODE_FILEPATH = 'code.filepath';
+
+    /**
+     * The method or function name, or equivalent (usually rightmost part of the code unit's name).
+     *
+     * @example serveRequest
+     */
+    public const CODE_FUNCTION = 'code.function';
+
+    /**
+     * The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
+     *
+     * @example 42
+     */
+    public const CODE_LINENO = 'code.lineno';
+
+    /**
+     * The &quot;namespace&quot; within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit.
+     *
+     * @example com.example.MyHttpService
+     */
+    public const CODE_NAMESPACE = 'code.namespace';
+
+    /**
      * HTTP request method.
+     *
+     * HTTP request method value SHOULD be &quot;known&quot; to the instrumentation.
+     * By default, this convention defines &quot;known&quot; methods as the ones listed in RFC9110
+     * and the PATCH method defined in RFC5789.If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+     * the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+     * OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+     * (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+     * Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+     * Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
      *
      * @example GET
      * @example POST
      * @example HEAD
      */
-    public const HTTP_METHOD = 'http.method';
+    public const HTTP_REQUEST_METHOD = 'http.request.method';
 
     /**
      * HTTP response status code.
      *
      * @example 200
      */
-    public const HTTP_STATUS_CODE = 'http.status_code';
+    public const HTTP_RESPONSE_STATUS_CODE = 'http.response.status_code';
 
     /**
-     * Kind of HTTP protocol used.
+     * OSI application layer or non-OSI equivalent.
+     *
+     * The value SHOULD be normalized to lowercase.
+     *
+     * @example http
+     * @example spdy
      */
-    public const HTTP_FLAVOR = 'http.flavor';
+    public const NETWORK_PROTOCOL_NAME = 'network.protocol.name';
+
+    /**
+     * Version of the protocol specified in `network.protocol.name`.
+     *
+     * `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+     *
+     * @example 1.0
+     * @example 1.1
+     * @example 2
+     * @example 3
+     */
+    public const NETWORK_PROTOCOL_VERSION = 'network.protocol.version';
 
     /**
      * Host identifier of the &quot;URI origin&quot; HTTP request is sent to.
@@ -65,30 +360,25 @@ interface TraceAttributes
      * if it's sent in absolute-form</li>
      * <li>Host identifier of the `Host` header</li>
      * </ul>
-     * SHOULD NOT be set if capturing it would require an extra DNS lookup.
+     * If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then
+     * `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
      *
      * @example example.com
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
      */
-    public const NET_PEER_NAME = 'net.peer.name';
+    public const SERVER_ADDRESS = 'server.address';
 
     /**
      * Port identifier of the &quot;URI origin&quot; HTTP request is sent to.
      *
-     * When request target is absolute URI, `net.peer.name` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+     * When request target is absolute URI, `server.port` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
      *
      * @example 80
      * @example 8080
      * @example 443
      */
-    public const NET_PEER_PORT = 'net.peer.port';
-
-    /**
-     * The URI scheme identifying the used protocol.
-     *
-     * @example http
-     * @example https
-     */
-    public const HTTP_SCHEME = 'http.scheme';
+    public const SERVER_PORT = 'server.port';
 
     /**
      * The matched route (path template in the format used by the respective server framework). See note below.
@@ -102,34 +392,20 @@ interface TraceAttributes
     public const HTTP_ROUTE = 'http.route';
 
     /**
-     * Name of the local HTTP server that received the request.
+     * The URI scheme component identifying the used protocol.
      *
-     * Determined by using the first of the following that applies<ul>
-     * <li>The primary server name of the matched virtual host. MUST only
-     * include host identifier.</li>
-     * <li>Host identifier of the request target
-     * if it's sent in absolute-form.</li>
-     * <li>Host identifier of the `Host` header</li>
-     * </ul>
-     * SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
-     *
-     * @example localhost
+     * @example http
+     * @example https
      */
-    public const NET_HOST_NAME = 'net.host.name';
+    public const URL_SCHEME = 'url.scheme';
 
     /**
-     * Port of the local HTTP server that received the request.
+     * The domain identifies the business context for the events.
      *
-     * Determined by using the first of the following that applies<ul>
-     * <li>Port identifier of the primary server host of the matched virtual host.</li>
-     * <li>Port identifier of the request target
-     * if it's sent in absolute-form.</li>
-     * <li>Port identifier of the `Host` header</li>
-     * </ul>
-     *
-     * @example 8080
+     * Events across different domains may have same `event.name`, yet be
+     * unrelated events.
      */
-    public const NET_HOST_PORT = 'net.host.port';
+    public const EVENT_DOMAIN = 'event.domain';
 
     /**
      * The name identifies the event.
@@ -140,12 +416,14 @@ interface TraceAttributes
     public const EVENT_NAME = 'event.name';
 
     /**
-     * The domain identifies the business context for the events.
+     * A unique identifier for the Log Record.
      *
-     * Events across different domains may have same `event.name`, yet be
-     * unrelated events.
+     * If an id is provided, other log records with the same id will be considered duplicates and can be removed safely. This means, that two distinguishable log records MUST have different values.
+     * The id MAY be an Universally Unique Lexicographically Sortable Identifier (ULID), but other identifiers (e.g. UUID) may be used as needed.
+     *
+     * @example 01ARZ3NDEKTSV4RRFFQ69G5FAV
      */
-    public const EVENT_DOMAIN = 'event.domain';
+    public const LOG_RECORD_UID = 'log.record.uid';
 
     /**
      * The unique identifier of the feature flag.
@@ -176,6 +454,423 @@ interface TraceAttributes
      * @example on
      */
     public const FEATURE_FLAG_VARIANT = 'feature_flag.variant';
+
+    /**
+     * The stream associated with the log. See below for a list of well-known values.
+     */
+    public const LOG_IOSTREAM = 'log.iostream';
+
+    /**
+     * The basename of the file.
+     *
+     * @example audit.log
+     */
+    public const LOG_FILE_NAME = 'log.file.name';
+
+    /**
+     * The basename of the file, with symlinks resolved.
+     *
+     * @example uuid.log
+     */
+    public const LOG_FILE_NAME_RESOLVED = 'log.file.name_resolved';
+
+    /**
+     * The full path to the file.
+     *
+     * @example /var/log/mysql/audit.log
+     */
+    public const LOG_FILE_PATH = 'log.file.path';
+
+    /**
+     * The full path to the file, with symlinks resolved.
+     *
+     * @example /var/lib/docker/uuid.log
+     */
+    public const LOG_FILE_PATH_RESOLVED = 'log.file.path_resolved';
+
+    /**
+     * The name of the connection pool; unique within the instrumented application. In case the connection pool implementation does not provide a name, then the db.connection_string should be used.
+     *
+     * @example myDataSource
+     */
+    public const POOL_NAME = 'pool.name';
+
+    /**
+     * The state of a connection in the pool.
+     *
+     * @example idle
+     */
+    public const STATE = 'state';
+
+    /**
+     * Name of the buffer pool.
+     *
+     * Pool names are generally obtained via BufferPoolMXBean#getName().
+     *
+     * @example mapped
+     * @example direct
+     */
+    public const JVM_BUFFER_POOL_NAME = 'jvm.buffer.pool.name';
+
+    /**
+     * Name of the memory pool.
+     *
+     * Pool names are generally obtained via MemoryPoolMXBean#getName().
+     *
+     * @example G1 Old Gen
+     * @example G1 Eden space
+     * @example G1 Survivor Space
+     */
+    public const JVM_MEMORY_POOL_NAME = 'jvm.memory.pool.name';
+
+    /**
+     * The type of memory.
+     *
+     * @example heap
+     * @example non_heap
+     */
+    public const JVM_MEMORY_TYPE = 'jvm.memory.type';
+
+    /**
+     * OSI transport layer or inter-process communication method.
+     *
+     * The value SHOULD be normalized to lowercase.Consider always setting the transport when setting a port number, since
+     * a port number is ambiguous without knowing the transport, for example
+     * different processes could be listening on TCP port 12345 and UDP port 12345.
+     *
+     * @example tcp
+     * @example udp
+     */
+    public const NETWORK_TRANSPORT = 'network.transport';
+
+    /**
+     * OSI network layer or non-OSI equivalent.
+     *
+     * The value SHOULD be normalized to lowercase.
+     *
+     * @example ipv4
+     * @example ipv6
+     */
+    public const NETWORK_TYPE = 'network.type';
+
+    /**
+     * The name of the (logical) method being called, must be equal to the $method part in the span name.
+     *
+     * This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
+     *
+     * @example exampleMethod
+     */
+    public const RPC_METHOD = 'rpc.method';
+
+    /**
+     * The full (logical) name of the service being called, including its package name, if applicable.
+     *
+     * This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
+     *
+     * @example myservice.EchoService
+     */
+    public const RPC_SERVICE = 'rpc.service';
+
+    /**
+     * A string identifying the remoting system. See below for a list of well-known identifiers.
+     */
+    public const RPC_SYSTEM = 'rpc.system';
+
+    /**
+     * The device identifier.
+     *
+     * @example (identifier)
+     */
+    public const SYSTEM_DEVICE = 'system.device';
+
+    /**
+     * The logical CPU number [0..n-1].
+     *
+     * @example 1
+     */
+    public const SYSTEM_CPU_LOGICAL_NUMBER = 'system.cpu.logical_number';
+
+    /**
+     * The state of the CPU.
+     *
+     * @example idle
+     * @example interrupt
+     */
+    public const SYSTEM_CPU_STATE = 'system.cpu.state';
+
+    /**
+     * The memory state.
+     *
+     * @example free
+     * @example cached
+     */
+    public const SYSTEM_MEMORY_STATE = 'system.memory.state';
+
+    /**
+     * The paging access direction.
+     *
+     * @example in
+     */
+    public const SYSTEM_PAGING_DIRECTION = 'system.paging.direction';
+
+    /**
+     * The memory paging state.
+     *
+     * @example free
+     */
+    public const SYSTEM_PAGING_STATE = 'system.paging.state';
+
+    /**
+     * The memory paging type.
+     *
+     * @example minor
+     */
+    public const SYSTEM_PAGING_TYPE = 'system.paging.type';
+
+    /**
+     * The disk operation direction.
+     *
+     * @example read
+     */
+    public const SYSTEM_DISK_DIRECTION = 'system.disk.direction';
+
+    /**
+     * The filesystem mode.
+     *
+     * @example rw, ro
+     */
+    public const SYSTEM_FILESYSTEM_MODE = 'system.filesystem.mode';
+
+    /**
+     * The filesystem mount path.
+     *
+     * @example /mnt/data
+     */
+    public const SYSTEM_FILESYSTEM_MOUNTPOINT = 'system.filesystem.mountpoint';
+
+    /**
+     * The filesystem state.
+     *
+     * @example used
+     */
+    public const SYSTEM_FILESYSTEM_STATE = 'system.filesystem.state';
+
+    /**
+     * The filesystem type.
+     *
+     * @example ext4
+     */
+    public const SYSTEM_FILESYSTEM_TYPE = 'system.filesystem.type';
+
+    /**
+     * .
+     *
+     * @example transmit
+     */
+    public const SYSTEM_NETWORK_DIRECTION = 'system.network.direction';
+
+    /**
+     * A stateless protocol MUST NOT set this attribute.
+     *
+     * @example close_wait
+     */
+    public const SYSTEM_NETWORK_STATE = 'system.network.state';
+
+    /**
+     * The process state, e.g., Linux Process State Codes.
+     *
+     * @example running
+     */
+    public const SYSTEM_PROCESSES_STATUS = 'system.processes.status';
+
+    /**
+     * Local address of the network connection - IP address or Unix domain socket name.
+     *
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
+     */
+    public const NETWORK_LOCAL_ADDRESS = 'network.local.address';
+
+    /**
+     * Local port number of the network connection.
+     *
+     * @example 65123
+     */
+    public const NETWORK_LOCAL_PORT = 'network.local.port';
+
+    /**
+     * Peer address of the network connection - IP address or Unix domain socket name.
+     *
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
+     */
+    public const NETWORK_PEER_ADDRESS = 'network.peer.address';
+
+    /**
+     * Peer port number of the network connection.
+     *
+     * @example 65123
+     */
+    public const NETWORK_PEER_PORT = 'network.peer.port';
+
+    /**
+     * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
+     *
+     * @example DE
+     */
+    public const NETWORK_CARRIER_ICC = 'network.carrier.icc';
+
+    /**
+     * The mobile carrier country code.
+     *
+     * @example 310
+     */
+    public const NETWORK_CARRIER_MCC = 'network.carrier.mcc';
+
+    /**
+     * The mobile carrier network code.
+     *
+     * @example 001
+     */
+    public const NETWORK_CARRIER_MNC = 'network.carrier.mnc';
+
+    /**
+     * The name of the mobile carrier.
+     *
+     * @example sprint
+     */
+    public const NETWORK_CARRIER_NAME = 'network.carrier.name';
+
+    /**
+     * This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
+     *
+     * @example LTE
+     */
+    public const NETWORK_CONNECTION_SUBTYPE = 'network.connection.subtype';
+
+    /**
+     * The internet connection type.
+     *
+     * @example wifi
+     */
+    public const NETWORK_CONNECTION_TYPE = 'network.connection.type';
+
+    /**
+     * Deprecated, use `http.request.method` instead.
+     *
+     * @deprecated Deprecated, use `http.request.method` instead..
+     * @example GET
+     * @example POST
+     * @example HEAD
+     */
+    public const HTTP_METHOD = 'http.method';
+
+    /**
+     * Deprecated, use `http.request.body.size` instead.
+     *
+     * @deprecated Deprecated, use `http.request.body.size` instead..
+     * @example 3495
+     */
+    public const HTTP_REQUEST_CONTENT_LENGTH = 'http.request_content_length';
+
+    /**
+     * Deprecated, use `http.response.body.size` instead.
+     *
+     * @deprecated Deprecated, use `http.response.body.size` instead..
+     * @example 3495
+     */
+    public const HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length';
+
+    /**
+     * Deprecated, use `url.scheme` instead.
+     *
+     * @deprecated Deprecated, use `url.scheme` instead..
+     * @example http
+     * @example https
+     */
+    public const HTTP_SCHEME = 'http.scheme';
+
+    /**
+     * Deprecated, use `http.response.status_code` instead.
+     *
+     * @deprecated Deprecated, use `http.response.status_code` instead..
+     * @example 200
+     */
+    public const HTTP_STATUS_CODE = 'http.status_code';
+
+    /**
+     * Deprecated, use `url.path` and `url.query` instead.
+     *
+     * @deprecated Deprecated, use `url.path` and `url.query` instead..
+     * @example /search?q=OpenTelemetry#SemConv
+     */
+    public const HTTP_TARGET = 'http.target';
+
+    /**
+     * Deprecated, use `url.full` instead.
+     *
+     * @deprecated Deprecated, use `url.full` instead..
+     * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
+     */
+    public const HTTP_URL = 'http.url';
+
+    /**
+     * The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
+     *
+     * @example 3495
+     */
+    public const HTTP_REQUEST_BODY_SIZE = 'http.request.body.size';
+
+    /**
+     * Original HTTP method sent by the client in the request line.
+     *
+     * @example GeT
+     * @example ACL
+     * @example foo
+     */
+    public const HTTP_REQUEST_METHOD_ORIGINAL = 'http.request.method_original';
+
+    /**
+     * The ordinal number of request resending attempt (for any reason, including redirects).
+     *
+     * The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
+     *
+     * @example 3
+     */
+    public const HTTP_RESEND_COUNT = 'http.resend_count';
+
+    /**
+     * The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
+     *
+     * @example 3495
+     */
+    public const HTTP_RESPONSE_BODY_SIZE = 'http.response.body.size';
+
+    /**
+     * A unique id to identify a session.
+     *
+     * @example 00112233-4455-6677-8899-aabbccddeeff
+     */
+    public const SESSION_ID = 'session.id';
+
+    /**
+     * Source address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name.
+     *
+     * When observed from the destination side, and when communicating through an intermediary, `source.address` SHOULD represent the source address behind any intermediaries (e.g. proxies) if it's available.
+     *
+     * @example source.example.com
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
+     */
+    public const SOURCE_ADDRESS = 'source.address';
+
+    /**
+     * Source port number.
+     *
+     * @example 3389
+     * @example 2888
+     */
+    public const SOURCE_PORT = 'source.port';
 
     /**
      * The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
@@ -211,19 +906,19 @@ interface TraceAttributes
     public const CLOUDEVENTS_EVENT_SPEC_VERSION = 'cloudevents.event_spec_version';
 
     /**
+     * The subject of the event in the context of the event producer (identified by source).
+     *
+     * @example mynewfile.jpg
+     */
+    public const CLOUDEVENTS_EVENT_SUBJECT = 'cloudevents.event_subject';
+
+    /**
      * The event_type contains a value describing the type of event related to the originating occurrence.
      *
      * @example com.github.pull_request.opened
      * @example com.example.object.deleted.v2
      */
     public const CLOUDEVENTS_EVENT_TYPE = 'cloudevents.event_type';
-
-    /**
-     * The subject of the event in the context of the event producer (identified by source).
-     *
-     * @example mynewfile.jpg
-     */
-    public const CLOUDEVENTS_EVENT_SUBJECT = 'cloudevents.event_subject';
 
     /**
      * Parent-child Reference type.
@@ -233,24 +928,11 @@ interface TraceAttributes
     public const OPENTRACING_REF_TYPE = 'opentracing.ref_type';
 
     /**
-     * An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
-     */
-    public const DB_SYSTEM = 'db.system';
-
-    /**
      * The connection string used to connect to the database. It is recommended to remove embedded credentials.
      *
      * @example Server=(localdb)\v11.0;Integrated Security=true;
      */
     public const DB_CONNECTION_STRING = 'db.connection_string';
-
-    /**
-     * Username for accessing the database.
-     *
-     * @example readonly_user
-     * @example reporting_user
-     */
-    public const DB_USER = 'db.user';
 
     /**
      * The fully-qualified class name of the Java Database Connectivity (JDBC) driver used to connect.
@@ -271,16 +953,6 @@ interface TraceAttributes
     public const DB_NAME = 'db.name';
 
     /**
-     * The database statement being executed.
-     *
-     * The value may be sanitized to exclude sensitive information.
-     *
-     * @example SELECT * FROM wuser_table
-     * @example SET mykey "WuValue"
-     */
-    public const DB_STATEMENT = 'db.statement';
-
-    /**
      * The name of the operation being executed, e.g. the MongoDB command name such as `findAndModify`, or the SQL keyword.
      *
      * When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
@@ -292,55 +964,34 @@ interface TraceAttributes
     public const DB_OPERATION = 'db.operation';
 
     /**
-     * Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, etc.
+     * The database statement being executed.
      *
-     * @example 127.0.0.1
-     * @example /tmp/mysql.sock
+     * @example SELECT * FROM wuser_table
+     * @example SET mykey "WuValue"
      */
-    public const NET_SOCK_PEER_ADDR = 'net.sock.peer.addr';
+    public const DB_STATEMENT = 'db.statement';
 
     /**
-     * Remote socket peer port.
-     *
-     * @example 16456
+     * An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
      */
-    public const NET_SOCK_PEER_PORT = 'net.sock.peer.port';
+    public const DB_SYSTEM = 'db.system';
 
     /**
-     * Protocol address family which is used for communication.
+     * Username for accessing the database.
      *
-     * @example inet6
-     * @example bluetooth
+     * @example readonly_user
+     * @example reporting_user
      */
-    public const NET_SOCK_FAMILY = 'net.sock.family';
-
-    /**
-     * Remote socket peer name.
-     *
-     * @example proxy.example.com
-     */
-    public const NET_SOCK_PEER_NAME = 'net.sock.peer.name';
-
-    /**
-     * Transport protocol used. See note below.
-     */
-    public const NET_TRANSPORT = 'net.transport';
+    public const DB_USER = 'db.user';
 
     /**
      * The Microsoft SQL Server instance name connecting to. This name is used to determine the port of a named instance.
      *
-     * If setting a `db.mssql.instance_name`, `net.peer.port` is no longer required (but still recommended if non-standard).
+     * If setting a `db.mssql.instance_name`, `server.port` is no longer required (but still recommended if non-standard).
      *
      * @example MSSQLSERVER
      */
     public const DB_MSSQL_INSTANCE_NAME = 'db.mssql.instance_name';
-
-    /**
-     * The fetch size used for paging, i.e. how many rows will be returned at once.
-     *
-     * @example 5000
-     */
-    public const DB_CASSANDRA_PAGE_SIZE = 'db.cassandra.page_size';
 
     /**
      * The consistency level of the query. Based on consistency values from CQL.
@@ -348,25 +999,11 @@ interface TraceAttributes
     public const DB_CASSANDRA_CONSISTENCY_LEVEL = 'db.cassandra.consistency_level';
 
     /**
-     * The name of the primary table that the operation is acting upon, including the keyspace name (if applicable).
+     * The data center of the coordinating node for a query.
      *
-     * This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
-     *
-     * @example mytable
+     * @example us-west-2
      */
-    public const DB_CASSANDRA_TABLE = 'db.cassandra.table';
-
-    /**
-     * Whether or not the query is idempotent.
-     */
-    public const DB_CASSANDRA_IDEMPOTENCE = 'db.cassandra.idempotence';
-
-    /**
-     * The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
-     *
-     * @example 2
-     */
-    public const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = 'db.cassandra.speculative_execution_count';
+    public const DB_CASSANDRA_COORDINATOR_DC = 'db.cassandra.coordinator.dc';
 
     /**
      * The ID of the coordinating node for a query.
@@ -376,11 +1013,32 @@ interface TraceAttributes
     public const DB_CASSANDRA_COORDINATOR_ID = 'db.cassandra.coordinator.id';
 
     /**
-     * The data center of the coordinating node for a query.
-     *
-     * @example us-west-2
+     * Whether or not the query is idempotent.
      */
-    public const DB_CASSANDRA_COORDINATOR_DC = 'db.cassandra.coordinator.dc';
+    public const DB_CASSANDRA_IDEMPOTENCE = 'db.cassandra.idempotence';
+
+    /**
+     * The fetch size used for paging, i.e. how many rows will be returned at once.
+     *
+     * @example 5000
+     */
+    public const DB_CASSANDRA_PAGE_SIZE = 'db.cassandra.page_size';
+
+    /**
+     * The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
+     *
+     * @example 2
+     */
+    public const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = 'db.cassandra.speculative_execution_count';
+
+    /**
+     * The name of the primary table that the operation is acting upon, including the keyspace name (if applicable).
+     *
+     * This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+     *
+     * @example mytable
+     */
+    public const DB_CASSANDRA_TABLE = 'db.cassandra.table';
 
     /**
      * The index of the database being accessed as used in the `SELECT` command, provided as an integer. To be used instead of the generic `db.name` attribute.
@@ -399,6 +1057,31 @@ interface TraceAttributes
     public const DB_MONGODB_COLLECTION = 'db.mongodb.collection';
 
     /**
+     * Represents the identifier of an Elasticsearch cluster.
+     *
+     * @example e9106fc68e3044f0b1475b04bf4ffd5f
+     */
+    public const DB_ELASTICSEARCH_CLUSTER_NAME = 'db.elasticsearch.cluster.name';
+
+    /**
+     * Represents the human-readable identifier of the node/instance to which a request was routed.
+     *
+     * @example instance-0000000001
+     */
+    public const DB_ELASTICSEARCH_NODE_NAME = 'db.elasticsearch.node.name';
+
+    /**
+     * Absolute URL describing a network resource according to RFC3986.
+     *
+     * For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+     * `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute's value should be `https://REDACTED:REDACTED@www.example.com/`.
+     * `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
+     *
+     * @example https://localhost:9200/index/_search?q=user.id:kimchy
+     */
+    public const URL_FULL = 'url.full';
+
+    /**
      * The name of the primary table that the operation is acting upon, including the database name (if applicable).
      *
      * It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
@@ -407,6 +1090,70 @@ interface TraceAttributes
      * @example customers
      */
     public const DB_SQL_TABLE = 'db.sql.table';
+
+    /**
+     * Unique Cosmos client instance id.
+     *
+     * @example 3ba4827d-4422-483f-b59f-85b74211c11d
+     */
+    public const DB_COSMOSDB_CLIENT_ID = 'db.cosmosdb.client_id';
+
+    /**
+     * Cosmos client connection mode.
+     */
+    public const DB_COSMOSDB_CONNECTION_MODE = 'db.cosmosdb.connection_mode';
+
+    /**
+     * Cosmos DB container name.
+     *
+     * @example anystring
+     */
+    public const DB_COSMOSDB_CONTAINER = 'db.cosmosdb.container';
+
+    /**
+     * CosmosDB Operation Type.
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE = 'db.cosmosdb.operation_type';
+
+    /**
+     * RU consumed for that operation.
+     *
+     * @example 46.18
+     * @example 1.0
+     */
+    public const DB_COSMOSDB_REQUEST_CHARGE = 'db.cosmosdb.request_charge';
+
+    /**
+     * Request payload size in bytes.
+     */
+    public const DB_COSMOSDB_REQUEST_CONTENT_LENGTH = 'db.cosmosdb.request_content_length';
+
+    /**
+     * Cosmos DB status code.
+     *
+     * @example 200
+     * @example 201
+     */
+    public const DB_COSMOSDB_STATUS_CODE = 'db.cosmosdb.status_code';
+
+    /**
+     * Cosmos DB sub status code.
+     *
+     * @example 1000
+     * @example 1002
+     */
+    public const DB_COSMOSDB_SUB_STATUS_CODE = 'db.cosmosdb.sub_status_code';
+
+    /**
+     * Full user-agent string is generated by Cosmos DB SDK.
+     *
+     * The user-agent value is generated by SDK which is a combination of&lt;br&gt; `sdk_version` : Current version of SDK. e.g. 'cosmos-netstandard-sdk/3.23.0'&lt;br&gt; `direct_pkg_version` : Direct package version used by Cosmos DB SDK. e.g. '3.23.1'&lt;br&gt; `number_of_client_instances` : Number of cosmos client instances created by the application. e.g. '1'&lt;br&gt; `type_of_machine_architecture` : Machine architecture. e.g. 'X64'&lt;br&gt; `operating_system` : Operating System. e.g. 'Linux 5.4.0-1098-azure 104 18'&lt;br&gt; `runtime_framework` : Runtime Framework. e.g. '.NET Core 3.1.32'&lt;br&gt; `failover_information` : Generated key to determine if region failover enabled.
+     *    Format Reg-{D (Disabled discovery)}-S(application region)|L(List of preferred regions)|N(None, user did not configure it).
+     *    Default value is &quot;NS&quot;.
+     *
+     * @example cosmos-netstandard-sdk/3.23.0\|3.23.1\|1\|X64\|Linux 5.4.0-1098-azure 104 18\|.NET Core 3.1.32\|S\|
+     */
+    public const USER_AGENT_ORIGINAL = 'user_agent.original';
 
     /**
      * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status code is UNSET.
@@ -419,26 +1166,6 @@ interface TraceAttributes
      * @example resource not found
      */
     public const OTEL_STATUS_DESCRIPTION = 'otel.status_description';
-
-    /**
-     * Type of the trigger which caused this function invocation.
-     *
-     * For the server/consumer span on the incoming side,
-     * `faas.trigger` MUST be set.Clients invoking FaaS instances usually cannot set `faas.trigger`,
-     * since they would typically need to look in the payload to determine
-     * the event type. If clients set it, it should be the same as the
-     * trigger that corresponding incoming would have (i.e., this has
-     * nothing to do with the underlying transport used to make the API
-     * call to invoke the lambda, which is often HTTP).
-     */
-    public const FAAS_TRIGGER = 'faas.trigger';
-
-    /**
-     * The invocation ID of the current function invocation.
-     *
-     * @example af9d5aa4-a685-4c5f-a22b-444f80b3cc28
-     */
-    public const FAAS_INVOCATION_ID = 'faas.invocation_id';
 
     /**
      * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an ARN on AWS, a fully qualified resource ID on Azure, a full resource name on GCP).
@@ -466,12 +1193,27 @@ interface TraceAttributes
     public const CLOUD_RESOURCE_ID = 'cloud.resource_id';
 
     /**
+     * The invocation ID of the current function invocation.
+     *
+     * @example af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+     */
+    public const FAAS_INVOCATION_ID = 'faas.invocation_id';
+
+    /**
      * The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
      *
      * @example myBucketName
      * @example myDbName
      */
     public const FAAS_DOCUMENT_COLLECTION = 'faas.document.collection';
+
+    /**
+     * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
+     *
+     * @example myFile.txt
+     * @example myTableName
+     */
+    public const FAAS_DOCUMENT_NAME = 'faas.document.name';
 
     /**
      * Describes the type of the operation that was performed on the data.
@@ -486,50 +1228,111 @@ interface TraceAttributes
     public const FAAS_DOCUMENT_TIME = 'faas.document.time';
 
     /**
-     * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
+     * The URI path component.
      *
-     * @example myFile.txt
-     * @example myTableName
+     * When missing, the value is assumed to be `/`
+     *
+     * @example /search
      */
-    public const FAAS_DOCUMENT_NAME = 'faas.document.name';
+    public const URL_PATH = 'url.path';
 
     /**
-     * The full request target as passed in a HTTP request line or equivalent.
+     * The URI query component.
      *
-     * @example /path/12314/?q=ddds
+     * Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
+     *
+     * @example q=OpenTelemetry
      */
-    public const HTTP_TARGET = 'http.target';
+    public const URL_QUERY = 'url.query';
 
     /**
-     * The IP address of the original client behind all proxies, if known (e.g. from X-Forwarded-For).
+     * The number of messages sent, received, or processed in the scope of the batching operation.
      *
-     * This is not necessarily the same as `net.sock.peer.addr`, which would
-     * identify the network-level peer, which may be a proxy.This attribute should be set when a source of information different
-     * from the one used for `net.sock.peer.addr`, is available even if that other
-     * source just confirms the same value as `net.sock.peer.addr`.
-     * Rationale: For `net.sock.peer.addr`, one typically does not know if it
-     * comes from a proxy, reverse proxy, or the actual client. Setting
-     * `http.client_ip` when it's the same as `net.sock.peer.addr` means that
-     * one is at least somewhat confident that the address is not that of
-     * the closest proxy.
+     * Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
      *
-     * @example 83.164.160.102
+     * @example 1
+     * @example 2
      */
-    public const HTTP_CLIENT_IP = 'http.client_ip';
+    public const MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count';
 
     /**
-     * Local socket address. Useful in case of a multi-IP host.
+     * A unique identifier for the client that consumes or produces a message.
      *
-     * @example 192.168.0.1
+     * @example client-5
+     * @example myhost@8742@s8083jm
      */
-    public const NET_SOCK_HOST_ADDR = 'net.sock.host.addr';
+    public const MESSAGING_CLIENT_ID = 'messaging.client_id';
 
     /**
-     * Local socket port number.
-     *
-     * @example 35555
+     * A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).
      */
-    public const NET_SOCK_HOST_PORT = 'net.sock.host.port';
+    public const MESSAGING_DESTINATION_ANONYMOUS = 'messaging.destination.anonymous';
+
+    /**
+     * The message destination name.
+     *
+     * Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
+     * the broker does not have such notion, the destination name SHOULD uniquely identify the broker.
+     *
+     * @example MyQueue
+     * @example MyTopic
+     */
+    public const MESSAGING_DESTINATION_NAME = 'messaging.destination.name';
+
+    /**
+     * Low cardinality representation of the messaging destination name.
+     *
+     * Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
+     *
+     * @example /customers/{customerId}
+     */
+    public const MESSAGING_DESTINATION_TEMPLATE = 'messaging.destination.template';
+
+    /**
+     * A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.
+     */
+    public const MESSAGING_DESTINATION_TEMPORARY = 'messaging.destination.temporary';
+
+    /**
+     * The size of the message body in bytes.
+     *
+     * This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
+     * body size should be used.
+     *
+     * @example 1439
+     */
+    public const MESSAGING_MESSAGE_BODY_SIZE = 'messaging.message.body.size';
+
+    /**
+     * The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called &quot;Correlation ID&quot;.
+     *
+     * @example MyConversationId
+     */
+    public const MESSAGING_MESSAGE_CONVERSATION_ID = 'messaging.message.conversation_id';
+
+    /**
+     * The size of the message body and metadata in bytes.
+     *
+     * This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
+     * size should be used.
+     *
+     * @example 2738
+     */
+    public const MESSAGING_MESSAGE_ENVELOPE_SIZE = 'messaging.message.envelope.size';
+
+    /**
+     * A value used by the messaging system as an identifier for the message, represented as a string.
+     *
+     * @example 452a7c7c7c7048c2f887f61572b18fc2
+     */
+    public const MESSAGING_MESSAGE_ID = 'messaging.message.id';
+
+    /**
+     * A string identifying the kind of messaging operation as defined in the Operation names section above.
+     *
+     * If a custom value is used, it MUST be of low cardinality.
+     */
+    public const MESSAGING_OPERATION = 'messaging.operation';
 
     /**
      * A string identifying the messaging system.
@@ -543,108 +1346,11 @@ interface TraceAttributes
     public const MESSAGING_SYSTEM = 'messaging.system';
 
     /**
-     * A string identifying the kind of messaging operation as defined in the Operation names section above.
+     * A string containing the schedule period as Cron Expression.
      *
-     * If a custom value is used, it MUST be of low cardinality.
+     * @example 0/5 * * * ? *
      */
-    public const MESSAGING_OPERATION = 'messaging.operation';
-
-    /**
-     * The number of messages sent, received, or processed in the scope of the batching operation.
-     *
-     * Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
-     *
-     * @example 1
-     * @example 2
-     */
-    public const MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count';
-
-    /**
-     * A value used by the messaging system as an identifier for the message, represented as a string.
-     *
-     * @example 452a7c7c7c7048c2f887f61572b18fc2
-     */
-    public const MESSAGING_MESSAGE_ID = 'messaging.message.id';
-
-    /**
-     * The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called &quot;Correlation ID&quot;.
-     *
-     * @example MyConversationId
-     */
-    public const MESSAGING_MESSAGE_CONVERSATION_ID = 'messaging.message.conversation_id';
-
-    /**
-     * The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
-     *
-     * @example 2738
-     */
-    public const MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES = 'messaging.message.payload_size_bytes';
-
-    /**
-     * The compressed size of the message payload in bytes.
-     *
-     * @example 2048
-     */
-    public const MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES = 'messaging.message.payload_compressed_size_bytes';
-
-    /**
-     * Application layer protocol used. The value SHOULD be normalized to lowercase.
-     *
-     * @example amqp
-     * @example mqtt
-     */
-    public const NET_APP_PROTOCOL_NAME = 'net.app.protocol.name';
-
-    /**
-     * Version of the application layer protocol used. See note below.
-     *
-     * `net.app.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-     *
-     * @example 3.1.1
-     */
-    public const NET_APP_PROTOCOL_VERSION = 'net.app.protocol.version';
-
-    /**
-     * The internet connection type currently being used by the host.
-     *
-     * @example wifi
-     */
-    public const NET_HOST_CONNECTION_TYPE = 'net.host.connection.type';
-
-    /**
-     * This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
-     *
-     * @example LTE
-     */
-    public const NET_HOST_CONNECTION_SUBTYPE = 'net.host.connection.subtype';
-
-    /**
-     * The name of the mobile carrier.
-     *
-     * @example sprint
-     */
-    public const NET_HOST_CARRIER_NAME = 'net.host.carrier.name';
-
-    /**
-     * The mobile carrier country code.
-     *
-     * @example 310
-     */
-    public const NET_HOST_CARRIER_MCC = 'net.host.carrier.mcc';
-
-    /**
-     * The mobile carrier network code.
-     *
-     * @example 001
-     */
-    public const NET_HOST_CARRIER_MNC = 'net.host.carrier.mnc';
-
-    /**
-     * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
-     *
-     * @example DE
-     */
-    public const NET_HOST_CARRIER_ICC = 'net.host.carrier.icc';
+    public const FAAS_CRON = 'faas.cron';
 
     /**
      * A string containing the function invocation time in the ISO 8601 format expressed in UTC.
@@ -654,192 +1360,30 @@ interface TraceAttributes
     public const FAAS_TIME = 'faas.time';
 
     /**
-     * A string containing the schedule period as Cron Expression.
-     *
-     * @example 0/5 * * * ? *
-     */
-    public const FAAS_CRON = 'faas.cron';
-
-    /**
      * A boolean that is true if the serverless function is executed for the first time (aka cold-start).
      */
     public const FAAS_COLDSTART = 'faas.coldstart';
 
     /**
-     * The name of the invoked function.
+     * The AWS request ID as returned in the response headers `x-amz-request-id` or `x-amz-requestid`.
      *
-     * SHOULD be equal to the `faas.name` resource attribute of the invoked function.
-     *
-     * @example my-function
+     * @example 79b9da39-b7ae-508a-a6bc-864b2829c622
+     * @example C9ER4AJX75574TDJ
      */
-    public const FAAS_INVOKED_NAME = 'faas.invoked_name';
+    public const AWS_REQUEST_ID = 'aws.request_id';
 
     /**
-     * The cloud provider of the invoked function.
+     * The value of the `AttributesToGet` request parameter.
      *
-     * SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
+     * @example lives
+     * @example id
      */
-    public const FAAS_INVOKED_PROVIDER = 'faas.invoked_provider';
+    public const AWS_DYNAMODB_ATTRIBUTES_TO_GET = 'aws.dynamodb.attributes_to_get';
 
     /**
-     * The cloud region of the invoked function.
-     *
-     * SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
-     *
-     * @example eu-central-1
+     * The value of the `ConsistentRead` request parameter.
      */
-    public const FAAS_INVOKED_REGION = 'faas.invoked_region';
-
-    /**
-     * The `service.name` of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
-     *
-     * @example AuthTokenCache
-     */
-    public const PEER_SERVICE = 'peer.service';
-
-    /**
-     * Username or client_id extracted from the access token or Authorization header in the inbound request from outside the system.
-     *
-     * @example username
-     */
-    public const ENDUSER_ID = 'enduser.id';
-
-    /**
-     * Actual/assumed role the client is making the request under extracted from token or application security context.
-     *
-     * @example admin
-     */
-    public const ENDUSER_ROLE = 'enduser.role';
-
-    /**
-     * Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
-     *
-     * @example read:message, write:files
-     */
-    public const ENDUSER_SCOPE = 'enduser.scope';
-
-    /**
-     * Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
-     *
-     * @example 42
-     */
-    public const THREAD_ID = 'thread.id';
-
-    /**
-     * Current thread name.
-     *
-     * @example main
-     */
-    public const THREAD_NAME = 'thread.name';
-
-    /**
-     * The method or function name, or equivalent (usually rightmost part of the code unit's name).
-     *
-     * @example serveRequest
-     */
-    public const CODE_FUNCTION = 'code.function';
-
-    /**
-     * The &quot;namespace&quot; within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit.
-     *
-     * @example com.example.MyHttpService
-     */
-    public const CODE_NAMESPACE = 'code.namespace';
-
-    /**
-     * The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
-     *
-     * @example /usr/local/MyApplication/content_root/app/index.php
-     */
-    public const CODE_FILEPATH = 'code.filepath';
-
-    /**
-     * The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
-     *
-     * @example 42
-     */
-    public const CODE_LINENO = 'code.lineno';
-
-    /**
-     * The column number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
-     *
-     * @example 16
-     */
-    public const CODE_COLUMN = 'code.column';
-
-    /**
-     * The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
-     *
-     * @example 3495
-     */
-    public const HTTP_REQUEST_CONTENT_LENGTH = 'http.request_content_length';
-
-    /**
-     * The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
-     *
-     * @example 3495
-     */
-    public const HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length';
-
-    /**
-     * Value of the HTTP User-Agent header sent by the client.
-     *
-     * @example CERN-LineMode/2.15 libwww/2.17b3
-     */
-    public const USER_AGENT_ORIGINAL = 'user_agent.original';
-
-    /**
-     * Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
-     *
-     * `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`.
-     *
-     * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
-     */
-    public const HTTP_URL = 'http.url';
-
-    /**
-     * The ordinal number of request resending attempt (for any reason, including redirects).
-     *
-     * The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
-     *
-     * @example 3
-     */
-    public const HTTP_RESEND_COUNT = 'http.resend_count';
-
-    /**
-     * The value `aws-api`.
-     *
-     * @example aws-api
-     */
-    public const RPC_SYSTEM = 'rpc.system';
-
-    /**
-     * The name of the service to which a request is made, as returned by the AWS SDK.
-     *
-     * This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
-     *
-     * @example DynamoDB
-     * @example S3
-     */
-    public const RPC_SERVICE = 'rpc.service';
-
-    /**
-     * The name of the operation corresponding to the request, as returned by the AWS SDK.
-     *
-     * This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
-     *
-     * @example GetItem
-     * @example PutItem
-     */
-    public const RPC_METHOD = 'rpc.method';
-
-    /**
-     * The keys in the `RequestItems` object field.
-     *
-     * @example Users
-     * @example Cats
-     */
-    public const AWS_DYNAMODB_TABLE_NAMES = 'aws.dynamodb.table_names';
+    public const AWS_DYNAMODB_CONSISTENT_READ = 'aws.dynamodb.consistent_read';
 
     /**
      * The JSON-serialized value of each item in the `ConsumedCapacity` response field.
@@ -849,11 +1393,34 @@ interface TraceAttributes
     public const AWS_DYNAMODB_CONSUMED_CAPACITY = 'aws.dynamodb.consumed_capacity';
 
     /**
+     * The value of the `IndexName` request parameter.
+     *
+     * @example name_to_group
+     */
+    public const AWS_DYNAMODB_INDEX_NAME = 'aws.dynamodb.index_name';
+
+    /**
      * The JSON-serialized value of the `ItemCollectionMetrics` response field.
      *
      * @example { "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }
      */
     public const AWS_DYNAMODB_ITEM_COLLECTION_METRICS = 'aws.dynamodb.item_collection_metrics';
+
+    /**
+     * The value of the `Limit` request parameter.
+     *
+     * @example 10
+     */
+    public const AWS_DYNAMODB_LIMIT = 'aws.dynamodb.limit';
+
+    /**
+     * The value of the `ProjectionExpression` request parameter.
+     *
+     * @example Title
+     * @example Title, Price, Color
+     * @example Title, Description, RelatedItems, ProductReviews
+     */
+    public const AWS_DYNAMODB_PROJECTION = 'aws.dynamodb.projection';
 
     /**
      * The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
@@ -872,48 +1439,20 @@ interface TraceAttributes
     public const AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = 'aws.dynamodb.provisioned_write_capacity';
 
     /**
-     * The value of the `ConsistentRead` request parameter.
-     */
-    public const AWS_DYNAMODB_CONSISTENT_READ = 'aws.dynamodb.consistent_read';
-
-    /**
-     * The value of the `ProjectionExpression` request parameter.
-     *
-     * @example Title
-     * @example Title, Price, Color
-     * @example Title, Description, RelatedItems, ProductReviews
-     */
-    public const AWS_DYNAMODB_PROJECTION = 'aws.dynamodb.projection';
-
-    /**
-     * The value of the `Limit` request parameter.
-     *
-     * @example 10
-     */
-    public const AWS_DYNAMODB_LIMIT = 'aws.dynamodb.limit';
-
-    /**
-     * The value of the `AttributesToGet` request parameter.
-     *
-     * @example lives
-     * @example id
-     */
-    public const AWS_DYNAMODB_ATTRIBUTES_TO_GET = 'aws.dynamodb.attributes_to_get';
-
-    /**
-     * The value of the `IndexName` request parameter.
-     *
-     * @example name_to_group
-     */
-    public const AWS_DYNAMODB_INDEX_NAME = 'aws.dynamodb.index_name';
-
-    /**
      * The value of the `Select` request parameter.
      *
      * @example ALL_ATTRIBUTES
      * @example COUNT
      */
     public const AWS_DYNAMODB_SELECT = 'aws.dynamodb.select';
+
+    /**
+     * The keys in the `RequestItems` object field.
+     *
+     * @example Users
+     * @example Cats
+     */
+    public const AWS_DYNAMODB_TABLE_NAMES = 'aws.dynamodb.table_names';
 
     /**
      * The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
@@ -950,20 +1489,6 @@ interface TraceAttributes
     public const AWS_DYNAMODB_SCAN_FORWARD = 'aws.dynamodb.scan_forward';
 
     /**
-     * The value of the `Segment` request parameter.
-     *
-     * @example 10
-     */
-    public const AWS_DYNAMODB_SEGMENT = 'aws.dynamodb.segment';
-
-    /**
-     * The value of the `TotalSegments` request parameter.
-     *
-     * @example 100
-     */
-    public const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
-
-    /**
      * The value of the `Count` response parameter.
      *
      * @example 10
@@ -978,6 +1503,20 @@ interface TraceAttributes
     public const AWS_DYNAMODB_SCANNED_COUNT = 'aws.dynamodb.scanned_count';
 
     /**
+     * The value of the `Segment` request parameter.
+     *
+     * @example 10
+     */
+    public const AWS_DYNAMODB_SEGMENT = 'aws.dynamodb.segment';
+
+    /**
+     * The value of the `TotalSegments` request parameter.
+     *
+     * @example 100
+     */
+    public const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
+
+    /**
      * The JSON-serialized value of each item in the `AttributeDefinitions` request field.
      *
      * @example { "AttributeName": "string", "AttributeType": "string" }
@@ -990,6 +1529,103 @@ interface TraceAttributes
      * @example { "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }
      */
     public const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = 'aws.dynamodb.global_secondary_index_updates';
+
+    /**
+     * The S3 bucket name the request refers to. Corresponds to the `--bucket` parameter of the S3 API operations.
+     *
+     * The `bucket` attribute is applicable to all S3 operations that reference a bucket, i.e. that require the bucket name as a mandatory parameter.
+     * This applies to almost all S3 operations except `list-buckets`.
+     *
+     * @example some-bucket-name
+     */
+    public const AWS_S3_BUCKET = 'aws.s3.bucket';
+
+    /**
+     * The source object (in the form `bucket`/`key`) for the copy operation.
+     *
+     * The `copy_source` attribute applies to S3 copy operations and corresponds to the `--copy-source` parameter
+     * of the copy-object operation within the S3 API.
+     * This applies in particular to the following operations:<ul>
+     * <li>copy-object</li>
+     * <li>upload-part-copy</li>
+     * </ul>
+     *
+     * @example someFile.yml
+     */
+    public const AWS_S3_COPY_SOURCE = 'aws.s3.copy_source';
+
+    /**
+     * The delete request container that specifies the objects to be deleted.
+     *
+     * The `delete` attribute is only applicable to the delete-object operation.
+     * The `delete` attribute corresponds to the `--delete` parameter of the
+     * delete-objects operation within the S3 API.
+     *
+     * @example Objects=[{Key=string,VersionId=string},{Key=string,VersionId=string}],Quiet=boolean
+     */
+    public const AWS_S3_DELETE = 'aws.s3.delete';
+
+    /**
+     * The S3 object key the request refers to. Corresponds to the `--key` parameter of the S3 API operations.
+     *
+     * The `key` attribute is applicable to all object-related S3 operations, i.e. that require the object key as a mandatory parameter.
+     * This applies in particular to the following operations:<ul>
+     * <li>copy-object</li>
+     * <li>delete-object</li>
+     * <li>get-object</li>
+     * <li>head-object</li>
+     * <li>put-object</li>
+     * <li>restore-object</li>
+     * <li>select-object-content</li>
+     * <li>abort-multipart-upload</li>
+     * <li>complete-multipart-upload</li>
+     * <li>create-multipart-upload</li>
+     * <li>list-parts</li>
+     * <li>upload-part</li>
+     * <li>upload-part-copy</li>
+     * </ul>
+     *
+     * @example someFile.yml
+     */
+    public const AWS_S3_KEY = 'aws.s3.key';
+
+    /**
+     * The part number of the part being uploaded in a multipart-upload operation. This is a positive integer between 1 and 10,000.
+     *
+     * The `part_number` attribute is only applicable to the upload-part
+     * and upload-part-copy operations.
+     * The `part_number` attribute corresponds to the `--part-number` parameter of the
+     * upload-part operation within the S3 API.
+     *
+     * @example 3456
+     */
+    public const AWS_S3_PART_NUMBER = 'aws.s3.part_number';
+
+    /**
+     * Upload ID that identifies the multipart upload.
+     *
+     * The `upload_id` attribute applies to S3 multipart-upload operations and corresponds to the `--upload-id` parameter
+     * of the S3 API multipart operations.
+     * This applies in particular to the following operations:<ul>
+     * <li>abort-multipart-upload</li>
+     * <li>complete-multipart-upload</li>
+     * <li>list-parts</li>
+     * <li>upload-part</li>
+     * <li>upload-part-copy</li>
+     * </ul>
+     *
+     * @example dfRtDYWFbkRONycy.Yxwh66Yjlx.cph0gtNBtJ
+     */
+    public const AWS_S3_UPLOAD_ID = 'aws.s3.upload_id';
+
+    /**
+     * The GraphQL document being executed.
+     *
+     * The value may be sanitized to exclude sensitive information.
+     *
+     * @example query findBookById { bookById(id: ?) { name } }
+     */
+    public const GRAPHQL_DOCUMENT = 'graphql.document';
 
     /**
      * The name of the operation being executed.
@@ -1008,90 +1644,20 @@ interface TraceAttributes
     public const GRAPHQL_OPERATION_TYPE = 'graphql.operation.type';
 
     /**
-     * The GraphQL document being executed.
-     *
-     * The value may be sanitized to exclude sensitive information.
-     *
-     * @example query findBookById { bookById(id: ?) { name } }
+     * A boolean that is true if the publish message destination is anonymous (could be unnamed or have auto-generated name).
      */
-    public const GRAPHQL_DOCUMENT = 'graphql.document';
+    public const MESSAGING_DESTINATION_PUBLISH_ANONYMOUS = 'messaging.destination_publish.anonymous';
 
     /**
-     * The message destination name.
+     * The name of the original destination the message was published to.
      *
-     * Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
-     * the broker does not have such notion, the destination name SHOULD uniquely identify the broker.
+     * The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
+     * the broker does not have such notion, the original destination name SHOULD uniquely identify the broker.
      *
      * @example MyQueue
      * @example MyTopic
      */
-    public const MESSAGING_DESTINATION_NAME = 'messaging.destination.name';
-
-    /**
-     * The message source name.
-     *
-     * Source name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
-     * the broker does not have such notion, the source name SHOULD uniquely identify the broker.
-     *
-     * @example MyQueue
-     * @example MyTopic
-     */
-    public const MESSAGING_SOURCE_NAME = 'messaging.source.name';
-
-    /**
-     * The kind of message destination.
-     */
-    public const MESSAGING_DESTINATION_KIND = 'messaging.destination.kind';
-
-    /**
-     * Low cardinality representation of the messaging destination name.
-     *
-     * Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
-     *
-     * @example /customers/{customerId}
-     */
-    public const MESSAGING_DESTINATION_TEMPLATE = 'messaging.destination.template';
-
-    /**
-     * A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.
-     */
-    public const MESSAGING_DESTINATION_TEMPORARY = 'messaging.destination.temporary';
-
-    /**
-     * A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).
-     */
-    public const MESSAGING_DESTINATION_ANONYMOUS = 'messaging.destination.anonymous';
-
-    /**
-     * The kind of message source.
-     */
-    public const MESSAGING_SOURCE_KIND = 'messaging.source.kind';
-
-    /**
-     * Low cardinality representation of the messaging source name.
-     *
-     * Source names could be constructed from templates. An example would be a source name involving a user name or product id. Although the source name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
-     *
-     * @example /customers/{customerId}
-     */
-    public const MESSAGING_SOURCE_TEMPLATE = 'messaging.source.template';
-
-    /**
-     * A boolean that is true if the message source is temporary and might not exist anymore after messages are processed.
-     */
-    public const MESSAGING_SOURCE_TEMPORARY = 'messaging.source.temporary';
-
-    /**
-     * A boolean that is true if the message source is anonymous (could be unnamed or have auto-generated name).
-     */
-    public const MESSAGING_SOURCE_ANONYMOUS = 'messaging.source.anonymous';
-
-    /**
-     * The identifier for the consumer receiving a message. For Kafka, set it to `{messaging.kafka.consumer.group} - {messaging.kafka.client_id}`, if both are present, or only `messaging.kafka.consumer.group`. For brokers, such as RabbitMQ and Artemis, set it to the `client_id` of the client consuming the message.
-     *
-     * @example mygroup - client-6
-     */
-    public const MESSAGING_CONSUMER_ID = 'messaging.consumer.id';
+    public const MESSAGING_DESTINATION_PUBLISH_NAME = 'messaging.destination_publish.name';
 
     /**
      * RabbitMQ message routing key.
@@ -1101,27 +1667,11 @@ interface TraceAttributes
     public const MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY = 'messaging.rabbitmq.destination.routing_key';
 
     /**
-     * Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message.id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set.
-     *
-     * If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
-     *
-     * @example myKey
-     */
-    public const MESSAGING_KAFKA_MESSAGE_KEY = 'messaging.kafka.message.key';
-
-    /**
      * Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
      *
      * @example my-group
      */
     public const MESSAGING_KAFKA_CONSUMER_GROUP = 'messaging.kafka.consumer.group';
-
-    /**
-     * Client Id for the Consumer or Producer that is handling the message.
-     *
-     * @example client-5
-     */
-    public const MESSAGING_KAFKA_CLIENT_ID = 'messaging.kafka.client_id';
 
     /**
      * Partition the message is sent to.
@@ -1131,11 +1681,13 @@ interface TraceAttributes
     public const MESSAGING_KAFKA_DESTINATION_PARTITION = 'messaging.kafka.destination.partition';
 
     /**
-     * Partition the message is received from.
+     * Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message.id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set.
      *
-     * @example 2
+     * If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
+     *
+     * @example myKey
      */
-    public const MESSAGING_KAFKA_SOURCE_PARTITION = 'messaging.kafka.source.partition';
+    public const MESSAGING_KAFKA_MESSAGE_KEY = 'messaging.kafka.message.key';
 
     /**
      * The offset of a record in the corresponding Kafka partition.
@@ -1150,13 +1702,6 @@ interface TraceAttributes
     public const MESSAGING_KAFKA_MESSAGE_TOMBSTONE = 'messaging.kafka.message.tombstone';
 
     /**
-     * Namespace of RocketMQ resources, resources in different namespaces are individual.
-     *
-     * @example myNamespace
-     */
-    public const MESSAGING_ROCKETMQ_NAMESPACE = 'messaging.rocketmq.namespace';
-
-    /**
      * Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind.
      *
      * @example myConsumerGroup
@@ -1164,18 +1709,9 @@ interface TraceAttributes
     public const MESSAGING_ROCKETMQ_CLIENT_GROUP = 'messaging.rocketmq.client_group';
 
     /**
-     * The unique identifier for each client.
-     *
-     * @example myhost@8742@s8083jm
+     * Model of message consumption. This only applies to consumer spans.
      */
-    public const MESSAGING_ROCKETMQ_CLIENT_ID = 'messaging.rocketmq.client_id';
-
-    /**
-     * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
-     *
-     * @example 1665987217045
-     */
-    public const MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP = 'messaging.rocketmq.message.delivery_timestamp';
+    public const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL = 'messaging.rocketmq.consumption_model';
 
     /**
      * The delay time level for delay message, which determines the message delay time.
@@ -1185,23 +1721,18 @@ interface TraceAttributes
     public const MESSAGING_ROCKETMQ_MESSAGE_DELAY_TIME_LEVEL = 'messaging.rocketmq.message.delay_time_level';
 
     /**
+     * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
+     *
+     * @example 1665987217045
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP = 'messaging.rocketmq.message.delivery_timestamp';
+
+    /**
      * It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
      *
      * @example myMessageGroup
      */
     public const MESSAGING_ROCKETMQ_MESSAGE_GROUP = 'messaging.rocketmq.message.group';
-
-    /**
-     * Type of message.
-     */
-    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE = 'messaging.rocketmq.message.type';
-
-    /**
-     * The secondary classifier of message besides topic.
-     *
-     * @example tagA
-     */
-    public const MESSAGING_ROCKETMQ_MESSAGE_TAG = 'messaging.rocketmq.message.tag';
 
     /**
      * Key(s) of message, another way to mark message besides message id.
@@ -1212,30 +1743,28 @@ interface TraceAttributes
     public const MESSAGING_ROCKETMQ_MESSAGE_KEYS = 'messaging.rocketmq.message.keys';
 
     /**
-     * Model of message consumption. This only applies to consumer spans.
+     * The secondary classifier of message besides topic.
+     *
+     * @example tagA
      */
-    public const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL = 'messaging.rocketmq.consumption_model';
+    public const MESSAGING_ROCKETMQ_MESSAGE_TAG = 'messaging.rocketmq.message.tag';
+
+    /**
+     * Type of message.
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE = 'messaging.rocketmq.message.type';
+
+    /**
+     * Namespace of RocketMQ resources, resources in different namespaces are individual.
+     *
+     * @example myNamespace
+     */
+    public const MESSAGING_ROCKETMQ_NAMESPACE = 'messaging.rocketmq.namespace';
 
     /**
      * The numeric status code of the gRPC request.
      */
     public const RPC_GRPC_STATUS_CODE = 'rpc.grpc.status_code';
-
-    /**
-     * Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 does not specify this, the value can be omitted.
-     *
-     * @example 2.0
-     * @example 1.0
-     */
-    public const RPC_JSONRPC_VERSION = 'rpc.jsonrpc.version';
-
-    /**
-     * `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification.
-     *
-     * @example 10
-     * @example request-7
-     */
-    public const RPC_JSONRPC_REQUEST_ID = 'rpc.jsonrpc.request_id';
 
     /**
      * `error.code` property of response if it is an error response.
@@ -1254,9 +1783,25 @@ interface TraceAttributes
     public const RPC_JSONRPC_ERROR_MESSAGE = 'rpc.jsonrpc.error_message';
 
     /**
-     * Whether this is a received or sent message.
+     * `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification.
+     *
+     * @example 10
+     * @example request-7
      */
-    public const MESSAGE_TYPE = 'message.type';
+    public const RPC_JSONRPC_REQUEST_ID = 'rpc.jsonrpc.request_id';
+
+    /**
+     * Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 does not specify this, the value can be omitted.
+     *
+     * @example 2.0
+     * @example 1.0
+     */
+    public const RPC_JSONRPC_VERSION = 'rpc.jsonrpc.version';
+
+    /**
+     * Compressed size of the message in bytes.
+     */
+    public const MESSAGE_COMPRESSED_SIZE = 'message.compressed_size';
 
     /**
      * MUST be calculated as two different counters starting from `1` one for sent messages and one for received message.
@@ -1266,9 +1811,9 @@ interface TraceAttributes
     public const MESSAGE_ID = 'message.id';
 
     /**
-     * Compressed size of the message in bytes.
+     * Whether this is a received or sent message.
      */
-    public const MESSAGE_COMPRESSED_SIZE = 'message.compressed_size';
+    public const MESSAGE_TYPE = 'message.type';
 
     /**
      * Uncompressed size of the message in bytes.
@@ -1297,6 +1842,13 @@ interface TraceAttributes
      * clear whether the exception will escape.
      */
     public const EXCEPTION_ESCAPED = 'exception.escaped';
+
+    /**
+     * The URI fragment component.
+     *
+     * @example SemConv
+     */
+    public const URL_FRAGMENT = 'url.fragment';
 
     /**
      * @deprecated


### PR DESCRIPTION
Since 1.19.0, the source has been split out of opentelemetry-specifiction into semantic-conventions. Update the build script accordingly. Update to latest generator.
Add 2 new deprecations for semconvs which were renamed since 1.19