### PR TITLE
Prevent propagator packages from throwing fatal error if sdk not installed

### DIFF
--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -1,2 +1,11 @@
 deptrac:
   skip_violations:
+    /src/Extension/Propagator/B3/_register.php:
+      - OpenTelemetry\SDK\Common\Configuration\KnownValues
+      - OpenTelemetry\SDK\Registry
+    /src/Extension/Propagator/CloudTrace/_register.php:
+      - OpenTelemetry\SDK\Common\Configuration\KnownValues
+      - OpenTelemetry\SDK\Registry
+    /src/Extension/Propagator/Jaeger/_register.php:
+      - OpenTelemetry\SDK\Common\Configuration\KnownValues
+      - OpenTelemetry\SDK\Registry

--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -1,11 +1,8 @@
 deptrac:
   skip_violations:
     /src/Extension/Propagator/B3/_register.php:
-      - OpenTelemetry\SDK\Common\Configuration\KnownValues
       - OpenTelemetry\SDK\Registry
     /src/Extension/Propagator/CloudTrace/_register.php:
-      - OpenTelemetry\SDK\Common\Configuration\KnownValues
       - OpenTelemetry\SDK\Registry
     /src/Extension/Propagator/Jaeger/_register.php:
-      - OpenTelemetry\SDK\Common\Configuration\KnownValues
       - OpenTelemetry\SDK\Registry

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -19,34 +19,32 @@ deptrac:
     layers:
       -   name: API
           collectors:
-              -   type: className
-                  regex: ^OpenTelemetry\\API\\*
+              -   type: directory
+                  value: src/API/.*
       -   name: SDK
           collectors:
-              -   type: className
-                  regex: ^OpenTelemetry\\SDK\\*
+              -   type: directory
+                  value: src/SDK/.*
       -   name: Context
           collectors:
-              -   type: className
-                  regex: ^OpenTelemetry\\Context\\*
+              -   type: directory
+                  value: src/Context/.*
       -   name: SemConv
           collectors:
-              -   type: className
-                  regex: ^OpenTelemetry\\SemConv\\*
+              -   type: directory
+                  value: src/SemConv/.*
       -   name: Contrib
           collectors:
-              -   type: className
-                  regex: ^OpenTelemetry\\Contrib\\*
+              -   type: directory
+                  value: src/Contrib/.*
       -   name: Extension
           collectors:
-            -   type: className
-                regex: ^OpenTelemetry\\Extension\\*
+              -   type: directory
+                  value: src/Extension/.*
       -   name: OtelProto
           collectors:
-              -   type: className
-                  regex: ^OpenTelemetry\\Proto\\*
-              -   type: className
-                  regex: ^GPBMetadata\\Opentelemetry\\*
+              -   type: directory
+                  value: proto/otel/.*
       -   name: GoogleProtobuf
           collectors:
               -   type: className

--- a/src/Extension/Propagator/B3/_register.php
+++ b/src/Extension/Propagator/B3/_register.php
@@ -6,6 +6,10 @@ use OpenTelemetry\Extension\Propagator\B3\B3Propagator;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Registry;
 
+if (!class_exists(Registry::class)) {
+    return;
+}
+
 Registry::registerTextMapPropagator(
     KnownValues::VALUE_B3,
     B3Propagator::getB3SingleHeaderInstance()

--- a/src/Extension/Propagator/B3/_register.php
+++ b/src/Extension/Propagator/B3/_register.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use OpenTelemetry\Extension\Propagator\B3\B3Propagator;
-use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Registry;
 
 if (!class_exists(Registry::class)) {
@@ -11,10 +10,10 @@ if (!class_exists(Registry::class)) {
 }
 
 Registry::registerTextMapPropagator(
-    KnownValues::VALUE_B3,
+    'b3',
     B3Propagator::getB3SingleHeaderInstance()
 );
 Registry::registerTextMapPropagator(
-    KnownValues::VALUE_B3_MULTI,
+    'b3multi',
     B3Propagator::getB3MultiHeaderInstance()
 );

--- a/src/Extension/Propagator/CloudTrace/_register.php
+++ b/src/Extension/Propagator/CloudTrace/_register.php
@@ -6,6 +6,10 @@ use OpenTelemetry\Extension\Propagator\CloudTrace\CloudTracePropagator;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Registry;
 
+if (!class_exists(Registry::class)) {
+    return;
+}
+
 Registry::registerTextMapPropagator(
     KnownValues::VALUE_CLOUD_TRACE,
     CloudTracePropagator::getInstance()

--- a/src/Extension/Propagator/CloudTrace/_register.php
+++ b/src/Extension/Propagator/CloudTrace/_register.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use OpenTelemetry\Extension\Propagator\CloudTrace\CloudTracePropagator;
-use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Registry;
 
 if (!class_exists(Registry::class)) {
@@ -11,11 +10,11 @@ if (!class_exists(Registry::class)) {
 }
 
 Registry::registerTextMapPropagator(
-    KnownValues::VALUE_CLOUD_TRACE,
+    'cloudtrace',
     CloudTracePropagator::getInstance()
 );
 
 Registry::registerTextMapPropagator(
-    KnownValues::VALUE_CLOUD_TRACE_ONEWAY,
+    'cloudtrace-oneway',
     CloudTracePropagator::getOneWayInstance()
 );

--- a/src/Extension/Propagator/Jaeger/_register.php
+++ b/src/Extension/Propagator/Jaeger/_register.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use OpenTelemetry\Extension\Propagator\Jaeger\JaegerBaggagePropagator;
 use OpenTelemetry\Extension\Propagator\Jaeger\JaegerPropagator;
-use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Registry;
 
 if (!class_exists(Registry::class)) {
@@ -12,11 +11,11 @@ if (!class_exists(Registry::class)) {
 }
 
 Registry::registerTextMapPropagator(
-    KnownValues::VALUE_JAEGER,
+    'jaeger',
     JaegerPropagator::getInstance()
 );
 
 Registry::registerTextMapPropagator(
-    KnownValues::VALUE_JAEGER_BAGGAGE,
+    'jaeger-baggage',
     JaegerBaggagePropagator::getInstance()
 );

--- a/src/Extension/Propagator/Jaeger/_register.php
+++ b/src/Extension/Propagator/Jaeger/_register.php
@@ -7,6 +7,10 @@ use OpenTelemetry\Extension\Propagator\Jaeger\JaegerPropagator;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues;
 use OpenTelemetry\SDK\Registry;
 
+if (!class_exists(Registry::class)) {
+    return;
+}
+
 Registry::registerTextMapPropagator(
     KnownValues::VALUE_JAEGER,
     JaegerPropagator::getInstance()


### PR DESCRIPTION
```shell
$ composer init --require open-telemetry/extension-propagator-b3:^1.0 -n && composer u && php vendor/autoload.php
```
```
Fatal error: Uncaught Error: Class "OpenTelemetry\SDK\Registry" not found in /php/propagators-fatal-error/vendor/open-telemetry/extension-propagator-b3/_register.php:9
Stack trace:
#0 /php/propagators-fatal-error/vendor/composer/autoload_real.php(41): require()
#1 /php/propagators-fatal-error/vendor/composer/autoload_real.php(45): {closure}('2cea4639ba6ec5b...', '/php/propagator...')
#2 /php/propagators-fatal-error/vendor/autoload.php(25): ComposerAutoloaderInit35b4c2f542c1313891bfa1d737057525::getLoader()
#3 {main}
  thrown in /php/propagators-fatal-error/vendor/open-telemetry/extension-propagator-b3/_register.php on line 9
```