### PR TITLE
support url-encoded OTEL_EXPORTER_OTLP_HEADERS values

### DIFF
--- a/src/Contrib/Otlp/LogsExporterFactory.php
+++ b/src/Contrib/Otlp/LogsExporterFactory.php
@@ -44,10 +44,7 @@ class LogsExporterFactory implements LogRecordExporterFactoryInterface
     {
         $endpoint = $this->getEndpoint($protocol);
 
-        $headers = Configuration::has(Variables::OTEL_EXPORTER_OTLP_LOGS_HEADERS)
-            ? Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_LOGS_HEADERS)
-            : Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_HEADERS);
-        $headers += OtlpUtil::getUserAgentHeader();
+        $headers = OtlpUtil::getHeaders(Signals::LOGS);
         $compression = $this->getCompression();
 
         $factoryClass = Registry::transportFactory($protocol);
@@ -56,7 +53,7 @@ class LogsExporterFactory implements LogRecordExporterFactoryInterface
         return $factory->create(
             $endpoint,
             Protocols::contentType($protocol),
-            array_map('urldecode', $headers),
+            $headers,
             $compression,
         );
     }

--- a/src/Contrib/Otlp/LogsExporterFactory.php
+++ b/src/Contrib/Otlp/LogsExporterFactory.php
@@ -56,7 +56,7 @@ class LogsExporterFactory implements LogRecordExporterFactoryInterface
         return $factory->create(
             $endpoint,
             Protocols::contentType($protocol),
-            $headers,
+            array_map('urldecode', $headers),
             $compression,
         );
     }

--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -51,10 +51,7 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
          */
         $endpoint = $this->getEndpoint($protocol);
 
-        $headers = Configuration::has(Variables::OTEL_EXPORTER_OTLP_METRICS_HEADERS)
-            ? Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_METRICS_HEADERS)
-            : Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_HEADERS);
-        $headers += OtlpUtil::getUserAgentHeader();
+        $headers = OtlpUtil::getHeaders(Signals::METRICS);
         $compression = $this->getCompression();
 
         $factoryClass = Registry::transportFactory($protocol);
@@ -63,7 +60,7 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
         return $factory->create(
             $endpoint,
             Protocols::contentType($protocol),
-            array_map('urldecode', $headers),
+            $headers,
             $compression,
         );
     }

--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -63,7 +63,7 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
         return $factory->create(
             $endpoint,
             Protocols::contentType($protocol),
-            $headers,
+            array_map('urldecode', $headers),
             $compression,
         );
     }

--- a/src/Contrib/Otlp/OtlpUtil.php
+++ b/src/Contrib/Otlp/OtlpUtil.php
@@ -44,7 +44,7 @@ class OtlpUtil
             Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_HEADERS);
         $headers += self::getUserAgentHeader();
 
-        return array_map('urldecode', $headers);
+        return array_map('rawurldecode', $headers);
     }
 
     /**

--- a/src/Contrib/Otlp/OtlpUtil.php
+++ b/src/Contrib/Otlp/OtlpUtil.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Otlp;
 
 use OpenTelemetry\API\Signals;
+use OpenTelemetry\SDK\Common\Configuration\Configuration;
+use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Resource\Detectors\Sdk;
 use OpenTelemetry\SemConv\ResourceAttributes;
 use UnexpectedValueException;
@@ -20,6 +22,11 @@ class OtlpUtil
         Signals::METRICS => '/opentelemetry.proto.collector.metrics.v1.MetricsService/Export',
         Signals::LOGS => '/opentelemetry.proto.collector.logs.v1.LogsService/Export',
     ];
+    private const HEADER_VARS = [
+        Signals::TRACE => Variables::OTEL_EXPORTER_OTLP_TRACES_HEADERS,
+        Signals::METRICS => Variables::OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+        Signals::LOGS => Variables::OTEL_EXPORTER_OTLP_LOGS_HEADERS,
+    ];
 
     public static function method(string $signal): string
     {
@@ -28,6 +35,16 @@ class OtlpUtil
         }
 
         return self::METHODS[$signal];
+    }
+
+    public static function getHeaders(string $signal): array
+    {
+        $headers = Configuration::has(self::HEADER_VARS[$signal]) ?
+            Configuration::getMap(self::HEADER_VARS[$signal]) :
+            Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_HEADERS);
+        $headers += self::getUserAgentHeader();
+
+        return array_map('urldecode', $headers);
     }
 
     /**

--- a/src/Contrib/Otlp/SpanExporterFactory.php
+++ b/src/Contrib/Otlp/SpanExporterFactory.php
@@ -47,7 +47,7 @@ class SpanExporterFactory implements SpanExporterFactoryInterface
         $protocol = $this->getProtocol();
         $contentType = Protocols::contentType($protocol);
         $endpoint = $this->getEndpoint($protocol);
-        $headers = array_map('urldecode', $this->getHeaders());
+        $headers = OtlpUtil::getHeaders(Signals::TRACE);
         $compression = $this->getCompression();
 
         $factoryClass = Registry::transportFactory($protocol);
@@ -76,15 +76,6 @@ class SpanExporterFactory implements SpanExporterFactoryInterface
         }
 
         return HttpEndpointResolver::create()->resolveToString($endpoint, Signals::TRACE);
-    }
-
-    private function getHeaders(): array
-    {
-        $headers = Configuration::has(Variables::OTEL_EXPORTER_OTLP_TRACES_HEADERS) ?
-            Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_TRACES_HEADERS) :
-            Configuration::getMap(Variables::OTEL_EXPORTER_OTLP_HEADERS);
-
-        return $headers + OtlpUtil::getUserAgentHeader();
     }
 
     private function getCompression(): string

--- a/src/Contrib/Otlp/SpanExporterFactory.php
+++ b/src/Contrib/Otlp/SpanExporterFactory.php
@@ -47,7 +47,7 @@ class SpanExporterFactory implements SpanExporterFactoryInterface
         $protocol = $this->getProtocol();
         $contentType = Protocols::contentType($protocol);
         $endpoint = $this->getEndpoint($protocol);
-        $headers = $this->getHeaders();
+        $headers = array_map('urldecode', $this->getHeaders());
         $compression = $this->getCompression();
 
         $factoryClass = Registry::transportFactory($protocol);

--- a/tests/Unit/Contrib/Otlp/OtlpUtilTest.php
+++ b/tests/Unit/Contrib/Otlp/OtlpUtilTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\Contrib\Otlp;
 
+use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use OpenTelemetry\API\Signals;
 use OpenTelemetry\Contrib\Otlp\OtlpUtil;
+use OpenTelemetry\SDK\Common\Configuration\Variables;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -13,6 +15,13 @@ use PHPUnit\Framework\TestCase;
  */
 class OtlpUtilTest extends TestCase
 {
+    use EnvironmentVariables;
+
+    public function tearDown(): void
+    {
+        $this->restoreEnvironmentVariables();
+    }
+
     public function test_get_user_agent_header(): void
     {
         $header = OtlpUtil::getUserAgentHeader();
@@ -41,6 +50,99 @@ class OtlpUtilTest extends TestCase
             [Signals::TRACE, 'TraceService'],
             [Signals::METRICS, 'MetricsService'],
             [Signals::LOGS, 'LogsService'],
+        ];
+    }
+
+    /**
+     * @dataProvider headersProvider
+     */
+    public function test_get_headers(string $signal, array $env, array $expected): void
+    {
+        foreach ($env as $var => $value) {
+            $this->setEnvironmentVariable($var, $value);
+        }
+        $headers = OtlpUtil::getHeaders($signal);
+
+        $this->assertGreaterThanOrEqual(count($expected), $headers);
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $headers);
+            $this->assertSame($value, $headers[$key]);
+        }
+    }
+
+    public static function headersProvider(): array
+    {
+        return [
+            'trace' => [
+                'signal' => Signals::TRACE,
+                'env' => [
+                    Variables::OTEL_EXPORTER_OTLP_TRACES_HEADERS => 'foo=bar,baz=bat',
+                ],
+                'expected' => [
+                    'foo' => 'bar',
+                    'baz' => 'bat',
+                ],
+            ],
+            'trace with default' => [
+                'signal' => Signals::TRACE,
+                'env' => [
+                    Variables::OTEL_EXPORTER_OTLP_HEADERS => 'foo=bar,baz=bat',
+                ],
+                'expected' => [
+                    'foo' => 'bar',
+                    'baz' => 'bat',
+                ],
+            ],
+            'metrics' => [
+                'signal' => Signals::METRICS,
+                'env' => [
+                    Variables::OTEL_EXPORTER_OTLP_METRICS_HEADERS => 'foo=bar,baz=bat',
+                ],
+                'expected' => [
+                    'foo' => 'bar',
+                    'baz' => 'bat',
+                ],
+            ],
+            'metrics with default' => [
+                'signal' => Signals::METRICS,
+                'env' => [
+                    Variables::OTEL_EXPORTER_OTLP_HEADERS => 'foo=bar,baz=bat',
+                ],
+                'expected' => [
+                    'foo' => 'bar',
+                    'baz' => 'bat',
+                ],
+            ],
+            'logs' => [
+                'signal' => Signals::LOGS,
+                'env' => [
+                    Variables::OTEL_EXPORTER_OTLP_LOGS_HEADERS => 'foo=bar,baz=bat',
+                ],
+                'expected' => [
+                    'foo' => 'bar',
+                    'baz' => 'bat',
+                ],
+            ],
+            'logs with default' => [
+                'signal' => Signals::LOGS,
+                'env' => [
+                    Variables::OTEL_EXPORTER_OTLP_HEADERS => 'foo=bar,baz=bat',
+                ],
+                'expected' => [
+                    'foo' => 'bar',
+                    'baz' => 'bat',
+                ],
+            ],
+            'url-encoded values' => [
+                'signal' => Signals::TRACE,
+                'env' => [
+                    Variables::OTEL_EXPORTER_OTLP_HEADERS => 'Authorization=Bearer%20secret,foo=%21%40%23%24%25%5E%26%2A%28%29',
+                ],
+                'expected' => [
+                    'Authorization' => 'Bearer secret',
+                    'foo' => '!@#$%^&*()',
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Per a recent spec clarification in https://github.com/open-telemetry/opentelemetry-specification/issues/3832 OTLP headers should support url-encoded header values.

Fixes: #1239 