### PR TITLE
Implement GCP X-Cloud-Trace-Context Propagator

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -24,6 +24,8 @@ splits:
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/exporter-zipkin.git"
   - prefix: "src/Extension/Propagator/B3"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/extension-propagator-b3.git"
+  - prefix: "src/Extension/Propagator/XCloudTrace"
+    target: "https://${GH_TOKEN}@github.com/opentelemetry-php/extension-propagator-cloudtrace.git"
 
 # List of references to split (defined as regexp)
 origins:

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
             "src/Contrib/Grpc/_register.php",
             "src/Contrib/Zipkin/_register.php",
             "src/Extension/Propagator/B3/_register.php",
+            "src/Extension/Propagator/XCloudTrace/_register.php",
             "src/SDK/Logs/Exporter/_register.php",
             "src/SDK/Metrics/MetricExporter/_register.php",
             "src/SDK/Propagation/_register.php",

--- a/src/Extension/Propagator/XCloudTrace/README.md
+++ b/src/Extension/Propagator/XCloudTrace/README.md
@@ -1,0 +1,27 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/extension-propagator-cloudtrace/releases)
+[![Source](https://img.shields.io/badge/source-extension--propagator--xcloudtrace-green)](https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Extension/Propagator/XCloudTrace)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php:extension--propagator--xcloudtrace-blue)](https://github.com/opentelemetry-php/extension-propagator-cloudtrace)
+[![Latest Version](http://poser.pugx.org/open-telemetry/extension-propagator-cloudtrace/v/unstable)](https://packagist.org/packages/open-telemetry/extension-propagator-cloudtrace/)
+[![Stable](http://poser.pugx.org/open-telemetry/extension-propagator-cloudtrace/v/stable)](https://packagist.org/packages/open-telemetry/extension-propagator-cloudtrace/)
+
+# OpenTelemetry Extension
+### XCloudTrace Propagator
+
+XCloudTrace is a propagator that supports the specification for the header "x-cloud-trace-context" used for trace context propagation across
+service boundaries. (https://cloud.google.com/trace/docs/setup#force-trace). OpenTelemetry PHP XCloudTrace Propagator Extension provides
+option to use it bi-directionally or one-way. One-way does not inject the header for downstream consumption, it only processes the incoming headers
+and returns the correct span context. It only attaches to existing X-Cloud-Trace-Context traces and does not create downstream ones.
+For one-way XCloudTrace:
+```text
+XCloudTracePropagator::getOneWayInstance()
+```
+
+For bi-directional XCloudTrace:
+```text
+XCloudTracePropagator::getInstance()
+```
+
+## Contributing
+
+This repository is a read-only git subtree split.
+To contribute, please see the main [OpenTelemetry PHP monorepo](https://github.com/open-telemetry/opentelemetry-php).

--- a/src/Extension/Propagator/XCloudTrace/Utils.php
+++ b/src/Extension/Propagator/XCloudTrace/Utils.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Extension\Propagator\XCloudTrace;
+
+/**
+ * This class contains utilities that are used by the XCloudTracePropagator.
+ * This class mostly contains numerical handling functions to work with
+ * trace and span IDs.
+ */
+final class Utils {
+
+    /**
+     * Pads the string with zero string characters on left hand side, to max total string size.
+     *
+     * @param string $str The string to pad.
+     * @param int $amount Total String size, default is 16.
+     * @return string The padded string
+     */
+    public static function leftZeroPad(string $str, int $amount = 16) : string {
+        return str_pad($str, $amount, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Converts a decimal number in string format to a hex number in string format.
+     * The returned number will not start with 0x.
+     *
+     * @param string $num The number to convert.
+     * @return string The converted number.
+     */
+    public static function decToHex(string $num) : string
+    {
+        $int = (int) $num;
+        if (Utils::isBigNum($int)) {
+            return Utils::baseConvert($num, 10, 16);
+        }
+        return dechex($int);
+    }
+
+    /**
+     * Converts a hex number in string format to a decimal number in string format.
+     * The given number does not have to start with 0x.
+     *
+     * @param string $num The number to convert.
+     * @return string The converted number.
+     */
+    public static function hexToDec(string $num) : string
+    {
+        $dec = hexdec($num);
+        if (Utils::isBigNum($dec)) {
+            return Utils::baseConvert($num, 16, 10);
+        }
+        return strval($dec);
+    }
+
+    /**
+     * Tests whether the given number is larger than the maximum integer of the installed PHP's build.
+     * On 32-bit system it's 2147483647 and on 64-bit it's 9223372036854775807.
+     * We are comparing with >= and no >, because this function is used in context of what method to use
+     * to convert to some base (in our case hex to octal and vice versa).
+     * So it's ok if we use >=, because it means that only for MAX_INT we will use the slower baseConvert
+     * method.
+     *
+     * @param int|float $number The number to test.
+     * @return bool Whether it was bigger or not than the max.
+     */
+    public static function isBigNum(int|float $number) : bool
+    {
+        return $number >= PHP_INT_MAX;
+    }
+
+    /**
+     * Custom function to convert a number in string format from one base to another.
+     * Built-in functions, specifically for hex, do not work well in PHP under
+     * all versions (32/64-bit) or if the number only fits into an unsigned long.
+     * PHP does not have unsigned longs, so this function is necessary.
+     *
+     * @param string $num The number to convert (in some base).
+     * @param int $fromBase The base to convert from.
+     * @param int $toBase The base to convert to.
+     * @return string Converted number in the new base.
+     */
+    public static function baseConvert(string $num, int $fromBase, int $toBase) : string
+    {
+        $num = strtolower($num);
+        $chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+        $newstring = substr($chars, 0, $toBase);
+
+        $length = strlen($num);
+        $result = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $number[$i] = strpos($chars, $num[$i]);
+        }
+
+        do {
+            $divide = 0;
+            $newlen = 0;
+            for ($i = 0; $i < $length; $i++) {
+                $divide = $divide * $fromBase + $number[$i];
+                if ($divide >= $toBase) {
+                    $number[$newlen++] = (int)($divide / $toBase);
+                    $divide = $divide % $toBase;
+                } elseif ($newlen > 0) {
+                    $number[$newlen++] = 0;
+                }
+            }
+            $length = $newlen;
+            $result = $newstring[$divide] . $result;
+        } while ($newlen != 0);
+
+        return $result;
+    }
+
+}

--- a/src/Extension/Propagator/XCloudTrace/Utils.php
+++ b/src/Extension/Propagator/XCloudTrace/Utils.php
@@ -69,7 +69,7 @@ final class Utils
      * @param int|float $number The number to test.
      * @return bool Whether it was bigger or not than the max.
      */
-    public static function isBigNum(int|float $number) : bool
+    public static function isBigNum($number) : bool
     {
         return $number >= PHP_INT_MAX;
     }
@@ -94,6 +94,7 @@ final class Utils
         $length = strlen($num);
         $result = '';
 
+        $number = [];
         for ($i = 0; $i < $length; $i++) {
             $number[$i] = strpos($chars, $num[$i]);
         }
@@ -102,10 +103,13 @@ final class Utils
             $divide = 0;
             $newlen = 0;
             for ($i = 0; $i < $length; $i++) {
+                if (!isset($number[$i]) || $number[$i] === false) {
+                    return '';
+                }
                 $divide = $divide * $fromBase + $number[$i];
                 if ($divide >= $toBase) {
                     $number[$newlen++] = (int) ($divide / $toBase);
-                    $divide = $divide % $toBase;
+                    $divide %= $toBase;
                 } elseif ($newlen > 0) {
                     $number[$newlen++] = 0;
                 }

--- a/src/Extension/Propagator/XCloudTrace/Utils.php
+++ b/src/Extension/Propagator/XCloudTrace/Utils.php
@@ -9,7 +9,8 @@ namespace OpenTelemetry\Extension\Propagator\XCloudTrace;
  * This class mostly contains numerical handling functions to work with
  * trace and span IDs.
  */
-final class Utils {
+final class Utils
+{
 
     /**
      * Pads the string with zero string characters on left hand side, to max total string size.
@@ -18,7 +19,8 @@ final class Utils {
      * @param int $amount Total String size, default is 16.
      * @return string The padded string
      */
-    public static function leftZeroPad(string $str, int $amount = 16) : string {
+    public static function leftZeroPad(string $str, int $amount = 16) : string
+    {
         return str_pad($str, $amount, '0', STR_PAD_LEFT);
     }
 
@@ -35,6 +37,7 @@ final class Utils {
         if (Utils::isBigNum($int)) {
             return Utils::baseConvert($num, 10, 16);
         }
+
         return dechex($int);
     }
 
@@ -51,7 +54,8 @@ final class Utils {
         if (Utils::isBigNum($dec)) {
             return Utils::baseConvert($num, 16, 10);
         }
-        return strval($dec);
+
+        return (string) $dec;
     }
 
     /**
@@ -84,7 +88,7 @@ final class Utils {
     public static function baseConvert(string $num, int $fromBase, int $toBase) : string
     {
         $num = strtolower($num);
-        $chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+        $chars = '0123456789abcdefghijklmnopqrstuvwxyz';
         $newstring = substr($chars, 0, $toBase);
 
         $length = strlen($num);
@@ -100,7 +104,7 @@ final class Utils {
             for ($i = 0; $i < $length; $i++) {
                 $divide = $divide * $fromBase + $number[$i];
                 if ($divide >= $toBase) {
-                    $number[$newlen++] = (int)($divide / $toBase);
+                    $number[$newlen++] = (int) ($divide / $toBase);
                     $divide = $divide % $toBase;
                 } elseif ($newlen > 0) {
                     $number[$newlen++] = 0;
@@ -112,5 +116,4 @@ final class Utils {
 
         return $result;
     }
-
 }

--- a/src/Extension/Propagator/XCloudTrace/Utils.php
+++ b/src/Extension/Propagator/XCloudTrace/Utils.php
@@ -34,8 +34,8 @@ final class Utils
     public static function decToHex(string $num) : string
     {
         $int = (int) $num;
-        if (Utils::isBigNum($int)) {
-            return Utils::baseConvert($num, 10, 16);
+        if (self::isBigNum($int)) {
+            return self::baseConvert($num, 10, 16);
         }
 
         return dechex($int);
@@ -51,8 +51,8 @@ final class Utils
     public static function hexToDec(string $num) : string
     {
         $dec = hexdec($num);
-        if (Utils::isBigNum($dec)) {
-            return Utils::baseConvert($num, 16, 10);
+        if (self::isBigNum($dec)) {
+            return self::baseConvert($num, 16, 10);
         }
 
         return (string) $dec;

--- a/src/Extension/Propagator/XCloudTrace/XCloudTraceFormatter.php
+++ b/src/Extension/Propagator/XCloudTrace/XCloudTraceFormatter.php
@@ -1,19 +1,6 @@
 <?php
-/**
- * Copyright 2017 OpenCensus Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+
+declare(strict_types=1);
 
 namespace OpenTelemetry\Extension\Propagator\XCloudTrace;
 
@@ -43,7 +30,7 @@ final class XCloudTraceFormatter
             return SpanContext::createFromRemoteParent(
                 strtolower($matches[1]),
                 array_key_exists(2, $matches) && !empty($matches[2])
-                    ? self::decToHex($matches[2])
+                    ? Utils::leftZeroPad(Utils::decToHex($matches[2]))
                     : null,
                 array_key_exists(3, $matches)
                     ? (int)($matches[3] == '1')
@@ -63,65 +50,10 @@ final class XCloudTraceFormatter
     {
         $ret = $context->getTraceId();
         if ($context->getSpanId()) {
-            $ret .= '/' . self::hexToDec($context->getSpanId());
+            $ret .= '/' . Utils::hexToDec($context->getSpanId());
         }
         $ret .= ';o=' . ($context->isSampled() ? '1' : '0');
         return $ret;
     }
 
-    private static function decToHex(string $num) : string
-    {
-        $int = (int) $num;
-        if (self::isBigNum($int)) {
-            $ret = self::baseConvert($num, 10, 16);
-        } else {
-            $ret = dechex($int);
-        }
-        return str_pad($ret, 16, '0', STR_PAD_LEFT);
-    }
-
-    private static function hexToDec(string $num) : string
-    {
-        $dec = hexdec($num);
-        if (self::isBigNum($dec)) {
-            return self::baseConvert($num, 16, 10);
-        }
-        return strval($dec);
-    }
-
-    private static function isBigNum(int|float $number) : bool
-    {
-        return $number >= PHP_INT_MAX;
-    }
-
-    private static function baseConvert(string $num, int $fromBase, int $toBase) : string
-    {
-        $chars = "0123456789abcdefghijklmnopqrstuvwxyz";
-        $newstring = substr($chars, 0, $toBase);
-
-        $length = strlen($num);
-        $result = '';
-
-        for ($i = 0; $i < $length; $i++) {
-            $number[$i] = strpos($chars, $num[$i]);
-        }
-
-        do {
-            $divide = 0;
-            $newlen = 0;
-            for ($i = 0; $i < $length; $i++) {
-                $divide = $divide * $fromBase + $number[$i];
-                if ($divide >= $toBase) {
-                    $number[$newlen++] = (int)($divide / $toBase);
-                    $divide = $divide % $toBase;
-                } elseif ($newlen > 0) {
-                    $number[$newlen++] = 0;
-                }
-            }
-            $length = $newlen;
-            $result = $newstring[$divide] . $result;
-        } while ($newlen != 0);
-
-        return $result;
-    }
 }

--- a/src/Extension/Propagator/XCloudTrace/XCloudTraceFormatter.php
+++ b/src/Extension/Propagator/XCloudTrace/XCloudTraceFormatter.php
@@ -33,10 +33,11 @@ final class XCloudTraceFormatter
                     ? Utils::leftZeroPad(Utils::decToHex($matches[2]))
                     : null,
                 array_key_exists(3, $matches)
-                    ? (int)($matches[3] == '1')
+                    ? (int) ($matches[3] == '1')
                     : null
             );
         }
+
         return SpanContext::getInvalid();
     }
 
@@ -53,7 +54,7 @@ final class XCloudTraceFormatter
             $ret .= '/' . Utils::hexToDec($context->getSpanId());
         }
         $ret .= ';o=' . ($context->isSampled() ? '1' : '0');
+
         return $ret;
     }
-
 }

--- a/src/Extension/Propagator/XCloudTrace/XCloudTraceFormatter.php
+++ b/src/Extension/Propagator/XCloudTrace/XCloudTraceFormatter.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Copyright 2017 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenTelemetry\Extension\Propagator\XCloudTrace;
+
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+
+/**
+ * This format using a human readable string encoding to propagate SpanContext.
+ * The current format of the header is `<trace-id>[/<span-id>][;o=<options>]`.
+ * The options are a bitmask of options. Currently the only option is the
+ * least significant bit which signals whether the request was traced or not
+ * (1 = traced, 0 = not traced).
+ */
+final class XCloudTraceFormatter
+{
+    const CONTEXT_HEADER_FORMAT = '/([0-9a-fA-F]{32})(?:\/(\d+))?(?:;o=(\d+))?/';
+
+    /**
+     * Generate a SpanContext object from the Trace Context header
+     *
+     * @param string $header
+     * @return SpanContextInterface
+     */
+    public static function deserialize(string $header) : SpanContextInterface
+    {
+        if (preg_match(self::CONTEXT_HEADER_FORMAT, $header, $matches)) {
+            return SpanContext::createFromRemoteParent(
+                strtolower($matches[1]),
+                array_key_exists(2, $matches) && !empty($matches[2])
+                    ? self::decToHex($matches[2])
+                    : null,
+                array_key_exists(3, $matches)
+                    ? (int)($matches[3] == '1')
+                    : null
+            );
+        }
+        return SpanContext::getInvalid();
+    }
+
+    /**
+     * Convert a SpanContextInterface to header string
+     *
+     * @param SpanContextInterface $context
+     * @return string
+     */
+    public static function serialize(SpanContextInterface $context) : string
+    {
+        $ret = $context->getTraceId();
+        if ($context->getSpanId()) {
+            $ret .= '/' . self::hexToDec($context->getSpanId());
+        }
+        $ret .= ';o=' . ($context->isSampled() ? '1' : '0');
+        return $ret;
+    }
+
+    private static function decToHex(string $num) : string
+    {
+        $int = (int) $num;
+        if (self::isBigNum($int)) {
+            $ret = self::baseConvert($num, 10, 16);
+        } else {
+            $ret = dechex($int);
+        }
+        return str_pad($ret, 16, '0', STR_PAD_LEFT);
+    }
+
+    private static function hexToDec(string $num) : string
+    {
+        $dec = hexdec($num);
+        if (self::isBigNum($dec)) {
+            return self::baseConvert($num, 16, 10);
+        }
+        return strval($dec);
+    }
+
+    private static function isBigNum(int|float $number) : bool
+    {
+        return $number >= PHP_INT_MAX;
+    }
+
+    private static function baseConvert(string $num, int $fromBase, int $toBase) : string
+    {
+        $chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+        $newstring = substr($chars, 0, $toBase);
+
+        $length = strlen($num);
+        $result = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $number[$i] = strpos($chars, $num[$i]);
+        }
+
+        do {
+            $divide = 0;
+            $newlen = 0;
+            for ($i = 0; $i < $length; $i++) {
+                $divide = $divide * $fromBase + $number[$i];
+                if ($divide >= $toBase) {
+                    $number[$newlen++] = (int)($divide / $toBase);
+                    $divide = $divide % $toBase;
+                } elseif ($newlen > 0) {
+                    $number[$newlen++] = 0;
+                }
+            }
+            $length = $newlen;
+            $result = $newstring[$divide] . $result;
+        } while ($newlen != 0);
+
+        return $result;
+    }
+}

--- a/src/Extension/Propagator/XCloudTrace/XCloudTracePropagator.php
+++ b/src/Extension/Propagator/XCloudTrace/XCloudTracePropagator.php
@@ -12,6 +12,11 @@ use OpenTelemetry\Context\Propagation\PropagationGetterInterface;
 use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 
+/**
+ * XCloudTracePropagator is a propagator that supports the specification for the X-Cloud-Trace-Context
+ * header used for trace context propagation across service boundaries.
+ * (https://cloud.google.com/trace/docs/setup#force-trace)
+ */
 final class XCloudTracePropagator implements TextMapPropagatorInterface
 {
 

--- a/src/Extension/Propagator/XCloudTrace/XCloudTracePropagator.php
+++ b/src/Extension/Propagator/XCloudTrace/XCloudTracePropagator.php
@@ -19,10 +19,8 @@ use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
  */
 final class XCloudTracePropagator implements TextMapPropagatorInterface
 {
-
     private static ?TextMapPropagatorInterface $oneWayInstance = null;
     private static ?TextMapPropagatorInterface $instance = null;
-
 
     public static function getOneWayInstance(): TextMapPropagatorInterface
     {
@@ -50,7 +48,8 @@ final class XCloudTracePropagator implements TextMapPropagatorInterface
 
     private bool $oneWay;
 
-    private function __construct(bool $oneWay) {
+    private function __construct(bool $oneWay)
+    {
         $this->oneWay = $oneWay;
     }
 
@@ -63,7 +62,7 @@ final class XCloudTracePropagator implements TextMapPropagatorInterface
     /** {@inheritdoc} */
     public function inject(&$carrier, PropagationSetterInterface $setter = null, ContextInterface $context = null): void
     {
-        if($this->oneWay) {
+        if ($this->oneWay) {
             return;
         }
 
@@ -97,5 +96,4 @@ final class XCloudTracePropagator implements TextMapPropagatorInterface
 
         return $context->withContextValue(Span::wrap($spanContext));
     }
-
 }

--- a/src/Extension/Propagator/XCloudTrace/XCloudTracePropagator.php
+++ b/src/Extension/Propagator/XCloudTrace/XCloudTracePropagator.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Extension\Propagator\XCloudTrace;
+
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Context\Propagation\ArrayAccessGetterSetter;
+use OpenTelemetry\Context\Propagation\PropagationGetterInterface;
+use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
+use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
+
+final class XCloudTracePropagator implements TextMapPropagatorInterface
+{
+
+    private static ?TextMapPropagatorInterface $oneWayInstance = null;
+    private static ?TextMapPropagatorInterface $instance = null;
+
+
+    public static function getOneWayInstance(): TextMapPropagatorInterface
+    {
+        if (self::$oneWayInstance === null) {
+            self::$oneWayInstance = new XCloudTracePropagator(true);
+        }
+
+        return self::$oneWayInstance;
+    }
+
+    public static function getInstance(): TextMapPropagatorInterface
+    {
+        if (self::$instance === null) {
+            self::$instance = new XCloudTracePropagator(false);
+        }
+
+        return self::$instance;
+    }
+
+    private const XCLOUD = 'x-cloud-trace-context';
+
+    private const FIELDS = [
+        self::XCLOUD,
+    ];
+
+    private bool $oneWay;
+
+    private function __construct(bool $oneWay) {
+        $this->oneWay = $oneWay;
+    }
+
+    /** {@inheritdoc} */
+    public function fields(): array
+    {
+        return self::FIELDS;
+    }
+
+    /** {@inheritdoc} */
+    public function inject(&$carrier, PropagationSetterInterface $setter = null, ContextInterface $context = null): void
+    {
+        if($this->oneWay) {
+            return;
+        }
+
+        $setter ??= ArrayAccessGetterSetter::getInstance();
+        $context ??= Context::getCurrent();
+        $spanContext = Span::fromContext($context)->getContext();
+
+        if (!$spanContext->isValid()) {
+            return;
+        }
+
+        $headerValue = XCloudTraceFormatter::serialize($spanContext);
+        $setter->set($carrier, self::XCLOUD, $headerValue);
+    }
+
+    /** {@inheritdoc} */
+    public function extract($carrier, PropagationGetterInterface $getter = null, ContextInterface $context = null): ContextInterface
+    {
+        $getter ??= ArrayAccessGetterSetter::getInstance();
+        $context ??= Context::getCurrent();
+
+        $headerValue = $getter->get($carrier, self::XCLOUD);
+        if ($headerValue === null) {
+            return $context;
+        }
+
+        $spanContext = XCloudTraceFormatter::deserialize($headerValue);
+        if (!$spanContext->isValid()) {
+            return $context;
+        }
+
+        return $context->withContextValue(Span::wrap($spanContext));
+    }
+
+}

--- a/src/Extension/Propagator/XCloudTrace/_register.php
+++ b/src/Extension/Propagator/XCloudTrace/_register.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTracePropagator;
+use OpenTelemetry\SDK\Common\Configuration\KnownValues;
+use OpenTelemetry\SDK\Registry;
+
+Registry::registerTextMapPropagator(
+    KnownValues::VALUE_XCLOUD_TRACE,
+    XCloudTracePropagator::getInstance()
+);

--- a/src/Extension/Propagator/XCloudTrace/composer.json
+++ b/src/Extension/Propagator/XCloudTrace/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "open-telemetry/extension-propagator-xcloudtrace",
+    "description": "XCloudTraceContext propagator extension for OpenTelemetry PHP.",
+    "keywords": ["opentelemetry", "otel", "tracing", "apm", "extension", "propagator", "xcloudtrace"],
+    "type": "library",
+    "support": {
+        "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+        "source": "https://github.com/open-telemetry/opentelemetry-php",
+        "docs": "https://opentelemetry.io/docs/php",
+        "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
+    },
+    "license": "Apache-2.0",
+    "authors": [
+        {
+            "name": "opentelemetry-php contributors",
+            "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+        }
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "open-telemetry/api": "^1.0",
+        "open-telemetry/context": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "OpenTelemetry\\Extension\\Propagator\\XCloudTrace\\": "."
+        },
+        "files": [
+            "_register.php"
+        ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.0.x-dev"
+        }
+    }
+}

--- a/src/SDK/Common/Configuration/KnownValues.php
+++ b/src/SDK/Common/Configuration/KnownValues.php
@@ -106,6 +106,7 @@ interface KnownValues
         self::VALUE_BAGGAGE, // W3C Baggage
         self::VALUE_B3, // B3 Single
         self::VALUE_B3_MULTI, // B3 Multi
+        self::VALUE_XCLOUD_TRACE, // GCP XCloudTraceContext
         self::VALUE_XRAY, // AWS X-Ray (third party)
         self::VALUE_OTTRACE, // OT Trace (third party)
         self::VALUE_NONE, // No automatically configured propagator.

--- a/src/SDK/Common/Configuration/KnownValues.php
+++ b/src/SDK/Common/Configuration/KnownValues.php
@@ -25,6 +25,7 @@ interface KnownValues
     public const VALUE_BAGGAGE = 'baggage';
     public const VALUE_B3 = 'b3';
     public const VALUE_B3_MULTI = 'b3multi';
+    public const VALUE_XCLOUD_TRACE = 'xcloudtrace';
     public const VALUE_XRAY = 'xray';
     public const VALUE_OTTRACE = 'ottrace';
     public const VALUE_ALWAYS_ON = 'always_on';

--- a/tests/Unit/Extension/Propagator/XCloudTrace/UtilsTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/UtilsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\Extension\Propagator\XCloudTrace;
+
+use OpenTelemetry\Extension\Propagator\XCloudTrace\Utils;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\Extension\Propagator\XCloudTrace\Utils
+ */
+class UtilsTest extends TestCase
+{
+
+    /**
+     * @dataProvider for_test_leftZeroPad
+     */
+    public function test_leftZeroPad(string $pad, int $howMuch, string $equalsTo) : void
+    {
+        $this->assertEquals(Utils::leftZeroPad($pad, $howMuch), $equalsTo, "Given leftZeroPad($pad, $howMuch) != $equalsTo");
+    }
+
+    public function for_test_leftZeroPad() : array {
+        return [
+            ['a', 3, '00a'],
+            ['aaa', 3, 'aaa'],
+            ['aaa', 16, '0000000000000aaa'],
+            ['', 1, '0'],
+        ];
+    }
+
+    /**
+     * @dataProvider for_test_decToHex
+     */
+    public function test_decToHex(string $decNum, string $equalsTo) : void
+    {
+        $this->assertEquals(Utils::decToHex($decNum), $equalsTo, "Given decToHex($decNum) != $equalsTo");
+    }
+
+    public function for_test_decToHex() : array {
+        return [
+            ['10', 'a'],
+            ['1', '1'],
+            ['9223372036854775807', '7fffffffffffffff'],
+            ['18446744073709551615', 'ffffffffffffffff'],
+            ['28446744073709551615', '18ac7230489e7ffff']
+        ];
+    }
+
+    /**
+     * @dataProvider for_test_hexToDec
+     */
+    public function test_hexToDec(string $hexNum, string $equalsTo) : void
+    {
+        $this->assertEquals(Utils::hexToDec($hexNum), $equalsTo, "Given hexToDec($hexNum) != $equalsTo");
+    }
+
+    public function for_test_hexToDec() : array {
+        return [
+            ['a', '10'],
+            ['B', '11'],
+            ['0xc', '12'],
+            ['1', '1'],
+            ['7fffffffffffffff', '9223372036854775807'],
+            ['1ffffffffffffffA', '2305843009213693946'],
+            ['1fffffffffffffff', '2305843009213693951'],
+            ['8fffffffffffffff', '10376293541461622783'],
+            ['7fffffffffffffff', '9223372036854775807'],
+            ['8000000000000000', '9223372036854775808'],
+            ['ffffffffffffffff', '18446744073709551615'],
+            ['18ac7230489e7ffff', '28446744073709551615']
+        ];
+    }
+
+    /**
+     * @dataProvider for_test_isBigNum
+     */
+    public function test_isBigNum(int|float $num, bool $equalsTo) : void
+    {
+        $this->assertEquals(Utils::isBigNum($num), $equalsTo, "Given isBigNum($num) != $equalsTo");
+    }
+
+    public function for_test_isBigNum() : array {
+        return [
+            [-100.5, false],
+            [-1, false],
+            [1, false],
+            [100.5, false],
+            [9223372036854775806, false],
+            [9223372036854775807, true],
+            [9223372036854775808, true],
+            [18446744073709551615, true],
+            [28446744073709551615, true],
+        ];
+    }
+
+    /**
+     * @dataProvider for_test_baseConvert
+     */
+    public function test_baseConvert(string $num, int $fromBase, int $toBase, string $equalsTo) : void
+    {
+        $result = Utils::baseConvert($num, $fromBase, $toBase);
+        $this->assertEquals($result, $equalsTo, "Given baseConvert($num, $fromBase, $toBase) != $equalsTo (result=$result)");
+    }
+
+    public function for_test_baseConvert() : array {
+        return [
+            ['b', 16, 10, '11'],
+            ['c', 16, 10, '12'],
+            ['fffffffffffff', 16, 10, '4503599627370495'],
+            ['7fffffff', 16, 10, '2147483647'],
+            ['7ffffffffffffffe', 16, 10, '9223372036854775806'],
+            ['7fffffffffffffff', 16, 10, '9223372036854775807'],
+            ['8000000000000000', 16, 10, '9223372036854775808'], // bigger than signed int max 64 bit
+            ['18ac7230489e7ffff', 16, 10, '28446744073709551615'],
+            ['28446744073709551615', 10, 16, '18ac7230489e7ffff'],
+            ['10', 10, 16, 'a']
+        ];
+    }
+
+}

--- a/tests/Unit/Extension/Propagator/XCloudTrace/UtilsTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/UtilsTest.php
@@ -79,7 +79,7 @@ class UtilsTest extends TestCase
     /**
      * @dataProvider for_test_is_big_num
      */
-    public function test_is_big_num(int|float $num, bool $equalsTo) : void
+    public function test_is_big_num($num, bool $equalsTo) : void
     {
         $this->assertEquals(Utils::isBigNum($num), $equalsTo, "Given isBigNum($num) != $equalsTo");
     }

--- a/tests/Unit/Extension/Propagator/XCloudTrace/UtilsTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/UtilsTest.php
@@ -14,14 +14,14 @@ class UtilsTest extends TestCase
 {
 
     /**
-     * @dataProvider for_test_leftZeroPad
+     * @dataProvider for_test_left_zero_pad
      */
-    public function test_leftZeroPad(string $pad, int $howMuch, string $equalsTo) : void
+    public function test_left_zero_pad(string $pad, int $howMuch, string $equalsTo) : void
     {
         $this->assertEquals(Utils::leftZeroPad($pad, $howMuch), $equalsTo, "Given leftZeroPad($pad, $howMuch) != $equalsTo");
     }
 
-    public function for_test_leftZeroPad() : array {
+    public function for_test_left_zero_pad() : array {
         return [
             ['a', 3, '00a'],
             ['aaa', 3, 'aaa'],
@@ -31,14 +31,14 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * @dataProvider for_test_decToHex
+     * @dataProvider for_test_dec_to_hex
      */
-    public function test_decToHex(string $decNum, string $equalsTo) : void
+    public function test_dec_to_hex(string $decNum, string $equalsTo) : void
     {
         $this->assertEquals(Utils::decToHex($decNum), $equalsTo, "Given decToHex($decNum) != $equalsTo");
     }
 
-    public function for_test_decToHex() : array {
+    public function for_test_dec_to_hex() : array {
         return [
             ['10', 'a'],
             ['1', '1'],
@@ -49,14 +49,14 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * @dataProvider for_test_hexToDec
+     * @dataProvider for_test_hex_to_dec
      */
-    public function test_hexToDec(string $hexNum, string $equalsTo) : void
+    public function test_hex_to_dec(string $hexNum, string $equalsTo) : void
     {
         $this->assertEquals(Utils::hexToDec($hexNum), $equalsTo, "Given hexToDec($hexNum) != $equalsTo");
     }
 
-    public function for_test_hexToDec() : array {
+    public function for_test_hex_to_dec() : array {
         return [
             ['a', '10'],
             ['B', '11'],
@@ -74,14 +74,14 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * @dataProvider for_test_isBigNum
+     * @dataProvider for_test_is_big_num
      */
-    public function test_isBigNum(int|float $num, bool $equalsTo) : void
+    public function test_is_big_num(int|float $num, bool $equalsTo) : void
     {
         $this->assertEquals(Utils::isBigNum($num), $equalsTo, "Given isBigNum($num) != $equalsTo");
     }
 
-    public function for_test_isBigNum() : array {
+    public function for_test_is_big_num() : array {
         return [
             [-100.5, false],
             [-1, false],
@@ -96,15 +96,15 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * @dataProvider for_test_baseConvert
+     * @dataProvider for_test_base_convert
      */
-    public function test_baseConvert(string $num, int $fromBase, int $toBase, string $equalsTo) : void
+    public function test_base_convert(string $num, int $fromBase, int $toBase, string $equalsTo) : void
     {
         $result = Utils::baseConvert($num, $fromBase, $toBase);
         $this->assertEquals($result, $equalsTo, "Given baseConvert($num, $fromBase, $toBase) != $equalsTo (result=$result)");
     }
 
-    public function for_test_baseConvert() : array {
+    public function for_test_base_convert() : array {
         return [
             ['b', 16, 10, '11'],
             ['c', 16, 10, '12'],

--- a/tests/Unit/Extension/Propagator/XCloudTrace/UtilsTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/UtilsTest.php
@@ -21,7 +21,8 @@ class UtilsTest extends TestCase
         $this->assertEquals(Utils::leftZeroPad($pad, $howMuch), $equalsTo, "Given leftZeroPad($pad, $howMuch) != $equalsTo");
     }
 
-    public function for_test_left_zero_pad() : array {
+    public function for_test_left_zero_pad() : array
+    {
         return [
             ['a', 3, '00a'],
             ['aaa', 3, 'aaa'],
@@ -38,13 +39,14 @@ class UtilsTest extends TestCase
         $this->assertEquals(Utils::decToHex($decNum), $equalsTo, "Given decToHex($decNum) != $equalsTo");
     }
 
-    public function for_test_dec_to_hex() : array {
+    public function for_test_dec_to_hex() : array
+    {
         return [
             ['10', 'a'],
             ['1', '1'],
             ['9223372036854775807', '7fffffffffffffff'],
             ['18446744073709551615', 'ffffffffffffffff'],
-            ['28446744073709551615', '18ac7230489e7ffff']
+            ['28446744073709551615', '18ac7230489e7ffff'],
         ];
     }
 
@@ -56,7 +58,8 @@ class UtilsTest extends TestCase
         $this->assertEquals(Utils::hexToDec($hexNum), $equalsTo, "Given hexToDec($hexNum) != $equalsTo");
     }
 
-    public function for_test_hex_to_dec() : array {
+    public function for_test_hex_to_dec() : array
+    {
         return [
             ['a', '10'],
             ['B', '11'],
@@ -69,7 +72,7 @@ class UtilsTest extends TestCase
             ['7fffffffffffffff', '9223372036854775807'],
             ['8000000000000000', '9223372036854775808'],
             ['ffffffffffffffff', '18446744073709551615'],
-            ['18ac7230489e7ffff', '28446744073709551615']
+            ['18ac7230489e7ffff', '28446744073709551615'],
         ];
     }
 
@@ -81,7 +84,8 @@ class UtilsTest extends TestCase
         $this->assertEquals(Utils::isBigNum($num), $equalsTo, "Given isBigNum($num) != $equalsTo");
     }
 
-    public function for_test_is_big_num() : array {
+    public function for_test_is_big_num() : array
+    {
         return [
             [-100.5, false],
             [-1, false],
@@ -104,7 +108,8 @@ class UtilsTest extends TestCase
         $this->assertEquals($result, $equalsTo, "Given baseConvert($num, $fromBase, $toBase) != $equalsTo (result=$result)");
     }
 
-    public function for_test_base_convert() : array {
+    public function for_test_base_convert() : array
+    {
         return [
             ['b', 16, 10, '11'],
             ['c', 16, 10, '12'],
@@ -115,8 +120,7 @@ class UtilsTest extends TestCase
             ['8000000000000000', 16, 10, '9223372036854775808'], // bigger than signed int max 64 bit
             ['18ac7230489e7ffff', 16, 10, '28446744073709551615'],
             ['28446744073709551615', 10, 16, '18ac7230489e7ffff'],
-            ['10', 10, 16, 'a']
+            ['10', 10, 16, 'a'],
         ];
     }
-
 }

--- a/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTraceFormatterTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTraceFormatterTest.php
@@ -27,7 +27,8 @@ class XCloudTraceFormatterTest extends TestCase
         $this->assertEquals($result->getTraceFlags(), $sample, "Given deserialize($header), traceFlags != $sample (result={$result->getTraceFlags()}");
     }
 
-    public function for_test_deserialize() : array {
+    public function for_test_deserialize() : array
+    {
         return [
             ['00000000000000000000000000000001/1;o=0', '00000000000000000000000000000001', '0000000000000001', 0],
             ['10000000000000000000000000000001/10;o=1', '10000000000000000000000000000001', '000000000000000a', 1],
@@ -43,11 +44,11 @@ class XCloudTraceFormatterTest extends TestCase
         $this->assertEquals($result, $header, "Given serialize(header), result != $header (result=$result");
     }
 
-    public function for_test_serialize() : array {
+    public function for_test_serialize() : array
+    {
         return [
             [SpanContext::createFromRemoteParent('00000000000000000000000000000001', '0000000000000001', TraceFlags::DEFAULT), '00000000000000000000000000000001/1;o=0'],
             [SpanContext::createFromRemoteParent('00000000000000000000000000000001', '000000000000000a', TraceFlags::SAMPLED), '00000000000000000000000000000001/10;o=1'],
         ];
     }
 }
-

--- a/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTraceFormatterTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTraceFormatterTest.php
@@ -6,14 +6,8 @@ namespace OpenTelemetry\Tests\Unit\Extension\Propagator\XCloudTrace;
 
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\API\Trace\SpanContextInterface;
-use OpenTelemetry\API\Trace\SpanContextValidator;
 use OpenTelemetry\API\Trace\TraceFlags;
-use OpenTelemetry\Context\Context;
-use OpenTelemetry\Context\ContextInterface;
-use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 use OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTraceFormatter;
-use OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTracePropagator;
-use OpenTelemetry\SDK\Trace\Span;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTraceFormatterTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTraceFormatterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\Extension\Propagator\XCloudTrace;
+
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use OpenTelemetry\API\Trace\SpanContextValidator;
+use OpenTelemetry\API\Trace\TraceFlags;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
+use OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTraceFormatter;
+use OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTracePropagator;
+use OpenTelemetry\SDK\Trace\Span;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTraceFormatter
+ */
+class XCloudTraceFormatterTest extends TestCase
+{
+
+    /**
+     * @dataProvider for_test_deserialize
+     */
+    public function test_deserialize(string $header, string $traceId, string $spanId, int $sample) : void
+    {
+        $result = XCloudTraceFormatter::deserialize($header);
+        $this->assertEquals($result->getTraceId(), $traceId, "Given deserialize($header), traceId != $traceId (result={$result->getTraceId()}");
+        $this->assertEquals($result->getSpanId(), $spanId, "Given deserialize($header), spanId != $spanId (result={$result->getSpanId()}");
+        $this->assertEquals($result->getTraceFlags(), $sample, "Given deserialize($header), traceFlags != $sample (result={$result->getTraceFlags()}");
+    }
+
+    public function for_test_deserialize() : array {
+        return [
+            ['00000000000000000000000000000001/1;o=0', '00000000000000000000000000000001', '0000000000000001', 0],
+            ['10000000000000000000000000000001/10;o=1', '10000000000000000000000000000001', '000000000000000a', 1],
+        ];
+    }
+
+    /**
+     * @dataProvider for_test_serialize
+     */
+    public function test_serialize(SpanContextInterface $span, string $header) : void
+    {
+        $result = XCloudTraceFormatter::serialize($span);
+        $this->assertEquals($result, $header, "Given serialize(header), result != $header (result=$result");
+    }
+
+    public function for_test_serialize() : array {
+        return [
+            [SpanContext::createFromRemoteParent('00000000000000000000000000000001', '0000000000000001', TraceFlags::DEFAULT), '00000000000000000000000000000001/1;o=0'],
+            [SpanContext::createFromRemoteParent('00000000000000000000000000000001', '000000000000000a', TraceFlags::SAMPLED), '00000000000000000000000000000001/10;o=1'],
+        ];
+    }
+}
+

--- a/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTracePropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTracePropagatorTest.php
@@ -16,7 +16,7 @@ use OpenTelemetry\SDK\Trace\Span;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTracePropagatorTest
+ * @covers \OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTracePropagator
  */
 class XCloudTracePropagatorTest extends TestCase
 {

--- a/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTracePropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTracePropagatorTest.php
@@ -20,7 +20,6 @@ use PHPUnit\Framework\TestCase;
  */
 class XCloudTracePropagatorTest extends TestCase
 {
-
     private const TRACE_ID_BASE16 = 'ff000000000000000000000000000041';
     private const SPAN_ID_BASE16 = '0000000000000013';
     private const SPAN_ID_BASE10 = '19';
@@ -136,7 +135,7 @@ class XCloudTracePropagatorTest extends TestCase
     public function test_extract_sampled_context(): void
     {
         $carrier = [
-            $this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_ENABLED
+            $this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_ENABLED,
         ];
 
         $context = $this->xCloudTracePropagator->extract($carrier);
@@ -150,7 +149,7 @@ class XCloudTracePropagatorTest extends TestCase
     public function test_extract_non_sampled_context(): void
     {
         $carrier = [
-            $this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_DISABLED
+            $this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_DISABLED,
         ];
 
         $context = $this->xCloudTracePropagator->extract($carrier);
@@ -170,5 +169,4 @@ class XCloudTracePropagatorTest extends TestCase
     {
         return $context->withContextValue(Span::wrap($spanContext));
     }
-
 }

--- a/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTracePropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/XCloudTrace/XCloudTracePropagatorTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\Extension\Propagator\XCloudTrace;
+
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanContextInterface;
+use OpenTelemetry\API\Trace\SpanContextValidator;
+use OpenTelemetry\API\Trace\TraceFlags;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
+use OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTracePropagator;
+use OpenTelemetry\SDK\Trace\Span;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTracePropagatorTest
+ */
+class XCloudTracePropagatorTest extends TestCase
+{
+
+    private const TRACE_ID_BASE16 = 'ff000000000000000000000000000041';
+    private const SPAN_ID_BASE16 = '0000000000000013';
+    private const SPAN_ID_BASE10 = '19';
+    private const TRACE_ENABLED = 1;
+    private const TRACE_DISABLED = 0;
+
+    private string $xcloud;
+
+    private TextMapPropagatorInterface $xCloudTracePropagator;
+
+    protected function setUp(): void
+    {
+        $this->xCloudTracePropagator = XCloudTracePropagator::getInstance();
+        [$this->xcloud] = $this->xCloudTracePropagator->fields();
+    }
+
+    public function test_fields(): void
+    {
+        $this->assertSame(
+            ['x-cloud-trace-context'],
+            $this->xCloudTracePropagator->fields()
+        );
+    }
+
+    public function test_inject_invalid_context(): void
+    {
+        $carrier = [];
+        $this
+            ->xCloudTracePropagator
+            ->inject(
+                $carrier,
+                null,
+                $this->withSpanContext(
+                    SpanContext::create(
+                        SpanContextValidator::INVALID_TRACE,
+                        SpanContextValidator::INVALID_SPAN,
+                        TraceFlags::SAMPLED
+                    ),
+                    Context::getCurrent()
+                )
+            );
+        $this->assertEmpty($carrier);
+    }
+
+    public function test_inject_sampled_context(): void
+    {
+        $carrier = [];
+        $this
+            ->xCloudTracePropagator
+            ->inject(
+                $carrier,
+                null,
+                $this->withSpanContext(
+                    SpanContext::create(self::TRACE_ID_BASE16, self::SPAN_ID_BASE16, TraceFlags::SAMPLED),
+                    Context::getCurrent()
+                )
+            );
+
+        $this->assertSame(
+            [$this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_ENABLED],
+            $carrier
+        );
+    }
+
+    public function test_inject_non_sampled_context(): void
+    {
+        $carrier = [];
+        $this
+            ->xCloudTracePropagator
+            ->inject(
+                $carrier,
+                null,
+                $this->withSpanContext(
+                    SpanContext::create(self::TRACE_ID_BASE16, self::SPAN_ID_BASE16, TraceFlags::DEFAULT),
+                    Context::getCurrent()
+                )
+            );
+
+        $this->assertSame(
+            [$this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_DISABLED],
+            $carrier
+        );
+    }
+
+    public function test_inject_non_sampled_default_context(): void
+    {
+        $carrier = [];
+        $this
+            ->xCloudTracePropagator
+            ->inject(
+                $carrier,
+                null,
+                $this->withSpanContext(
+                    SpanContext::create(self::TRACE_ID_BASE16, self::SPAN_ID_BASE16),
+                    Context::getCurrent()
+                )
+            );
+
+        $this->assertSame(
+            [$this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_DISABLED],
+            $carrier
+        );
+    }
+
+    public function test_extract_nothing(): void
+    {
+        $this->assertSame(
+            Context::getCurrent(),
+            $this->xCloudTracePropagator->extract([])
+        );
+    }
+
+    public function test_extract_sampled_context(): void
+    {
+        $carrier = [
+            $this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_ENABLED
+        ];
+
+        $context = $this->xCloudTracePropagator->extract($carrier);
+
+        $this->assertEquals(
+            SpanContext::createFromRemoteParent(self::TRACE_ID_BASE16, self::SPAN_ID_BASE16, TraceFlags::SAMPLED),
+            $this->getSpanContext($context)
+        );
+    }
+
+    public function test_extract_non_sampled_context(): void
+    {
+        $carrier = [
+            $this->xcloud => self::TRACE_ID_BASE16 . '/' . self::SPAN_ID_BASE10 . ';o=' . self::TRACE_DISABLED
+        ];
+
+        $context = $this->xCloudTracePropagator->extract($carrier);
+
+        $this->assertEquals(
+            SpanContext::createFromRemoteParent(self::TRACE_ID_BASE16, self::SPAN_ID_BASE16, TraceFlags::DEFAULT),
+            $this->getSpanContext($context)
+        );
+    }
+
+    private function getSpanContext(ContextInterface $context): SpanContextInterface
+    {
+        return Span::fromContext($context)->getContext();
+    }
+
+    private function withSpanContext(SpanContextInterface $spanContext, ContextInterface $context): ContextInterface
+    {
+        return $context->withContextValue(Span::wrap($spanContext));
+    }
+
+}

--- a/tests/Unit/SDK/FactoryRegistryTest.php
+++ b/tests/Unit/SDK/FactoryRegistryTest.php
@@ -108,7 +108,7 @@ class FactoryRegistryTest extends TestCase
             ['tracecontext'],
             ['b3multi'],
             ['b3'],
-            ['xcloudtrace']
+            ['xcloudtrace'],
         ];
     }
 

--- a/tests/Unit/SDK/FactoryRegistryTest.php
+++ b/tests/Unit/SDK/FactoryRegistryTest.php
@@ -108,6 +108,7 @@ class FactoryRegistryTest extends TestCase
             ['tracecontext'],
             ['b3multi'],
             ['b3'],
+            ['xcloudtrace']
         ];
     }
 

--- a/tests/Unit/SDK/Propagation/PropagatorFactoryTest.php
+++ b/tests/Unit/SDK/Propagation/PropagatorFactoryTest.php
@@ -11,6 +11,7 @@ use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\Context\Propagation\MultiTextMapPropagator;
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Extension\Propagator\B3\B3Propagator;
+use OpenTelemetry\Extension\Propagator\XCloudTrace\XCloudTracePropagator;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Propagation\PropagatorFactory;
@@ -51,6 +52,7 @@ class PropagatorFactoryTest extends TestCase
             [KnownValues::VALUE_BAGGAGE, BaggagePropagator::class],
             [KnownValues::VALUE_TRACECONTEXT, TraceContextPropagator::class],
             [KnownValues::VALUE_B3, B3Propagator::class],
+            [KnownValues::VALUE_XCLOUD_TRACE, XCloudTracePropagator::class],
             [KnownValues::VALUE_B3_MULTI, B3Propagator::class],
             [KnownValues::VALUE_NONE, NoopTextMapPropagator::class],
             [sprintf('%s,%s', KnownValues::VALUE_B3, KnownValues::VALUE_BAGGAGE), MultiTextMapPropagator::class],


### PR DESCRIPTION
This is an implementation for GCP/Google X-Cloud-Trace-Context header propagator. Propagator for this header is available in most languages except PHP and my team needs it, thus I'm presenting this PR for review.

The formatting/parsing logic is heavily borrowed from OpenCensus implementation with a few changes: https://github.com/census-instrumentation/opencensus-php/blob/master/src/Trace/Propagator/TraceContextFormatter.php

Tests are heavily borrowed from existing B3 Propagator tests in this library.

Please let me know how this needs to be adjusted. This has also been tested end to end with a Slim API and Honeycomb exporter.