### PR TITLE
optimize resource merging

### DIFF
--- a/src/SDK/Common/Attribute/AttributesBuilder.php
+++ b/src/SDK/Common/Attribute/AttributesBuilder.php
@@ -43,6 +43,21 @@ final class AttributesBuilder implements AttributesBuilderInterface
         return new Attributes($this->attributes, $this->droppedAttributesCount);
     }
 
+    public function merge(AttributesInterface $old, AttributesInterface $updating): AttributesInterface
+    {
+        $new = $old->toArray();
+        $dropped = $old->getDroppedAttributesCount() + $updating->getDroppedAttributesCount();
+        foreach ($updating->toArray() as $key => $value) {
+            if (count($new) === $this->attributeCountLimit && !array_key_exists($key, $new)) {
+                $dropped++;
+            } else {
+                $new[$key] = $value;
+            }
+        }
+
+        return new Attributes($new, $dropped);
+    }
+
     public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->attributes);

--- a/src/SDK/Common/Attribute/AttributesBuilderInterface.php
+++ b/src/SDK/Common/Attribute/AttributesBuilderInterface.php
@@ -9,4 +9,5 @@ use ArrayAccess;
 interface AttributesBuilderInterface extends ArrayAccess
 {
     public function build(): AttributesInterface;
+    public function merge(AttributesInterface $old, AttributesInterface $updating): AttributesInterface;
 }

--- a/src/SDK/Common/Attribute/FilteredAttributesBuilder.php
+++ b/src/SDK/Common/Attribute/FilteredAttributesBuilder.php
@@ -37,6 +37,11 @@ final class FilteredAttributesBuilder implements AttributesBuilderInterface
         return new Attributes($attributes->toArray(), $dropped);
     }
 
+    public function merge(AttributesInterface $old, AttributesInterface $updating): AttributesInterface
+    {
+        return $this->builder->merge($old, $updating);
+    }
+
     public function offsetExists($offset): bool
     {
         return $this->builder->offsetExists($offset);

--- a/src/SDK/Common/Util/ClassConstantAccessor.php
+++ b/src/SDK/Common/Util/ClassConstantAccessor.php
@@ -30,6 +30,6 @@ class ClassConstantAccessor
 
     private static function getFullName(string $className, string $constantName): string
     {
-        return sprintf('%s::%s', $className, $constantName);
+        return $className . '::' . $constantName;
     }
 }

--- a/src/SDK/Resource/ResourceInfo.php
+++ b/src/SDK/Resource/ResourceInfo.php
@@ -67,9 +67,9 @@ class ResourceInfo
     public function merge(ResourceInfo $updating): ResourceInfo
     {
         $schemaUrl = self::mergeSchemaUrl($this->getSchemaUrl(), $updating->getSchemaUrl());
-        $attributes = $updating->getAttributes()->toArray() + $this->getAttributes()->toArray();
+        $attributes = Attributes::factory()->builder()->merge($this->getAttributes(), $updating->getAttributes());
 
-        return ResourceInfo::create(Attributes::create($attributes), $schemaUrl);
+        return ResourceInfo::create($attributes, $schemaUrl);
     }
 
     /**

--- a/tests/Unit/SDK/Common/Attribute/AttributesTest.php
+++ b/tests/Unit/SDK/Common/Attribute/AttributesTest.php
@@ -169,4 +169,17 @@ class AttributesTest extends TestCase
         $attributesBuilder['foo'] = 'bar';
         $this->assertEquals(0, $attributesBuilder->build()->getDroppedAttributesCount());
     }
+
+    public function test_merge_attributes(): void
+    {
+        $one = Attributes::factory(1)->builder(['foo' => 'foo', 'foobar' => 'foobar'])->build();
+        $two = Attributes::factory(2)->builder(['bar' => 'bar', 'baz' => 'baz'])->build();
+        $merged = Attributes::factory(2)->builder()->merge($one, $two);
+
+        $this->assertEquals([
+            'foo' => 'foo',
+            'bar' => 'bar',
+        ], $merged->toArray());
+        $this->assertSame(2, $merged->getDroppedAttributesCount(), 'foobar and baz dropped');
+    }
 }


### PR DESCRIPTION
- do not revalidate/normalize resource attributes on merge, since they have already been validated/normalized
- string concat is about 10x faster than sprintf, so use it in ClassConstantAccessor since it's called many times