### PR TITLE
generate semconv for 1.23.1

### DIFF
--- a/script/semantic-conventions/semconv.sh
+++ b/script/semantic-conventions/semconv.sh
@@ -12,7 +12,7 @@ SPEC_DIR="${ROOT_DIR}/var/semantic-conventions"
 CODE_DIR="${ROOT_DIR}/src/SemConv"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=${SEMCONV_VERSION:=1.23.0}
+SEMCONV_VERSION=${SEMCONV_VERSION:=1.23.1}
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.23.0

--- a/script/semantic-conventions/templates/AttributeValues.php.j2
+++ b/script/semantic-conventions/templates/AttributeValues.php.j2
@@ -13,7 +13,7 @@ interface {{ class }}AttributeValues
      */
     public const SCHEMA_URL = '{{schemaUrl}}';
 
-{%- for attribute in attributes | unique(attribute="fqn") %}
+{%- for attribute in attributes | unique(attribute="fqn") | sort(attribute="fqn") %}
 {%- if attribute.attr_type.members %}
 {%- for member in attribute.attr_type.members %}
     {%- if member.brief %}

--- a/script/semantic-conventions/templates/Attributes.php.j2
+++ b/script/semantic-conventions/templates/Attributes.php.j2
@@ -12,7 +12,7 @@ interface {{ class }}Attributes
      * The URL of the OpenTelemetry schema for these keys and values.
      */
     public const SCHEMA_URL = '{{schemaUrl}}';
-{% for attribute in attributes | unique(attribute="fqn") %}
+{% for attribute in attributes | unique(attribute="fqn") | sort(attribute="fqn") %}
     /**
      * {{ attribute.brief | render_markdown(code="`{0}`", paragraph="{0}", link="{1}") | to_doc_brief | regex_replace(pattern="\n", replace="\n     * ") }}.
      {%- if attribute.note %}

--- a/src/SemConv/ResourceAttributes.php
+++ b/src/SemConv/ResourceAttributes.php
@@ -11,7 +11,7 @@ interface ResourceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.23.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.23.1';
 
     /**
      * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found here.
@@ -20,121 +20,6 @@ interface ResourceAttributes
      * @example 32
      */
     public const ANDROID_OS_API_LEVEL = 'android.os.api_level';
-
-    /**
-     * Array of brand name and version separated by a space.
-     *
-     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.brands`).
-     *
-     * @example  Not A;Brand 99
-     * @example Chromium 99
-     * @example Chrome 99
-     */
-    public const BROWSER_BRANDS = 'browser.brands';
-
-    /**
-     * Preferred language of the user using the browser.
-     *
-     * This value is intended to be taken from the Navigator API `navigator.language`.
-     *
-     * @example en
-     * @example en-US
-     * @example fr
-     * @example fr-FR
-     */
-    public const BROWSER_LANGUAGE = 'browser.language';
-
-    /**
-     * A boolean that is true if the browser is running on a mobile device.
-     *
-     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.mobile`). If unavailable, this attribute SHOULD be left unset.
-     */
-    public const BROWSER_MOBILE = 'browser.mobile';
-
-    /**
-     * The platform on which the browser is running.
-     *
-     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
-     * The list of possible values is defined in the W3C User-Agent Client Hints specification. Note that some (but not all) of these values can overlap with values in the `os.type` and `os.name` attributes. However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
-     *
-     * @example Windows
-     * @example macOS
-     * @example Android
-     */
-    public const BROWSER_PLATFORM = 'browser.platform';
-
-    /**
-     * Full user-agent string provided by the browser.
-     *
-     * The user-agent value SHOULD be provided only from browsers that do not have a mechanism to retrieve brands and platform individually from the User-Agent Client Hints API. To retrieve the value, the legacy `navigator.userAgent` API can be used.
-     *
-     * @example Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36
-     */
-    public const USER_AGENT_ORIGINAL = 'user_agent.original';
-
-    /**
-     * The cloud account ID the resource is assigned to.
-     *
-     * @example 111111111111
-     * @example opentelemetry
-     */
-    public const CLOUD_ACCOUNT_ID = 'cloud.account.id';
-
-    /**
-     * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
-     *
-     * Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
-     *
-     * @example us-east-1c
-     */
-    public const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
-
-    /**
-     * The cloud platform in use.
-     *
-     * The prefix of the service SHOULD match the one specified in `cloud.provider`.
-     */
-    public const CLOUD_PLATFORM = 'cloud.platform';
-
-    /**
-     * Name of the cloud provider.
-     */
-    public const CLOUD_PROVIDER = 'cloud.provider';
-
-    /**
-     * The geographical region the resource is running.
-     *
-     * Refer to your provider's docs to see the available regions, for example Alibaba Cloud regions, AWS regions, Azure regions, Google Cloud regions, or Tencent Cloud regions.
-     *
-     * @example us-central1
-     * @example us-east-1
-     */
-    public const CLOUD_REGION = 'cloud.region';
-
-    /**
-     * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an ARN on AWS, a fully qualified resource ID on Azure, a full resource name on GCP).
-     *
-     * On some cloud providers, it may not be possible to determine the full ID at startup,
-     * so it may be necessary to set `cloud.resource_id` as a span attribute instead.The exact value to use for `cloud.resource_id` depends on the cloud provider.
-     * The following well-known definitions MUST be used if you set this attribute and they apply:<ul>
-     * <li><strong>AWS Lambda:</strong> The function ARN.
-     * Take care not to use the &quot;invoked ARN&quot; directly but replace any
-     * alias suffix
-     * with the resolved function version, as the same runtime instance may be invokable with
-     * multiple different aliases.</li>
-     * <li><strong>GCP:</strong> The URI of the resource</li>
-     * <li><strong>Azure:</strong> The Fully Qualified Resource ID of the invoked function,
-     * <em>not</em> the function app, having the form
-     * `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`.
-     * This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
-     * a TracerProvider.</li>
-     * </ul>
-     *
-     * @example arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function
-     * @example //run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID
-     * @example /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>
-     */
-    public const CLOUD_RESOURCE_ID = 'cloud.resource_id';
 
     /**
      * The ARN of an ECS cluster.
@@ -220,56 +105,110 @@ interface ResourceAttributes
     public const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
 
     /**
-     * The name of the Cloud Run execution being run for the Job, as set by the `CLOUD_RUN_EXECUTION` environment variable.
+     * Array of brand name and version separated by a space.
      *
-     * @example job-name-xxxx
-     * @example sample-job-mdw84
+     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.brands`).
+     *
+     * @example  Not A;Brand 99
+     * @example Chromium 99
+     * @example Chrome 99
      */
-    public const GCP_CLOUD_RUN_JOB_EXECUTION = 'gcp.cloud_run.job.execution';
+    public const BROWSER_BRANDS = 'browser.brands';
 
     /**
-     * The index for a task within an execution as provided by the `CLOUD_RUN_TASK_INDEX` environment variable.
+     * Preferred language of the user using the browser.
      *
-     * @example 1
+     * This value is intended to be taken from the Navigator API `navigator.language`.
+     *
+     * @example en
+     * @example en-US
+     * @example fr
+     * @example fr-FR
      */
-    public const GCP_CLOUD_RUN_JOB_TASK_INDEX = 'gcp.cloud_run.job.task_index';
+    public const BROWSER_LANGUAGE = 'browser.language';
 
     /**
-     * The hostname of a GCE instance. This is the full value of the default or custom hostname.
+     * A boolean that is true if the browser is running on a mobile device.
      *
-     * @example my-host1234.example.com
-     * @example sample-vm.us-west1-b.c.my-project.internal
+     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.mobile`). If unavailable, this attribute SHOULD be left unset.
      */
-    public const GCP_GCE_INSTANCE_HOSTNAME = 'gcp.gce.instance.hostname';
+    public const BROWSER_MOBILE = 'browser.mobile';
 
     /**
-     * The instance name of a GCE instance. This is the value provided by `host.name`, the visible name of the instance in the Cloud Console UI, and the prefix for the default hostname of the instance as defined by the default internal DNS name.
+     * The platform on which the browser is running.
      *
-     * @example instance-1
-     * @example my-vm-name
+     * This value is intended to be taken from the UA client hints API (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
+     * The list of possible values is defined in the W3C User-Agent Client Hints specification. Note that some (but not all) of these values can overlap with values in the `os.type` and `os.name` attributes. However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
+     *
+     * @example Windows
+     * @example macOS
+     * @example Android
      */
-    public const GCP_GCE_INSTANCE_NAME = 'gcp.gce.instance.name';
+    public const BROWSER_PLATFORM = 'browser.platform';
 
     /**
-     * Unique identifier for the application.
+     * The cloud account ID the resource is assigned to.
      *
-     * @example 2daa2797-e42b-4624-9322-ec3f968df4da
+     * @example 111111111111
+     * @example opentelemetry
      */
-    public const HEROKU_APP_ID = 'heroku.app.id';
+    public const CLOUD_ACCOUNT_ID = 'cloud.account.id';
 
     /**
-     * Commit hash for the current release.
+     * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
      *
-     * @example e6134959463efd8966b20e75b913cafe3f5ec
+     * Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
+     *
+     * @example us-east-1c
      */
-    public const HEROKU_RELEASE_COMMIT = 'heroku.release.commit';
+    public const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
 
     /**
-     * Time and date the release was created.
+     * The cloud platform in use.
      *
-     * @example 2022-10-23T18:00:42Z
+     * The prefix of the service SHOULD match the one specified in `cloud.provider`.
      */
-    public const HEROKU_RELEASE_CREATION_TIMESTAMP = 'heroku.release.creation_timestamp';
+    public const CLOUD_PLATFORM = 'cloud.platform';
+
+    /**
+     * Name of the cloud provider.
+     */
+    public const CLOUD_PROVIDER = 'cloud.provider';
+
+    /**
+     * The geographical region the resource is running.
+     *
+     * Refer to your provider's docs to see the available regions, for example Alibaba Cloud regions, AWS regions, Azure regions, Google Cloud regions, or Tencent Cloud regions.
+     *
+     * @example us-central1
+     * @example us-east-1
+     */
+    public const CLOUD_REGION = 'cloud.region';
+
+    /**
+     * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an ARN on AWS, a fully qualified resource ID on Azure, a full resource name on GCP).
+     *
+     * On some cloud providers, it may not be possible to determine the full ID at startup,
+     * so it may be necessary to set `cloud.resource_id` as a span attribute instead.The exact value to use for `cloud.resource_id` depends on the cloud provider.
+     * The following well-known definitions MUST be used if you set this attribute and they apply:<ul>
+     * <li><strong>AWS Lambda:</strong> The function ARN.
+     * Take care not to use the &quot;invoked ARN&quot; directly but replace any
+     * alias suffix
+     * with the resolved function version, as the same runtime instance may be invokable with
+     * multiple different aliases.</li>
+     * <li><strong>GCP:</strong> The URI of the resource</li>
+     * <li><strong>Azure:</strong> The Fully Qualified Resource ID of the invoked function,
+     * <em>not</em> the function app, having the form
+     * `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`.
+     * This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
+     * a TracerProvider.</li>
+     * </ul>
+     *
+     * @example arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function
+     * @example //run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID
+     * @example /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>
+     */
+    public const CLOUD_RESOURCE_ID = 'cloud.resource_id';
 
     /**
      * The command used to run the container (i.e. the command name).
@@ -352,16 +291,6 @@ interface ResourceAttributes
      * @example rkt
      */
     public const CONTAINER_RUNTIME = 'container.runtime';
-
-    /**
-     * The digest of the OCI image manifest. For container images specifically is the digest by which the container image is known.
-     *
-     * Follows OCI Image Manifest Specification, and specifically the Digest property.
-     * An example can be found in Example Image Manifest.
-     *
-     * @example sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4
-     */
-    public const OCI_MANIFEST_DIGEST = 'oci.manifest.digest';
 
     /**
      * Name of the deployment environment (aka deployment tier).
@@ -472,9 +401,105 @@ interface ResourceAttributes
     public const FAAS_VERSION = 'faas.version';
 
     /**
+     * The name of the Cloud Run execution being run for the Job, as set by the `CLOUD_RUN_EXECUTION` environment variable.
+     *
+     * @example job-name-xxxx
+     * @example sample-job-mdw84
+     */
+    public const GCP_CLOUD_RUN_JOB_EXECUTION = 'gcp.cloud_run.job.execution';
+
+    /**
+     * The index for a task within an execution as provided by the `CLOUD_RUN_TASK_INDEX` environment variable.
+     *
+     * @example 1
+     */
+    public const GCP_CLOUD_RUN_JOB_TASK_INDEX = 'gcp.cloud_run.job.task_index';
+
+    /**
+     * The hostname of a GCE instance. This is the full value of the default or custom hostname.
+     *
+     * @example my-host1234.example.com
+     * @example sample-vm.us-west1-b.c.my-project.internal
+     */
+    public const GCP_GCE_INSTANCE_HOSTNAME = 'gcp.gce.instance.hostname';
+
+    /**
+     * The instance name of a GCE instance. This is the value provided by `host.name`, the visible name of the instance in the Cloud Console UI, and the prefix for the default hostname of the instance as defined by the default internal DNS name.
+     *
+     * @example instance-1
+     * @example my-vm-name
+     */
+    public const GCP_GCE_INSTANCE_NAME = 'gcp.gce.instance.name';
+
+    /**
+     * Unique identifier for the application.
+     *
+     * @example 2daa2797-e42b-4624-9322-ec3f968df4da
+     */
+    public const HEROKU_APP_ID = 'heroku.app.id';
+
+    /**
+     * Commit hash for the current release.
+     *
+     * @example e6134959463efd8966b20e75b913cafe3f5ec
+     */
+    public const HEROKU_RELEASE_COMMIT = 'heroku.release.commit';
+
+    /**
+     * Time and date the release was created.
+     *
+     * @example 2022-10-23T18:00:42Z
+     */
+    public const HEROKU_RELEASE_CREATION_TIMESTAMP = 'heroku.release.creation_timestamp';
+
+    /**
      * The CPU architecture the host system is running on.
      */
     public const HOST_ARCH = 'host.arch';
+
+    /**
+     * The amount of level 2 memory cache available to the processor (in Bytes).
+     *
+     * @example 12288000
+     */
+    public const HOST_CPU_CACHE_L2_SIZE = 'host.cpu.cache.l2.size';
+
+    /**
+     * Numeric value specifying the family or generation of the CPU.
+     *
+     * @example 6
+     */
+    public const HOST_CPU_FAMILY = 'host.cpu.family';
+
+    /**
+     * Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family.
+     *
+     * @example 6
+     */
+    public const HOST_CPU_MODEL_ID = 'host.cpu.model.id';
+
+    /**
+     * Model designation of the processor.
+     *
+     * @example 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
+     */
+    public const HOST_CPU_MODEL_NAME = 'host.cpu.model.name';
+
+    /**
+     * Stepping or core revisions.
+     *
+     * @example 1
+     */
+    public const HOST_CPU_STEPPING = 'host.cpu.stepping';
+
+    /**
+     * Processor manufacturer identifier. A maximum 12-character string.
+     *
+     * CPUID command returns the vendor ID string in EBX, EDX and ECX registers. Writing these to memory in this order results in a 12-character string.
+     *
+     * @example GenuineIntel
+     */
+    public const HOST_CPU_VENDOR_ID = 'host.cpu.vendor.id';
 
     /**
      * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system.
@@ -540,50 +565,6 @@ interface ResourceAttributes
     public const HOST_TYPE = 'host.type';
 
     /**
-     * The amount of level 2 memory cache available to the processor (in Bytes).
-     *
-     * @example 12288000
-     */
-    public const HOST_CPU_CACHE_L2_SIZE = 'host.cpu.cache.l2.size';
-
-    /**
-     * Numeric value specifying the family or generation of the CPU.
-     *
-     * @example 6
-     */
-    public const HOST_CPU_FAMILY = 'host.cpu.family';
-
-    /**
-     * Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family.
-     *
-     * @example 6
-     */
-    public const HOST_CPU_MODEL_ID = 'host.cpu.model.id';
-
-    /**
-     * Model designation of the processor.
-     *
-     * @example 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
-     */
-    public const HOST_CPU_MODEL_NAME = 'host.cpu.model.name';
-
-    /**
-     * Stepping or core revisions.
-     *
-     * @example 1
-     */
-    public const HOST_CPU_STEPPING = 'host.cpu.stepping';
-
-    /**
-     * Processor manufacturer identifier. A maximum 12-character string.
-     *
-     * CPUID command returns the vendor ID string in EBX, EDX and ECX registers. Writing these to memory in this order results in a 12-character string.
-     *
-     * @example GenuineIntel
-     */
-    public const HOST_CPU_VENDOR_ID = 'host.cpu.vendor.id';
-
-    /**
      * The name of the cluster.
      *
      * @example opentelemetry-cluster
@@ -616,41 +597,6 @@ interface ResourceAttributes
     public const K8S_CLUSTER_UID = 'k8s.cluster.uid';
 
     /**
-     * The name of the Node.
-     *
-     * @example node-1
-     */
-    public const K8S_NODE_NAME = 'k8s.node.name';
-
-    /**
-     * The UID of the Node.
-     *
-     * @example 1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2
-     */
-    public const K8S_NODE_UID = 'k8s.node.uid';
-
-    /**
-     * The name of the namespace that the pod is running in.
-     *
-     * @example default
-     */
-    public const K8S_NAMESPACE_NAME = 'k8s.namespace.name';
-
-    /**
-     * The name of the Pod.
-     *
-     * @example opentelemetry-pod-autoconf
-     */
-    public const K8S_POD_NAME = 'k8s.pod.name';
-
-    /**
-     * The UID of the Pod.
-     *
-     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
-     */
-    public const K8S_POD_UID = 'k8s.pod.uid';
-
-    /**
      * The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`).
      *
      * @example redis
@@ -665,46 +611,18 @@ interface ResourceAttributes
     public const K8S_CONTAINER_RESTART_COUNT = 'k8s.container.restart_count';
 
     /**
-     * The name of the ReplicaSet.
+     * The name of the CronJob.
      *
      * @example opentelemetry
      */
-    public const K8S_REPLICASET_NAME = 'k8s.replicaset.name';
+    public const K8S_CRONJOB_NAME = 'k8s.cronjob.name';
 
     /**
-     * The UID of the ReplicaSet.
+     * The UID of the CronJob.
      *
      * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
      */
-    public const K8S_REPLICASET_UID = 'k8s.replicaset.uid';
-
-    /**
-     * The name of the Deployment.
-     *
-     * @example opentelemetry
-     */
-    public const K8S_DEPLOYMENT_NAME = 'k8s.deployment.name';
-
-    /**
-     * The UID of the Deployment.
-     *
-     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
-     */
-    public const K8S_DEPLOYMENT_UID = 'k8s.deployment.uid';
-
-    /**
-     * The name of the StatefulSet.
-     *
-     * @example opentelemetry
-     */
-    public const K8S_STATEFULSET_NAME = 'k8s.statefulset.name';
-
-    /**
-     * The UID of the StatefulSet.
-     *
-     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
-     */
-    public const K8S_STATEFULSET_UID = 'k8s.statefulset.uid';
+    public const K8S_CRONJOB_UID = 'k8s.cronjob.uid';
 
     /**
      * The name of the DaemonSet.
@@ -721,6 +639,20 @@ interface ResourceAttributes
     public const K8S_DAEMONSET_UID = 'k8s.daemonset.uid';
 
     /**
+     * The name of the Deployment.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_DEPLOYMENT_NAME = 'k8s.deployment.name';
+
+    /**
+     * The UID of the Deployment.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_DEPLOYMENT_UID = 'k8s.deployment.uid';
+
+    /**
      * The name of the Job.
      *
      * @example opentelemetry
@@ -735,18 +667,77 @@ interface ResourceAttributes
     public const K8S_JOB_UID = 'k8s.job.uid';
 
     /**
-     * The name of the CronJob.
+     * The name of the namespace that the pod is running in.
      *
-     * @example opentelemetry
+     * @example default
      */
-    public const K8S_CRONJOB_NAME = 'k8s.cronjob.name';
+    public const K8S_NAMESPACE_NAME = 'k8s.namespace.name';
 
     /**
-     * The UID of the CronJob.
+     * The name of the Node.
+     *
+     * @example node-1
+     */
+    public const K8S_NODE_NAME = 'k8s.node.name';
+
+    /**
+     * The UID of the Node.
+     *
+     * @example 1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2
+     */
+    public const K8S_NODE_UID = 'k8s.node.uid';
+
+    /**
+     * The name of the Pod.
+     *
+     * @example opentelemetry-pod-autoconf
+     */
+    public const K8S_POD_NAME = 'k8s.pod.name';
+
+    /**
+     * The UID of the Pod.
      *
      * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
      */
-    public const K8S_CRONJOB_UID = 'k8s.cronjob.uid';
+    public const K8S_POD_UID = 'k8s.pod.uid';
+
+    /**
+     * The name of the ReplicaSet.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_REPLICASET_NAME = 'k8s.replicaset.name';
+
+    /**
+     * The UID of the ReplicaSet.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_REPLICASET_UID = 'k8s.replicaset.uid';
+
+    /**
+     * The name of the StatefulSet.
+     *
+     * @example opentelemetry
+     */
+    public const K8S_STATEFULSET_NAME = 'k8s.statefulset.name';
+
+    /**
+     * The UID of the StatefulSet.
+     *
+     * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+     */
+    public const K8S_STATEFULSET_UID = 'k8s.statefulset.uid';
+
+    /**
+     * The digest of the OCI image manifest. For container images specifically is the digest by which the container image is known.
+     *
+     * Follows OCI Image Manifest Specification, and specifically the Digest property.
+     * An example can be found in Example Image Manifest.
+     *
+     * @example sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4
+     */
+    public const OCI_MANIFEST_DIGEST = 'oci.manifest.digest';
 
     /**
      * Unique identifier for a particular build or compilation of the operating system.
@@ -786,6 +777,36 @@ interface ResourceAttributes
      * @example 18.04.1
      */
     public const OS_VERSION = 'os.version';
+
+    /**
+     * Deprecated, use the `otel.scope.name` attribute.
+     *
+     * @deprecated Deprecated, use the `otel.scope.name` attribute..
+     * @example io.opentelemetry.contrib.mongodb
+     */
+    public const OTEL_LIBRARY_NAME = 'otel.library.name';
+
+    /**
+     * Deprecated, use the `otel.scope.version` attribute.
+     *
+     * @deprecated Deprecated, use the `otel.scope.version` attribute..
+     * @example 1.0.0
+     */
+    public const OTEL_LIBRARY_VERSION = 'otel.library.version';
+
+    /**
+     * The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
+     *
+     * @example io.opentelemetry.contrib.mongodb
+     */
+    public const OTEL_SCOPE_NAME = 'otel.scope.name';
+
+    /**
+     * The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP).
+     *
+     * @example 1.0.0
+     */
+    public const OTEL_SCOPE_VERSION = 'otel.scope.version';
 
     /**
      * The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
@@ -866,23 +887,6 @@ interface ResourceAttributes
     public const PROCESS_RUNTIME_VERSION = 'process.runtime.version';
 
     /**
-     * Logical name of the service.
-     *
-     * MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with `process.executable.name`, e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
-     *
-     * @example shoppingcart
-     */
-    public const SERVICE_NAME = 'service.name';
-
-    /**
-     * The version string of the service API or implementation. The format is not defined by these conventions.
-     *
-     * @example 2.0.0
-     * @example a01dbef8a
-     */
-    public const SERVICE_VERSION = 'service.version';
-
-    /**
      * The string ID of the service instance.
      *
      * MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
@@ -893,6 +897,15 @@ interface ResourceAttributes
     public const SERVICE_INSTANCE_ID = 'service.instance.id';
 
     /**
+     * Logical name of the service.
+     *
+     * MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with `process.executable.name`, e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+     *
+     * @example shoppingcart
+     */
+    public const SERVICE_NAME = 'service.name';
+
+    /**
      * A namespace for `service.name`.
      *
      * A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
@@ -900,6 +913,31 @@ interface ResourceAttributes
      * @example Shop
      */
     public const SERVICE_NAMESPACE = 'service.namespace';
+
+    /**
+     * The version string of the service API or implementation. The format is not defined by these conventions.
+     *
+     * @example 2.0.0
+     * @example a01dbef8a
+     */
+    public const SERVICE_VERSION = 'service.version';
+
+    /**
+     * The name of the auto instrumentation agent or distribution, if used.
+     *
+     * Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
+     * a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
+     *
+     * @example parts-unlimited-java
+     */
+    public const TELEMETRY_DISTRO_NAME = 'telemetry.distro.name';
+
+    /**
+     * The version string of the auto instrumentation agent or distribution, if used.
+     *
+     * @example 1.2.3
+     */
+    public const TELEMETRY_DISTRO_VERSION = 'telemetry.distro.version';
 
     /**
      * The language of the telemetry SDK.
@@ -928,21 +966,13 @@ interface ResourceAttributes
     public const TELEMETRY_SDK_VERSION = 'telemetry.sdk.version';
 
     /**
-     * The name of the auto instrumentation agent or distribution, if used.
+     * Full user-agent string provided by the browser.
      *
-     * Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
-     * a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
+     * The user-agent value SHOULD be provided only from browsers that do not have a mechanism to retrieve brands and platform individually from the User-Agent Client Hints API. To retrieve the value, the legacy `navigator.userAgent` API can be used.
      *
-     * @example parts-unlimited-java
+     * @example Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36
      */
-    public const TELEMETRY_DISTRO_NAME = 'telemetry.distro.name';
-
-    /**
-     * The version string of the auto instrumentation agent or distribution, if used.
-     *
-     * @example 1.2.3
-     */
-    public const TELEMETRY_DISTRO_VERSION = 'telemetry.distro.version';
+    public const USER_AGENT_ORIGINAL = 'user_agent.original';
 
     /**
      * Additional description of the web engine (e.g. detailed version and edition information).
@@ -964,36 +994,6 @@ interface ResourceAttributes
      * @example 21.0.0
      */
     public const WEBENGINE_VERSION = 'webengine.version';
-
-    /**
-     * The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
-     *
-     * @example io.opentelemetry.contrib.mongodb
-     */
-    public const OTEL_SCOPE_NAME = 'otel.scope.name';
-
-    /**
-     * The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP).
-     *
-     * @example 1.0.0
-     */
-    public const OTEL_SCOPE_VERSION = 'otel.scope.version';
-
-    /**
-     * Deprecated, use the `otel.scope.name` attribute.
-     *
-     * @deprecated Deprecated, use the `otel.scope.name` attribute..
-     * @example io.opentelemetry.contrib.mongodb
-     */
-    public const OTEL_LIBRARY_NAME = 'otel.library.name';
-
-    /**
-     * Deprecated, use the `otel.scope.version` attribute.
-     *
-     * @deprecated Deprecated, use the `otel.scope.version` attribute..
-     * @example 1.0.0
-     */
-    public const OTEL_LIBRARY_VERSION = 'otel.library.version';
 
     /**
      * @deprecated Use USER_AGENT_ORIGINAL

--- a/src/SemConv/TraceAttributes.php
+++ b/src/SemConv/TraceAttributes.php
@@ -11,7 +11,277 @@ interface TraceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.23.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.23.1';
+
+    /**
+     * This attribute represents the state the application has transitioned into at the occurrence of the event.
+     *
+     * The Android lifecycle states are defined in Activity lifecycle callbacks, and from which the `OS identifiers` are derived.
+     */
+    public const ANDROID_STATE = 'android.state';
+
+    /**
+     * The JSON-serialized value of each item in the `AttributeDefinitions` request field.
+     *
+     * @example { "AttributeName": "string", "AttributeType": "string" }
+     */
+    public const AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS = 'aws.dynamodb.attribute_definitions';
+
+    /**
+     * The value of the `AttributesToGet` request parameter.
+     *
+     * @example lives
+     * @example id
+     */
+    public const AWS_DYNAMODB_ATTRIBUTES_TO_GET = 'aws.dynamodb.attributes_to_get';
+
+    /**
+     * The value of the `ConsistentRead` request parameter.
+     */
+    public const AWS_DYNAMODB_CONSISTENT_READ = 'aws.dynamodb.consistent_read';
+
+    /**
+     * The JSON-serialized value of each item in the `ConsumedCapacity` response field.
+     *
+     * @example { "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }
+     */
+    public const AWS_DYNAMODB_CONSUMED_CAPACITY = 'aws.dynamodb.consumed_capacity';
+
+    /**
+     * The value of the `Count` response parameter.
+     *
+     * @example 10
+     */
+    public const AWS_DYNAMODB_COUNT = 'aws.dynamodb.count';
+
+    /**
+     * The value of the `ExclusiveStartTableName` request parameter.
+     *
+     * @example Users
+     * @example CatsTable
+     */
+    public const AWS_DYNAMODB_EXCLUSIVE_START_TABLE = 'aws.dynamodb.exclusive_start_table';
+
+    /**
+     * The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates` request field.
+     *
+     * @example { "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }
+     */
+    public const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = 'aws.dynamodb.global_secondary_index_updates';
+
+    /**
+     * The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
+     *
+     * @example { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }
+     */
+    public const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = 'aws.dynamodb.global_secondary_indexes';
+
+    /**
+     * The value of the `IndexName` request parameter.
+     *
+     * @example name_to_group
+     */
+    public const AWS_DYNAMODB_INDEX_NAME = 'aws.dynamodb.index_name';
+
+    /**
+     * The JSON-serialized value of the `ItemCollectionMetrics` response field.
+     *
+     * @example { "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }
+     */
+    public const AWS_DYNAMODB_ITEM_COLLECTION_METRICS = 'aws.dynamodb.item_collection_metrics';
+
+    /**
+     * The value of the `Limit` request parameter.
+     *
+     * @example 10
+     */
+    public const AWS_DYNAMODB_LIMIT = 'aws.dynamodb.limit';
+
+    /**
+     * The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.
+     *
+     * @example { "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }
+     */
+    public const AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = 'aws.dynamodb.local_secondary_indexes';
+
+    /**
+     * The value of the `ProjectionExpression` request parameter.
+     *
+     * @example Title
+     * @example Title, Price, Color
+     * @example Title, Description, RelatedItems, ProductReviews
+     */
+    public const AWS_DYNAMODB_PROJECTION = 'aws.dynamodb.projection';
+
+    /**
+     * The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
+     *
+     * @example 1.0
+     * @example 2.0
+     */
+    public const AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = 'aws.dynamodb.provisioned_read_capacity';
+
+    /**
+     * The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
+     *
+     * @example 1.0
+     * @example 2.0
+     */
+    public const AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = 'aws.dynamodb.provisioned_write_capacity';
+
+    /**
+     * The value of the `ScanIndexForward` request parameter.
+     */
+    public const AWS_DYNAMODB_SCAN_FORWARD = 'aws.dynamodb.scan_forward';
+
+    /**
+     * The value of the `ScannedCount` response parameter.
+     *
+     * @example 50
+     */
+    public const AWS_DYNAMODB_SCANNED_COUNT = 'aws.dynamodb.scanned_count';
+
+    /**
+     * The value of the `Segment` request parameter.
+     *
+     * @example 10
+     */
+    public const AWS_DYNAMODB_SEGMENT = 'aws.dynamodb.segment';
+
+    /**
+     * The value of the `Select` request parameter.
+     *
+     * @example ALL_ATTRIBUTES
+     * @example COUNT
+     */
+    public const AWS_DYNAMODB_SELECT = 'aws.dynamodb.select';
+
+    /**
+     * The the number of items in the `TableNames` response parameter.
+     *
+     * @example 20
+     */
+    public const AWS_DYNAMODB_TABLE_COUNT = 'aws.dynamodb.table_count';
+
+    /**
+     * The keys in the `RequestItems` object field.
+     *
+     * @example Users
+     * @example Cats
+     */
+    public const AWS_DYNAMODB_TABLE_NAMES = 'aws.dynamodb.table_names';
+
+    /**
+     * The value of the `TotalSegments` request parameter.
+     *
+     * @example 100
+     */
+    public const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
+
+    /**
+     * The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
+     *
+     * This may be different from `cloud.resource_id` if an alias is involved.
+     *
+     * @example arn:aws:lambda:us-east-1:123456:function:myfunction:myalias
+     */
+    public const AWS_LAMBDA_INVOKED_ARN = 'aws.lambda.invoked_arn';
+
+    /**
+     * The AWS request ID as returned in the response headers `x-amz-request-id` or `x-amz-requestid`.
+     *
+     * @example 79b9da39-b7ae-508a-a6bc-864b2829c622
+     * @example C9ER4AJX75574TDJ
+     */
+    public const AWS_REQUEST_ID = 'aws.request_id';
+
+    /**
+     * The S3 bucket name the request refers to. Corresponds to the `--bucket` parameter of the S3 API operations.
+     *
+     * The `bucket` attribute is applicable to all S3 operations that reference a bucket, i.e. that require the bucket name as a mandatory parameter.
+     * This applies to almost all S3 operations except `list-buckets`.
+     *
+     * @example some-bucket-name
+     */
+    public const AWS_S3_BUCKET = 'aws.s3.bucket';
+
+    /**
+     * The source object (in the form `bucket`/`key`) for the copy operation.
+     *
+     * The `copy_source` attribute applies to S3 copy operations and corresponds to the `--copy-source` parameter
+     * of the copy-object operation within the S3 API.
+     * This applies in particular to the following operations:<ul>
+     * <li>copy-object</li>
+     * <li>upload-part-copy</li>
+     * </ul>
+     *
+     * @example someFile.yml
+     */
+    public const AWS_S3_COPY_SOURCE = 'aws.s3.copy_source';
+
+    /**
+     * The delete request container that specifies the objects to be deleted.
+     *
+     * The `delete` attribute is only applicable to the delete-object operation.
+     * The `delete` attribute corresponds to the `--delete` parameter of the
+     * delete-objects operation within the S3 API.
+     *
+     * @example Objects=[{Key=string,VersionId=string},{Key=string,VersionId=string}],Quiet=boolean
+     */
+    public const AWS_S3_DELETE = 'aws.s3.delete';
+
+    /**
+     * The S3 object key the request refers to. Corresponds to the `--key` parameter of the S3 API operations.
+     *
+     * The `key` attribute is applicable to all object-related S3 operations, i.e. that require the object key as a mandatory parameter.
+     * This applies in particular to the following operations:<ul>
+     * <li>copy-object</li>
+     * <li>delete-object</li>
+     * <li>get-object</li>
+     * <li>head-object</li>
+     * <li>put-object</li>
+     * <li>restore-object</li>
+     * <li>select-object-content</li>
+     * <li>abort-multipart-upload</li>
+     * <li>complete-multipart-upload</li>
+     * <li>create-multipart-upload</li>
+     * <li>list-parts</li>
+     * <li>upload-part</li>
+     * <li>upload-part-copy</li>
+     * </ul>
+     *
+     * @example someFile.yml
+     */
+    public const AWS_S3_KEY = 'aws.s3.key';
+
+    /**
+     * The part number of the part being uploaded in a multipart-upload operation. This is a positive integer between 1 and 10,000.
+     *
+     * The `part_number` attribute is only applicable to the upload-part
+     * and upload-part-copy operations.
+     * The `part_number` attribute corresponds to the `--part-number` parameter of the
+     * upload-part operation within the S3 API.
+     *
+     * @example 3456
+     */
+    public const AWS_S3_PART_NUMBER = 'aws.s3.part_number';
+
+    /**
+     * Upload ID that identifies the multipart upload.
+     *
+     * The `upload_id` attribute applies to S3 multipart-upload operations and corresponds to the `--upload-id` parameter
+     * of the S3 API multipart operations.
+     * This applies in particular to the following operations:<ul>
+     * <li>abort-multipart-upload</li>
+     * <li>complete-multipart-upload</li>
+     * <li>list-parts</li>
+     * <li>upload-part</li>
+     * <li>upload-part-copy</li>
+     * </ul>
+     *
+     * @example dfRtDYWFbkRONycy.Yxwh66Yjlx.cph0gtNBtJ
+     */
+    public const AWS_S3_UPLOAD_ID = 'aws.s3.upload_id';
 
     /**
      * Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
@@ -34,138 +304,68 @@ interface TraceAttributes
     public const CLIENT_PORT = 'client.port';
 
     /**
-     * Destination address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+     * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an ARN on AWS, a fully qualified resource ID on Azure, a full resource name on GCP).
      *
-     * When observed from the source side, and when communicating through an intermediary, `destination.address` SHOULD represent the destination address behind any intermediaries, for example proxies, if it's available.
-     *
-     * @example destination.example.com
-     * @example 10.1.2.80
-     * @example /tmp/my.sock
-     */
-    public const DESTINATION_ADDRESS = 'destination.address';
-
-    /**
-     * Destination port number.
-     *
-     * @example 3389
-     * @example 2888
-     */
-    public const DESTINATION_PORT = 'destination.port';
-
-    /**
-     * Describes a class of error the operation ended with.
-     *
-     * The `error.type` SHOULD be predictable and SHOULD have low cardinality.
-     * Instrumentations SHOULD document the list of errors they report.The cardinality of `error.type` within one instrumentation library SHOULD be low.
-     * Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-     * should be prepared for `error.type` to have high cardinality at query time when no
-     * additional filters are applied.If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
-     * it's RECOMMENDED to:<ul>
-     * <li>Use a domain-specific attribute</li>
-     * <li>Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.</li>
+     * On some cloud providers, it may not be possible to determine the full ID at startup,
+     * so it may be necessary to set `cloud.resource_id` as a span attribute instead.The exact value to use for `cloud.resource_id` depends on the cloud provider.
+     * The following well-known definitions MUST be used if you set this attribute and they apply:<ul>
+     * <li><strong>AWS Lambda:</strong> The function ARN.
+     * Take care not to use the &quot;invoked ARN&quot; directly but replace any
+     * alias suffix
+     * with the resolved function version, as the same runtime instance may be invokable with
+     * multiple different aliases.</li>
+     * <li><strong>GCP:</strong> The URI of the resource</li>
+     * <li><strong>Azure:</strong> The Fully Qualified Resource ID of the invoked function,
+     * <em>not</em> the function app, having the form
+     * `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`.
+     * This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
+     * a TracerProvider.</li>
      * </ul>
      *
-     * @example timeout
-     * @example java.net.UnknownHostException
-     * @example server_certificate_invalid
-     * @example 500
+     * @example arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function
+     * @example //run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID
+     * @example /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>
      */
-    public const ERROR_TYPE = 'error.type';
+    public const CLOUD_RESOURCE_ID = 'cloud.resource_id';
 
     /**
-     * The exception message.
+     * The event_id uniquely identifies the event.
      *
-     * @example Division by zero
-     * @example Can't convert 'int' object to str implicitly
+     * @example 123e4567-e89b-12d3-a456-426614174000
+     * @example 0001
      */
-    public const EXCEPTION_MESSAGE = 'exception.message';
+    public const CLOUDEVENTS_EVENT_ID = 'cloudevents.event_id';
 
     /**
-     * A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
+     * The source identifies the context in which an event happened.
      *
-     * @example Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
+     * @example https://github.com/cloudevents
+     * @example /cloudevents/spec/pull/123
+     * @example my-service
      */
-    public const EXCEPTION_STACKTRACE = 'exception.stacktrace';
+    public const CLOUDEVENTS_EVENT_SOURCE = 'cloudevents.event_source';
 
     /**
-     * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+     * The version of the CloudEvents specification which the event uses.
      *
-     * @example java.net.ConnectException
-     * @example OSError
+     * @example 1.0
      */
-    public const EXCEPTION_TYPE = 'exception.type';
+    public const CLOUDEVENTS_EVENT_SPEC_VERSION = 'cloudevents.event_spec_version';
 
     /**
-     * The name of the invoked function.
+     * The subject of the event in the context of the event producer (identified by source).
      *
-     * SHOULD be equal to the `faas.name` resource attribute of the invoked function.
-     *
-     * @example my-function
+     * @example mynewfile.jpg
      */
-    public const FAAS_INVOKED_NAME = 'faas.invoked_name';
+    public const CLOUDEVENTS_EVENT_SUBJECT = 'cloudevents.event_subject';
 
     /**
-     * The cloud provider of the invoked function.
+     * The event_type contains a value describing the type of event related to the originating occurrence.
      *
-     * SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
+     * @example com.github.pull_request.opened
+     * @example com.example.object.deleted.v2
      */
-    public const FAAS_INVOKED_PROVIDER = 'faas.invoked_provider';
-
-    /**
-     * The cloud region of the invoked function.
-     *
-     * SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
-     *
-     * @example eu-central-1
-     */
-    public const FAAS_INVOKED_REGION = 'faas.invoked_region';
-
-    /**
-     * Type of the trigger which caused this function invocation.
-     */
-    public const FAAS_TRIGGER = 'faas.trigger';
-
-    /**
-     * The `service.name` of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
-     *
-     * @example AuthTokenCache
-     */
-    public const PEER_SERVICE = 'peer.service';
-
-    /**
-     * Username or client_id extracted from the access token or Authorization header in the inbound request from outside the system.
-     *
-     * @example username
-     */
-    public const ENDUSER_ID = 'enduser.id';
-
-    /**
-     * Actual/assumed role the client is making the request under extracted from token or application security context.
-     *
-     * @example admin
-     */
-    public const ENDUSER_ROLE = 'enduser.role';
-
-    /**
-     * Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
-     *
-     * @example read:message, write:files
-     */
-    public const ENDUSER_SCOPE = 'enduser.scope';
-
-    /**
-     * Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
-     *
-     * @example 42
-     */
-    public const THREAD_ID = 'thread.id';
-
-    /**
-     * Current thread name.
-     *
-     * @example main
-     */
-    public const THREAD_NAME = 'thread.name';
+    public const CLOUDEVENTS_EVENT_TYPE = 'cloudevents.event_type';
 
     /**
      * The column number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
@@ -203,92 +403,270 @@ interface TraceAttributes
     public const CODE_NAMESPACE = 'code.namespace';
 
     /**
-     * HTTP request method.
-     *
-     * HTTP request method value SHOULD be &quot;known&quot; to the instrumentation.
-     * By default, this convention defines &quot;known&quot; methods as the ones listed in RFC9110
-     * and the PATCH method defined in RFC5789.If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-     * the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-     * OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-     * (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-     * Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-     * Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-     *
-     * @example GET
-     * @example POST
-     * @example HEAD
+     * The consistency level of the query. Based on consistency values from CQL.
      */
-    public const HTTP_REQUEST_METHOD = 'http.request.method';
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL = 'db.cassandra.consistency_level';
 
     /**
-     * HTTP response status code.
+     * The data center of the coordinating node for a query.
+     *
+     * @example us-west-2
+     */
+    public const DB_CASSANDRA_COORDINATOR_DC = 'db.cassandra.coordinator.dc';
+
+    /**
+     * The ID of the coordinating node for a query.
+     *
+     * @example be13faa2-8574-4d71-926d-27f16cf8a7af
+     */
+    public const DB_CASSANDRA_COORDINATOR_ID = 'db.cassandra.coordinator.id';
+
+    /**
+     * Whether or not the query is idempotent.
+     */
+    public const DB_CASSANDRA_IDEMPOTENCE = 'db.cassandra.idempotence';
+
+    /**
+     * The fetch size used for paging, i.e. how many rows will be returned at once.
+     *
+     * @example 5000
+     */
+    public const DB_CASSANDRA_PAGE_SIZE = 'db.cassandra.page_size';
+
+    /**
+     * The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
+     *
+     * @example 2
+     */
+    public const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = 'db.cassandra.speculative_execution_count';
+
+    /**
+     * The name of the primary table that the operation is acting upon, including the keyspace name (if applicable).
+     *
+     * This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+     *
+     * @example mytable
+     */
+    public const DB_CASSANDRA_TABLE = 'db.cassandra.table';
+
+    /**
+     * The connection string used to connect to the database. It is recommended to remove embedded credentials.
+     *
+     * @example Server=(localdb)\v11.0;Integrated Security=true;
+     */
+    public const DB_CONNECTION_STRING = 'db.connection_string';
+
+    /**
+     * Unique Cosmos client instance id.
+     *
+     * @example 3ba4827d-4422-483f-b59f-85b74211c11d
+     */
+    public const DB_COSMOSDB_CLIENT_ID = 'db.cosmosdb.client_id';
+
+    /**
+     * Cosmos client connection mode.
+     */
+    public const DB_COSMOSDB_CONNECTION_MODE = 'db.cosmosdb.connection_mode';
+
+    /**
+     * Cosmos DB container name.
+     *
+     * @example anystring
+     */
+    public const DB_COSMOSDB_CONTAINER = 'db.cosmosdb.container';
+
+    /**
+     * CosmosDB Operation Type.
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE = 'db.cosmosdb.operation_type';
+
+    /**
+     * RU consumed for that operation.
+     *
+     * @example 46.18
+     * @example 1.0
+     */
+    public const DB_COSMOSDB_REQUEST_CHARGE = 'db.cosmosdb.request_charge';
+
+    /**
+     * Request payload size in bytes.
+     */
+    public const DB_COSMOSDB_REQUEST_CONTENT_LENGTH = 'db.cosmosdb.request_content_length';
+
+    /**
+     * Cosmos DB status code.
      *
      * @example 200
+     * @example 201
      */
-    public const HTTP_RESPONSE_STATUS_CODE = 'http.response.status_code';
+    public const DB_COSMOSDB_STATUS_CODE = 'db.cosmosdb.status_code';
 
     /**
-     * OSI application layer or non-OSI equivalent.
+     * Cosmos DB sub status code.
      *
-     * The value SHOULD be normalized to lowercase.
-     *
-     * @example http
-     * @example spdy
+     * @example 1000
+     * @example 1002
      */
-    public const NETWORK_PROTOCOL_NAME = 'network.protocol.name';
+    public const DB_COSMOSDB_SUB_STATUS_CODE = 'db.cosmosdb.sub_status_code';
 
     /**
-     * Version of the protocol specified in `network.protocol.name`.
+     * Represents the identifier of an Elasticsearch cluster.
      *
-     * `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-     *
-     * @example 1.0
-     * @example 1.1
-     * @example 2
-     * @example 3
+     * @example e9106fc68e3044f0b1475b04bf4ffd5f
      */
-    public const NETWORK_PROTOCOL_VERSION = 'network.protocol.version';
+    public const DB_ELASTICSEARCH_CLUSTER_NAME = 'db.elasticsearch.cluster.name';
 
     /**
-     * Host identifier of the &quot;URI origin&quot; HTTP request is sent to.
+     * Represents the human-readable identifier of the node/instance to which a request was routed.
      *
-     * If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
+     * @example instance-0000000001
+     */
+    public const DB_ELASTICSEARCH_NODE_NAME = 'db.elasticsearch.node.name';
+
+    /**
+     * The fully-qualified class name of the Java Database Connectivity (JDBC) driver used to connect.
      *
-     * @example example.com
+     * @example org.postgresql.Driver
+     * @example com.microsoft.sqlserver.jdbc.SQLServerDriver
+     */
+    public const DB_JDBC_DRIVER_CLASSNAME = 'db.jdbc.driver_classname';
+
+    /**
+     * The collection being accessed within the database stated in `db.name`.
+     *
+     * @example customers
+     * @example products
+     */
+    public const DB_MONGODB_COLLECTION = 'db.mongodb.collection';
+
+    /**
+     * The Microsoft SQL Server instance name connecting to. This name is used to determine the port of a named instance.
+     *
+     * If setting a `db.mssql.instance_name`, `server.port` is no longer required (but still recommended if non-standard).
+     *
+     * @example MSSQLSERVER
+     */
+    public const DB_MSSQL_INSTANCE_NAME = 'db.mssql.instance_name';
+
+    /**
+     * This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails).
+     *
+     * In some SQL databases, the database name to be used is called &quot;schema name&quot;. In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name).
+     *
+     * @example customers
+     * @example main
+     */
+    public const DB_NAME = 'db.name';
+
+    /**
+     * The name of the operation being executed, e.g. the MongoDB command name such as `findAndModify`, or the SQL keyword.
+     *
+     * When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+     *
+     * @example findAndModify
+     * @example HMSET
+     * @example SELECT
+     */
+    public const DB_OPERATION = 'db.operation';
+
+    /**
+     * The index of the database being accessed as used in the `SELECT` command, provided as an integer. To be used instead of the generic `db.name` attribute.
+     *
+     * @example 1
+     * @example 15
+     */
+    public const DB_REDIS_DATABASE_INDEX = 'db.redis.database_index';
+
+    /**
+     * The name of the primary table that the operation is acting upon, including the database name (if applicable).
+     *
+     * It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+     *
+     * @example public.users
+     * @example customers
+     */
+    public const DB_SQL_TABLE = 'db.sql.table';
+
+    /**
+     * The database statement being executed.
+     *
+     * @example SELECT * FROM wuser_table
+     * @example SET mykey "WuValue"
+     */
+    public const DB_STATEMENT = 'db.statement';
+
+    /**
+     * An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
+     */
+    public const DB_SYSTEM = 'db.system';
+
+    /**
+     * Username for accessing the database.
+     *
+     * @example readonly_user
+     * @example reporting_user
+     */
+    public const DB_USER = 'db.user';
+
+    /**
+     * Destination address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+     *
+     * When observed from the source side, and when communicating through an intermediary, `destination.address` SHOULD represent the destination address behind any intermediaries, for example proxies, if it's available.
+     *
+     * @example destination.example.com
      * @example 10.1.2.80
      * @example /tmp/my.sock
      */
-    public const SERVER_ADDRESS = 'server.address';
+    public const DESTINATION_ADDRESS = 'destination.address';
 
     /**
-     * Port identifier of the &quot;URI origin&quot; HTTP request is sent to.
+     * Destination port number.
      *
-     * When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
-     *
-     * @example 80
-     * @example 8080
-     * @example 443
+     * @example 3389
+     * @example 2888
      */
-    public const SERVER_PORT = 'server.port';
+    public const DESTINATION_PORT = 'destination.port';
 
     /**
-     * The URI scheme component identifying the used protocol.
+     * Username or client_id extracted from the access token or Authorization header in the inbound request from outside the system.
      *
-     * @example http
-     * @example https
+     * @example username
      */
-    public const URL_SCHEME = 'url.scheme';
+    public const ENDUSER_ID = 'enduser.id';
 
     /**
-     * The matched route, that is, the path template in the format used by the respective server framework.
+     * Actual/assumed role the client is making the request under extracted from token or application security context.
      *
-     * MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-     * SHOULD include the application root if there is one.
-     *
-     * @example /users/:userID?
-     * @example {controller}/{action}/{id?}
+     * @example admin
      */
-    public const HTTP_ROUTE = 'http.route';
+    public const ENDUSER_ROLE = 'enduser.role';
+
+    /**
+     * Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
+     *
+     * @example read:message, write:files
+     */
+    public const ENDUSER_SCOPE = 'enduser.scope';
+
+    /**
+     * Describes a class of error the operation ended with.
+     *
+     * The `error.type` SHOULD be predictable and SHOULD have low cardinality.
+     * Instrumentations SHOULD document the list of errors they report.The cardinality of `error.type` within one instrumentation library SHOULD be low.
+     * Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+     * should be prepared for `error.type` to have high cardinality at query time when no
+     * additional filters are applied.If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
+     * it's RECOMMENDED to:<ul>
+     * <li>Use a domain-specific attribute</li>
+     * <li>Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.</li>
+     * </ul>
+     *
+     * @example timeout
+     * @example java.net.UnknownHostException
+     * @example server_certificate_invalid
+     * @example 500
+     */
+    public const ERROR_TYPE = 'error.type';
 
     /**
      * The domain identifies the business context for the events.
@@ -306,14 +684,129 @@ interface TraceAttributes
     public const EVENT_NAME = 'event.name';
 
     /**
-     * A unique identifier for the Log Record.
+     * SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.
      *
-     * If an id is provided, other log records with the same id will be considered duplicates and can be removed safely. This means, that two distinguishable log records MUST have different values.
-     * The id MAY be an Universally Unique Lexicographically Sortable Identifier (ULID), but other identifiers (e.g. UUID) may be used as needed.
-     *
-     * @example 01ARZ3NDEKTSV4RRFFQ69G5FAV
+     * An exception is considered to have escaped (or left) the scope of a span,
+     * if that span is ended while the exception is still logically &quot;in flight&quot;.
+     * This may be actually &quot;in flight&quot; in some languages (e.g. if the exception
+     * is passed to a Context manager's `__exit__` method in Python) but will
+     * usually be caught at the point of recording the exception in most languages.It is usually not possible to determine at the point where an exception is thrown
+     * whether it will escape the scope of a span.
+     * However, it is trivial to know that an exception
+     * will escape, if one checks for an active exception just before ending the span,
+     * as done in the example above.It follows that an exception may still escape the scope of the span
+     * even if the `exception.escaped` attribute was not set or set to false,
+     * since the event might have been recorded at a time where it was not
+     * clear whether the exception will escape.
      */
-    public const LOG_RECORD_UID = 'log.record.uid';
+    public const EXCEPTION_ESCAPED = 'exception.escaped';
+
+    /**
+     * The exception message.
+     *
+     * @example Division by zero
+     * @example Can't convert 'int' object to str implicitly
+     */
+    public const EXCEPTION_MESSAGE = 'exception.message';
+
+    /**
+     * A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
+     *
+     * @example Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
+     */
+    public const EXCEPTION_STACKTRACE = 'exception.stacktrace';
+
+    /**
+     * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+     *
+     * @example java.net.ConnectException
+     * @example OSError
+     */
+    public const EXCEPTION_TYPE = 'exception.type';
+
+    /**
+     * A boolean that is true if the serverless function is executed for the first time (aka cold-start).
+     */
+    public const FAAS_COLDSTART = 'faas.coldstart';
+
+    /**
+     * A string containing the schedule period as Cron Expression.
+     *
+     * @example 0/5 * * * ? *
+     */
+    public const FAAS_CRON = 'faas.cron';
+
+    /**
+     * The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
+     *
+     * @example myBucketName
+     * @example myDbName
+     */
+    public const FAAS_DOCUMENT_COLLECTION = 'faas.document.collection';
+
+    /**
+     * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
+     *
+     * @example myFile.txt
+     * @example myTableName
+     */
+    public const FAAS_DOCUMENT_NAME = 'faas.document.name';
+
+    /**
+     * Describes the type of the operation that was performed on the data.
+     */
+    public const FAAS_DOCUMENT_OPERATION = 'faas.document.operation';
+
+    /**
+     * A string containing the time when the data was accessed in the ISO 8601 format expressed in UTC.
+     *
+     * @example 2020-01-23T13:47:06Z
+     */
+    public const FAAS_DOCUMENT_TIME = 'faas.document.time';
+
+    /**
+     * The invocation ID of the current function invocation.
+     *
+     * @example af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+     */
+    public const FAAS_INVOCATION_ID = 'faas.invocation_id';
+
+    /**
+     * The name of the invoked function.
+     *
+     * SHOULD be equal to the `faas.name` resource attribute of the invoked function.
+     *
+     * @example my-function
+     */
+    public const FAAS_INVOKED_NAME = 'faas.invoked_name';
+
+    /**
+     * The cloud provider of the invoked function.
+     *
+     * SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
+     */
+    public const FAAS_INVOKED_PROVIDER = 'faas.invoked_provider';
+
+    /**
+     * The cloud region of the invoked function.
+     *
+     * SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
+     *
+     * @example eu-central-1
+     */
+    public const FAAS_INVOKED_REGION = 'faas.invoked_region';
+
+    /**
+     * A string containing the function invocation time in the ISO 8601 format expressed in UTC.
+     *
+     * @example 2020-01-23T13:47:06Z
+     */
+    public const FAAS_TIME = 'faas.time';
+
+    /**
+     * Type of the trigger which caused this function invocation.
+     */
+    public const FAAS_TRIGGER = 'faas.trigger';
 
     /**
      * The unique identifier of the feature flag.
@@ -346,464 +839,29 @@ interface TraceAttributes
     public const FEATURE_FLAG_VARIANT = 'feature_flag.variant';
 
     /**
-     * The stream associated with the log. See below for a list of well-known values.
+     * The GraphQL document being executed.
+     *
+     * The value may be sanitized to exclude sensitive information.
+     *
+     * @example query findBookById { bookById(id: ?) { name } }
      */
-    public const LOG_IOSTREAM = 'log.iostream';
+    public const GRAPHQL_DOCUMENT = 'graphql.document';
 
     /**
-     * The basename of the file.
+     * The name of the operation being executed.
      *
-     * @example audit.log
+     * @example findBookById
      */
-    public const LOG_FILE_NAME = 'log.file.name';
+    public const GRAPHQL_OPERATION_NAME = 'graphql.operation.name';
 
     /**
-     * The basename of the file, with symlinks resolved.
+     * The type of the operation being executed.
      *
-     * @example uuid.log
+     * @example query
+     * @example mutation
+     * @example subscription
      */
-    public const LOG_FILE_NAME_RESOLVED = 'log.file.name_resolved';
-
-    /**
-     * The full path to the file.
-     *
-     * @example /var/log/mysql/audit.log
-     */
-    public const LOG_FILE_PATH = 'log.file.path';
-
-    /**
-     * The full path to the file, with symlinks resolved.
-     *
-     * @example /var/lib/docker/uuid.log
-     */
-    public const LOG_FILE_PATH_RESOLVED = 'log.file.path_resolved';
-
-    /**
-     * This attribute represents the state the application has transitioned into at the occurrence of the event.
-     *
-     * The iOS lifecycle states are defined in the UIApplicationDelegate documentation, and from which the `OS terminology` column values are derived.
-     */
-    public const IOS_STATE = 'ios.state';
-
-    /**
-     * This attribute represents the state the application has transitioned into at the occurrence of the event.
-     *
-     * The Android lifecycle states are defined in Activity lifecycle callbacks, and from which the `OS identifiers` are derived.
-     */
-    public const ANDROID_STATE = 'android.state';
-
-    /**
-     * The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the db.connection_string should be used.
-     *
-     * @example myDataSource
-     */
-    public const POOL_NAME = 'pool.name';
-
-    /**
-     * The state of a connection in the pool.
-     *
-     * @example idle
-     */
-    public const STATE = 'state';
-
-    /**
-     * Name of the buffer pool.
-     *
-     * Pool names are generally obtained via BufferPoolMXBean#getName().
-     *
-     * @example mapped
-     * @example direct
-     */
-    public const JVM_BUFFER_POOL_NAME = 'jvm.buffer.pool.name';
-
-    /**
-     * Name of the memory pool.
-     *
-     * Pool names are generally obtained via MemoryPoolMXBean#getName().
-     *
-     * @example G1 Old Gen
-     * @example G1 Eden space
-     * @example G1 Survivor Space
-     */
-    public const JVM_MEMORY_POOL_NAME = 'jvm.memory.pool.name';
-
-    /**
-     * The type of memory.
-     *
-     * @example heap
-     * @example non_heap
-     */
-    public const JVM_MEMORY_TYPE = 'jvm.memory.type';
-
-    /**
-     * OSI transport layer or inter-process communication method.
-     *
-     * The value SHOULD be normalized to lowercase.Consider always setting the transport when setting a port number, since
-     * a port number is ambiguous without knowing the transport. For example
-     * different processes could be listening on TCP port 12345 and UDP port 12345.
-     *
-     * @example tcp
-     * @example udp
-     */
-    public const NETWORK_TRANSPORT = 'network.transport';
-
-    /**
-     * OSI network layer or non-OSI equivalent.
-     *
-     * The value SHOULD be normalized to lowercase.
-     *
-     * @example ipv4
-     * @example ipv6
-     */
-    public const NETWORK_TYPE = 'network.type';
-
-    /**
-     * The name of the (logical) method being called, must be equal to the $method part in the span name.
-     *
-     * This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
-     *
-     * @example exampleMethod
-     */
-    public const RPC_METHOD = 'rpc.method';
-
-    /**
-     * The full (logical) name of the service being called, including its package name, if applicable.
-     *
-     * This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
-     *
-     * @example myservice.EchoService
-     */
-    public const RPC_SERVICE = 'rpc.service';
-
-    /**
-     * A string identifying the remoting system. See below for a list of well-known identifiers.
-     */
-    public const RPC_SYSTEM = 'rpc.system';
-
-    /**
-     * The device identifier.
-     *
-     * @example (identifier)
-     */
-    public const SYSTEM_DEVICE = 'system.device';
-
-    /**
-     * The logical CPU number [0..n-1].
-     *
-     * @example 1
-     */
-    public const SYSTEM_CPU_LOGICAL_NUMBER = 'system.cpu.logical_number';
-
-    /**
-     * The state of the CPU.
-     *
-     * @example idle
-     * @example interrupt
-     */
-    public const SYSTEM_CPU_STATE = 'system.cpu.state';
-
-    /**
-     * The memory state.
-     *
-     * @example free
-     * @example cached
-     */
-    public const SYSTEM_MEMORY_STATE = 'system.memory.state';
-
-    /**
-     * The paging access direction.
-     *
-     * @example in
-     */
-    public const SYSTEM_PAGING_DIRECTION = 'system.paging.direction';
-
-    /**
-     * The memory paging state.
-     *
-     * @example free
-     */
-    public const SYSTEM_PAGING_STATE = 'system.paging.state';
-
-    /**
-     * The memory paging type.
-     *
-     * @example minor
-     */
-    public const SYSTEM_PAGING_TYPE = 'system.paging.type';
-
-    /**
-     * The disk operation direction.
-     *
-     * @example read
-     */
-    public const SYSTEM_DISK_DIRECTION = 'system.disk.direction';
-
-    /**
-     * The filesystem mode.
-     *
-     * @example rw, ro
-     */
-    public const SYSTEM_FILESYSTEM_MODE = 'system.filesystem.mode';
-
-    /**
-     * The filesystem mount path.
-     *
-     * @example /mnt/data
-     */
-    public const SYSTEM_FILESYSTEM_MOUNTPOINT = 'system.filesystem.mountpoint';
-
-    /**
-     * The filesystem state.
-     *
-     * @example used
-     */
-    public const SYSTEM_FILESYSTEM_STATE = 'system.filesystem.state';
-
-    /**
-     * The filesystem type.
-     *
-     * @example ext4
-     */
-    public const SYSTEM_FILESYSTEM_TYPE = 'system.filesystem.type';
-
-    /**
-     * .
-     *
-     * @example transmit
-     */
-    public const SYSTEM_NETWORK_DIRECTION = 'system.network.direction';
-
-    /**
-     * A stateless protocol MUST NOT set this attribute.
-     *
-     * @example close_wait
-     */
-    public const SYSTEM_NETWORK_STATE = 'system.network.state';
-
-    /**
-     * The process state, e.g., Linux Process State Codes.
-     *
-     * @example running
-     */
-    public const SYSTEM_PROCESSES_STATUS = 'system.processes.status';
-
-    /**
-     * Local address of the network connection - IP address or Unix domain socket name.
-     *
-     * @example 10.1.2.80
-     * @example /tmp/my.sock
-     */
-    public const NETWORK_LOCAL_ADDRESS = 'network.local.address';
-
-    /**
-     * Local port number of the network connection.
-     *
-     * @example 65123
-     */
-    public const NETWORK_LOCAL_PORT = 'network.local.port';
-
-    /**
-     * Peer address of the network connection - IP address or Unix domain socket name.
-     *
-     * @example 10.1.2.80
-     * @example /tmp/my.sock
-     */
-    public const NETWORK_PEER_ADDRESS = 'network.peer.address';
-
-    /**
-     * Peer port number of the network connection.
-     *
-     * @example 65123
-     */
-    public const NETWORK_PEER_PORT = 'network.peer.port';
-
-    /**
-     * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
-     *
-     * @example DE
-     */
-    public const NETWORK_CARRIER_ICC = 'network.carrier.icc';
-
-    /**
-     * The mobile carrier country code.
-     *
-     * @example 310
-     */
-    public const NETWORK_CARRIER_MCC = 'network.carrier.mcc';
-
-    /**
-     * The mobile carrier network code.
-     *
-     * @example 001
-     */
-    public const NETWORK_CARRIER_MNC = 'network.carrier.mnc';
-
-    /**
-     * The name of the mobile carrier.
-     *
-     * @example sprint
-     */
-    public const NETWORK_CARRIER_NAME = 'network.carrier.name';
-
-    /**
-     * This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
-     *
-     * @example LTE
-     */
-    public const NETWORK_CONNECTION_SUBTYPE = 'network.connection.subtype';
-
-    /**
-     * The internet connection type.
-     *
-     * @example wifi
-     */
-    public const NETWORK_CONNECTION_TYPE = 'network.connection.type';
-
-    /**
-     * The cloud account ID the resource is assigned to.
-     *
-     * @example 111111111111
-     * @example opentelemetry
-     */
-    public const CLOUD_ACCOUNT_ID = 'cloud.account.id';
-
-    /**
-     * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
-     *
-     * Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.
-     *
-     * @example us-east-1c
-     */
-    public const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
-
-    /**
-     * The cloud platform in use.
-     *
-     * The prefix of the service SHOULD match the one specified in `cloud.provider`.
-     */
-    public const CLOUD_PLATFORM = 'cloud.platform';
-
-    /**
-     * Name of the cloud provider.
-     */
-    public const CLOUD_PROVIDER = 'cloud.provider';
-
-    /**
-     * The geographical region the resource is running.
-     *
-     * Refer to your provider's docs to see the available regions, for example Alibaba Cloud regions, AWS regions, Azure regions, Google Cloud regions, or Tencent Cloud regions.
-     *
-     * @example us-central1
-     * @example us-east-1
-     */
-    public const CLOUD_REGION = 'cloud.region';
-
-    /**
-     * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an ARN on AWS, a fully qualified resource ID on Azure, a full resource name on GCP).
-     *
-     * On some cloud providers, it may not be possible to determine the full ID at startup,
-     * so it may be necessary to set `cloud.resource_id` as a span attribute instead.The exact value to use for `cloud.resource_id` depends on the cloud provider.
-     * The following well-known definitions MUST be used if you set this attribute and they apply:<ul>
-     * <li><strong>AWS Lambda:</strong> The function ARN.
-     * Take care not to use the &quot;invoked ARN&quot; directly but replace any
-     * alias suffix
-     * with the resolved function version, as the same runtime instance may be invokable with
-     * multiple different aliases.</li>
-     * <li><strong>GCP:</strong> The URI of the resource</li>
-     * <li><strong>Azure:</strong> The Fully Qualified Resource ID of the invoked function,
-     * <em>not</em> the function app, having the form
-     * `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`.
-     * This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
-     * a TracerProvider.</li>
-     * </ul>
-     *
-     * @example arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function
-     * @example //run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID
-     * @example /subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>
-     */
-    public const CLOUD_RESOURCE_ID = 'cloud.resource_id';
-
-    /**
-     * The command used to run the container (i.e. the command name).
-     *
-     * If using embedded credentials or sensitive data, it is recommended to remove them to prevent potential leakage.
-     *
-     * @example otelcontribcol
-     */
-    public const CONTAINER_COMMAND = 'container.command';
-
-    /**
-     * All the command arguments (including the command/executable itself) run by the container. [2].
-     *
-     * @example otelcontribcol, --config, config.yaml
-     */
-    public const CONTAINER_COMMAND_ARGS = 'container.command_args';
-
-    /**
-     * The full command run by the container as a single string representing the full command. [2].
-     *
-     * @example otelcontribcol --config config.yaml
-     */
-    public const CONTAINER_COMMAND_LINE = 'container.command_line';
-
-    /**
-     * Container ID. Usually a UUID, as for example used to identify Docker containers. The UUID might be abbreviated.
-     *
-     * @example a3bf90e006b2
-     */
-    public const CONTAINER_ID = 'container.id';
-
-    /**
-     * Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
-     *
-     * Docker defines a sha256 of the image id; `container.image.id` corresponds to the `Image` field from the Docker container inspect API endpoint.
-     * K8s defines a link to the container registry repository with digest `"imageID": "registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625"`.
-     * The ID is assinged by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
-     *
-     * @example sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f
-     */
-    public const CONTAINER_IMAGE_ID = 'container.image.id';
-
-    /**
-     * Name of the image the container was built on.
-     *
-     * @example gcr.io/opentelemetry/operator
-     */
-    public const CONTAINER_IMAGE_NAME = 'container.image.name';
-
-    /**
-     * Repo digests of the container image as provided by the container runtime.
-     *
-     * Docker and CRI report those under the `RepoDigests` field.
-     *
-     * @example example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb
-     * @example internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578
-     */
-    public const CONTAINER_IMAGE_REPO_DIGESTS = 'container.image.repo_digests';
-
-    /**
-     * Container image tags. An example can be found in Docker Image Inspect. Should be only the `<tag>` section of the full name for example from `registry.example.com/my-org/my-image:<tag>`.
-     *
-     * @example v1.27.1
-     * @example 3.5.7-0
-     */
-    public const CONTAINER_IMAGE_TAGS = 'container.image.tags';
-
-    /**
-     * Container name used by container runtime.
-     *
-     * @example opentelemetry-autoconf
-     */
-    public const CONTAINER_NAME = 'container.name';
-
-    /**
-     * The container runtime managing this container.
-     *
-     * @example docker
-     * @example containerd
-     * @example rkt
-     */
-    public const CONTAINER_RUNTIME = 'container.runtime';
+    public const GRAPHQL_OPERATION_TYPE = 'graphql.operation.type';
 
     /**
      * Deprecated, use `http.request.method` instead.
@@ -816,6 +874,49 @@ interface TraceAttributes
     public const HTTP_METHOD = 'http.method';
 
     /**
+     * The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
+     *
+     * @example 3495
+     */
+    public const HTTP_REQUEST_BODY_SIZE = 'http.request.body.size';
+
+    /**
+     * HTTP request method.
+     *
+     * HTTP request method value SHOULD be &quot;known&quot; to the instrumentation.
+     * By default, this convention defines &quot;known&quot; methods as the ones listed in RFC9110
+     * and the PATCH method defined in RFC5789.If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+     * the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+     * OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+     * (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+     * Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+     * Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+     *
+     * @example GET
+     * @example POST
+     * @example HEAD
+     */
+    public const HTTP_REQUEST_METHOD = 'http.request.method';
+
+    /**
+     * Original HTTP method sent by the client in the request line.
+     *
+     * @example GeT
+     * @example ACL
+     * @example foo
+     */
+    public const HTTP_REQUEST_METHOD_ORIGINAL = 'http.request.method_original';
+
+    /**
+     * The ordinal number of request resending attempt (for any reason, including redirects).
+     *
+     * The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
+     *
+     * @example 3
+     */
+    public const HTTP_REQUEST_RESEND_COUNT = 'http.request.resend_count';
+
+    /**
      * Deprecated, use `http.request.header.content-length` instead.
      *
      * @deprecated Deprecated, use `http.request.header.content-length` instead..
@@ -824,12 +925,37 @@ interface TraceAttributes
     public const HTTP_REQUEST_CONTENT_LENGTH = 'http.request_content_length';
 
     /**
+     * The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
+     *
+     * @example 3495
+     */
+    public const HTTP_RESPONSE_BODY_SIZE = 'http.response.body.size';
+
+    /**
+     * HTTP response status code.
+     *
+     * @example 200
+     */
+    public const HTTP_RESPONSE_STATUS_CODE = 'http.response.status_code';
+
+    /**
      * Deprecated, use `http.response.header.content-length` instead.
      *
      * @deprecated Deprecated, use `http.response.header.content-length` instead..
      * @example 3495
      */
     public const HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length';
+
+    /**
+     * The matched route, that is, the path template in the format used by the respective server framework.
+     *
+     * MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+     * SHOULD include the application root if there is one.
+     *
+     * @example /users/:userID?
+     * @example {controller}/{action}/{id?}
+     */
+    public const HTTP_ROUTE = 'http.route';
 
     /**
      * Deprecated, use `url.scheme` instead.
@@ -865,136 +991,105 @@ interface TraceAttributes
     public const HTTP_URL = 'http.url';
 
     /**
-     * Deprecated, use `server.address`.
+     * This attribute represents the state the application has transitioned into at the occurrence of the event.
      *
-     * @deprecated Deprecated, use `server.address`..
-     * @example example.com
+     * The iOS lifecycle states are defined in the UIApplicationDelegate documentation, and from which the `OS terminology` column values are derived.
      */
-    public const NET_HOST_NAME = 'net.host.name';
+    public const IOS_STATE = 'ios.state';
 
     /**
-     * Deprecated, use `server.port`.
+     * Name of the buffer pool.
      *
-     * @deprecated Deprecated, use `server.port`..
-     * @example 8080
+     * Pool names are generally obtained via BufferPoolMXBean#getName().
+     *
+     * @example mapped
+     * @example direct
      */
-    public const NET_HOST_PORT = 'net.host.port';
+    public const JVM_BUFFER_POOL_NAME = 'jvm.buffer.pool.name';
 
     /**
-     * Deprecated, use `server.address` on client spans and `client.address` on server spans.
+     * Name of the memory pool.
      *
-     * @deprecated Deprecated, use `server.address` on client spans and `client.address` on server spans..
-     * @example example.com
+     * Pool names are generally obtained via MemoryPoolMXBean#getName().
+     *
+     * @example G1 Old Gen
+     * @example G1 Eden space
+     * @example G1 Survivor Space
      */
-    public const NET_PEER_NAME = 'net.peer.name';
+    public const JVM_MEMORY_POOL_NAME = 'jvm.memory.pool.name';
 
     /**
-     * Deprecated, use `server.port` on client spans and `client.port` on server spans.
+     * The type of memory.
      *
-     * @deprecated Deprecated, use `server.port` on client spans and `client.port` on server spans..
-     * @example 8080
+     * @example heap
+     * @example non_heap
      */
-    public const NET_PEER_PORT = 'net.peer.port';
+    public const JVM_MEMORY_TYPE = 'jvm.memory.type';
 
     /**
-     * Deprecated, use `network.protocol.name`.
+     * The basename of the file.
      *
-     * @deprecated Deprecated, use `network.protocol.name`..
-     * @example amqp
-     * @example http
-     * @example mqtt
+     * @example audit.log
      */
-    public const NET_PROTOCOL_NAME = 'net.protocol.name';
+    public const LOG_FILE_NAME = 'log.file.name';
 
     /**
-     * Deprecated, use `network.protocol.version`.
+     * The basename of the file, with symlinks resolved.
      *
-     * @deprecated Deprecated, use `network.protocol.version`..
-     * @example 3.1.1
+     * @example uuid.log
      */
-    public const NET_PROTOCOL_VERSION = 'net.protocol.version';
+    public const LOG_FILE_NAME_RESOLVED = 'log.file.name_resolved';
 
     /**
-     * Deprecated, use `network.transport` and `network.type`.
+     * The full path to the file.
+     *
+     * @example /var/log/mysql/audit.log
      */
-    public const NET_SOCK_FAMILY = 'net.sock.family';
+    public const LOG_FILE_PATH = 'log.file.path';
 
     /**
-     * Deprecated, use `network.local.address`.
+     * The full path to the file, with symlinks resolved.
      *
-     * @deprecated Deprecated, use `network.local.address`..
-     * @example /var/my.sock
+     * @example /var/lib/docker/uuid.log
      */
-    public const NET_SOCK_HOST_ADDR = 'net.sock.host.addr';
+    public const LOG_FILE_PATH_RESOLVED = 'log.file.path_resolved';
 
     /**
-     * Deprecated, use `network.local.port`.
-     *
-     * @deprecated Deprecated, use `network.local.port`..
-     * @example 8080
+     * The stream associated with the log. See below for a list of well-known values.
      */
-    public const NET_SOCK_HOST_PORT = 'net.sock.host.port';
+    public const LOG_IOSTREAM = 'log.iostream';
 
     /**
-     * Deprecated, use `network.peer.address`.
+     * A unique identifier for the Log Record.
      *
-     * @deprecated Deprecated, use `network.peer.address`..
-     * @example 192.168.0.1
+     * If an id is provided, other log records with the same id will be considered duplicates and can be removed safely. This means, that two distinguishable log records MUST have different values.
+     * The id MAY be an Universally Unique Lexicographically Sortable Identifier (ULID), but other identifiers (e.g. UUID) may be used as needed.
+     *
+     * @example 01ARZ3NDEKTSV4RRFFQ69G5FAV
      */
-    public const NET_SOCK_PEER_ADDR = 'net.sock.peer.addr';
+    public const LOG_RECORD_UID = 'log.record.uid';
 
     /**
-     * Deprecated, no replacement at this time.
-     *
-     * @deprecated Deprecated, no replacement at this time..
-     * @example /var/my.sock
+     * Compressed size of the message in bytes.
      */
-    public const NET_SOCK_PEER_NAME = 'net.sock.peer.name';
+    public const MESSAGE_COMPRESSED_SIZE = 'message.compressed_size';
 
     /**
-     * Deprecated, use `network.peer.port`.
+     * MUST be calculated as two different counters starting from `1` one for sent messages and one for received message.
      *
-     * @deprecated Deprecated, use `network.peer.port`..
-     * @example 65531
+     * This way we guarantee that the values will be consistent between different implementations.
      */
-    public const NET_SOCK_PEER_PORT = 'net.sock.peer.port';
+    public const MESSAGE_ID = 'message.id';
 
     /**
-     * Deprecated, use `network.transport`.
+     * Whether this is a received or sent message.
      */
-    public const NET_TRANSPORT = 'net.transport';
+    public const MESSAGE_TYPE = 'message.type';
 
     /**
-     * The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
-     *
-     * @example 3495
+     * Uncompressed size of the message in bytes.
      */
-    public const HTTP_REQUEST_BODY_SIZE = 'http.request.body.size';
-
-    /**
-     * Original HTTP method sent by the client in the request line.
-     *
-     * @example GeT
-     * @example ACL
-     * @example foo
-     */
-    public const HTTP_REQUEST_METHOD_ORIGINAL = 'http.request.method_original';
-
-    /**
-     * The ordinal number of request resending attempt (for any reason, including redirects).
-     *
-     * The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
-     *
-     * @example 3
-     */
-    public const HTTP_REQUEST_RESEND_COUNT = 'http.request.resend_count';
-
-    /**
-     * The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
-     *
-     * @example 3495
-     */
-    public const HTTP_RESPONSE_BODY_SIZE = 'http.response.body.size';
+    public const MESSAGE_UNCOMPRESSED_SIZE = 'message.uncompressed_size';
 
     /**
      * The number of messages sent, received, or processed in the scope of the batching operation.
@@ -1215,14 +1310,253 @@ interface TraceAttributes
     public const MESSAGING_SYSTEM = 'messaging.system';
 
     /**
-     * The digest of the OCI image manifest. For container images specifically is the digest by which the container image is known.
+     * Deprecated, use `server.address`.
      *
-     * Follows OCI Image Manifest Specification, and specifically the Digest property.
-     * An example can be found in Example Image Manifest.
-     *
-     * @example sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4
+     * @deprecated Deprecated, use `server.address`..
+     * @example example.com
      */
-    public const OCI_MANIFEST_DIGEST = 'oci.manifest.digest';
+    public const NET_HOST_NAME = 'net.host.name';
+
+    /**
+     * Deprecated, use `server.port`.
+     *
+     * @deprecated Deprecated, use `server.port`..
+     * @example 8080
+     */
+    public const NET_HOST_PORT = 'net.host.port';
+
+    /**
+     * Deprecated, use `server.address` on client spans and `client.address` on server spans.
+     *
+     * @deprecated Deprecated, use `server.address` on client spans and `client.address` on server spans..
+     * @example example.com
+     */
+    public const NET_PEER_NAME = 'net.peer.name';
+
+    /**
+     * Deprecated, use `server.port` on client spans and `client.port` on server spans.
+     *
+     * @deprecated Deprecated, use `server.port` on client spans and `client.port` on server spans..
+     * @example 8080
+     */
+    public const NET_PEER_PORT = 'net.peer.port';
+
+    /**
+     * Deprecated, use `network.protocol.name`.
+     *
+     * @deprecated Deprecated, use `network.protocol.name`..
+     * @example amqp
+     * @example http
+     * @example mqtt
+     */
+    public const NET_PROTOCOL_NAME = 'net.protocol.name';
+
+    /**
+     * Deprecated, use `network.protocol.version`.
+     *
+     * @deprecated Deprecated, use `network.protocol.version`..
+     * @example 3.1.1
+     */
+    public const NET_PROTOCOL_VERSION = 'net.protocol.version';
+
+    /**
+     * Deprecated, use `network.transport` and `network.type`.
+     */
+    public const NET_SOCK_FAMILY = 'net.sock.family';
+
+    /**
+     * Deprecated, use `network.local.address`.
+     *
+     * @deprecated Deprecated, use `network.local.address`..
+     * @example /var/my.sock
+     */
+    public const NET_SOCK_HOST_ADDR = 'net.sock.host.addr';
+
+    /**
+     * Deprecated, use `network.local.port`.
+     *
+     * @deprecated Deprecated, use `network.local.port`..
+     * @example 8080
+     */
+    public const NET_SOCK_HOST_PORT = 'net.sock.host.port';
+
+    /**
+     * Deprecated, use `network.peer.address`.
+     *
+     * @deprecated Deprecated, use `network.peer.address`..
+     * @example 192.168.0.1
+     */
+    public const NET_SOCK_PEER_ADDR = 'net.sock.peer.addr';
+
+    /**
+     * Deprecated, no replacement at this time.
+     *
+     * @deprecated Deprecated, no replacement at this time..
+     * @example /var/my.sock
+     */
+    public const NET_SOCK_PEER_NAME = 'net.sock.peer.name';
+
+    /**
+     * Deprecated, use `network.peer.port`.
+     *
+     * @deprecated Deprecated, use `network.peer.port`..
+     * @example 65531
+     */
+    public const NET_SOCK_PEER_PORT = 'net.sock.peer.port';
+
+    /**
+     * Deprecated, use `network.transport`.
+     */
+    public const NET_TRANSPORT = 'net.transport';
+
+    /**
+     * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
+     *
+     * @example DE
+     */
+    public const NETWORK_CARRIER_ICC = 'network.carrier.icc';
+
+    /**
+     * The mobile carrier country code.
+     *
+     * @example 310
+     */
+    public const NETWORK_CARRIER_MCC = 'network.carrier.mcc';
+
+    /**
+     * The mobile carrier network code.
+     *
+     * @example 001
+     */
+    public const NETWORK_CARRIER_MNC = 'network.carrier.mnc';
+
+    /**
+     * The name of the mobile carrier.
+     *
+     * @example sprint
+     */
+    public const NETWORK_CARRIER_NAME = 'network.carrier.name';
+
+    /**
+     * This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
+     *
+     * @example LTE
+     */
+    public const NETWORK_CONNECTION_SUBTYPE = 'network.connection.subtype';
+
+    /**
+     * The internet connection type.
+     *
+     * @example wifi
+     */
+    public const NETWORK_CONNECTION_TYPE = 'network.connection.type';
+
+    /**
+     * Local address of the network connection - IP address or Unix domain socket name.
+     *
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
+     */
+    public const NETWORK_LOCAL_ADDRESS = 'network.local.address';
+
+    /**
+     * Local port number of the network connection.
+     *
+     * @example 65123
+     */
+    public const NETWORK_LOCAL_PORT = 'network.local.port';
+
+    /**
+     * Peer address of the network connection - IP address or Unix domain socket name.
+     *
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
+     */
+    public const NETWORK_PEER_ADDRESS = 'network.peer.address';
+
+    /**
+     * Peer port number of the network connection.
+     *
+     * @example 65123
+     */
+    public const NETWORK_PEER_PORT = 'network.peer.port';
+
+    /**
+     * OSI application layer or non-OSI equivalent.
+     *
+     * The value SHOULD be normalized to lowercase.
+     *
+     * @example http
+     * @example spdy
+     */
+    public const NETWORK_PROTOCOL_NAME = 'network.protocol.name';
+
+    /**
+     * Version of the protocol specified in `network.protocol.name`.
+     *
+     * `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+     *
+     * @example 1.0
+     * @example 1.1
+     * @example 2
+     * @example 3
+     */
+    public const NETWORK_PROTOCOL_VERSION = 'network.protocol.version';
+
+    /**
+     * OSI transport layer or inter-process communication method.
+     *
+     * The value SHOULD be normalized to lowercase.Consider always setting the transport when setting a port number, since
+     * a port number is ambiguous without knowing the transport. For example
+     * different processes could be listening on TCP port 12345 and UDP port 12345.
+     *
+     * @example tcp
+     * @example udp
+     */
+    public const NETWORK_TRANSPORT = 'network.transport';
+
+    /**
+     * OSI network layer or non-OSI equivalent.
+     *
+     * The value SHOULD be normalized to lowercase.
+     *
+     * @example ipv4
+     * @example ipv6
+     */
+    public const NETWORK_TYPE = 'network.type';
+
+    /**
+     * Parent-child Reference type.
+     *
+     * The causal relationship between a child Span and a parent Span.
+     */
+    public const OPENTRACING_REF_TYPE = 'opentracing.ref_type';
+
+    /**
+     * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status code is UNSET.
+     */
+    public const OTEL_STATUS_CODE = 'otel.status_code';
+
+    /**
+     * Description of the Status if it has a value, otherwise not set.
+     *
+     * @example resource not found
+     */
+    public const OTEL_STATUS_DESCRIPTION = 'otel.status_description';
+
+    /**
+     * The `service.name` of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
+     *
+     * @example AuthTokenCache
+     */
+    public const PEER_SERVICE = 'peer.service';
+
+    /**
+     * The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, then the db.connection_string should be used.
+     *
+     * @example myDataSource
+     */
+    public const POOL_NAME = 'pool.name';
 
     /**
      * The error codes of the Connect request. Error codes are always string values.
@@ -1267,47 +1601,49 @@ interface TraceAttributes
     public const RPC_JSONRPC_VERSION = 'rpc.jsonrpc.version';
 
     /**
-     * The URI fragment component.
+     * The name of the (logical) method being called, must be equal to the $method part in the span name.
      *
-     * @example SemConv
+     * This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
+     *
+     * @example exampleMethod
      */
-    public const URL_FRAGMENT = 'url.fragment';
+    public const RPC_METHOD = 'rpc.method';
 
     /**
-     * Absolute URL describing a network resource according to RFC3986.
+     * The full (logical) name of the service being called, including its package name, if applicable.
      *
-     * For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.
-     * `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password SHOULD be redacted and attribute's value SHOULD be `https://REDACTED:REDACTED@www.example.com/`.
-     * `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
+     * This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
      *
-     * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
-     * @example //localhost
+     * @example myservice.EchoService
      */
-    public const URL_FULL = 'url.full';
+    public const RPC_SERVICE = 'rpc.service';
 
     /**
-     * The URI path component.
-     *
-     * @example /search
+     * A string identifying the remoting system. See below for a list of well-known identifiers.
      */
-    public const URL_PATH = 'url.path';
+    public const RPC_SYSTEM = 'rpc.system';
 
     /**
-     * The URI query component.
+     * Host identifier of the &quot;URI origin&quot; HTTP request is sent to.
      *
-     * Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
+     * If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
      *
-     * @example q=OpenTelemetry
+     * @example example.com
+     * @example 10.1.2.80
+     * @example /tmp/my.sock
      */
-    public const URL_QUERY = 'url.query';
+    public const SERVER_ADDRESS = 'server.address';
 
     /**
-     * Value of the HTTP User-Agent header sent by the client.
+     * Port identifier of the &quot;URI origin&quot; HTTP request is sent to.
      *
-     * @example CERN-LineMode/2.15 libwww/2.17b3
-     * @example Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1
+     * When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+     *
+     * @example 80
+     * @example 8080
+     * @example 443
      */
-    public const USER_AGENT_ORIGINAL = 'user_agent.original';
+    public const SERVER_PORT = 'server.port';
 
     /**
      * A unique id to identify a session.
@@ -1343,650 +1679,183 @@ interface TraceAttributes
     public const SOURCE_PORT = 'source.port';
 
     /**
-     * The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
+     * The state of a connection in the pool.
      *
-     * This may be different from `cloud.resource_id` if an alias is involved.
-     *
-     * @example arn:aws:lambda:us-east-1:123456:function:myfunction:myalias
+     * @example idle
      */
-    public const AWS_LAMBDA_INVOKED_ARN = 'aws.lambda.invoked_arn';
+    public const STATE = 'state';
 
     /**
-     * The event_id uniquely identifies the event.
-     *
-     * @example 123e4567-e89b-12d3-a456-426614174000
-     * @example 0001
-     */
-    public const CLOUDEVENTS_EVENT_ID = 'cloudevents.event_id';
-
-    /**
-     * The source identifies the context in which an event happened.
-     *
-     * @example https://github.com/cloudevents
-     * @example /cloudevents/spec/pull/123
-     * @example my-service
-     */
-    public const CLOUDEVENTS_EVENT_SOURCE = 'cloudevents.event_source';
-
-    /**
-     * The version of the CloudEvents specification which the event uses.
-     *
-     * @example 1.0
-     */
-    public const CLOUDEVENTS_EVENT_SPEC_VERSION = 'cloudevents.event_spec_version';
-
-    /**
-     * The subject of the event in the context of the event producer (identified by source).
-     *
-     * @example mynewfile.jpg
-     */
-    public const CLOUDEVENTS_EVENT_SUBJECT = 'cloudevents.event_subject';
-
-    /**
-     * The event_type contains a value describing the type of event related to the originating occurrence.
-     *
-     * @example com.github.pull_request.opened
-     * @example com.example.object.deleted.v2
-     */
-    public const CLOUDEVENTS_EVENT_TYPE = 'cloudevents.event_type';
-
-    /**
-     * Parent-child Reference type.
-     *
-     * The causal relationship between a child Span and a parent Span.
-     */
-    public const OPENTRACING_REF_TYPE = 'opentracing.ref_type';
-
-    /**
-     * The connection string used to connect to the database. It is recommended to remove embedded credentials.
-     *
-     * @example Server=(localdb)\v11.0;Integrated Security=true;
-     */
-    public const DB_CONNECTION_STRING = 'db.connection_string';
-
-    /**
-     * The fully-qualified class name of the Java Database Connectivity (JDBC) driver used to connect.
-     *
-     * @example org.postgresql.Driver
-     * @example com.microsoft.sqlserver.jdbc.SQLServerDriver
-     */
-    public const DB_JDBC_DRIVER_CLASSNAME = 'db.jdbc.driver_classname';
-
-    /**
-     * This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails).
-     *
-     * In some SQL databases, the database name to be used is called &quot;schema name&quot;. In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name).
-     *
-     * @example customers
-     * @example main
-     */
-    public const DB_NAME = 'db.name';
-
-    /**
-     * The name of the operation being executed, e.g. the MongoDB command name such as `findAndModify`, or the SQL keyword.
-     *
-     * When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
-     *
-     * @example findAndModify
-     * @example HMSET
-     * @example SELECT
-     */
-    public const DB_OPERATION = 'db.operation';
-
-    /**
-     * The database statement being executed.
-     *
-     * @example SELECT * FROM wuser_table
-     * @example SET mykey "WuValue"
-     */
-    public const DB_STATEMENT = 'db.statement';
-
-    /**
-     * An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
-     */
-    public const DB_SYSTEM = 'db.system';
-
-    /**
-     * Username for accessing the database.
-     *
-     * @example readonly_user
-     * @example reporting_user
-     */
-    public const DB_USER = 'db.user';
-
-    /**
-     * The Microsoft SQL Server instance name connecting to. This name is used to determine the port of a named instance.
-     *
-     * If setting a `db.mssql.instance_name`, `server.port` is no longer required (but still recommended if non-standard).
-     *
-     * @example MSSQLSERVER
-     */
-    public const DB_MSSQL_INSTANCE_NAME = 'db.mssql.instance_name';
-
-    /**
-     * The consistency level of the query. Based on consistency values from CQL.
-     */
-    public const DB_CASSANDRA_CONSISTENCY_LEVEL = 'db.cassandra.consistency_level';
-
-    /**
-     * The data center of the coordinating node for a query.
-     *
-     * @example us-west-2
-     */
-    public const DB_CASSANDRA_COORDINATOR_DC = 'db.cassandra.coordinator.dc';
-
-    /**
-     * The ID of the coordinating node for a query.
-     *
-     * @example be13faa2-8574-4d71-926d-27f16cf8a7af
-     */
-    public const DB_CASSANDRA_COORDINATOR_ID = 'db.cassandra.coordinator.id';
-
-    /**
-     * Whether or not the query is idempotent.
-     */
-    public const DB_CASSANDRA_IDEMPOTENCE = 'db.cassandra.idempotence';
-
-    /**
-     * The fetch size used for paging, i.e. how many rows will be returned at once.
-     *
-     * @example 5000
-     */
-    public const DB_CASSANDRA_PAGE_SIZE = 'db.cassandra.page_size';
-
-    /**
-     * The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
-     *
-     * @example 2
-     */
-    public const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = 'db.cassandra.speculative_execution_count';
-
-    /**
-     * The name of the primary table that the operation is acting upon, including the keyspace name (if applicable).
-     *
-     * This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
-     *
-     * @example mytable
-     */
-    public const DB_CASSANDRA_TABLE = 'db.cassandra.table';
-
-    /**
-     * The index of the database being accessed as used in the `SELECT` command, provided as an integer. To be used instead of the generic `db.name` attribute.
+     * The logical CPU number [0..n-1].
      *
      * @example 1
-     * @example 15
      */
-    public const DB_REDIS_DATABASE_INDEX = 'db.redis.database_index';
+    public const SYSTEM_CPU_LOGICAL_NUMBER = 'system.cpu.logical_number';
 
     /**
-     * The collection being accessed within the database stated in `db.name`.
+     * The state of the CPU.
      *
-     * @example customers
-     * @example products
+     * @example idle
+     * @example interrupt
      */
-    public const DB_MONGODB_COLLECTION = 'db.mongodb.collection';
+    public const SYSTEM_CPU_STATE = 'system.cpu.state';
 
     /**
-     * Represents the identifier of an Elasticsearch cluster.
+     * The device identifier.
      *
-     * @example e9106fc68e3044f0b1475b04bf4ffd5f
+     * @example (identifier)
      */
-    public const DB_ELASTICSEARCH_CLUSTER_NAME = 'db.elasticsearch.cluster.name';
+    public const SYSTEM_DEVICE = 'system.device';
 
     /**
-     * Represents the human-readable identifier of the node/instance to which a request was routed.
+     * The disk operation direction.
      *
-     * @example instance-0000000001
+     * @example read
      */
-    public const DB_ELASTICSEARCH_NODE_NAME = 'db.elasticsearch.node.name';
+    public const SYSTEM_DISK_DIRECTION = 'system.disk.direction';
 
     /**
-     * The name of the primary table that the operation is acting upon, including the database name (if applicable).
+     * The filesystem mode.
      *
-     * It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+     * @example rw, ro
+     */
+    public const SYSTEM_FILESYSTEM_MODE = 'system.filesystem.mode';
+
+    /**
+     * The filesystem mount path.
      *
-     * @example public.users
-     * @example customers
+     * @example /mnt/data
      */
-    public const DB_SQL_TABLE = 'db.sql.table';
+    public const SYSTEM_FILESYSTEM_MOUNTPOINT = 'system.filesystem.mountpoint';
 
     /**
-     * Unique Cosmos client instance id.
+     * The filesystem state.
      *
-     * @example 3ba4827d-4422-483f-b59f-85b74211c11d
+     * @example used
      */
-    public const DB_COSMOSDB_CLIENT_ID = 'db.cosmosdb.client_id';
+    public const SYSTEM_FILESYSTEM_STATE = 'system.filesystem.state';
 
     /**
-     * Cosmos client connection mode.
-     */
-    public const DB_COSMOSDB_CONNECTION_MODE = 'db.cosmosdb.connection_mode';
-
-    /**
-     * Cosmos DB container name.
+     * The filesystem type.
      *
-     * @example anystring
+     * @example ext4
      */
-    public const DB_COSMOSDB_CONTAINER = 'db.cosmosdb.container';
+    public const SYSTEM_FILESYSTEM_TYPE = 'system.filesystem.type';
 
     /**
-     * CosmosDB Operation Type.
-     */
-    public const DB_COSMOSDB_OPERATION_TYPE = 'db.cosmosdb.operation_type';
-
-    /**
-     * RU consumed for that operation.
+     * The memory state.
      *
-     * @example 46.18
-     * @example 1.0
+     * @example free
+     * @example cached
      */
-    public const DB_COSMOSDB_REQUEST_CHARGE = 'db.cosmosdb.request_charge';
+    public const SYSTEM_MEMORY_STATE = 'system.memory.state';
 
     /**
-     * Request payload size in bytes.
-     */
-    public const DB_COSMOSDB_REQUEST_CONTENT_LENGTH = 'db.cosmosdb.request_content_length';
-
-    /**
-     * Cosmos DB status code.
+     * .
      *
-     * @example 200
-     * @example 201
+     * @example transmit
      */
-    public const DB_COSMOSDB_STATUS_CODE = 'db.cosmosdb.status_code';
+    public const SYSTEM_NETWORK_DIRECTION = 'system.network.direction';
 
     /**
-     * Cosmos DB sub status code.
+     * A stateless protocol MUST NOT set this attribute.
      *
-     * @example 1000
-     * @example 1002
+     * @example close_wait
      */
-    public const DB_COSMOSDB_SUB_STATUS_CODE = 'db.cosmosdb.sub_status_code';
+    public const SYSTEM_NETWORK_STATE = 'system.network.state';
 
     /**
-     * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status code is UNSET.
-     */
-    public const OTEL_STATUS_CODE = 'otel.status_code';
-
-    /**
-     * Description of the Status if it has a value, otherwise not set.
+     * The paging access direction.
      *
-     * @example resource not found
+     * @example in
      */
-    public const OTEL_STATUS_DESCRIPTION = 'otel.status_description';
+    public const SYSTEM_PAGING_DIRECTION = 'system.paging.direction';
 
     /**
-     * The invocation ID of the current function invocation.
+     * The memory paging state.
      *
-     * @example af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+     * @example free
      */
-    public const FAAS_INVOCATION_ID = 'faas.invocation_id';
+    public const SYSTEM_PAGING_STATE = 'system.paging.state';
 
     /**
-     * The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
+     * The memory paging type.
      *
-     * @example myBucketName
-     * @example myDbName
+     * @example minor
      */
-    public const FAAS_DOCUMENT_COLLECTION = 'faas.document.collection';
+    public const SYSTEM_PAGING_TYPE = 'system.paging.type';
 
     /**
-     * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
+     * The process state, e.g., Linux Process State Codes.
      *
-     * @example myFile.txt
-     * @example myTableName
+     * @example running
      */
-    public const FAAS_DOCUMENT_NAME = 'faas.document.name';
+    public const SYSTEM_PROCESSES_STATUS = 'system.processes.status';
 
     /**
-     * Describes the type of the operation that was performed on the data.
+     * Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
+     *
+     * @example 42
      */
-    public const FAAS_DOCUMENT_OPERATION = 'faas.document.operation';
+    public const THREAD_ID = 'thread.id';
 
     /**
-     * A string containing the time when the data was accessed in the ISO 8601 format expressed in UTC.
+     * Current thread name.
      *
-     * @example 2020-01-23T13:47:06Z
+     * @example main
      */
-    public const FAAS_DOCUMENT_TIME = 'faas.document.time';
+    public const THREAD_NAME = 'thread.name';
 
     /**
-     * A string containing the schedule period as Cron Expression.
+     * The URI fragment component.
      *
-     * @example 0/5 * * * ? *
+     * @example SemConv
      */
-    public const FAAS_CRON = 'faas.cron';
+    public const URL_FRAGMENT = 'url.fragment';
 
     /**
-     * A string containing the function invocation time in the ISO 8601 format expressed in UTC.
+     * Absolute URL describing a network resource according to RFC3986.
      *
-     * @example 2020-01-23T13:47:06Z
+     * For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.
+     * `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password SHOULD be redacted and attribute's value SHOULD be `https://REDACTED:REDACTED@www.example.com/`.
+     * `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
+     *
+     * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
+     * @example //localhost
      */
-    public const FAAS_TIME = 'faas.time';
+    public const URL_FULL = 'url.full';
 
     /**
-     * A boolean that is true if the serverless function is executed for the first time (aka cold-start).
+     * The URI path component.
+     *
+     * @example /search
      */
-    public const FAAS_COLDSTART = 'faas.coldstart';
+    public const URL_PATH = 'url.path';
 
     /**
-     * The AWS request ID as returned in the response headers `x-amz-request-id` or `x-amz-requestid`.
+     * The URI query component.
      *
-     * @example 79b9da39-b7ae-508a-a6bc-864b2829c622
-     * @example C9ER4AJX75574TDJ
+     * Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
+     *
+     * @example q=OpenTelemetry
      */
-    public const AWS_REQUEST_ID = 'aws.request_id';
+    public const URL_QUERY = 'url.query';
 
     /**
-     * The value of the `AttributesToGet` request parameter.
+     * The URI scheme component identifying the used protocol.
      *
-     * @example lives
-     * @example id
+     * @example http
+     * @example https
      */
-    public const AWS_DYNAMODB_ATTRIBUTES_TO_GET = 'aws.dynamodb.attributes_to_get';
+    public const URL_SCHEME = 'url.scheme';
 
     /**
-     * The value of the `ConsistentRead` request parameter.
+     * Value of the HTTP User-Agent header sent by the client.
+     *
+     * @example CERN-LineMode/2.15 libwww/2.17b3
+     * @example Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1
      */
-    public const AWS_DYNAMODB_CONSISTENT_READ = 'aws.dynamodb.consistent_read';
-
-    /**
-     * The JSON-serialized value of each item in the `ConsumedCapacity` response field.
-     *
-     * @example { "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }
-     */
-    public const AWS_DYNAMODB_CONSUMED_CAPACITY = 'aws.dynamodb.consumed_capacity';
-
-    /**
-     * The value of the `IndexName` request parameter.
-     *
-     * @example name_to_group
-     */
-    public const AWS_DYNAMODB_INDEX_NAME = 'aws.dynamodb.index_name';
-
-    /**
-     * The JSON-serialized value of the `ItemCollectionMetrics` response field.
-     *
-     * @example { "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }
-     */
-    public const AWS_DYNAMODB_ITEM_COLLECTION_METRICS = 'aws.dynamodb.item_collection_metrics';
-
-    /**
-     * The value of the `Limit` request parameter.
-     *
-     * @example 10
-     */
-    public const AWS_DYNAMODB_LIMIT = 'aws.dynamodb.limit';
-
-    /**
-     * The value of the `ProjectionExpression` request parameter.
-     *
-     * @example Title
-     * @example Title, Price, Color
-     * @example Title, Description, RelatedItems, ProductReviews
-     */
-    public const AWS_DYNAMODB_PROJECTION = 'aws.dynamodb.projection';
-
-    /**
-     * The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
-     *
-     * @example 1.0
-     * @example 2.0
-     */
-    public const AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = 'aws.dynamodb.provisioned_read_capacity';
-
-    /**
-     * The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
-     *
-     * @example 1.0
-     * @example 2.0
-     */
-    public const AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = 'aws.dynamodb.provisioned_write_capacity';
-
-    /**
-     * The value of the `Select` request parameter.
-     *
-     * @example ALL_ATTRIBUTES
-     * @example COUNT
-     */
-    public const AWS_DYNAMODB_SELECT = 'aws.dynamodb.select';
-
-    /**
-     * The keys in the `RequestItems` object field.
-     *
-     * @example Users
-     * @example Cats
-     */
-    public const AWS_DYNAMODB_TABLE_NAMES = 'aws.dynamodb.table_names';
-
-    /**
-     * The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
-     *
-     * @example { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }
-     */
-    public const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = 'aws.dynamodb.global_secondary_indexes';
-
-    /**
-     * The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.
-     *
-     * @example { "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }
-     */
-    public const AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = 'aws.dynamodb.local_secondary_indexes';
-
-    /**
-     * The value of the `ExclusiveStartTableName` request parameter.
-     *
-     * @example Users
-     * @example CatsTable
-     */
-    public const AWS_DYNAMODB_EXCLUSIVE_START_TABLE = 'aws.dynamodb.exclusive_start_table';
-
-    /**
-     * The the number of items in the `TableNames` response parameter.
-     *
-     * @example 20
-     */
-    public const AWS_DYNAMODB_TABLE_COUNT = 'aws.dynamodb.table_count';
-
-    /**
-     * The value of the `ScanIndexForward` request parameter.
-     */
-    public const AWS_DYNAMODB_SCAN_FORWARD = 'aws.dynamodb.scan_forward';
-
-    /**
-     * The value of the `Count` response parameter.
-     *
-     * @example 10
-     */
-    public const AWS_DYNAMODB_COUNT = 'aws.dynamodb.count';
-
-    /**
-     * The value of the `ScannedCount` response parameter.
-     *
-     * @example 50
-     */
-    public const AWS_DYNAMODB_SCANNED_COUNT = 'aws.dynamodb.scanned_count';
-
-    /**
-     * The value of the `Segment` request parameter.
-     *
-     * @example 10
-     */
-    public const AWS_DYNAMODB_SEGMENT = 'aws.dynamodb.segment';
-
-    /**
-     * The value of the `TotalSegments` request parameter.
-     *
-     * @example 100
-     */
-    public const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
-
-    /**
-     * The JSON-serialized value of each item in the `AttributeDefinitions` request field.
-     *
-     * @example { "AttributeName": "string", "AttributeType": "string" }
-     */
-    public const AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS = 'aws.dynamodb.attribute_definitions';
-
-    /**
-     * The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates` request field.
-     *
-     * @example { "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }
-     */
-    public const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = 'aws.dynamodb.global_secondary_index_updates';
-
-    /**
-     * The S3 bucket name the request refers to. Corresponds to the `--bucket` parameter of the S3 API operations.
-     *
-     * The `bucket` attribute is applicable to all S3 operations that reference a bucket, i.e. that require the bucket name as a mandatory parameter.
-     * This applies to almost all S3 operations except `list-buckets`.
-     *
-     * @example some-bucket-name
-     */
-    public const AWS_S3_BUCKET = 'aws.s3.bucket';
-
-    /**
-     * The source object (in the form `bucket`/`key`) for the copy operation.
-     *
-     * The `copy_source` attribute applies to S3 copy operations and corresponds to the `--copy-source` parameter
-     * of the copy-object operation within the S3 API.
-     * This applies in particular to the following operations:<ul>
-     * <li>copy-object</li>
-     * <li>upload-part-copy</li>
-     * </ul>
-     *
-     * @example someFile.yml
-     */
-    public const AWS_S3_COPY_SOURCE = 'aws.s3.copy_source';
-
-    /**
-     * The delete request container that specifies the objects to be deleted.
-     *
-     * The `delete` attribute is only applicable to the delete-object operation.
-     * The `delete` attribute corresponds to the `--delete` parameter of the
-     * delete-objects operation within the S3 API.
-     *
-     * @example Objects=[{Key=string,VersionId=string},{Key=string,VersionId=string}],Quiet=boolean
-     */
-    public const AWS_S3_DELETE = 'aws.s3.delete';
-
-    /**
-     * The S3 object key the request refers to. Corresponds to the `--key` parameter of the S3 API operations.
-     *
-     * The `key` attribute is applicable to all object-related S3 operations, i.e. that require the object key as a mandatory parameter.
-     * This applies in particular to the following operations:<ul>
-     * <li>copy-object</li>
-     * <li>delete-object</li>
-     * <li>get-object</li>
-     * <li>head-object</li>
-     * <li>put-object</li>
-     * <li>restore-object</li>
-     * <li>select-object-content</li>
-     * <li>abort-multipart-upload</li>
-     * <li>complete-multipart-upload</li>
-     * <li>create-multipart-upload</li>
-     * <li>list-parts</li>
-     * <li>upload-part</li>
-     * <li>upload-part-copy</li>
-     * </ul>
-     *
-     * @example someFile.yml
-     */
-    public const AWS_S3_KEY = 'aws.s3.key';
-
-    /**
-     * The part number of the part being uploaded in a multipart-upload operation. This is a positive integer between 1 and 10,000.
-     *
-     * The `part_number` attribute is only applicable to the upload-part
-     * and upload-part-copy operations.
-     * The `part_number` attribute corresponds to the `--part-number` parameter of the
-     * upload-part operation within the S3 API.
-     *
-     * @example 3456
-     */
-    public const AWS_S3_PART_NUMBER = 'aws.s3.part_number';
-
-    /**
-     * Upload ID that identifies the multipart upload.
-     *
-     * The `upload_id` attribute applies to S3 multipart-upload operations and corresponds to the `--upload-id` parameter
-     * of the S3 API multipart operations.
-     * This applies in particular to the following operations:<ul>
-     * <li>abort-multipart-upload</li>
-     * <li>complete-multipart-upload</li>
-     * <li>list-parts</li>
-     * <li>upload-part</li>
-     * <li>upload-part-copy</li>
-     * </ul>
-     *
-     * @example dfRtDYWFbkRONycy.Yxwh66Yjlx.cph0gtNBtJ
-     */
-    public const AWS_S3_UPLOAD_ID = 'aws.s3.upload_id';
-
-    /**
-     * The GraphQL document being executed.
-     *
-     * The value may be sanitized to exclude sensitive information.
-     *
-     * @example query findBookById { bookById(id: ?) { name } }
-     */
-    public const GRAPHQL_DOCUMENT = 'graphql.document';
-
-    /**
-     * The name of the operation being executed.
-     *
-     * @example findBookById
-     */
-    public const GRAPHQL_OPERATION_NAME = 'graphql.operation.name';
-
-    /**
-     * The type of the operation being executed.
-     *
-     * @example query
-     * @example mutation
-     * @example subscription
-     */
-    public const GRAPHQL_OPERATION_TYPE = 'graphql.operation.type';
-
-    /**
-     * Compressed size of the message in bytes.
-     */
-    public const MESSAGE_COMPRESSED_SIZE = 'message.compressed_size';
-
-    /**
-     * MUST be calculated as two different counters starting from `1` one for sent messages and one for received message.
-     *
-     * This way we guarantee that the values will be consistent between different implementations.
-     */
-    public const MESSAGE_ID = 'message.id';
-
-    /**
-     * Whether this is a received or sent message.
-     */
-    public const MESSAGE_TYPE = 'message.type';
-
-    /**
-     * Uncompressed size of the message in bytes.
-     */
-    public const MESSAGE_UNCOMPRESSED_SIZE = 'message.uncompressed_size';
-
-    /**
-     * SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.
-     *
-     * An exception is considered to have escaped (or left) the scope of a span,
-     * if that span is ended while the exception is still logically &quot;in flight&quot;.
-     * This may be actually &quot;in flight&quot; in some languages (e.g. if the exception
-     * is passed to a Context manager's `__exit__` method in Python) but will
-     * usually be caught at the point of recording the exception in most languages.It is usually not possible to determine at the point where an exception is thrown
-     * whether it will escape the scope of a span.
-     * However, it is trivial to know that an exception
-     * will escape, if one checks for an active exception just before ending the span,
-     * as done in the example above.It follows that an exception may still escape the scope of the span
-     * even if the `exception.escaped` attribute was not set or set to false,
-     * since the event might have been recorded at a time where it was not
-     * clear whether the exception will escape.
-     */
-    public const EXCEPTION_ESCAPED = 'exception.escaped';
+    public const USER_AGENT_ORIGINAL = 'user_agent.original';
 
     /**
      * @deprecated


### PR DESCRIPTION
a bug in 1.23.0 meant that cloud, container and oci resource attributes were incorrectly published under trace attributes. sort the attributes, so that future diffs are easier to read.