### PR TITLE
optimize resource creation

### DIFF
--- a/src/Contrib/Otlp/OtlpUtil.php
+++ b/src/Contrib/Otlp/OtlpUtil.php
@@ -35,11 +35,16 @@ class OtlpUtil
      */
     public static function getUserAgentHeader(): array
     {
-        $resource = (new Sdk())->getResource();
+        static $header;
+        if ($header === null) {
+            $resource = (new Sdk())->getResource();
 
-        return ['User-Agent' => sprintf(
-            'OTel OTLP Exporter PHP/%s',
-            $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_VERSION) ?: 'unknown'
-        )];
+            $header = ['User-Agent' => sprintf(
+                'OTel OTLP Exporter PHP/%s',
+                $resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_VERSION) ?: 'unknown'
+            )];
+        }
+
+        return $header;
     }
 }

--- a/src/Contrib/Otlp/SpanExporterFactory.php
+++ b/src/Contrib/Otlp/SpanExporterFactory.php
@@ -12,7 +12,6 @@ use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Registry;
-use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 

--- a/src/Contrib/Otlp/SpanExporterFactory.php
+++ b/src/Contrib/Otlp/SpanExporterFactory.php
@@ -12,6 +12,7 @@ use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Registry;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 

--- a/src/SDK/Common/Configuration/Resolver/CompositeResolver.php
+++ b/src/SDK/Common/Configuration/Resolver/CompositeResolver.php
@@ -18,8 +18,8 @@ class CompositeResolver
     {
         static $instance;
         $instance ??= new self([
-            new PhpIniResolver(),
             new EnvironmentResolver(),
+            new PhpIniResolver(),
         ]);
 
         return $instance;

--- a/src/SDK/Logs/LoggerProviderFactory.php
+++ b/src/SDK/Logs/LoggerProviderFactory.php
@@ -6,11 +6,12 @@ namespace OpenTelemetry\SDK\Logs;
 
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
 use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Sdk;
 
 class LoggerProviderFactory
 {
-    public function create(?MeterProviderInterface $meterProvider = null): LoggerProviderInterface
+    public function create(?MeterProviderInterface $meterProvider = null, ?ResourceInfo $resource = null): LoggerProviderInterface
     {
         if (Sdk::isDisabled()) {
             return NoopLoggerProvider::getInstance();
@@ -19,6 +20,6 @@ class LoggerProviderFactory
         $processor = (new LogRecordProcessorFactory())->create($exporter, $meterProvider);
         $instrumentationScopeFactory = new InstrumentationScopeFactory((new LogRecordLimitsBuilder())->build()->getAttributeFactory());
 
-        return new LoggerProvider($processor, $instrumentationScopeFactory);
+        return new LoggerProvider($processor, $instrumentationScopeFactory, $resource);
     }
 }

--- a/src/SDK/Metrics/MeterProviderFactory.php
+++ b/src/SDK/Metrics/MeterProviderFactory.php
@@ -16,6 +16,7 @@ use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporter\NoopMetricExporter;
 use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
 use OpenTelemetry\SDK\Registry;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 use OpenTelemetry\SDK\Sdk;
 
@@ -28,7 +29,7 @@ class MeterProviderFactory
      *       - "The exporter MUST configure the default aggregation on the basis of instrument kind using the
      *         OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION variable as described below if it is implemented."
      */
-    public function create(): MeterProviderInterface
+    public function create(?ResourceInfo $resource = null): MeterProviderInterface
     {
         if (Sdk::isDisabled()) {
             return new NoopMeterProvider();
@@ -50,7 +51,7 @@ class MeterProviderFactory
 
         // @todo "The exporter MUST be paired with a periodic exporting MetricReader"
         $reader = new ExportingReader($exporter);
-        $resource = ResourceInfoFactory::defaultResource();
+        $resource ??= ResourceInfoFactory::defaultResource();
         $exemplarFilter = $this->createExemplarFilter(Configuration::getEnum(Variables::OTEL_METRICS_EXEMPLAR_FILTER));
 
         return MeterProvider::builder()

--- a/src/SDK/Resource/ResourceInfo.php
+++ b/src/SDK/Resource/ResourceInfo.php
@@ -50,7 +50,7 @@ class ResourceInfo
         $copyOfAttributesAsArray = array_slice($this->attributes->toArray(), 0); //This may be overly cautious (in trying to avoid mutating the source array)
         ksort($copyOfAttributesAsArray); //sort the associative array by keys since the serializer will consider equal arrays different otherwise
 
-        //The exact return value doesn't matter, as long as it can distingusih between instances that represent the same/different resources
+        //The exact return value doesn't matter, as long as it can distinguish between instances that represent the same/different resources
         return serialize([
             'schemaUrl' => $this->schemaUrl,
             'attributes' => $copyOfAttributesAsArray,
@@ -62,6 +62,7 @@ class ResourceInfo
      * resource, the value of the updating resource MUST be picked (even if the updated value is empty)
      *
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/resource/sdk.md#merge
+     * @todo can we optimize this to avoid re-validating the attributes on merge?
      */
     public function merge(ResourceInfo $updating): ResourceInfo
     {

--- a/tests/Benchmark/ResourceCreationBench.php
+++ b/tests/Benchmark/ResourceCreationBench.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Benchmark;
+
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+
+class ResourceCreationBench
+{
+    /**
+     * @Revs({100, 1000})
+     * @Iterations(10)
+     * @OutputTimeUnit("microseconds")
+     */
+    public function bench_create_default_resource(): void
+    {
+        ResourceInfoFactory::defaultResource();
+    }
+}


### PR DESCRIPTION
Profiling the SDK autoloader startup with xdebug, I could see that we re-detect resources multiple times which adds overhead.

- instead of creating new resources from various factories, create them once from sdk autoloader and
pass them to the factories (most of which already supported this).
- cache header from OtlpUtil, to save a couple of constructor calls to Sdk detector
- check env before php.ini for config, since this is the more popular approach and saves some cycles
- note as a todo that we could save some further cycles around resource merging by not re-validating attributes