### PR TITLE
otel-sig-security - adding SBOM to builds

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -79,6 +79,7 @@ jobs:
     - name: Code Coverage
       run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.php-version }}
 
+    - uses: anchore/sbom-action@v0
   packages:
     uses: opentelemetry-php/gh-workflows/.github/workflows/validate-packages.yml@main
     needs: php


### PR DESCRIPTION
#otel-sig-security asked for SBOM to be added to builds.  This PR adds it to our php actions.  It may be too frequent, but we can ensure we have this for when we do our builds.