### PR TITLE
feat: Allow OTEL_PHP_DEBUG_SCOPES_DISABLED as en environment variable

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -7,7 +7,6 @@ namespace OpenTelemetry\Context;
 use function assert;
 use const FILTER_VALIDATE_BOOLEAN;
 use function filter_var;
-use function ini_get;
 use function spl_object_id;
 
 /**
@@ -15,6 +14,8 @@ use function spl_object_id;
  */
 final class Context implements ContextInterface
 {
+    private const OTEL_PHP_DEBUG_SCOPES_DISABLED = 'OTEL_PHP_DEBUG_SCOPES_DISABLED';
+
     /** @var ContextStorageInterface&ExecutionContextAwareInterface */
     private static ContextStorageInterface $storage;
 
@@ -91,11 +92,11 @@ final class Context implements ContextInterface
 
     private static function debugScopesDisabled(): bool
     {
-        if (isset($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED']) && filter_var($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'], FILTER_VALIDATE_BOOLEAN)) {
+        if (isset($_SERVER[self::OTEL_PHP_DEBUG_SCOPES_DISABLED]) && filter_var($_SERVER[self::OTEL_PHP_DEBUG_SCOPES_DISABLED], FILTER_VALIDATE_BOOLEAN)) {
             return true;
-        } elseif (($env = \getenv('OTEL_PHP_DEBUG_SCOPES_DISABLED')) && filter_var($env, FILTER_VALIDATE_BOOLEAN)) {
+        } elseif (($env = \getenv(self::OTEL_PHP_DEBUG_SCOPES_DISABLED)) && filter_var($env, FILTER_VALIDATE_BOOLEAN)) {
             return true;
-        } elseif (($ini = \ini_get('OTEL_PHP_DEBUG_SCOPES_DISABLED')) && filter_var($ini, FILTER_VALIDATE_BOOLEAN)) {
+        } elseif (($ini = \ini_get(self::OTEL_PHP_DEBUG_SCOPES_DISABLED)) && filter_var($ini, FILTER_VALIDATE_BOOLEAN)) {
             return true;
         }
 

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -91,9 +91,15 @@ final class Context implements ContextInterface
 
     private static function debugScopesDisabled(): bool
     {
-        $disabled = $_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'] ?? ini_get('OTEL_PHP_DEBUG_SCOPES_DISABLED');
+        if (isset($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED']) && filter_var($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'], FILTER_VALIDATE_BOOLEAN)) {
+            return true;
+        } elseif (($ini = \ini_get('OTEL_PHP_DEBUG_SCOPES_DISABLED')) && filter_var($ini, FILTER_VALIDATE_BOOLEAN)) {
+            return true;
+        } elseif (($env = \getenv('OTEL_PHP_DEBUG_SCOPES_DISABLED')) && filter_var($env, FILTER_VALIDATE_BOOLEAN)) {
+            return true;
+        }
 
-        return filter_var($disabled, FILTER_VALIDATE_BOOLEAN);
+        return false;
     }
 
     public function withContextValue(ImplicitContextKeyedInterface $value): ContextInterface

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -92,15 +92,11 @@ final class Context implements ContextInterface
 
     private static function debugScopesDisabled(): bool
     {
-        if (isset($_SERVER[self::OTEL_PHP_DEBUG_SCOPES_DISABLED]) && filter_var($_SERVER[self::OTEL_PHP_DEBUG_SCOPES_DISABLED], FILTER_VALIDATE_BOOLEAN)) {
-            return true;
-        } elseif (($env = \getenv(self::OTEL_PHP_DEBUG_SCOPES_DISABLED)) && filter_var($env, FILTER_VALIDATE_BOOLEAN)) {
-            return true;
-        } elseif (($ini = \ini_get(self::OTEL_PHP_DEBUG_SCOPES_DISABLED)) && filter_var($ini, FILTER_VALIDATE_BOOLEAN)) {
-            return true;
-        }
+        return filter_var(
+            $_SERVER[self::OTEL_PHP_DEBUG_SCOPES_DISABLED] ?? \getenv(self::OTEL_PHP_DEBUG_SCOPES_DISABLED) ?: \ini_get(self::OTEL_PHP_DEBUG_SCOPES_DISABLED),
+            FILTER_VALIDATE_BOOLEAN
+        );
 
-        return false;
     }
 
     public function withContextValue(ImplicitContextKeyedInterface $value): ContextInterface

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -96,7 +96,6 @@ final class Context implements ContextInterface
             $_SERVER[self::OTEL_PHP_DEBUG_SCOPES_DISABLED] ?? \getenv(self::OTEL_PHP_DEBUG_SCOPES_DISABLED) ?: \ini_get(self::OTEL_PHP_DEBUG_SCOPES_DISABLED),
             FILTER_VALIDATE_BOOLEAN
         );
-
     }
 
     public function withContextValue(ImplicitContextKeyedInterface $value): ContextInterface

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -93,9 +93,9 @@ final class Context implements ContextInterface
     {
         if (isset($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED']) && filter_var($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'], FILTER_VALIDATE_BOOLEAN)) {
             return true;
-        } elseif (($ini = \ini_get('OTEL_PHP_DEBUG_SCOPES_DISABLED')) && filter_var($ini, FILTER_VALIDATE_BOOLEAN)) {
-            return true;
         } elseif (($env = \getenv('OTEL_PHP_DEBUG_SCOPES_DISABLED')) && filter_var($env, FILTER_VALIDATE_BOOLEAN)) {
+            return true;
+        } elseif (($ini = \ini_get('OTEL_PHP_DEBUG_SCOPES_DISABLED')) && filter_var($ini, FILTER_VALIDATE_BOOLEAN)) {
             return true;
         }
 

--- a/tests/Unit/Context/ContextTest.php
+++ b/tests/Unit/Context/ContextTest.php
@@ -191,6 +191,7 @@ class ContextTest extends TestCase
             $this->assertNotInstanceOf(DebugScope::class, $scope);
         } finally {
             $scope->detach();
+            \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED');
         }
     }
 }

--- a/tests/Unit/Context/ContextTest.php
+++ b/tests/Unit/Context/ContextTest.php
@@ -194,4 +194,38 @@ class ContextTest extends TestCase
             \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED');
         }
     }
+
+    public function test_debug_scopes_disabled_server_var(): void
+    {
+        $_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'] = '1';
+
+        $context = Context::getRoot();
+
+        $scope = $context->activate();
+
+        try {
+            $this->assertNotInstanceOf(DebugScope::class, $scope);
+        } finally {
+            $scope->detach();
+            unset($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED']);
+        }
+    }
+
+    public function test_debug_scopes_disabled_order_server(): void
+    {
+        $_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'] = '1';
+        \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED=0');
+
+        $context = Context::getRoot();
+
+        $scope = $context->activate();
+
+        try {
+            $this->assertNotInstanceOf(DebugScope::class, $scope);
+        } finally {
+            $scope->detach();
+            unset($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED']);
+            \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED');
+        }
+    }
 }

--- a/tests/Unit/Context/ContextTest.php
+++ b/tests/Unit/Context/ContextTest.php
@@ -228,4 +228,38 @@ class ContextTest extends TestCase
             \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED');
         }
     }
+
+    public function test_debug_scopes_disabled_falsey_server(): void
+    {
+        $_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED'] = '0';
+        \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED=1');
+
+        $context = Context::getRoot();
+
+        $scope = $context->activate();
+
+        try {
+            $this->assertInstanceOf(DebugScope::class, $scope);
+        } finally {
+            $scope->detach();
+            unset($_SERVER['OTEL_PHP_DEBUG_SCOPES_DISABLED']);
+            \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED');
+        }
+    }
+
+    public function test_debug_scopes_disabled_falsey_env(): void
+    {
+        \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED=0');
+
+        $context = Context::getRoot();
+
+        $scope = $context->activate();
+
+        try {
+            $this->assertInstanceOf(DebugScope::class, $scope);
+        } finally {
+            $scope->detach();
+            \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED');
+        }
+    }
 }

--- a/tests/Unit/Context/ContextTest.php
+++ b/tests/Unit/Context/ContextTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\Context;
 
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextKeys;
+use OpenTelemetry\Context\DebugScope;
 use OpenTelemetry\Context\ImplicitContextKeyedInterface;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -173,6 +174,21 @@ class ContextTest extends TestCase
 
             $token->detach();
             $this->assertSame(Context::getCurrent()->get($key), '111');
+        } finally {
+            $scope->detach();
+        }
+    }
+
+    public function test_debug_scopes_disabled_env_var(): void
+    {
+        \putenv('OTEL_PHP_DEBUG_SCOPES_DISABLED=1');
+
+        $context = Context::getRoot();
+
+        $scope = $context->activate();
+
+        try {
+            $this->assertNotInstanceOf(DebugScope::class, $scope);
         } finally {
             $scope->detach();
         }


### PR DESCRIPTION
Hi :wave:

While doing some tests and trying to set `OTEL_PHP_DEBUG_SCOPES_DISABLED` to `1` as an **environment variable** to disable the use of `DebugScope`, it wouldn't work. This is because it wasn't considered.

I guess it could have also made sense to use some kind of a `ResolverInterface`, considering both INIs and env var.

Also, my personal opinion on this env var is that it could make sense to have it enabled by default (in the next major, being a breaking change), considering that the use of `debug_backtrace` has a non-negligible performance impact.