### PR TITLE
Add option to disable debug scopes

### DIFF
--- a/src/Context/README.md
+++ b/src/Context/README.md
@@ -31,6 +31,12 @@ try {
 
 It is recommended to use a `try-finally` statement after `::activate()` to ensure that the created scope is properly `::detach()`ed.
 
+### Debug scopes
+
+By default, scopes created by `::activate()` warn on invalid and missing calls to `::detach()` in non-production
+environments. This feature can be disabled by setting the environment variable `OTEL_PHP_DEBUG_SCOPES_DISABLED` to a
+truthy value. Disabling is only recommended for applications using `exit` / `die` to prevent unavoidable notices.
+
 ## Async applications
 
 ### Fiber support

--- a/tests/Unit/Context/DebugScopeTest.php
+++ b/tests/Unit/Context/DebugScopeTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\Context;
 
+use function ini_set;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\DebugScope;
 use PHPUnit\Framework\Exception as PHPUnitFrameworkException;
 use PHPUnit\Framework\TestCase;
 
@@ -13,6 +15,55 @@ use PHPUnit\Framework\TestCase;
  */
 final class DebugScopeTest extends TestCase
 {
+
+    /**
+     * @covers \OpenTelemetry\Context\Context::activate
+     * @covers \OpenTelemetry\Context\Context::debugScopesDisabled
+     */
+    public function test_debug_scope_enabled_by_default(): void
+    {
+        $scope = Context::getCurrent()->activate();
+
+        try {
+            self::assertInstanceOf(DebugScope::class, $scope);
+        } finally {
+            $scope->detach();
+        }
+    }
+
+    /**
+     * @covers \OpenTelemetry\Context\Context::activate
+     */
+    public function test_disable_debug_scope_using_assertion_mode(): void
+    {
+        ini_set('zend.assertions', '0');
+        $scope = Context::getCurrent()->activate();
+
+        try {
+            self::assertNotInstanceOf(DebugScope::class, $scope);
+        } finally {
+            ini_set('zend.assertions', '1');
+            $scope->detach();
+        }
+    }
+
+    /**
+     * @covers \OpenTelemetry\Context\Context::activate
+     * @covers \OpenTelemetry\Context\Context::debugScopesDisabled
+     * @backupGlobals
+     */
+    public function test_disable_debug_scope_using_otel_php_debug_scopes_disabled(): void
+    {
+        $_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'] = 'true';
+        $scope = Context::getCurrent()->activate();
+
+        try {
+            self::assertNotInstanceOf(DebugScope::class, $scope);
+        } finally {
+            $scope->detach();
+        }
+    }
+
     public function test_detached_scope_detach(): void
     {
         $scope1 = Context::getCurrent()->activate();


### PR DESCRIPTION
Allows disabling debug scopes via `OTEL_PHP_DEBUG_SCOPES_DISABLED`; resolves https://github.com/open-telemetry/opentelemetry-php/pull/1140#issuecomment-1880249248.
