### PR TITLE
Serialize protobuf enums as integer

### DIFF
--- a/tests/Unit/Contrib/Otlp/MetricExporterTest.php
+++ b/tests/Unit/Contrib/Otlp/MetricExporterTest.php
@@ -50,7 +50,7 @@ final class MetricExporterTest extends TestCase
 
         fseek($this->stream, 0);
         $this->assertSame(<<<METRICS
-            {"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"test"},"metrics":[{"name":"test","sum":{"dataPoints":[{"startTimeUnixNano":"17","timeUnixNano":"42","asInt":"5"}],"aggregationTemporality":"AGGREGATION_TEMPORALITY_DELTA"}}]}]}]}
+            {"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"test"},"metrics":[{"name":"test","sum":{"dataPoints":[{"startTimeUnixNano":"17","timeUnixNano":"42","asInt":"5"}],"aggregationTemporality":1}}]}]}]}
 
             METRICS, stream_get_contents($this->stream));
     }
@@ -84,8 +84,8 @@ final class MetricExporterTest extends TestCase
 
         fseek($this->stream, 0);
         $this->assertSame(<<<METRICS
-            {"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"test"},"metrics":[{"name":"test","sum":{"dataPoints":[{"startTimeUnixNano":"17","timeUnixNano":"42","asInt":"5"}],"aggregationTemporality":"AGGREGATION_TEMPORALITY_DELTA"}}]}]}]}
-            {"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"test"},"metrics":[{"name":"test","sum":{"dataPoints":[{"startTimeUnixNano":"42","timeUnixNano":"57","asInt":"7"}],"aggregationTemporality":"AGGREGATION_TEMPORALITY_DELTA"}}]}]}]}
+            {"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"test"},"metrics":[{"name":"test","sum":{"dataPoints":[{"startTimeUnixNano":"17","timeUnixNano":"42","asInt":"5"}],"aggregationTemporality":1}}]}]}]}
+            {"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{"name":"test"},"metrics":[{"name":"test","sum":{"dataPoints":[{"startTimeUnixNano":"42","timeUnixNano":"57","asInt":"7"}],"aggregationTemporality":1}}]}]}]}
 
             METRICS, stream_get_contents($this->stream));
     }

--- a/tests/Unit/Contrib/Otlp/SpanExporterTest.php
+++ b/tests/Unit/Contrib/Otlp/SpanExporterTest.php
@@ -91,7 +91,7 @@ class SpanExporterTest extends TestCase
                                         "traceId": "0af7651916cd43dd8448eb211c80319c",
                                         "spanId": "b7ad6b7169203331",
                                         "name": "test-span-data",
-                                        "kind": "SPAN_KIND_INTERNAL",
+                                        "kind": 1,
                                         "startTimeUnixNano": "1505855794194009601",
                                         "endTimeUnixNano": "1505855799465726528",
                                         "status": {}


### PR DESCRIPTION
Workaround for #978, traverses the serialized json payload and replaces every enum value with its respective numeric value.