### PR TITLE
perf: Re-use empty resource instance

### DIFF
--- a/src/SDK/Resource/ResourceInfoFactory.php
+++ b/src/SDK/Resource/ResourceInfoFactory.php
@@ -17,6 +17,9 @@ class ResourceInfoFactory
 {
     use LogsMessagesTrait;
 
+    private static ?ResourceInfo $emptyResource = null;
+
+
     public static function defaultResource(): ResourceInfo
     {
         $detectors = Configuration::getList(Env::OTEL_PHP_DETECTORS);
@@ -90,6 +93,10 @@ class ResourceInfoFactory
 
     public static function emptyResource(): ResourceInfo
     {
-        return ResourceInfo::create(Attributes::create([]));
+        if (null === self::$emptyResource) {
+            self::$emptyResource = ResourceInfo::create(Attributes::create([]));
+        }
+
+        return self::$emptyResource;
     }
 }

--- a/src/SDK/Resource/ResourceInfoFactory.php
+++ b/src/SDK/Resource/ResourceInfoFactory.php
@@ -19,7 +19,6 @@ class ResourceInfoFactory
 
     private static ?ResourceInfo $emptyResource = null;
 
-
     public static function defaultResource(): ResourceInfo
     {
         $detectors = Configuration::getList(Env::OTEL_PHP_DETECTORS);


### PR DESCRIPTION
Hello :wave:

While searching for low-hanging fruits to improve performance, it appeared from a profile of mine that repeated calls to `ResourceInfoFactory::emptyResource` would start having a non-negligible impact on the performances.

![Screenshot 2024-03-08 at 13 35 47](https://github.com/open-telemetry/opentelemetry-php/assets/42672104/ff9aaf55-4630-48a7-a193-a1efcac554d1)

The instance - being immutable - could be re-used.

Note: I haven't added a test with this PR as imo this is already been tested through the numerous calls to `ResourceInfoFactory::emptyResource`

Thanks! 😃 

---

FYI, this is the code I used to generate the above profile, if you care, which I ran a few dozen thousand times:

```php
function benchOpenTelemetryAPI($tracer) {
	$span = $tracer->spanBuilder('bench.basic_scenario')->setParent(false)->startSpan();
	$span->setAttribute('foo', 'bar');
	$span->setAttribute('bar', 1);

	$spans = [];
	for ($i = 0; $i < 6; $i++) {
		$childSpan = $tracer->spanBuilder('bench.basic_scenario.child')->startSpan();
		$childSpan->setAttribute('foo', 'bar');
		$childSpan->setAttribute('bar', 1);
		$spans[] = $childSpan;
	}

	for ($i = 5; $i >= 0; $i--) {
		$spans[$i]->end();
	}

	$span->end();
}
```