### PR TITLE
Set default value for SchemaURL in cached instrumentation

### DIFF
--- a/src/API/Instrumentation/CachedInstrumentation.php
+++ b/src/API/Instrumentation/CachedInstrumentation.php
@@ -38,11 +38,11 @@ final class CachedInstrumentation
     /** @var ArrayAccess<LoggerProviderInterface, LoggerInterface>|null */
     private ?ArrayAccess $loggers;
 
-    public function __construct(string $name, ?string $version = null, string $schemaUrl = TraceAttributes::SCHEMA_URL, iterable $attributes = [])
+    public function __construct(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = [])
     {
         $this->name = $name;
         $this->version = $version;
-        $this->schemaUrl = $schemaUrl;
+        $this->schemaUrl = ($schemaUrl !== null && $schemaUrl !== '') ? $schemaUrl : TraceAttributes::SCHEMA_URL;
         $this->attributes = $attributes;
         $this->tracers = self::createWeakMap();
         $this->meters = self::createWeakMap();

--- a/src/API/Instrumentation/CachedInstrumentation.php
+++ b/src/API/Instrumentation/CachedInstrumentation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\API\Instrumentation;
 
 use ArrayAccess;
+use OpenTelemetry\SemConv\TraceAttributes;
 use function assert;
 use function class_exists;
 use OpenTelemetry\API\Globals;
@@ -37,7 +38,7 @@ final class CachedInstrumentation
     /** @var ArrayAccess<LoggerProviderInterface, LoggerInterface>|null */
     private ?ArrayAccess $loggers;
 
-    public function __construct(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = [])
+    public function __construct(string $name, ?string $version = null, string $schemaUrl = TraceAttributes::SCHEMA_URL, iterable $attributes = [])
     {
         $this->name = $name;
         $this->version = $version;

--- a/src/API/Instrumentation/CachedInstrumentation.php
+++ b/src/API/Instrumentation/CachedInstrumentation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\API\Instrumentation;
 
 use ArrayAccess;
-use OpenTelemetry\SemConv\TraceAttributes;
 use function assert;
 use function class_exists;
 use OpenTelemetry\API\Globals;
@@ -15,6 +14,7 @@ use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Metrics\MeterProviderInterface;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\SemConv\TraceAttributes;
 use const PHP_VERSION_ID;
 
 /**


### PR DESCRIPTION
Based on our conversation [here](https://github.com/open-telemetry/opentelemetry-php-contrib/pull/218#discussion_r1416347123), we probably want to apply the schema url as a default value.