### PR TITLE
generate semconv 1.24.0

### DIFF
--- a/script/semantic-conventions/semconv.sh
+++ b/script/semantic-conventions/semconv.sh
@@ -5,6 +5,10 @@
 # Supported semantic conventions:
 #  - Trace
 #  - Resource
+#
+# Source repositories:
+#  - https://github.com/open-telemetry/semantic-conventions/releases
+#  - https://github.com/open-telemetry/build-tools/releases
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"

--- a/script/semantic-conventions/semconv.sh
+++ b/script/semantic-conventions/semconv.sh
@@ -12,7 +12,7 @@ SPEC_DIR="${ROOT_DIR}/var/semantic-conventions"
 CODE_DIR="${ROOT_DIR}/src/SemConv"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=${SEMCONV_VERSION:=1.23.1}
+SEMCONV_VERSION=${SEMCONV_VERSION:=1.24.0}
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.23.0
@@ -61,6 +61,38 @@ docker run --rm \
   code \
   --template /templates/Attributes.php.j2 \
   --output "/output/ResourceAttributes.php" \
+  -Dnamespace="OpenTelemetry\\SemConv" \
+  -Dclass="Resource" \
+  -DschemaUrl=$SCHEMA_URL
+
+# Trace attribute values
+docker run --rm \
+  -v "${SPEC_DIR}/model:/source" \
+  -v "${SCRIPT_DIR}/templates:/templates" \
+  -v "${CODE_DIR}:/output" \
+  -u "${UID}" \
+  otel/semconvgen:$GENERATOR_VERSION \
+  --only span,event,attribute_group,scope \
+  --yaml-root /source \
+  code \
+  --template /templates/AttributeValues.php.j2 \
+  --output "/output/TraceAttributeValues.php" \
+  -Dnamespace="OpenTelemetry\\SemConv" \
+  -Dclass="Trace" \
+  -DschemaUrl=$SCHEMA_URL
+
+# Resource attribute values
+docker run --rm \
+  -v "${SPEC_DIR}/model:/source" \
+  -v "${SCRIPT_DIR}/templates:/templates" \
+  -v "${CODE_DIR}:/output" \
+  -u "${UID}" \
+  otel/semconvgen:$GENERATOR_VERSION \
+  --only resource \
+  --yaml-root /source \
+  code \
+  --template /templates/AttributeValues.php.j2 \
+  --output "/output/ResourceAttributeValues.php" \
   -Dnamespace="OpenTelemetry\\SemConv" \
   -Dclass="Resource" \
   -DschemaUrl=$SCHEMA_URL

--- a/script/semantic-conventions/templates/trace_deprecations.php.partial
+++ b/script/semantic-conventions/templates/trace_deprecations.php.partial
@@ -31,11 +31,6 @@
     /**
      * @deprecated
      */
-    public const HTTP_USER_AGENT = 'http.user_agent';
-
-    /**
-     * @deprecated
-     */
     public const MESSAGING_CONVERSATION_ID = 'messaging.conversation_id';
 
     /**
@@ -92,11 +87,6 @@
      * @deprecated
      */
     public const HTTP_CLIENT_IP = 'http.client_ip';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_FLAVOR = 'http.flavor';
 
     /**
      * @deprecated

--- a/script/semantic-conventions/templates/trace_deprecations.php.partial
+++ b/script/semantic-conventions/templates/trace_deprecations.php.partial
@@ -207,3 +207,18 @@
      * @deprecated
      */
     public const THREAD_DAEMON = 'thread.daemon';
+
+    /**
+     * @deprecated
+     */
+    public const EVENT_DOMAIN = 'event.domain';
+
+    /**
+     * @deprecated
+     */
+    public const SYSTEM_DISK_DIRECTION = 'system.disk.direction';
+
+    /**
+     * @deprecated
+     */
+    public const SYSTEM_NETWORK_DIRECTION = 'system.network.direction';

--- a/src/SemConv/ResourceAttributeValues.php
+++ b/src/SemConv/ResourceAttributeValues.php
@@ -1,0 +1,349 @@
+<?php
+
+// DO NOT EDIT, this is an Auto-generated file from script/semantic-convention/templates/AttributeValues.php.j2
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SemConv;
+
+interface ResourceAttributeValues
+{
+    /**
+     * The URL of the OpenTelemetry schema for these keys and values.
+     */
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.24.0';
+    /**
+     * @see ResourceAttributes::AWS_ECS_LAUNCHTYPE ec2
+     */
+    public const AWS_ECS_LAUNCHTYPE_EC2 = 'ec2';
+
+    /**
+     * @see ResourceAttributes::AWS_ECS_LAUNCHTYPE fargate
+     */
+    public const AWS_ECS_LAUNCHTYPE_FARGATE = 'fargate';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Alibaba Cloud Elastic Compute Service
+     */
+    public const CLOUD_PLATFORM_ALIBABA_CLOUD_ECS = 'alibaba_cloud_ecs';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Alibaba Cloud Function Compute
+     */
+    public const CLOUD_PLATFORM_ALIBABA_CLOUD_FC = 'alibaba_cloud_fc';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Red Hat OpenShift on Alibaba Cloud
+     */
+    public const CLOUD_PLATFORM_ALIBABA_CLOUD_OPENSHIFT = 'alibaba_cloud_openshift';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Elastic Compute Cloud
+     */
+    public const CLOUD_PLATFORM_AWS_EC2 = 'aws_ec2';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Elastic Container Service
+     */
+    public const CLOUD_PLATFORM_AWS_ECS = 'aws_ecs';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Elastic Kubernetes Service
+     */
+    public const CLOUD_PLATFORM_AWS_EKS = 'aws_eks';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Lambda
+     */
+    public const CLOUD_PLATFORM_AWS_LAMBDA = 'aws_lambda';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS Elastic Beanstalk
+     */
+    public const CLOUD_PLATFORM_AWS_ELASTIC_BEANSTALK = 'aws_elastic_beanstalk';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM AWS App Runner
+     */
+    public const CLOUD_PLATFORM_AWS_APP_RUNNER = 'aws_app_runner';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Red Hat OpenShift on AWS (ROSA)
+     */
+    public const CLOUD_PLATFORM_AWS_OPENSHIFT = 'aws_openshift';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Virtual Machines
+     */
+    public const CLOUD_PLATFORM_AZURE_VM = 'azure_vm';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Container Instances
+     */
+    public const CLOUD_PLATFORM_AZURE_CONTAINER_INSTANCES = 'azure_container_instances';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Kubernetes Service
+     */
+    public const CLOUD_PLATFORM_AZURE_AKS = 'azure_aks';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Functions
+     */
+    public const CLOUD_PLATFORM_AZURE_FUNCTIONS = 'azure_functions';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure App Service
+     */
+    public const CLOUD_PLATFORM_AZURE_APP_SERVICE = 'azure_app_service';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Azure Red Hat OpenShift
+     */
+    public const CLOUD_PLATFORM_AZURE_OPENSHIFT = 'azure_openshift';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Bare Metal Solution (BMS)
+     */
+    public const CLOUD_PLATFORM_GCP_BARE_METAL_SOLUTION = 'gcp_bare_metal_solution';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud Compute Engine (GCE)
+     */
+    public const CLOUD_PLATFORM_GCP_COMPUTE_ENGINE = 'gcp_compute_engine';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud Run
+     */
+    public const CLOUD_PLATFORM_GCP_CLOUD_RUN = 'gcp_cloud_run';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud Kubernetes Engine (GKE)
+     */
+    public const CLOUD_PLATFORM_GCP_KUBERNETES_ENGINE = 'gcp_kubernetes_engine';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud Functions (GCF)
+     */
+    public const CLOUD_PLATFORM_GCP_CLOUD_FUNCTIONS = 'gcp_cloud_functions';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Google Cloud App Engine (GAE)
+     */
+    public const CLOUD_PLATFORM_GCP_APP_ENGINE = 'gcp_app_engine';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Red Hat OpenShift on Google Cloud
+     */
+    public const CLOUD_PLATFORM_GCP_OPENSHIFT = 'gcp_openshift';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Red Hat OpenShift on IBM Cloud
+     */
+    public const CLOUD_PLATFORM_IBM_CLOUD_OPENSHIFT = 'ibm_cloud_openshift';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Tencent Cloud Cloud Virtual Machine (CVM)
+     */
+    public const CLOUD_PLATFORM_TENCENT_CLOUD_CVM = 'tencent_cloud_cvm';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Tencent Cloud Elastic Kubernetes Service (EKS)
+     */
+    public const CLOUD_PLATFORM_TENCENT_CLOUD_EKS = 'tencent_cloud_eks';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PLATFORM Tencent Cloud Serverless Cloud Function (SCF)
+     */
+    public const CLOUD_PLATFORM_TENCENT_CLOUD_SCF = 'tencent_cloud_scf';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Alibaba Cloud
+     */
+    public const CLOUD_PROVIDER_ALIBABA_CLOUD = 'alibaba_cloud';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Amazon Web Services
+     */
+    public const CLOUD_PROVIDER_AWS = 'aws';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Microsoft Azure
+     */
+    public const CLOUD_PROVIDER_AZURE = 'azure';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Google Cloud Platform
+     */
+    public const CLOUD_PROVIDER_GCP = 'gcp';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Heroku Platform as a Service
+     */
+    public const CLOUD_PROVIDER_HEROKU = 'heroku';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER IBM Cloud
+     */
+    public const CLOUD_PROVIDER_IBM_CLOUD = 'ibm_cloud';
+
+    /**
+     * @see ResourceAttributes::CLOUD_PROVIDER Tencent Cloud
+     */
+    public const CLOUD_PROVIDER_TENCENT_CLOUD = 'tencent_cloud';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH AMD64
+     */
+    public const HOST_ARCH_AMD64 = 'amd64';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH ARM32
+     */
+    public const HOST_ARCH_ARM32 = 'arm32';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH ARM64
+     */
+    public const HOST_ARCH_ARM64 = 'arm64';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH Itanium
+     */
+    public const HOST_ARCH_IA64 = 'ia64';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH 32-bit PowerPC
+     */
+    public const HOST_ARCH_PPC32 = 'ppc32';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH 64-bit PowerPC
+     */
+    public const HOST_ARCH_PPC64 = 'ppc64';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH IBM z/Architecture
+     */
+    public const HOST_ARCH_S390X = 's390x';
+
+    /**
+     * @see ResourceAttributes::HOST_ARCH 32-bit x86
+     */
+    public const HOST_ARCH_X86 = 'x86';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE Microsoft Windows
+     */
+    public const OS_TYPE_WINDOWS = 'windows';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE Linux
+     */
+    public const OS_TYPE_LINUX = 'linux';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE Apple Darwin
+     */
+    public const OS_TYPE_DARWIN = 'darwin';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE FreeBSD
+     */
+    public const OS_TYPE_FREEBSD = 'freebsd';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE NetBSD
+     */
+    public const OS_TYPE_NETBSD = 'netbsd';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE OpenBSD
+     */
+    public const OS_TYPE_OPENBSD = 'openbsd';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE DragonFly BSD
+     */
+    public const OS_TYPE_DRAGONFLYBSD = 'dragonflybsd';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE HP-UX (Hewlett Packard Unix)
+     */
+    public const OS_TYPE_HPUX = 'hpux';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE AIX (Advanced Interactive eXecutive)
+     */
+    public const OS_TYPE_AIX = 'aix';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE SunOS, Oracle Solaris
+     */
+    public const OS_TYPE_SOLARIS = 'solaris';
+
+    /**
+     * @see ResourceAttributes::OS_TYPE IBM z/OS
+     */
+    public const OS_TYPE_Z_OS = 'z_os';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE cpp
+     */
+    public const TELEMETRY_SDK_LANGUAGE_CPP = 'cpp';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE dotnet
+     */
+    public const TELEMETRY_SDK_LANGUAGE_DOTNET = 'dotnet';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE erlang
+     */
+    public const TELEMETRY_SDK_LANGUAGE_ERLANG = 'erlang';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE go
+     */
+    public const TELEMETRY_SDK_LANGUAGE_GO = 'go';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE java
+     */
+    public const TELEMETRY_SDK_LANGUAGE_JAVA = 'java';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE nodejs
+     */
+    public const TELEMETRY_SDK_LANGUAGE_NODEJS = 'nodejs';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE php
+     */
+    public const TELEMETRY_SDK_LANGUAGE_PHP = 'php';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE python
+     */
+    public const TELEMETRY_SDK_LANGUAGE_PYTHON = 'python';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE ruby
+     */
+    public const TELEMETRY_SDK_LANGUAGE_RUBY = 'ruby';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE rust
+     */
+    public const TELEMETRY_SDK_LANGUAGE_RUST = 'rust';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE swift
+     */
+    public const TELEMETRY_SDK_LANGUAGE_SWIFT = 'swift';
+
+    /**
+     * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE webjs
+     */
+    public const TELEMETRY_SDK_LANGUAGE_WEBJS = 'webjs';
+}

--- a/src/SemConv/ResourceAttributes.php
+++ b/src/SemConv/ResourceAttributes.php
@@ -11,7 +11,7 @@ interface ResourceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.23.1';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.24.0';
 
     /**
      * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found here.
@@ -295,6 +295,14 @@ interface ResourceAttributes
     /**
      * Name of the deployment environment (aka deployment tier).
      *
+     * `deployment.environment` does not affect the uniqueness constraints defined through
+     * the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
+     * This implies that resources carrying the following attribute combinations MUST be
+     * considered to be identifying the same service:<ul>
+     * <li>`service.name=frontend`, `deployment.environment=production`</li>
+     * <li>`service.name=frontend`, `deployment.environment=staging`.</li>
+     * </ul>
+     *
      * @example staging
      * @example production
      */
@@ -322,7 +330,7 @@ interface ResourceAttributes
     /**
      * The model identifier for the device.
      *
-     * It's recommended this value represents a machine readable version of the model identifier rather than the market or consumer-friendly name of the device.
+     * It's recommended this value represents a machine-readable version of the model identifier rather than the market or consumer-friendly name of the device.
      *
      * @example iPhone3,4
      * @example SM-G920F
@@ -332,7 +340,7 @@ interface ResourceAttributes
     /**
      * The marketing name for the device model.
      *
-     * It's recommended this value represents a human readable version of the device model rather than a machine readable alternative.
+     * It's recommended this value represents a human-readable version of the device model rather than a machine-readable alternative.
      *
      * @example iPhone 6s Plus
      * @example Samsung Galaxy S6
@@ -465,9 +473,10 @@ interface ResourceAttributes
     public const HOST_CPU_CACHE_L2_SIZE = 'host.cpu.cache.l2.size';
 
     /**
-     * Numeric value specifying the family or generation of the CPU.
+     * Family or generation of the CPU.
      *
      * @example 6
+     * @example PA-RISC 1.1e
      */
     public const HOST_CPU_FAMILY = 'host.cpu.family';
 
@@ -475,6 +484,7 @@ interface ResourceAttributes
      * Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family.
      *
      * @example 6
+     * @example 9000/778/B180L
      */
     public const HOST_CPU_MODEL_ID = 'host.cpu.model.id';
 
@@ -852,7 +862,7 @@ interface ResourceAttributes
     public const PROCESS_OWNER = 'process.owner';
 
     /**
-     * Parent Process identifier (PID).
+     * Parent Process identifier (PPID).
      *
      * @example 111
      */

--- a/src/SemConv/TraceAttributeValues.php
+++ b/src/SemConv/TraceAttributeValues.php
@@ -1,0 +1,1466 @@
+<?php
+
+// DO NOT EDIT, this is an Auto-generated file from script/semantic-convention/templates/AttributeValues.php.j2
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SemConv;
+
+interface TraceAttributeValues
+{
+    /**
+     * The URL of the OpenTelemetry schema for these keys and values.
+     */
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.24.0';
+    /**
+     * @see TraceAttributes::ANDROID_STATE Any time before Activity.onResume() or, if the app has no Activity, Context.startService() has been called in the app for the first time
+     */
+    public const ANDROID_STATE_CREATED = 'created';
+
+    /**
+     * @see TraceAttributes::ANDROID_STATE Any time after Activity.onPause() or, if the app has no Activity, Context.stopService() has been called when the app was in the foreground state
+     */
+    public const ANDROID_STATE_BACKGROUND = 'background';
+
+    /**
+     * @see TraceAttributes::ANDROID_STATE Any time after Activity.onResume() or, if the app has no Activity, Context.startService() has been called when the app was in either the created or background states
+     */
+    public const ANDROID_STATE_FOREGROUND = 'foreground';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_RATE_LIMITING_RESULT Lease was acquired
+     */
+    public const ASPNETCORE_RATE_LIMITING_RESULT_ACQUIRED = 'acquired';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_RATE_LIMITING_RESULT Lease request was rejected by the endpoint limiter
+     */
+    public const ASPNETCORE_RATE_LIMITING_RESULT_ENDPOINT_LIMITER = 'endpoint_limiter';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_RATE_LIMITING_RESULT Lease request was rejected by the global limiter
+     */
+    public const ASPNETCORE_RATE_LIMITING_RESULT_GLOBAL_LIMITER = 'global_limiter';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_RATE_LIMITING_RESULT Lease request was canceled
+     */
+    public const ASPNETCORE_RATE_LIMITING_RESULT_REQUEST_CANCELED = 'request_canceled';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL all
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_ALL = 'all';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL each_quorum
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_EACH_QUORUM = 'each_quorum';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL quorum
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_QUORUM = 'quorum';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL local_quorum
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_LOCAL_QUORUM = 'local_quorum';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL one
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_ONE = 'one';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL two
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_TWO = 'two';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL three
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_THREE = 'three';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL local_one
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_LOCAL_ONE = 'local_one';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL any
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_ANY = 'any';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL serial
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_SERIAL = 'serial';
+
+    /**
+     * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL local_serial
+     */
+    public const DB_CASSANDRA_CONSISTENCY_LEVEL_LOCAL_SERIAL = 'local_serial';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_CONNECTION_MODE Gateway (HTTP) connections mode
+     */
+    public const DB_COSMOSDB_CONNECTION_MODE_GATEWAY = 'gateway';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_CONNECTION_MODE Direct connection
+     */
+    public const DB_COSMOSDB_CONNECTION_MODE_DIRECT = 'direct';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE invalid
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_INVALID = 'Invalid';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE create
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_CREATE = 'Create';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE patch
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_PATCH = 'Patch';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE read
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_READ = 'Read';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE read_feed
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_READ_FEED = 'ReadFeed';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE delete
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_DELETE = 'Delete';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE replace
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_REPLACE = 'Replace';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE execute
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_EXECUTE = 'Execute';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE query
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_QUERY = 'Query';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE head
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_HEAD = 'Head';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE head_feed
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_HEAD_FEED = 'HeadFeed';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE upsert
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_UPSERT = 'Upsert';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE batch
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_BATCH = 'Batch';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE query_plan
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_QUERY_PLAN = 'QueryPlan';
+
+    /**
+     * @see TraceAttributes::DB_COSMOSDB_OPERATION_TYPE execute_javascript
+     */
+    public const DB_COSMOSDB_OPERATION_TYPE_EXECUTE_JAVASCRIPT = 'ExecuteJavaScript';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Some other SQL database. Fallback only. See notes
+     */
+    public const DB_SYSTEM_OTHER_SQL = 'other_sql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Microsoft SQL Server
+     */
+    public const DB_SYSTEM_MSSQL = 'mssql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Microsoft SQL Server Compact
+     */
+    public const DB_SYSTEM_MSSQLCOMPACT = 'mssqlcompact';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM MySQL
+     */
+    public const DB_SYSTEM_MYSQL = 'mysql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Oracle Database
+     */
+    public const DB_SYSTEM_ORACLE = 'oracle';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM IBM Db2
+     */
+    public const DB_SYSTEM_DB2 = 'db2';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM PostgreSQL
+     */
+    public const DB_SYSTEM_POSTGRESQL = 'postgresql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Amazon Redshift
+     */
+    public const DB_SYSTEM_REDSHIFT = 'redshift';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache Hive
+     */
+    public const DB_SYSTEM_HIVE = 'hive';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Cloudscape
+     */
+    public const DB_SYSTEM_CLOUDSCAPE = 'cloudscape';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM HyperSQL DataBase
+     */
+    public const DB_SYSTEM_HSQLDB = 'hsqldb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Progress Database
+     */
+    public const DB_SYSTEM_PROGRESS = 'progress';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM SAP MaxDB
+     */
+    public const DB_SYSTEM_MAXDB = 'maxdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM SAP HANA
+     */
+    public const DB_SYSTEM_HANADB = 'hanadb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Ingres
+     */
+    public const DB_SYSTEM_INGRES = 'ingres';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM FirstSQL
+     */
+    public const DB_SYSTEM_FIRSTSQL = 'firstsql';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM EnterpriseDB
+     */
+    public const DB_SYSTEM_EDB = 'edb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM InterSystems Caché
+     */
+    public const DB_SYSTEM_CACHE = 'cache';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Adabas (Adaptable Database System)
+     */
+    public const DB_SYSTEM_ADABAS = 'adabas';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Firebird
+     */
+    public const DB_SYSTEM_FIREBIRD = 'firebird';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache Derby
+     */
+    public const DB_SYSTEM_DERBY = 'derby';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM FileMaker
+     */
+    public const DB_SYSTEM_FILEMAKER = 'filemaker';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Informix
+     */
+    public const DB_SYSTEM_INFORMIX = 'informix';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM InstantDB
+     */
+    public const DB_SYSTEM_INSTANTDB = 'instantdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM InterBase
+     */
+    public const DB_SYSTEM_INTERBASE = 'interbase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM MariaDB
+     */
+    public const DB_SYSTEM_MARIADB = 'mariadb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Netezza
+     */
+    public const DB_SYSTEM_NETEZZA = 'netezza';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Pervasive PSQL
+     */
+    public const DB_SYSTEM_PERVASIVE = 'pervasive';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM PointBase
+     */
+    public const DB_SYSTEM_POINTBASE = 'pointbase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM SQLite
+     */
+    public const DB_SYSTEM_SQLITE = 'sqlite';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Sybase
+     */
+    public const DB_SYSTEM_SYBASE = 'sybase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Teradata
+     */
+    public const DB_SYSTEM_TERADATA = 'teradata';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Vertica
+     */
+    public const DB_SYSTEM_VERTICA = 'vertica';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM H2
+     */
+    public const DB_SYSTEM_H2 = 'h2';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM ColdFusion IMQ
+     */
+    public const DB_SYSTEM_COLDFUSION = 'coldfusion';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache Cassandra
+     */
+    public const DB_SYSTEM_CASSANDRA = 'cassandra';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache HBase
+     */
+    public const DB_SYSTEM_HBASE = 'hbase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM MongoDB
+     */
+    public const DB_SYSTEM_MONGODB = 'mongodb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Redis
+     */
+    public const DB_SYSTEM_REDIS = 'redis';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Couchbase
+     */
+    public const DB_SYSTEM_COUCHBASE = 'couchbase';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM CouchDB
+     */
+    public const DB_SYSTEM_COUCHDB = 'couchdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Microsoft Azure Cosmos DB
+     */
+    public const DB_SYSTEM_COSMOSDB = 'cosmosdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Amazon DynamoDB
+     */
+    public const DB_SYSTEM_DYNAMODB = 'dynamodb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Neo4j
+     */
+    public const DB_SYSTEM_NEO4J = 'neo4j';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Apache Geode
+     */
+    public const DB_SYSTEM_GEODE = 'geode';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Elasticsearch
+     */
+    public const DB_SYSTEM_ELASTICSEARCH = 'elasticsearch';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Memcached
+     */
+    public const DB_SYSTEM_MEMCACHED = 'memcached';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM CockroachDB
+     */
+    public const DB_SYSTEM_COCKROACHDB = 'cockroachdb';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM OpenSearch
+     */
+    public const DB_SYSTEM_OPENSEARCH = 'opensearch';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM ClickHouse
+     */
+    public const DB_SYSTEM_CLICKHOUSE = 'clickhouse';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Cloud Spanner
+     */
+    public const DB_SYSTEM_SPANNER = 'spanner';
+
+    /**
+     * @see TraceAttributes::DB_SYSTEM Trino
+     */
+    public const DB_SYSTEM_TRINO = 'trino';
+
+    /**
+     * @see TraceAttributes::DISK_IO_DIRECTION read
+     */
+    public const DISK_IO_DIRECTION_READ = 'read';
+
+    /**
+     * @see TraceAttributes::DISK_IO_DIRECTION write
+     */
+    public const DISK_IO_DIRECTION_WRITE = 'write';
+
+    /**
+     * @see TraceAttributes::ERROR_TYPE A fallback error value to be used when the instrumentation doesn&#39;t define a custom value
+     */
+    public const ERROR_TYPE_OTHER = '_OTHER';
+
+    /**
+     * @see TraceAttributes::FAAS_DOCUMENT_OPERATION When a new object is created
+     */
+    public const FAAS_DOCUMENT_OPERATION_INSERT = 'insert';
+
+    /**
+     * @see TraceAttributes::FAAS_DOCUMENT_OPERATION When an object is modified
+     */
+    public const FAAS_DOCUMENT_OPERATION_EDIT = 'edit';
+
+    /**
+     * @see TraceAttributes::FAAS_DOCUMENT_OPERATION When an object is deleted
+     */
+    public const FAAS_DOCUMENT_OPERATION_DELETE = 'delete';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Alibaba Cloud
+     */
+    public const FAAS_INVOKED_PROVIDER_ALIBABA_CLOUD = 'alibaba_cloud';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Amazon Web Services
+     */
+    public const FAAS_INVOKED_PROVIDER_AWS = 'aws';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Microsoft Azure
+     */
+    public const FAAS_INVOKED_PROVIDER_AZURE = 'azure';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Google Cloud Platform
+     */
+    public const FAAS_INVOKED_PROVIDER_GCP = 'gcp';
+
+    /**
+     * @see TraceAttributes::FAAS_INVOKED_PROVIDER Tencent Cloud
+     */
+    public const FAAS_INVOKED_PROVIDER_TENCENT_CLOUD = 'tencent_cloud';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER A response to some data source operation such as a database or filesystem read/write
+     */
+    public const FAAS_TRIGGER_DATASOURCE = 'datasource';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER To provide an answer to an inbound HTTP request
+     */
+    public const FAAS_TRIGGER_HTTP = 'http';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER A function is set to be executed when messages are sent to a messaging system
+     */
+    public const FAAS_TRIGGER_PUBSUB = 'pubsub';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER A function is scheduled to be executed regularly
+     */
+    public const FAAS_TRIGGER_TIMER = 'timer';
+
+    /**
+     * @see TraceAttributes::FAAS_TRIGGER If none of the others apply
+     */
+    public const FAAS_TRIGGER_OTHER = 'other';
+
+    /**
+     * @see TraceAttributes::GRAPHQL_OPERATION_TYPE GraphQL query
+     */
+    public const GRAPHQL_OPERATION_TYPE_QUERY = 'query';
+
+    /**
+     * @see TraceAttributes::GRAPHQL_OPERATION_TYPE GraphQL mutation
+     */
+    public const GRAPHQL_OPERATION_TYPE_MUTATION = 'mutation';
+
+    /**
+     * @see TraceAttributes::GRAPHQL_OPERATION_TYPE GraphQL subscription
+     */
+    public const GRAPHQL_OPERATION_TYPE_SUBSCRIPTION = 'subscription';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR HTTP/1.0
+     */
+    public const HTTP_FLAVOR_HTTP_1_0 = '1.0';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR HTTP/1.1
+     */
+    public const HTTP_FLAVOR_HTTP_1_1 = '1.1';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR HTTP/2
+     */
+    public const HTTP_FLAVOR_HTTP_2_0 = '2.0';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR HTTP/3
+     */
+    public const HTTP_FLAVOR_HTTP_3_0 = '3.0';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR SPDY protocol
+     */
+    public const HTTP_FLAVOR_SPDY = 'SPDY';
+
+    /**
+     * @see TraceAttributes::HTTP_FLAVOR QUIC protocol
+     */
+    public const HTTP_FLAVOR_QUIC = 'QUIC';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD CONNECT method
+     */
+    public const HTTP_REQUEST_METHOD_CONNECT = 'CONNECT';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD DELETE method
+     */
+    public const HTTP_REQUEST_METHOD_DELETE = 'DELETE';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD GET method
+     */
+    public const HTTP_REQUEST_METHOD_GET = 'GET';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD HEAD method
+     */
+    public const HTTP_REQUEST_METHOD_HEAD = 'HEAD';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD OPTIONS method
+     */
+    public const HTTP_REQUEST_METHOD_OPTIONS = 'OPTIONS';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD PATCH method
+     */
+    public const HTTP_REQUEST_METHOD_PATCH = 'PATCH';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD POST method
+     */
+    public const HTTP_REQUEST_METHOD_POST = 'POST';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD PUT method
+     */
+    public const HTTP_REQUEST_METHOD_PUT = 'PUT';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD TRACE method
+     */
+    public const HTTP_REQUEST_METHOD_TRACE = 'TRACE';
+
+    /**
+     * @see TraceAttributes::HTTP_REQUEST_METHOD Any HTTP method that the instrumentation has no prior knowledge of
+     */
+    public const HTTP_REQUEST_METHOD_OTHER = '_OTHER';
+
+    /**
+     * @see TraceAttributes::IOS_STATE The app has become `active`. Associated with UIKit notification `applicationDidBecomeActive`
+     */
+    public const IOS_STATE_ACTIVE = 'active';
+
+    /**
+     * @see TraceAttributes::IOS_STATE The app is now `inactive`. Associated with UIKit notification `applicationWillResignActive`
+     */
+    public const IOS_STATE_INACTIVE = 'inactive';
+
+    /**
+     * @see TraceAttributes::IOS_STATE The app is now in the background. This value is associated with UIKit notification `applicationDidEnterBackground`
+     */
+    public const IOS_STATE_BACKGROUND = 'background';
+
+    /**
+     * @see TraceAttributes::IOS_STATE The app is now in the foreground. This value is associated with UIKit notification `applicationWillEnterForeground`
+     */
+    public const IOS_STATE_FOREGROUND = 'foreground';
+
+    /**
+     * @see TraceAttributes::IOS_STATE The app is about to terminate. Associated with UIKit notification `applicationWillTerminate`
+     */
+    public const IOS_STATE_TERMINATE = 'terminate';
+
+    /**
+     * @see TraceAttributes::JVM_MEMORY_TYPE Heap memory
+     */
+    public const JVM_MEMORY_TYPE_HEAP = 'heap';
+
+    /**
+     * @see TraceAttributes::JVM_MEMORY_TYPE Non-heap memory
+     */
+    public const JVM_MEMORY_TYPE_NON_HEAP = 'non_heap';
+
+    /**
+     * @see TraceAttributes::LOG_IOSTREAM Logs from stdout stream
+     */
+    public const LOG_IOSTREAM_STDOUT = 'stdout';
+
+    /**
+     * @see TraceAttributes::LOG_IOSTREAM Events from stderr stream
+     */
+    public const LOG_IOSTREAM_STDERR = 'stderr';
+
+    /**
+     * @see TraceAttributes::MESSAGE_TYPE sent
+     */
+    public const MESSAGE_TYPE_SENT = 'SENT';
+
+    /**
+     * @see TraceAttributes::MESSAGE_TYPE received
+     */
+    public const MESSAGE_TYPE_RECEIVED = 'RECEIVED';
+
+    /**
+     * @see TraceAttributes::MESSAGING_OPERATION One or more messages are provided for publishing to an intermediary. If a single message is published, the context of the &#34;Publish&#34; span can be used as the creation context and no &#34;Create&#34; span needs to be created
+     */
+    public const MESSAGING_OPERATION_PUBLISH = 'publish';
+
+    /**
+     * @see TraceAttributes::MESSAGING_OPERATION A message is created. &#34;Create&#34; spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios
+     */
+    public const MESSAGING_OPERATION_CREATE = 'create';
+
+    /**
+     * @see TraceAttributes::MESSAGING_OPERATION One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages
+     */
+    public const MESSAGING_OPERATION_RECEIVE = 'receive';
+
+    /**
+     * @see TraceAttributes::MESSAGING_OPERATION One or more messages are passed to a consumer. This operation refers to push-based scenarios, where consumer register callbacks which get called by messaging SDKs
+     */
+    public const MESSAGING_OPERATION_DELIVER = 'deliver';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_CONSUMPTION_MODEL Clustering consumption model
+     */
+    public const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL_CLUSTERING = 'clustering';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_CONSUMPTION_MODEL Broadcasting consumption model
+     */
+    public const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL_BROADCASTING = 'broadcasting';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_MESSAGE_TYPE Normal message
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE_NORMAL = 'normal';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_MESSAGE_TYPE FIFO message
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE_FIFO = 'fifo';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_MESSAGE_TYPE Delay message
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE_DELAY = 'delay';
+
+    /**
+     * @see TraceAttributes::MESSAGING_ROCKETMQ_MESSAGE_TYPE Transaction message
+     */
+    public const MESSAGING_ROCKETMQ_MESSAGE_TYPE_TRANSACTION = 'transaction';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Apache ActiveMQ
+     */
+    public const MESSAGING_SYSTEM_ACTIVEMQ = 'activemq';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Amazon Simple Queue Service (SQS)
+     */
+    public const MESSAGING_SYSTEM_AWS_SQS = 'aws_sqs';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Azure Event Grid
+     */
+    public const MESSAGING_SYSTEM_AZURE_EVENTGRID = 'azure_eventgrid';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Azure Event Hubs
+     */
+    public const MESSAGING_SYSTEM_AZURE_EVENTHUBS = 'azure_eventhubs';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Azure Service Bus
+     */
+    public const MESSAGING_SYSTEM_AZURE_SERVICEBUS = 'azure_servicebus';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Google Cloud Pub/Sub
+     */
+    public const MESSAGING_SYSTEM_GCP_PUBSUB = 'gcp_pubsub';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Java Message Service
+     */
+    public const MESSAGING_SYSTEM_JMS = 'jms';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Apache Kafka
+     */
+    public const MESSAGING_SYSTEM_KAFKA = 'kafka';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM RabbitMQ
+     */
+    public const MESSAGING_SYSTEM_RABBITMQ = 'rabbitmq';
+
+    /**
+     * @see TraceAttributes::MESSAGING_SYSTEM Apache RocketMQ
+     */
+    public const MESSAGING_SYSTEM_ROCKETMQ = 'rocketmq';
+
+    /**
+     * @see TraceAttributes::NET_SOCK_FAMILY IPv4 address
+     */
+    public const NET_SOCK_FAMILY_INET = 'inet';
+
+    /**
+     * @see TraceAttributes::NET_SOCK_FAMILY IPv6 address
+     */
+    public const NET_SOCK_FAMILY_INET6 = 'inet6';
+
+    /**
+     * @see TraceAttributes::NET_SOCK_FAMILY Unix domain socket path
+     */
+    public const NET_SOCK_FAMILY_UNIX = 'unix';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT ip_tcp
+     */
+    public const NET_TRANSPORT_IP_TCP = 'ip_tcp';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT ip_udp
+     */
+    public const NET_TRANSPORT_IP_UDP = 'ip_udp';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT Named or anonymous pipe
+     */
+    public const NET_TRANSPORT_PIPE = 'pipe';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT In-process communication
+     *
+     * Signals that there is only in-process communication not using a &quot;real&quot; network protocol in cases where network attributes would normally be expected. Usually all other network attributes can be left out in that case.
+     */
+    public const NET_TRANSPORT_INPROC = 'inproc';
+
+    /**
+     * @see TraceAttributes::NET_TRANSPORT Something else (non IP-based)
+     */
+    public const NET_TRANSPORT_OTHER = 'other';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE GPRS
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_GPRS = 'gprs';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE EDGE
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_EDGE = 'edge';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE UMTS
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_UMTS = 'umts';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE CDMA
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_CDMA = 'cdma';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE EVDO Rel. 0
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_EVDO_0 = 'evdo_0';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE EVDO Rev. A
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_EVDO_A = 'evdo_a';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE CDMA2000 1XRTT
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_CDMA2000_1XRTT = 'cdma2000_1xrtt';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE HSDPA
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_HSDPA = 'hsdpa';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE HSUPA
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_HSUPA = 'hsupa';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE HSPA
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_HSPA = 'hspa';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE IDEN
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_IDEN = 'iden';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE EVDO Rev. B
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_EVDO_B = 'evdo_b';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE LTE
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_LTE = 'lte';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE EHRPD
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_EHRPD = 'ehrpd';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE HSPAP
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_HSPAP = 'hspap';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE GSM
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_GSM = 'gsm';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE TD-SCDMA
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_TD_SCDMA = 'td_scdma';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE IWLAN
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_IWLAN = 'iwlan';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE 5G NR (New Radio)
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_NR = 'nr';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE 5G NRNSA (New Radio Non-Standalone)
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_NRNSA = 'nrnsa';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_SUBTYPE LTE CA
+     */
+    public const NETWORK_CONNECTION_SUBTYPE_LTE_CA = 'lte_ca';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_TYPE wifi
+     */
+    public const NETWORK_CONNECTION_TYPE_WIFI = 'wifi';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_TYPE wired
+     */
+    public const NETWORK_CONNECTION_TYPE_WIRED = 'wired';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_TYPE cell
+     */
+    public const NETWORK_CONNECTION_TYPE_CELL = 'cell';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_TYPE unavailable
+     */
+    public const NETWORK_CONNECTION_TYPE_UNAVAILABLE = 'unavailable';
+
+    /**
+     * @see TraceAttributes::NETWORK_CONNECTION_TYPE unknown
+     */
+    public const NETWORK_CONNECTION_TYPE_UNKNOWN = 'unknown';
+
+    /**
+     * @see TraceAttributes::NETWORK_IO_DIRECTION transmit
+     */
+    public const NETWORK_IO_DIRECTION_TRANSMIT = 'transmit';
+
+    /**
+     * @see TraceAttributes::NETWORK_IO_DIRECTION receive
+     */
+    public const NETWORK_IO_DIRECTION_RECEIVE = 'receive';
+
+    /**
+     * @see TraceAttributes::NETWORK_TRANSPORT TCP
+     */
+    public const NETWORK_TRANSPORT_TCP = 'tcp';
+
+    /**
+     * @see TraceAttributes::NETWORK_TRANSPORT UDP
+     */
+    public const NETWORK_TRANSPORT_UDP = 'udp';
+
+    /**
+     * @see TraceAttributes::NETWORK_TRANSPORT Named or anonymous pipe
+     */
+    public const NETWORK_TRANSPORT_PIPE = 'pipe';
+
+    /**
+     * @see TraceAttributes::NETWORK_TRANSPORT Unix domain socket
+     */
+    public const NETWORK_TRANSPORT_UNIX = 'unix';
+
+    /**
+     * @see TraceAttributes::NETWORK_TYPE IPv4
+     */
+    public const NETWORK_TYPE_IPV4 = 'ipv4';
+
+    /**
+     * @see TraceAttributes::NETWORK_TYPE IPv6
+     */
+    public const NETWORK_TYPE_IPV6 = 'ipv6';
+
+    /**
+     * @see TraceAttributes::OPENTRACING_REF_TYPE The parent Span depends on the child Span in some capacity
+     */
+    public const OPENTRACING_REF_TYPE_CHILD_OF = 'child_of';
+
+    /**
+     * @see TraceAttributes::OPENTRACING_REF_TYPE The parent Span doesn&#39;t depend in any way on the result of the child Span
+     */
+    public const OPENTRACING_REF_TYPE_FOLLOWS_FROM = 'follows_from';
+
+    /**
+     * @see TraceAttributes::OTEL_STATUS_CODE The operation has been validated by an Application developer or Operator to have completed successfully
+     */
+    public const OTEL_STATUS_CODE_OK = 'OK';
+
+    /**
+     * @see TraceAttributes::OTEL_STATUS_CODE The operation contains an error
+     */
+    public const OTEL_STATUS_CODE_ERROR = 'ERROR';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE cancelled
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_CANCELLED = 'cancelled';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE unknown
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_UNKNOWN = 'unknown';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE invalid_argument
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_INVALID_ARGUMENT = 'invalid_argument';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE deadline_exceeded
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_DEADLINE_EXCEEDED = 'deadline_exceeded';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE not_found
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_NOT_FOUND = 'not_found';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE already_exists
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_ALREADY_EXISTS = 'already_exists';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE permission_denied
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_PERMISSION_DENIED = 'permission_denied';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE resource_exhausted
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_RESOURCE_EXHAUSTED = 'resource_exhausted';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE failed_precondition
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_FAILED_PRECONDITION = 'failed_precondition';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE aborted
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_ABORTED = 'aborted';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE out_of_range
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_OUT_OF_RANGE = 'out_of_range';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE unimplemented
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_UNIMPLEMENTED = 'unimplemented';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE internal
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_INTERNAL = 'internal';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE unavailable
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_UNAVAILABLE = 'unavailable';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE data_loss
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_DATA_LOSS = 'data_loss';
+
+    /**
+     * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE unauthenticated
+     */
+    public const RPC_CONNECT_RPC_ERROR_CODE_UNAUTHENTICATED = 'unauthenticated';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE OK
+     */
+    public const RPC_GRPC_STATUS_CODE_OK = '0';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE CANCELLED
+     */
+    public const RPC_GRPC_STATUS_CODE_CANCELLED = '1';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNKNOWN
+     */
+    public const RPC_GRPC_STATUS_CODE_UNKNOWN = '2';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE INVALID_ARGUMENT
+     */
+    public const RPC_GRPC_STATUS_CODE_INVALID_ARGUMENT = '3';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE DEADLINE_EXCEEDED
+     */
+    public const RPC_GRPC_STATUS_CODE_DEADLINE_EXCEEDED = '4';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE NOT_FOUND
+     */
+    public const RPC_GRPC_STATUS_CODE_NOT_FOUND = '5';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE ALREADY_EXISTS
+     */
+    public const RPC_GRPC_STATUS_CODE_ALREADY_EXISTS = '6';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE PERMISSION_DENIED
+     */
+    public const RPC_GRPC_STATUS_CODE_PERMISSION_DENIED = '7';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE RESOURCE_EXHAUSTED
+     */
+    public const RPC_GRPC_STATUS_CODE_RESOURCE_EXHAUSTED = '8';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE FAILED_PRECONDITION
+     */
+    public const RPC_GRPC_STATUS_CODE_FAILED_PRECONDITION = '9';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE ABORTED
+     */
+    public const RPC_GRPC_STATUS_CODE_ABORTED = '10';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE OUT_OF_RANGE
+     */
+    public const RPC_GRPC_STATUS_CODE_OUT_OF_RANGE = '11';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNIMPLEMENTED
+     */
+    public const RPC_GRPC_STATUS_CODE_UNIMPLEMENTED = '12';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE INTERNAL
+     */
+    public const RPC_GRPC_STATUS_CODE_INTERNAL = '13';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNAVAILABLE
+     */
+    public const RPC_GRPC_STATUS_CODE_UNAVAILABLE = '14';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE DATA_LOSS
+     */
+    public const RPC_GRPC_STATUS_CODE_DATA_LOSS = '15';
+
+    /**
+     * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNAUTHENTICATED
+     */
+    public const RPC_GRPC_STATUS_CODE_UNAUTHENTICATED = '16';
+
+    /**
+     * @see TraceAttributes::RPC_SYSTEM gRPC
+     */
+    public const RPC_SYSTEM_GRPC = 'grpc';
+
+    /**
+     * @see TraceAttributes::RPC_SYSTEM Java RMI
+     */
+    public const RPC_SYSTEM_JAVA_RMI = 'java_rmi';
+
+    /**
+     * @see TraceAttributes::RPC_SYSTEM .NET WCF
+     */
+    public const RPC_SYSTEM_DOTNET_WCF = 'dotnet_wcf';
+
+    /**
+     * @see TraceAttributes::RPC_SYSTEM Apache Dubbo
+     */
+    public const RPC_SYSTEM_APACHE_DUBBO = 'apache_dubbo';
+
+    /**
+     * @see TraceAttributes::RPC_SYSTEM Connect RPC
+     */
+    public const RPC_SYSTEM_CONNECT_RPC = 'connect_rpc';
+
+    /**
+     * @see TraceAttributes::SIGNALR_CONNECTION_STATUS The connection was closed normally
+     */
+    public const SIGNALR_CONNECTION_STATUS_NORMAL_CLOSURE = 'normal_closure';
+
+    /**
+     * @see TraceAttributes::SIGNALR_CONNECTION_STATUS The connection was closed due to a timeout
+     */
+    public const SIGNALR_CONNECTION_STATUS_TIMEOUT = 'timeout';
+
+    /**
+     * @see TraceAttributes::SIGNALR_CONNECTION_STATUS The connection was closed because the app is shutting down
+     */
+    public const SIGNALR_CONNECTION_STATUS_APP_SHUTDOWN = 'app_shutdown';
+
+    /**
+     * @see TraceAttributes::SIGNALR_TRANSPORT ServerSentEvents protocol
+     */
+    public const SIGNALR_TRANSPORT_SERVER_SENT_EVENTS = 'server_sent_events';
+
+    /**
+     * @see TraceAttributes::SIGNALR_TRANSPORT LongPolling protocol
+     */
+    public const SIGNALR_TRANSPORT_LONG_POLLING = 'long_polling';
+
+    /**
+     * @see TraceAttributes::SIGNALR_TRANSPORT WebSockets protocol
+     */
+    public const SIGNALR_TRANSPORT_WEB_SOCKETS = 'web_sockets';
+
+    /**
+     * @see TraceAttributes::STATE idle
+     */
+    public const STATE_IDLE = 'idle';
+
+    /**
+     * @see TraceAttributes::STATE used
+     */
+    public const STATE_USED = 'used';
+
+    /**
+     * @see TraceAttributes::SYSTEM_CPU_STATE user
+     */
+    public const SYSTEM_CPU_STATE_USER = 'user';
+
+    /**
+     * @see TraceAttributes::SYSTEM_CPU_STATE system
+     */
+    public const SYSTEM_CPU_STATE_SYSTEM = 'system';
+
+    /**
+     * @see TraceAttributes::SYSTEM_CPU_STATE nice
+     */
+    public const SYSTEM_CPU_STATE_NICE = 'nice';
+
+    /**
+     * @see TraceAttributes::SYSTEM_CPU_STATE idle
+     */
+    public const SYSTEM_CPU_STATE_IDLE = 'idle';
+
+    /**
+     * @see TraceAttributes::SYSTEM_CPU_STATE iowait
+     */
+    public const SYSTEM_CPU_STATE_IOWAIT = 'iowait';
+
+    /**
+     * @see TraceAttributes::SYSTEM_CPU_STATE interrupt
+     */
+    public const SYSTEM_CPU_STATE_INTERRUPT = 'interrupt';
+
+    /**
+     * @see TraceAttributes::SYSTEM_CPU_STATE steal
+     */
+    public const SYSTEM_CPU_STATE_STEAL = 'steal';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_STATE used
+     */
+    public const SYSTEM_FILESYSTEM_STATE_USED = 'used';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_STATE free
+     */
+    public const SYSTEM_FILESYSTEM_STATE_FREE = 'free';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_STATE reserved
+     */
+    public const SYSTEM_FILESYSTEM_STATE_RESERVED = 'reserved';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_TYPE fat32
+     */
+    public const SYSTEM_FILESYSTEM_TYPE_FAT32 = 'fat32';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_TYPE exfat
+     */
+    public const SYSTEM_FILESYSTEM_TYPE_EXFAT = 'exfat';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_TYPE ntfs
+     */
+    public const SYSTEM_FILESYSTEM_TYPE_NTFS = 'ntfs';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_TYPE refs
+     */
+    public const SYSTEM_FILESYSTEM_TYPE_REFS = 'refs';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_TYPE hfsplus
+     */
+    public const SYSTEM_FILESYSTEM_TYPE_HFSPLUS = 'hfsplus';
+
+    /**
+     * @see TraceAttributes::SYSTEM_FILESYSTEM_TYPE ext4
+     */
+    public const SYSTEM_FILESYSTEM_TYPE_EXT4 = 'ext4';
+
+    /**
+     * @see TraceAttributes::SYSTEM_MEMORY_STATE used
+     */
+    public const SYSTEM_MEMORY_STATE_USED = 'used';
+
+    /**
+     * @see TraceAttributes::SYSTEM_MEMORY_STATE free
+     */
+    public const SYSTEM_MEMORY_STATE_FREE = 'free';
+
+    /**
+     * @see TraceAttributes::SYSTEM_MEMORY_STATE shared
+     */
+    public const SYSTEM_MEMORY_STATE_SHARED = 'shared';
+
+    /**
+     * @see TraceAttributes::SYSTEM_MEMORY_STATE buffers
+     */
+    public const SYSTEM_MEMORY_STATE_BUFFERS = 'buffers';
+
+    /**
+     * @see TraceAttributes::SYSTEM_MEMORY_STATE cached
+     */
+    public const SYSTEM_MEMORY_STATE_CACHED = 'cached';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE close
+     */
+    public const SYSTEM_NETWORK_STATE_CLOSE = 'close';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE close_wait
+     */
+    public const SYSTEM_NETWORK_STATE_CLOSE_WAIT = 'close_wait';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE closing
+     */
+    public const SYSTEM_NETWORK_STATE_CLOSING = 'closing';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE delete
+     */
+    public const SYSTEM_NETWORK_STATE_DELETE = 'delete';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE established
+     */
+    public const SYSTEM_NETWORK_STATE_ESTABLISHED = 'established';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE fin_wait_1
+     */
+    public const SYSTEM_NETWORK_STATE_FIN_WAIT_1 = 'fin_wait_1';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE fin_wait_2
+     */
+    public const SYSTEM_NETWORK_STATE_FIN_WAIT_2 = 'fin_wait_2';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE last_ack
+     */
+    public const SYSTEM_NETWORK_STATE_LAST_ACK = 'last_ack';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE listen
+     */
+    public const SYSTEM_NETWORK_STATE_LISTEN = 'listen';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE syn_recv
+     */
+    public const SYSTEM_NETWORK_STATE_SYN_RECV = 'syn_recv';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE syn_sent
+     */
+    public const SYSTEM_NETWORK_STATE_SYN_SENT = 'syn_sent';
+
+    /**
+     * @see TraceAttributes::SYSTEM_NETWORK_STATE time_wait
+     */
+    public const SYSTEM_NETWORK_STATE_TIME_WAIT = 'time_wait';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PAGING_DIRECTION in
+     */
+    public const SYSTEM_PAGING_DIRECTION_IN = 'in';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PAGING_DIRECTION out
+     */
+    public const SYSTEM_PAGING_DIRECTION_OUT = 'out';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PAGING_STATE used
+     */
+    public const SYSTEM_PAGING_STATE_USED = 'used';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PAGING_STATE free
+     */
+    public const SYSTEM_PAGING_STATE_FREE = 'free';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PAGING_TYPE major
+     */
+    public const SYSTEM_PAGING_TYPE_MAJOR = 'major';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PAGING_TYPE minor
+     */
+    public const SYSTEM_PAGING_TYPE_MINOR = 'minor';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PROCESSES_STATUS running
+     */
+    public const SYSTEM_PROCESSES_STATUS_RUNNING = 'running';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PROCESSES_STATUS sleeping
+     */
+    public const SYSTEM_PROCESSES_STATUS_SLEEPING = 'sleeping';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PROCESSES_STATUS stopped
+     */
+    public const SYSTEM_PROCESSES_STATUS_STOPPED = 'stopped';
+
+    /**
+     * @see TraceAttributes::SYSTEM_PROCESSES_STATUS defunct
+     */
+    public const SYSTEM_PROCESSES_STATUS_DEFUNCT = 'defunct';
+
+    /**
+     * @see TraceAttributes::TLS_PROTOCOL_NAME ssl
+     */
+    public const TLS_PROTOCOL_NAME_SSL = 'ssl';
+
+    /**
+     * @see TraceAttributes::TLS_PROTOCOL_NAME tls
+     */
+    public const TLS_PROTOCOL_NAME_TLS = 'tls';
+}

--- a/src/SemConv/TraceAttributes.php
+++ b/src/SemConv/TraceAttributes.php
@@ -2174,11 +2174,6 @@ interface TraceAttributes
     /**
      * @deprecated
      */
-    public const HTTP_USER_AGENT = 'http.user_agent';
-
-    /**
-     * @deprecated
-     */
     public const MESSAGING_CONVERSATION_ID = 'messaging.conversation_id';
 
     /**
@@ -2235,11 +2230,6 @@ interface TraceAttributes
      * @deprecated
      */
     public const HTTP_CLIENT_IP = 'http.client_ip';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_FLAVOR = 'http.flavor';
 
     /**
      * @deprecated

--- a/src/SemConv/TraceAttributes.php
+++ b/src/SemConv/TraceAttributes.php
@@ -11,7 +11,7 @@ interface TraceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.23.1';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.24.0';
 
     /**
      * This attribute represents the state the application has transitioned into at the occurrence of the event.
@@ -19,6 +19,44 @@ interface TraceAttributes
      * The Android lifecycle states are defined in Activity lifecycle callbacks, and from which the `OS identifiers` are derived.
      */
     public const ANDROID_STATE = 'android.state';
+
+    /**
+     * Full type name of the `IExceptionHandler` implementation that handled the exception.
+     *
+     * @example Contoso.MyHandler
+     */
+    public const ASPNETCORE_DIAGNOSTICS_HANDLER_TYPE = 'aspnetcore.diagnostics.handler.type';
+
+    /**
+     * Rate limiting policy name.
+     *
+     * @example fixed
+     * @example sliding
+     * @example token
+     */
+    public const ASPNETCORE_RATE_LIMITING_POLICY = 'aspnetcore.rate_limiting.policy';
+
+    /**
+     * Rate-limiting result, shows whether the lease was acquired or contains a rejection reason.
+     *
+     * @example acquired
+     * @example request_canceled
+     */
+    public const ASPNETCORE_RATE_LIMITING_RESULT = 'aspnetcore.rate_limiting.result';
+
+    /**
+     * Flag indicating if request was handled by the application pipeline.
+     *
+     * @example True
+     */
+    public const ASPNETCORE_REQUEST_IS_UNHANDLED = 'aspnetcore.request.is_unhandled';
+
+    /**
+     * A value that indicates whether the matched route is a fallback route.
+     *
+     * @example True
+     */
+    public const ASPNETCORE_ROUTING_IS_FALLBACK = 'aspnetcore.routing.is_fallback';
 
     /**
      * The JSON-serialized value of each item in the `AttributeDefinitions` request field.
@@ -403,6 +441,13 @@ interface TraceAttributes
     public const CODE_NAMESPACE = 'code.namespace';
 
     /**
+     * A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
+     *
+     * @example at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
+     */
+    public const CODE_STACKTRACE = 'code.stacktrace';
+
+    /**
      * The consistency level of the query. Based on consistency values from CQL.
      */
     public const DB_CASSANDRA_CONSISTENCY_LEVEL = 'db.cassandra.consistency_level';
@@ -441,7 +486,7 @@ interface TraceAttributes
     public const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = 'db.cassandra.speculative_execution_count';
 
     /**
-     * The name of the primary table that the operation is acting upon, including the keyspace name (if applicable).
+     * The name of the primary Cassandra table that the operation is acting upon, including the keyspace name (if applicable).
      *
      * This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
      *
@@ -524,6 +569,13 @@ interface TraceAttributes
     public const DB_ELASTICSEARCH_NODE_NAME = 'db.elasticsearch.node.name';
 
     /**
+     * An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`.
+     *
+     * @example mysql-e26b99z.example.com
+     */
+    public const DB_INSTANCE_ID = 'db.instance.id';
+
+    /**
      * The fully-qualified class name of the Java Database Connectivity (JDBC) driver used to connect.
      *
      * @example org.postgresql.Driver
@@ -532,7 +584,7 @@ interface TraceAttributes
     public const DB_JDBC_DRIVER_CLASSNAME = 'db.jdbc.driver_classname';
 
     /**
-     * The collection being accessed within the database stated in `db.name`.
+     * The MongoDB collection being accessed within the database stated in `db.name`.
      *
      * @example customers
      * @example products
@@ -628,6 +680,13 @@ interface TraceAttributes
     public const DESTINATION_PORT = 'destination.port';
 
     /**
+     * The disk IO operation direction.
+     *
+     * @example read
+     */
+    public const DISK_IO_DIRECTION = 'disk.io.direction';
+
+    /**
      * Username or client_id extracted from the access token or Authorization header in the inbound request from outside the system.
      *
      * @example username
@@ -651,15 +710,14 @@ interface TraceAttributes
     /**
      * Describes a class of error the operation ended with.
      *
-     * The `error.type` SHOULD be predictable and SHOULD have low cardinality.
-     * Instrumentations SHOULD document the list of errors they report.The cardinality of `error.type` within one instrumentation library SHOULD be low.
-     * Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-     * should be prepared for `error.type` to have high cardinality at query time when no
-     * additional filters are applied.If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
-     * it's RECOMMENDED to:<ul>
-     * <li>Use a domain-specific attribute</li>
-     * <li>Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.</li>
-     * </ul>
+     * If the request fails with an error before response status code was sent or received,
+     * `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
+     * or a component-specific low cardinality error identifier.If response status code was sent or received and status indicates an error according to HTTP span status definition,
+     * `error.type` SHOULD be set to the status code number (represented as a string), an exception type (if thrown) or a component-specific error identifier.The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
+     * Instrumentations SHOULD document the list of errors they report.The cardinality of `error.type` within one instrumentation library SHOULD be low, but
+     * telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+     * should be prepared for `error.type` to have high cardinality at query time, when no
+     * additional filters are applied.If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
      *
      * @example timeout
      * @example java.net.UnknownHostException
@@ -669,17 +727,12 @@ interface TraceAttributes
     public const ERROR_TYPE = 'error.type';
 
     /**
-     * The domain identifies the business context for the events.
+     * Identifies the class / type of event.
      *
-     * Events across different domains may have same `event.name`, yet be unrelated events.
-     */
-    public const EVENT_DOMAIN = 'event.domain';
-
-    /**
-     * The name identifies the event.
+     * Event names are subject to the same rules as attribute names. Notably, event names are namespaced to avoid collisions and provide a clean separation of semantics for events in separate domains like browser, mobile, and kubernetes.
      *
-     * @example click
-     * @example exception
+     * @example browser.mouse.click
+     * @example device.app.lifecycle
      */
     public const EVENT_NAME = 'event.name';
 
@@ -694,7 +747,7 @@ interface TraceAttributes
      * whether it will escape the scope of a span.
      * However, it is trivial to know that an exception
      * will escape, if one checks for an active exception just before ending the span,
-     * as done in the example above.It follows that an exception may still escape the scope of the span
+     * as done in the example for recording span exceptions.It follows that an exception may still escape the scope of the span
      * even if the `exception.escaped` attribute was not set or set to false,
      * since the event might have been recorded at a time where it was not
      * clear whether the exception will escape.
@@ -864,6 +917,11 @@ interface TraceAttributes
     public const GRAPHQL_OPERATION_TYPE = 'graphql.operation.type';
 
     /**
+     * Deprecated, use `network.protocol.name` instead.
+     */
+    public const HTTP_FLAVOR = 'http.flavor';
+
+    /**
      * Deprecated, use `http.request.method` instead.
      *
      * @deprecated Deprecated, use `http.request.method` instead..
@@ -989,6 +1047,15 @@ interface TraceAttributes
      * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
      */
     public const HTTP_URL = 'http.url';
+
+    /**
+     * Deprecated, use `user_agent.original` instead.
+     *
+     * @deprecated Deprecated, use `user_agent.original` instead..
+     * @example CERN-LineMode/2.15 libwww/2.17b3
+     * @example Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1
+     */
+    public const HTTP_USER_AGENT = 'http.user_agent';
 
     /**
      * This attribute represents the state the application has transitioned into at the occurrence of the event.
@@ -1156,6 +1223,13 @@ interface TraceAttributes
     public const MESSAGING_DESTINATION_PUBLISH_NAME = 'messaging.destination_publish.name';
 
     /**
+     * The ordering key for a given message. If the attribute is not present, the message does not have an ordering key.
+     *
+     * @example ordering_key
+     */
+    public const MESSAGING_GCP_PUBSUB_MESSAGE_ORDERING_KEY = 'messaging.gcp_pubsub.message.ordering_key';
+
+    /**
      * Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
      *
      * @example my-group
@@ -1299,13 +1373,7 @@ interface TraceAttributes
     public const MESSAGING_ROCKETMQ_NAMESPACE = 'messaging.rocketmq.namespace';
 
     /**
-     * A string identifying the messaging system.
-     *
-     * @example kafka
-     * @example rabbitmq
-     * @example rocketmq
-     * @example activemq
-     * @example AmazonSQS
+     * An identifier for the messaging system being used. See below for a list of well-known identifiers.
      */
     public const MESSAGING_SYSTEM = 'messaging.system';
 
@@ -1452,6 +1520,13 @@ interface TraceAttributes
     public const NETWORK_CONNECTION_TYPE = 'network.connection.type';
 
     /**
+     * The network IO operation direction.
+     *
+     * @example transmit
+     */
+    public const NETWORK_IO_DIRECTION = 'network.io.direction';
+
+    /**
      * Local address of the network connection - IP address or Unix domain socket name.
      *
      * @example 10.1.2.80
@@ -1511,7 +1586,7 @@ interface TraceAttributes
      * different processes could be listening on TCP port 12345 and UDP port 12345.
      *
      * @example tcp
-     * @example udp
+     * @example unix
      */
     public const NETWORK_TRANSPORT = 'network.transport';
 
@@ -1624,9 +1699,9 @@ interface TraceAttributes
     public const RPC_SYSTEM = 'rpc.system';
 
     /**
-     * Host identifier of the &quot;URI origin&quot; HTTP request is sent to.
+     * Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
      *
-     * If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
+     * When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
      *
      * @example example.com
      * @example 10.1.2.80
@@ -1635,7 +1710,7 @@ interface TraceAttributes
     public const SERVER_ADDRESS = 'server.address';
 
     /**
-     * Port identifier of the &quot;URI origin&quot; HTTP request is sent to.
+     * Server port number.
      *
      * When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
      *
@@ -1658,6 +1733,22 @@ interface TraceAttributes
      * @example 00112233-4455-6677-8899-aabbccddeeff
      */
     public const SESSION_PREVIOUS_ID = 'session.previous_id';
+
+    /**
+     * SignalR HTTP connection closure status.
+     *
+     * @example app_shutdown
+     * @example timeout
+     */
+    public const SIGNALR_CONNECTION_STATUS = 'signalr.connection.status';
+
+    /**
+     * SignalR transport type.
+     *
+     * @example web_sockets
+     * @example long_polling
+     */
+    public const SIGNALR_TRANSPORT = 'signalr.transport';
 
     /**
      * Source address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
@@ -1708,13 +1799,6 @@ interface TraceAttributes
     public const SYSTEM_DEVICE = 'system.device';
 
     /**
-     * The disk operation direction.
-     *
-     * @example read
-     */
-    public const SYSTEM_DISK_DIRECTION = 'system.disk.direction';
-
-    /**
      * The filesystem mode.
      *
      * @example rw, ro
@@ -1749,13 +1833,6 @@ interface TraceAttributes
      * @example cached
      */
     public const SYSTEM_MEMORY_STATE = 'system.memory.state';
-
-    /**
-     * .
-     *
-     * @example transmit
-     */
-    public const SYSTEM_NETWORK_DIRECTION = 'system.network.direction';
 
     /**
      * A stateless protocol MUST NOT set this attribute.
@@ -1805,6 +1882,213 @@ interface TraceAttributes
      * @example main
      */
     public const THREAD_NAME = 'thread.name';
+
+    /**
+     * String indicating the cipher used during the current connection.
+     *
+     * The values allowed for `tls.cipher` MUST be one of the `Descriptions` of the registered TLS Cipher Suits.
+     *
+     * @example TLS_RSA_WITH_3DES_EDE_CBC_SHA
+     * @example TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+     */
+    public const TLS_CIPHER = 'tls.cipher';
+
+    /**
+     * PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.
+     *
+     * @example MII...
+     */
+    public const TLS_CLIENT_CERTIFICATE = 'tls.client.certificate';
+
+    /**
+     * Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.
+     *
+     * @example MII...
+     * @example MI...
+     */
+    public const TLS_CLIENT_CERTIFICATE_CHAIN = 'tls.client.certificate_chain';
+
+    /**
+     * Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
+     *
+     * @example 0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC
+     */
+    public const TLS_CLIENT_HASH_MD5 = 'tls.client.hash.md5';
+
+    /**
+     * Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
+     *
+     * @example 9E393D93138888D288266C2D915214D1D1CCEB2A
+     */
+    public const TLS_CLIENT_HASH_SHA1 = 'tls.client.hash.sha1';
+
+    /**
+     * Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
+     *
+     * @example 0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0
+     */
+    public const TLS_CLIENT_HASH_SHA256 = 'tls.client.hash.sha256';
+
+    /**
+     * Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
+     *
+     * @example CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
+     */
+    public const TLS_CLIENT_ISSUER = 'tls.client.issuer';
+
+    /**
+     * A hash that identifies clients based on how they perform an SSL/TLS handshake.
+     *
+     * @example d4e5b18d6b55c71272893221c96ba240
+     */
+    public const TLS_CLIENT_JA3 = 'tls.client.ja3';
+
+    /**
+     * Date/Time indicating when client certificate is no longer considered valid.
+     *
+     * @example 2021-01-01T00:00:00.000Z
+     */
+    public const TLS_CLIENT_NOT_AFTER = 'tls.client.not_after';
+
+    /**
+     * Date/Time indicating when client certificate is first considered valid.
+     *
+     * @example 1970-01-01T00:00:00.000Z
+     */
+    public const TLS_CLIENT_NOT_BEFORE = 'tls.client.not_before';
+
+    /**
+     * Also called an SNI, this tells the server which hostname to which the client is attempting to connect to.
+     *
+     * @example opentelemetry.io
+     */
+    public const TLS_CLIENT_SERVER_NAME = 'tls.client.server_name';
+
+    /**
+     * Distinguished name of subject of the x.509 certificate presented by the client.
+     *
+     * @example CN=myclient, OU=Documentation Team, DC=example, DC=com
+     */
+    public const TLS_CLIENT_SUBJECT = 'tls.client.subject';
+
+    /**
+     * Array of ciphers offered by the client during the client hello.
+     *
+     * @example "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "..."
+     */
+    public const TLS_CLIENT_SUPPORTED_CIPHERS = 'tls.client.supported_ciphers';
+
+    /**
+     * String indicating the curve used for the given cipher, when applicable.
+     *
+     * @example secp256r1
+     */
+    public const TLS_CURVE = 'tls.curve';
+
+    /**
+     * Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.
+     *
+     * @example True
+     */
+    public const TLS_ESTABLISHED = 'tls.established';
+
+    /**
+     * String indicating the protocol being tunneled. Per the values in the IANA registry, this string should be lower case.
+     *
+     * @example http/1.1
+     */
+    public const TLS_NEXT_PROTOCOL = 'tls.next_protocol';
+
+    /**
+     * Normalized lowercase protocol name parsed from original string of the negotiated SSL/TLS protocol version.
+     */
+    public const TLS_PROTOCOL_NAME = 'tls.protocol.name';
+
+    /**
+     * Numeric part of the version parsed from the original string of the negotiated SSL/TLS protocol version.
+     *
+     * @example 1.2
+     * @example 3
+     */
+    public const TLS_PROTOCOL_VERSION = 'tls.protocol.version';
+
+    /**
+     * Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.
+     *
+     * @example True
+     */
+    public const TLS_RESUMED = 'tls.resumed';
+
+    /**
+     * PEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of `server.certificate_chain` since this value also exists in that list.
+     *
+     * @example MII...
+     */
+    public const TLS_SERVER_CERTIFICATE = 'tls.server.certificate';
+
+    /**
+     * Array of PEM-encoded certificates that make up the certificate chain offered by the server. This is usually mutually-exclusive of `server.certificate` since that value should be the first certificate in the chain.
+     *
+     * @example MII...
+     * @example MI...
+     */
+    public const TLS_SERVER_CERTIFICATE_CHAIN = 'tls.server.certificate_chain';
+
+    /**
+     * Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
+     *
+     * @example 0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC
+     */
+    public const TLS_SERVER_HASH_MD5 = 'tls.server.hash.md5';
+
+    /**
+     * Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
+     *
+     * @example 9E393D93138888D288266C2D915214D1D1CCEB2A
+     */
+    public const TLS_SERVER_HASH_SHA1 = 'tls.server.hash.sha1';
+
+    /**
+     * Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
+     *
+     * @example 0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0
+     */
+    public const TLS_SERVER_HASH_SHA256 = 'tls.server.hash.sha256';
+
+    /**
+     * Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
+     *
+     * @example CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
+     */
+    public const TLS_SERVER_ISSUER = 'tls.server.issuer';
+
+    /**
+     * A hash that identifies servers based on how they perform an SSL/TLS handshake.
+     *
+     * @example d4e5b18d6b55c71272893221c96ba240
+     */
+    public const TLS_SERVER_JA3S = 'tls.server.ja3s';
+
+    /**
+     * Date/Time indicating when server certificate is no longer considered valid.
+     *
+     * @example 2021-01-01T00:00:00.000Z
+     */
+    public const TLS_SERVER_NOT_AFTER = 'tls.server.not_after';
+
+    /**
+     * Date/Time indicating when server certificate is first considered valid.
+     *
+     * @example 1970-01-01T00:00:00.000Z
+     */
+    public const TLS_SERVER_NOT_BEFORE = 'tls.server.not_before';
+
+    /**
+     * Distinguished name of subject of the x.509 certificate presented by the server.
+     *
+     * @example CN=myserver, OU=Documentation Team, DC=example, DC=com
+     */
+    public const TLS_SERVER_SUBJECT = 'tls.server.subject';
 
     /**
      * The URI fragment component.
@@ -2066,4 +2350,19 @@ interface TraceAttributes
      * @deprecated
      */
     public const THREAD_DAEMON = 'thread.daemon';
+
+    /**
+     * @deprecated
+     */
+    public const EVENT_DOMAIN = 'event.domain';
+
+    /**
+     * @deprecated
+     */
+    public const SYSTEM_DISK_DIRECTION = 'system.disk.direction';
+
+    /**
+     * @deprecated
+     */
+    public const SYSTEM_NETWORK_DIRECTION = 'system.network.direction';
 }


### PR DESCRIPTION
generate latest semconv version, and add back Trace and Resource attribute values which seem to have been dropped in a previous change.