### PR TITLE
Fix conversion of non-utf8 sequences to `AnyValue`

### DIFF
--- a/src/Contrib/Otlp/AttributesConverter.php
+++ b/src/Contrib/Otlp/AttributesConverter.php
@@ -46,10 +46,21 @@ final class AttributesConverter
             $result->setDoubleValue($value);
         }
         if (is_string($value)) {
-            $result->setStringValue($value);
+            if (self::isUtf8($value)) {
+                $result->setStringValue($value);
+            } else {
+                $result->setBytesValue($value);
+            }
         }
 
         return $result;
+    }
+
+    private static function isUtf8(string $value): bool
+    {
+        return \extension_loaded('mbstring')
+            ? \mb_check_encoding($value, 'UTF-8')
+            : (bool) \preg_match('//u', $value);
     }
 
     /**

--- a/tests/Unit/Contrib/Otlp/AttributesConverterTest.php
+++ b/tests/Unit/Contrib/Otlp/AttributesConverterTest.php
@@ -36,6 +36,13 @@ class AttributesConverterTest extends TestCase
         ];
     }
 
+    public function test_convert_bytes(): void
+    {
+        $anyValue = AttributesConverter::convertAnyValue("\xe2");
+        $this->assertTrue($anyValue->hasBytesValue());
+        $this->assertSame("\xe2", $anyValue->getBytesValue());
+    }
+
     /**
      * @dataProvider arrayProvider
      */


### PR DESCRIPTION
[Converting to AnyValue](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/attribute-type-mapping.md#string-values):
> String values which are not valid Unicode sequences SHOULD be converted to AnyValue's bytes_value with the bytes representing the string in the original order and format of the source string.