### PR TITLE
log previous exception message from error writer

### DIFF
--- a/src/API/Behavior/Internal/LogWriter/Formatter.php
+++ b/src/API/Behavior/Internal/LogWriter/Formatter.php
@@ -12,11 +12,13 @@ class Formatter
             ? $context['exception']
             : null;
         if ($exception) {
+            $previous = $exception->getPrevious() ? $exception->getPrevious()->getMessage() : '';
             $message = sprintf(
-                'OpenTelemetry: [%s] %s [exception] %s%s%s',
+                'OpenTelemetry: [%s] %s [exception] %s [previous] %s%s%s',
                 $level,
                 $message,
                 $exception->getMessage(),
+                $previous,
                 PHP_EOL,
                 $exception->getTraceAsString()
             );


### PR DESCRIPTION
it's not always clear from an exception message what the underlying issue was, so also print out the previous exception's message, if available.

Fixes: #1112 