### PR TITLE
Fix delta storage failing to merge node under rare circumstances

### DIFF
--- a/src/SDK/Metrics/Stream/DeltaStorage.php
+++ b/src/SDK/Metrics/Stream/DeltaStorage.php
@@ -91,7 +91,7 @@ final class DeltaStorage
              $c = $c->prev) {
         }
 
-        if ($c && $n->prev->readers === $c->readers) {
+        if ($c && $n->prev->readers == $c->readers) {
             $this->mergeInto($c->metric, $n->prev->metric);
             $n->prev = $n->prev->prev;
         }


### PR DESCRIPTION
Only fails if a node that was created after exceeding 63 readers should be merged with a node that was created before exceeding 63 readers, resulting in a `GMP===int` comparison. Affected nodes were still merged on the next `::collect()` call -> solely internal change.

```php
$stream = new SynchronousMetricStream(new SumAggregation(), 0, 2000);
for ($i = 0; $i < 63; $i++) {
    $stream->register(Temporality::Delta);
}

$stream->push(new Metric([], [], 0));
$reader = $stream->register(Temporality::Delta);
$stream->push(new Metric([], [], 0));

$stream->collect($reader); // storage should contain a single node at this point
```