### PR TITLE
drop php 8.0 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3']
         experimental: [false]
         composer_args: [""]
         include:
@@ -138,5 +138,5 @@ jobs:
     needs: php
     with:
       matrix_extension: '["ast, json, grpc"]'
-      matrix_php_version: '["8.0", "8.1", "8.2", "8.3"]'
+      matrix_php_version: '["8.1", "8.2", "8.3"]'
       install_directory: '~/.test/.packages'

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -44,7 +44,7 @@ return [
     //
     // Note that the **only** effect of choosing `'5.6'` is to infer that functions removed in php 7.0 exist.
     // (See `backward_compatibility_checks` for additional options)
-    'target_php_version' => '8.0',
+    'target_php_version' => '8.1',
 
     // If enabled, missing properties will be created when
     // they are first seen. If false, we'll report an

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "psr/http-message": "^1.0.1|^2.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/polyfill-mbstring": "^1.23",
-        "symfony/polyfill-php81": "^1.26",
         "symfony/polyfill-php82": "^1.26"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     "readme": "./README.md",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.0",
-        "ext-json": "*",
+        "php": "^8.1",
         "google/protobuf": "^3.22",
         "php-http/discovery": "^1.14",
         "psr/http-client-implementation": "^1.0",

--- a/rector.php
+++ b/rector.php
@@ -25,6 +25,9 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/src/SDK/SdkAutoloader.php',
         ],
         FlipTypeControlToUseExclusiveTypeRector::class,
+        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class => [
+            __DIR__ . '/src/SDK/Metrics/Stream/SynchronousMetricStream.php',
+        ],
         \Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector::class,
         \Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector::class,
         \Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector::class,

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRe
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\ValueObject\PhpVersion;
@@ -29,6 +30,9 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/src/SDK/SdkAutoloader.php',
         ],
         FlipTypeControlToUseExclusiveTypeRector::class,
+        NewInInitializerRector::class => [
+            __DIR__ . '/src/SDK/Trace/Sampler/ParentBased.php',
+        ],
         ReadOnlyPropertyRector::class => [
             __DIR__ . '/src/SDK/Metrics/Stream/SynchronousMetricStream.php',
         ],

--- a/rector.php
+++ b/rector.php
@@ -9,14 +9,14 @@ use Rector\ValueObject\PhpVersion;
 use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->phpVersion(PhpVersion::PHP_80);
+    $rectorConfig->phpVersion(PhpVersion::PHP_81);
 
     $rectorConfig->paths([
         __DIR__ . '/src',
     ]);
 
     $rectorConfig->sets([
-        SetList::PHP_80,
+        SetList::PHP_81,
         SetList::CODE_QUALITY,
     ]);
     $rectorConfig->skip([

--- a/rector.php
+++ b/rector.php
@@ -3,8 +3,12 @@
 declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
+use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\ValueObject\PhpVersion;
 use Rector\Set\ValueObject\SetList;
 
@@ -25,11 +29,11 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/src/SDK/SdkAutoloader.php',
         ],
         FlipTypeControlToUseExclusiveTypeRector::class,
-        \Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class => [
+        ReadOnlyPropertyRector::class => [
             __DIR__ . '/src/SDK/Metrics/Stream/SynchronousMetricStream.php',
         ],
-        \Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector::class,
-        \Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector::class,
-        \Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector::class,
+        DisallowedEmptyRuleFixerRector::class,
+        ExplicitBoolCompareRector::class,
+        LocallyCalledStaticMethodToNonStaticRector::class,
     ]);
 };

--- a/src/API/Baggage/Baggage.php
+++ b/src/API/Baggage/Baggage.php
@@ -42,7 +42,7 @@ final class Baggage implements BaggageInterface
     }
 
     /** @param array<string, Entry> $entries */
-    public function __construct(private array $entries = [])
+    public function __construct(private readonly array $entries = [])
     {
     }
 

--- a/src/API/Baggage/Entry.php
+++ b/src/API/Baggage/Entry.php
@@ -7,8 +7,8 @@ namespace OpenTelemetry\API\Baggage;
 final class Entry
 {
     public function __construct(
-        private mixed $value,
-        private MetadataInterface $metadata,
+        private readonly mixed $value,
+        private readonly MetadataInterface $metadata,
     ) {
     }
 

--- a/src/API/Baggage/Metadata.php
+++ b/src/API/Baggage/Metadata.php
@@ -13,7 +13,7 @@ final class Metadata implements MetadataInterface
         return self::$instance ??= new self('');
     }
 
-    public function __construct(private string $metadata)
+    public function __construct(private readonly string $metadata)
     {
     }
 

--- a/src/API/Baggage/Propagation/BaggagePropagator.php
+++ b/src/API/Baggage/Propagation/BaggagePropagator.php
@@ -54,7 +54,7 @@ final class BaggagePropagator implements TextMapPropagatorInterface
 
         /** @var Entry $entry */
         foreach ($baggage->getAll() as $key => $entry) {
-            $value = urlencode($entry->getValue());
+            $value = urlencode((string) $entry->getValue());
             $headerString.= "{$key}={$value}";
 
             if (($metadata = $entry->getMetadata()->getValue()) !== '' && ($metadata = $entry->getMetadata()->getValue()) !== '0') {

--- a/src/API/Baggage/Propagation/Parser.php
+++ b/src/API/Baggage/Propagation/Parser.php
@@ -19,7 +19,7 @@ final class Parser
 
     public function __construct(
         /** @readonly */
-        private string $baggageHeader,
+        private readonly string $baggageHeader,
     ) {
     }
 

--- a/src/API/Baggage/Propagation/Parser.php
+++ b/src/API/Baggage/Propagation/Parser.php
@@ -18,7 +18,6 @@ final class Parser
     private const EQUALS = '=';
 
     public function __construct(
-        /** @readonly */
         private readonly string $baggageHeader,
     ) {
     }

--- a/src/API/Behavior/Internal/LogWriter/Psr3LogWriter.php
+++ b/src/API/Behavior/Internal/LogWriter/Psr3LogWriter.php
@@ -8,7 +8,7 @@ use Psr\Log\LoggerInterface;
 
 class Psr3LogWriter implements LogWriterInterface
 {
-    public function __construct(private LoggerInterface $logger)
+    public function __construct(private readonly LoggerInterface $logger)
     {
     }
 

--- a/src/API/Globals.php
+++ b/src/API/Globals.php
@@ -28,10 +28,10 @@ final class Globals
     private static ?self $globals = null;
 
     public function __construct(
-        private TracerProviderInterface $tracerProvider,
-        private MeterProviderInterface $meterProvider,
-        private LoggerProviderInterface $loggerProvider,
-        private TextMapPropagatorInterface $propagator,
+        private readonly TracerProviderInterface $tracerProvider,
+        private readonly MeterProviderInterface $meterProvider,
+        private readonly LoggerProviderInterface $loggerProvider,
+        private readonly TextMapPropagatorInterface $propagator,
     ) {
     }
 

--- a/src/API/Instrumentation/CachedInstrumentation.php
+++ b/src/API/Instrumentation/CachedInstrumentation.php
@@ -34,10 +34,10 @@ final class CachedInstrumentation
      * @psalm-suppress PropertyTypeCoercion
      */
     public function __construct(
-        private string $name,
-        private ?string $version = null,
-        private ?string $schemaUrl = null,
-        private iterable $attributes = [],
+        private readonly string $name,
+        private readonly ?string $version = null,
+        private readonly ?string $schemaUrl = null,
+        private readonly iterable $attributes = [],
     ) {
         $this->tracers = new \WeakMap();
         $this->meters = new \WeakMap();

--- a/src/API/Logs/EventLogger.php
+++ b/src/API/Logs/EventLogger.php
@@ -7,8 +7,8 @@ namespace OpenTelemetry\API\Logs;
 class EventLogger implements EventLoggerInterface
 {
     public function __construct(
-        private LoggerInterface $logger,
-        private string $domain,
+        private readonly LoggerInterface $logger,
+        private readonly string $domain,
     ) {
     }
 

--- a/src/API/Trace/NonRecordingSpan.php
+++ b/src/API/Trace/NonRecordingSpan.php
@@ -13,7 +13,7 @@ use Throwable;
  */
 final class NonRecordingSpan extends Span
 {
-    public function __construct(private SpanContextInterface $context)
+    public function __construct(private readonly SpanContextInterface $context)
     {
     }
 

--- a/src/API/Trace/NoopSpanBuilder.php
+++ b/src/API/Trace/NoopSpanBuilder.php
@@ -12,7 +12,7 @@ final class NoopSpanBuilder implements SpanBuilderInterface
 {
     private ContextInterface|false|null $parentContext = null;
 
-    public function __construct(private ContextStorageInterface $contextStorage)
+    public function __construct(private readonly ContextStorageInterface $contextStorage)
     {
     }
 

--- a/src/API/Trace/SpanContext.php
+++ b/src/API/Trace/SpanContext.php
@@ -14,15 +14,15 @@ final class SpanContext implements SpanContextInterface
      * @see https://www.w3.org/TR/trace-context/#trace-flags
      * @see https://www.w3.org/TR/trace-context/#sampled-flag
      */
-    private bool $isSampled;
+    private readonly bool $isSampled;
     private bool $isValid = true;
 
     private function __construct(
         private string $traceId,
         private string $spanId,
-        private int $traceFlags,
-        private bool $isRemote,
-        private ?TraceStateInterface $traceState = null,
+        private readonly int $traceFlags,
+        private readonly bool $isRemote,
+        private readonly ?TraceStateInterface $traceState = null,
     ) {
         // TraceId must be exactly 16 bytes (32 chars) and at least one non-zero byte
         // SpanId must be exactly 8 bytes (16 chars) and at least one non-zero byte

--- a/src/API/Trace/TraceState.php
+++ b/src/API/Trace/TraceState.php
@@ -23,9 +23,7 @@ class TraceState implements TraceStateInterface
     private const VALID_VALUE_BASE_REGEX = '/^[ -~]{0,255}[!-~]$/';
     private const INVALID_VALUE_COMMA_EQUAL_REGEX = '/,|=/';
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private array $traceState = [];
 
     public function __construct(string $rawTracestate = null)

--- a/src/API/composer.json
+++ b/src/API/composer.json
@@ -20,7 +20,6 @@
         "php": "^8.1",
         "open-telemetry/context": "^1.0",
         "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/polyfill-php81": "^1.26",
         "symfony/polyfill-php82": "^1.26"
     },
     "conflict": {

--- a/src/API/composer.json
+++ b/src/API/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "open-telemetry/context": "^1.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/polyfill-php81": "^1.26",

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -16,8 +16,7 @@ final class Context implements ContextInterface
 {
     private const OTEL_PHP_DEBUG_SCOPES_DISABLED = 'OTEL_PHP_DEBUG_SCOPES_DISABLED';
 
-    /** @var ContextStorageInterface&ExecutionContextAwareInterface */
-    private static ContextStorageInterface $storage;
+    private static ContextStorageInterface&ExecutionContextAwareInterface $storage;
 
     // Optimization for spans to avoid copying the context array.
     private static ContextKeyInterface $spanContextKey;
@@ -37,20 +36,12 @@ final class Context implements ContextInterface
         return new ContextKey($key);
     }
 
-    /**
-     * @param ContextStorageInterface&ExecutionContextAwareInterface $storage
-     * @todo update type-hint (php >= 8.1)
-     */
-    public static function setStorage(ContextStorageInterface $storage): void
+    public static function setStorage(ContextStorageInterface&ExecutionContextAwareInterface $storage): void
     {
         self::$storage = $storage;
     }
 
-    /**
-     * @return ContextStorageInterface&ExecutionContextAwareInterface
-     * @todo update return type-hint (php >= 8.1)
-     */
-    public static function storage(): ContextStorageInterface
+    public static function storage(): ContextStorageInterface&ExecutionContextAwareInterface
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
         return self::$storage ??= new ContextStorage();

--- a/src/Context/ContextKey.php
+++ b/src/Context/ContextKey.php
@@ -10,7 +10,7 @@ namespace OpenTelemetry\Context;
  */
 final class ContextKey implements ContextKeyInterface
 {
-    public function __construct(private ?string $name = null)
+    public function __construct(private readonly ?string $name = null)
     {
     }
 

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -19,17 +19,17 @@ final class ContextStorage implements ContextStorageInterface, ExecutionContextA
         $this->current = $this->main = new ContextStorageHead($this);
     }
 
-    public function fork($id): void
+    public function fork(int|string $id): void
     {
         $this->forks[$id] = clone $this->current;
     }
 
-    public function switch($id): void
+    public function switch(int|string $id): void
     {
         $this->current = $this->forks[$id] ?? $this->main;
     }
 
-    public function destroy($id): void
+    public function destroy(int|string $id): void
     {
         unset($this->forks[$id]);
     }

--- a/src/Context/DebugScope.php
+++ b/src/Context/DebugScope.php
@@ -24,11 +24,11 @@ final class DebugScope implements ScopeInterface
 {
     private static bool $shutdownHandlerInitialized = false;
     private static bool $finalShutdownPhase = false;
-    private ?int $fiberId;
-    private array $createdAt;
+    private readonly ?int $fiberId;
+    private readonly array $createdAt;
     private ?array $detachedAt = null;
 
-    public function __construct(private ContextStorageScopeInterface $scope)
+    public function __construct(private readonly ContextStorageScopeInterface $scope)
     {
         $this->fiberId = self::currentFiberId();
         $this->createdAt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
@@ -114,7 +114,7 @@ final class DebugScope implements ScopeInterface
             $s .= strtr($trace[$i]['function'] ?? '{main}', ['\\' => '.']);
             $s .= '(';
             if (isset($trace[$i - 1]['file'])) {
-                $s .= basename($trace[$i - 1]['file']);
+                $s .= basename((string) $trace[$i - 1]['file']);
                 if (isset($trace[$i - 1]['line'])) {
                     $s .= ':';
                     $s .= $trace[$i - 1]['line'];

--- a/src/Context/ExecutionContextAwareInterface.php
+++ b/src/Context/ExecutionContextAwareInterface.php
@@ -6,18 +6,9 @@ namespace OpenTelemetry\Context;
 
 interface ExecutionContextAwareInterface
 {
-    /**
-     * @param int|string $id
-     */
-    public function fork($id): void;
+    public function fork(int|string $id): void;
 
-    /**
-     * @param int|string $id
-     */
-    public function switch($id): void;
+    public function switch(int|string $id): void;
 
-    /**
-     * @param int|string $id
-     */
-    public function destroy($id): void;
+    public function destroy(int|string $id): void;
 }

--- a/src/Context/FiberBoundContextStorage.php
+++ b/src/Context/FiberBoundContextStorage.php
@@ -20,10 +20,7 @@ use function trigger_error;
  */
 final class FiberBoundContextStorage implements ContextStorageInterface, ExecutionContextAwareInterface
 {
-    /**
-     * @param ContextStorageInterface&ExecutionContextAwareInterface $storage
-     */
-    public function __construct(private readonly ContextStorageInterface $storage)
+    public function __construct(private readonly ContextStorageInterface&ExecutionContextAwareInterface $storage)
     {
     }
 

--- a/src/Context/FiberBoundContextStorage.php
+++ b/src/Context/FiberBoundContextStorage.php
@@ -24,17 +24,17 @@ final class FiberBoundContextStorage implements ContextStorageInterface, Executi
     {
     }
 
-    public function fork($id): void
+    public function fork(int|string $id): void
     {
         $this->storage->fork($id);
     }
 
-    public function switch($id): void
+    public function switch(int|string $id): void
     {
         $this->storage->switch($id);
     }
 
-    public function destroy($id): void
+    public function destroy(int|string $id): void
     {
         $this->storage->destroy($id);
     }

--- a/src/Context/FiberBoundContextStorage.php
+++ b/src/Context/FiberBoundContextStorage.php
@@ -23,7 +23,7 @@ final class FiberBoundContextStorage implements ContextStorageInterface, Executi
     /**
      * @param ContextStorageInterface&ExecutionContextAwareInterface $storage
      */
-    public function __construct(private ContextStorageInterface $storage)
+    public function __construct(private readonly ContextStorageInterface $storage)
     {
     }
 

--- a/src/Context/Propagation/MultiTextMapPropagator.php
+++ b/src/Context/Propagation/MultiTextMapPropagator.php
@@ -17,7 +17,7 @@ final class MultiTextMapPropagator implements TextMapPropagatorInterface
      * @readonly
      * @var list<string>
      */
-    private array $fields;
+    private readonly array $fields;
 
     /**
      * @no-named-arguments
@@ -26,7 +26,7 @@ final class MultiTextMapPropagator implements TextMapPropagatorInterface
      */
     public function __construct(
         /** @readonly */
-        private array $propagators,
+        private readonly array $propagators,
     ) {
         $this->fields = $this->extractFields($this->propagators);
     }

--- a/src/Context/Propagation/MultiTextMapPropagator.php
+++ b/src/Context/Propagation/MultiTextMapPropagator.php
@@ -13,9 +13,7 @@ use OpenTelemetry\Context\ContextInterface;
 
 final class MultiTextMapPropagator implements TextMapPropagatorInterface
 {
-    /**
-     * @var list<string>
-     */
+    /** @var list<string> */
     private readonly array $fields;
 
     /**

--- a/src/Context/Propagation/MultiTextMapPropagator.php
+++ b/src/Context/Propagation/MultiTextMapPropagator.php
@@ -14,7 +14,6 @@ use OpenTelemetry\Context\ContextInterface;
 final class MultiTextMapPropagator implements TextMapPropagatorInterface
 {
     /**
-     * @readonly
      * @var list<string>
      */
     private readonly array $fields;
@@ -25,7 +24,6 @@ final class MultiTextMapPropagator implements TextMapPropagatorInterface
      * @param list<TextMapPropagatorInterface> $propagators
      */
     public function __construct(
-        /** @readonly */
         private readonly array $propagators,
     ) {
         $this->fields = $this->extractFields($this->propagators);

--- a/src/Context/Propagation/SanitizeCombinedHeadersPropagationGetter.php
+++ b/src/Context/Propagation/SanitizeCombinedHeadersPropagationGetter.php
@@ -18,7 +18,7 @@ final class SanitizeCombinedHeadersPropagationGetter implements PropagationGette
     private const SERVER_CONCAT_HEADERS_REGEX = '/;(?=[^,=;]*=|$)/';
     private const TRAILING_LEADING_SEPARATOR_REGEX = '/^' . self::LIST_MEMBERS_SEPARATOR . '+|' . self::LIST_MEMBERS_SEPARATOR . '+$/';
 
-    public function __construct(private PropagationGetterInterface $getter)
+    public function __construct(private readonly PropagationGetterInterface $getter)
     {
     }
 

--- a/src/Context/composer.json
+++ b/src/Context/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "symfony/polyfill-php81": "^1.26",
         "symfony/polyfill-php82": "^1.26"
     },

--- a/src/Context/composer.json
+++ b/src/Context/composer.json
@@ -18,7 +18,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "symfony/polyfill-php81": "^1.26",
         "symfony/polyfill-php82": "^1.26"
     },
     "autoload": {

--- a/src/Contrib/Grpc/GrpcTransport.php
+++ b/src/Contrib/Grpc/GrpcTransport.php
@@ -35,14 +35,14 @@ use Throwable;
  */
 final class GrpcTransport implements TransportInterface
 {
-    private array $metadata;
-    private Channel $channel;
+    private readonly array $metadata;
+    private readonly Channel $channel;
     private bool $closed = false;
 
     public function __construct(
         string $endpoint,
         array $opts,
-        private string $method,
+        private readonly string $method,
         array $headers = [],
     ) {
         $this->channel = new Channel($endpoint, $opts);

--- a/src/Contrib/Grpc/composer.json
+++ b/src/Contrib/Grpc/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "ext-grpc": "*",
     "grpc/grpc": "*",
     "open-telemetry/sdk": "^1.0"

--- a/src/Contrib/Otlp/HttpEndpointResolver.php
+++ b/src/Contrib/Otlp/HttpEndpointResolver.php
@@ -25,7 +25,7 @@ class HttpEndpointResolver implements HttpEndpointResolverInterface
     private const DEFAULT_SCHEME = 'https';
     private const ROOT_PATH = '/';
 
-    private FactoryResolverInterface $httpFactoryResolver;
+    private readonly FactoryResolverInterface $httpFactoryResolver;
 
     public function __construct(?FactoryResolverInterface $httpFactoryResolver = null)
     {

--- a/src/Contrib/Otlp/LogsConverter.php
+++ b/src/Contrib/Otlp/LogsConverter.php
@@ -18,7 +18,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 class LogsConverter
 {
-    private ProtobufSerializer $serializer;
+    private readonly ProtobufSerializer $serializer;
 
     public function __construct(?ProtobufSerializer $serializer = null)
     {

--- a/src/Contrib/Otlp/LogsExporterFactory.php
+++ b/src/Contrib/Otlp/LogsExporterFactory.php
@@ -18,7 +18,7 @@ class LogsExporterFactory implements LogRecordExporterFactoryInterface
 {
     private const DEFAULT_COMPRESSION = 'none';
 
-    public function __construct(private ?TransportFactoryInterface $transportFactory = null)
+    public function __construct(private readonly ?TransportFactoryInterface $transportFactory = null)
     {
     }
 

--- a/src/Contrib/Otlp/MetricConverter.php
+++ b/src/Contrib/Otlp/MetricConverter.php
@@ -27,7 +27,7 @@ use function serialize;
 
 final class MetricConverter
 {
-    private ProtobufSerializer $serializer;
+    private readonly ProtobufSerializer $serializer;
 
     public function __construct(?ProtobufSerializer $serializer = null)
     {

--- a/src/Contrib/Otlp/MetricExporter.php
+++ b/src/Contrib/Otlp/MetricExporter.php
@@ -28,8 +28,8 @@ final class MetricExporter implements PushMetricExporterInterface, AggregationTe
      * @psalm-param TransportInterface<SUPPORTED_CONTENT_TYPES> $transport
      */
     public function __construct(
-        private TransportInterface $transport,
-        private string|Temporality|null $temporality = null,
+        private readonly TransportInterface $transport,
+        private readonly string|Temporality|null $temporality = null,
     ) {
         if (!class_exists('\Google\Protobuf\Api')) {
             throw new RuntimeException('No protobuf implementation found (ext-protobuf or google/protobuf)');
@@ -37,7 +37,7 @@ final class MetricExporter implements PushMetricExporterInterface, AggregationTe
         $this->serializer = ProtobufSerializer::forTransport($this->transport);
     }
 
-    public function temporality(MetricMetadataInterface $metric)
+    public function temporality(MetricMetadataInterface $metric): Temporality|string|null
     {
         return $this->temporality ?? $metric->temporality();
     }

--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -19,7 +19,7 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
 {
     private const DEFAULT_COMPRESSION = 'none';
 
-    public function __construct(private ?TransportFactoryInterface $transportFactory = null)
+    public function __construct(private readonly ?TransportFactoryInterface $transportFactory = null)
     {
     }
 

--- a/src/Contrib/Otlp/ProtobufSerializer.php
+++ b/src/Contrib/Otlp/ProtobufSerializer.php
@@ -30,7 +30,7 @@ use function ucwords;
  */
 final class ProtobufSerializer
 {
-    private function __construct(private string $contentType)
+    private function __construct(private readonly string $contentType)
     {
     }
 
@@ -120,7 +120,7 @@ final class ProtobufSerializer
         for ($i = 0, $n = $desc->getFieldCount(); $i < $n; $i++) {
             // @phan-suppress-next-line PhanParamTooManyInternal
             $field = $desc->getField($i);
-            $name = lcfirst(strtr(ucwords($field->getName(), '_'), ['_' => '']));
+            $name = lcfirst(strtr(ucwords((string) $field->getName(), '_'), ['_' => '']));
             if (!property_exists($data, $name)) {
                 continue;
             }

--- a/src/Contrib/Otlp/SpanConverter.php
+++ b/src/Contrib/Otlp/SpanConverter.php
@@ -26,7 +26,7 @@ use function spl_object_id;
 
 final class SpanConverter
 {
-    private ProtobufSerializer $serializer;
+    private readonly ProtobufSerializer $serializer;
 
     public function __construct(?ProtobufSerializer $serializer = null)
     {

--- a/src/Contrib/Otlp/composer.json
+++ b/src/Contrib/Otlp/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "php-http/discovery": "^1.14",
     "open-telemetry/gen-otlp-protobuf": "^1.1",
     "open-telemetry/api": "^1.0",

--- a/src/Contrib/Zipkin/Exporter.php
+++ b/src/Contrib/Zipkin/Exporter.php
@@ -24,7 +24,7 @@ class Exporter implements SpanExporterInterface
     use UsesSpanConverterTrait;
 
     public function __construct(
-        private TransportInterface $transport,
+        private readonly TransportInterface $transport,
         SpanConverterInterface $spanConverter = null,
     ) {
         $this->setSpanConverter($spanConverter ?? new SpanConverter());

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -37,7 +37,7 @@ class SpanConverter implements SpanConverterInterface
 
     const NET_PEER_IP_KEY = 'net.peer.ip';
 
-    private string $defaultServiceName;
+    private readonly string $defaultServiceName;
 
     public function __construct()
     {

--- a/src/Contrib/Zipkin/composer.json
+++ b/src/Contrib/Zipkin/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "open-telemetry/api": "^1.0",
     "open-telemetry/sdk": "^1.0",
     "php-http/async-client-implementation": "^1.0",

--- a/src/Contrib/composer.json
+++ b/src/Contrib/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "open-telemetry/api": "^1.0",
         "open-telemetry/context": "^1.0",

--- a/src/Contrib/composer.json
+++ b/src/Contrib/composer.json
@@ -23,7 +23,6 @@
         "psr/http-factory-implementation": "^1.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/polyfill-mbstring": "^1.23",
-        "symfony/polyfill-php81": "^1.26",
         "symfony/polyfill-php82": "^1.26"
     },
     "autoload": {

--- a/src/Extension/Propagator/B3/B3Propagator.php
+++ b/src/Extension/Propagator/B3/B3Propagator.php
@@ -18,7 +18,7 @@ use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
  */
 final class B3Propagator implements TextMapPropagatorInterface
 {
-    private function __construct(private TextMapPropagatorInterface $propagator)
+    private function __construct(private readonly TextMapPropagatorInterface $propagator)
     {
     }
 

--- a/src/Extension/Propagator/B3/B3SinglePropagator.php
+++ b/src/Extension/Propagator/B3/B3SinglePropagator.php
@@ -97,15 +97,15 @@ final class B3SinglePropagator implements TextMapPropagatorInterface
             return null;
         }
 
-        if (strtolower($value) === self::IS_DEBUG) {
+        if (strtolower((string) $value) === self::IS_DEBUG) {
             return (int) self::IS_SAMPLED;
         }
 
-        if (in_array(strtolower($value), self::VALID_SAMPLED)) {
+        if (in_array(strtolower((string) $value), self::VALID_SAMPLED)) {
             return (int) self::IS_SAMPLED;
         }
 
-        if (in_array(strtolower($value), self::VALID_NON_SAMPLED)) {
+        if (in_array(strtolower((string) $value), self::VALID_NON_SAMPLED)) {
             return (int) self::IS_NOT_SAMPLED;
         }
 

--- a/src/Extension/Propagator/B3/composer.json
+++ b/src/Extension/Propagator/B3/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "open-telemetry/api": "^1.0",
         "open-telemetry/context": "^1.0"
     },

--- a/src/Extension/Propagator/CloudTrace/CloudTraceFormatter.php
+++ b/src/Extension/Propagator/CloudTrace/CloudTraceFormatter.php
@@ -38,7 +38,7 @@ final class CloudTraceFormatter
         return SpanContext::createFromRemoteParent(
             strtolower($matches[1]),
             Utils::leftZeroPad(Utils::decToHex($matches[2])),
-            (int) ($matches[3] == '1')
+            (int) ($matches[3] === '1')
         );
     }
 

--- a/src/Extension/Propagator/CloudTrace/CloudTracePropagator.php
+++ b/src/Extension/Propagator/CloudTrace/CloudTracePropagator.php
@@ -46,7 +46,7 @@ final class CloudTracePropagator implements TextMapPropagatorInterface
         self::XCLOUD,
     ];
 
-    private function __construct(private bool $oneWay)
+    private function __construct(private readonly bool $oneWay)
     {
     }
 

--- a/src/Extension/Propagator/CloudTrace/composer.json
+++ b/src/Extension/Propagator/CloudTrace/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "open-telemetry/api": "^1.0",
         "open-telemetry/context": "^1.0"
     },

--- a/src/Extension/Propagator/Jaeger/composer.json
+++ b/src/Extension/Propagator/Jaeger/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "open-telemetry/api": "^1.0",
         "open-telemetry/context": "^1.0"
     },

--- a/src/SDK/Common/Adapter/HttpDiscovery/DependencyResolver.php
+++ b/src/SDK/Common/Adapter/HttpDiscovery/DependencyResolver.php
@@ -19,9 +19,9 @@ use Psr\Http\Message\UriFactoryInterface;
 
 final class DependencyResolver implements DependencyResolverInterface
 {
-    private MessageFactoryResolverInterface $messageFactoryResolver;
-    private PsrClientResolverInterface $psrClientResolver;
-    private HttpPlugClientResolverInterface $httpPlugClientResolver;
+    private readonly MessageFactoryResolverInterface $messageFactoryResolver;
+    private readonly PsrClientResolverInterface $psrClientResolver;
+    private readonly HttpPlugClientResolverInterface $httpPlugClientResolver;
 
     public function __construct(
         ?MessageFactoryResolverInterface $messageFactoryResolver = null,

--- a/src/SDK/Common/Attribute/Attributes.php
+++ b/src/SDK/Common/Attribute/Attributes.php
@@ -18,7 +18,7 @@ final class Attributes implements AttributesInterface, IteratorAggregate
      */
     public function __construct(
         private array $attributes,
-        private int $droppedAttributesCount,
+        private readonly int $droppedAttributesCount,
     ) {
     }
 

--- a/src/SDK/Common/Attribute/Attributes.php
+++ b/src/SDK/Common/Attribute/Attributes.php
@@ -17,7 +17,7 @@ final class Attributes implements AttributesInterface, IteratorAggregate
      * @internal
      */
     public function __construct(
-        private array $attributes,
+        private readonly array $attributes,
         private readonly int $droppedAttributesCount,
     ) {
     }

--- a/src/SDK/Common/Attribute/AttributesBuilder.php
+++ b/src/SDK/Common/Attribute/AttributesBuilder.php
@@ -17,16 +17,9 @@ use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 final class AttributesBuilder implements AttributesBuilderInterface
 {
     use LogsMessagesTrait;
-    private AttributeValidatorInterface $attributeValidator;
 
-    public function __construct(
-        private array $attributes,
-        private ?int $attributeCountLimit,
-        private ?int $attributeValueLengthLimit,
-        private int $droppedAttributesCount,
-        ?AttributeValidatorInterface $attributeValidator,
-    ) {
-        $this->attributeValidator = $attributeValidator ?? new AttributeValidator();
+    public function __construct(private array $attributes, private ?int $attributeCountLimit, private ?int $attributeValueLengthLimit, private int $droppedAttributesCount, private AttributeValidatorInterface $attributeValidator = new AttributeValidator())
+    {
     }
 
     public function build(): AttributesInterface

--- a/src/SDK/Common/Attribute/AttributesFactory.php
+++ b/src/SDK/Common/Attribute/AttributesFactory.php
@@ -22,7 +22,7 @@ final class AttributesFactory implements AttributesFactoryInterface
             $this->attributeCountLimit,
             $this->attributeValueLengthLimit,
             0,
-            $attributeValidator,
+            $attributeValidator ?? new AttributeValidator(),
         );
         foreach ($attributes as $key => $value) {
             $builder[$key] = $value;

--- a/src/SDK/Common/Attribute/AttributesFactory.php
+++ b/src/SDK/Common/Attribute/AttributesFactory.php
@@ -10,8 +10,8 @@ namespace OpenTelemetry\SDK\Common\Attribute;
 final class AttributesFactory implements AttributesFactoryInterface
 {
     public function __construct(
-        private ?int $attributeCountLimit = null,
-        private ?int $attributeValueLengthLimit = null,
+        private readonly ?int $attributeCountLimit = null,
+        private readonly ?int $attributeValueLengthLimit = null,
     ) {
     }
 

--- a/src/SDK/Common/Attribute/FilteredAttributesBuilder.php
+++ b/src/SDK/Common/Attribute/FilteredAttributesBuilder.php
@@ -18,7 +18,7 @@ final class FilteredAttributesBuilder implements AttributesBuilderInterface
      */
     public function __construct(
         private AttributesBuilderInterface $builder,
-        private array $rejectedKeys,
+        private readonly array $rejectedKeys,
     ) {
     }
 

--- a/src/SDK/Common/Attribute/FilteredAttributesFactory.php
+++ b/src/SDK/Common/Attribute/FilteredAttributesFactory.php
@@ -13,8 +13,8 @@ final class FilteredAttributesFactory implements AttributesFactoryInterface
      * @param list<string> $rejectedKeys
      */
     public function __construct(
-        private AttributesFactoryInterface $factory,
-        private array $rejectedKeys,
+        private readonly AttributesFactoryInterface $factory,
+        private readonly array $rejectedKeys,
     ) {
     }
 

--- a/src/SDK/Common/Configuration/Parser/MapParser.php
+++ b/src/SDK/Common/Configuration/Parser/MapParser.php
@@ -18,11 +18,11 @@ class MapParser
         }
         $result = [];
 
-        if (null === $value || trim($value) === '') {
+        if (null === $value || trim((string) $value) === '') {
             return $result;
         }
 
-        foreach (explode(self::VARIABLE_SEPARATOR, $value) as $pair) {
+        foreach (explode(self::VARIABLE_SEPARATOR, (string) $value) as $pair) {
             self::validateKeyValuePair($pair);
 
             /** @psalm-suppress PossiblyUndefinedArrayOffset */

--- a/src/SDK/Common/Configuration/Resolver/CompositeResolver.php
+++ b/src/SDK/Common/Configuration/Resolver/CompositeResolver.php
@@ -11,7 +11,7 @@ use OpenTelemetry\SDK\Common\Configuration\Configuration;
  */
 class CompositeResolver
 {
-    // @var array<ResolverInterface>
+    /** @var list<ResolverInterface> */
     private array $resolvers = [];
 
     public static function instance(): self

--- a/src/SDK/Common/Configuration/Resolver/PhpIniResolver.php
+++ b/src/SDK/Common/Configuration/Resolver/PhpIniResolver.php
@@ -12,11 +12,8 @@ use OpenTelemetry\SDK\Common\Configuration\Configuration;
  */
 class PhpIniResolver implements ResolverInterface
 {
-    private PhpIniAccessor $accessor;
-
-    public function __construct(?PhpIniAccessor $accessor = null)
+    public function __construct(private readonly PhpIniAccessor $accessor = new PhpIniAccessor())
     {
-        $this->accessor = $accessor ?? new PhpIniAccessor();
     }
 
     public function retrieveValue(string $variableName)

--- a/src/SDK/Common/Export/Http/PsrTransport.php
+++ b/src/SDK/Common/Export/Http/PsrTransport.php
@@ -36,15 +36,15 @@ final class PsrTransport implements TransportInterface
      * @psalm-param CONTENT_TYPE $contentType
      */
     public function __construct(
-        private ClientInterface $client,
-        private RequestFactoryInterface $requestFactory,
-        private StreamFactoryInterface $streamFactory,
-        private string $endpoint,
-        private string $contentType,
-        private array $headers,
-        private array $compression,
-        private int $retryDelay,
-        private int $maxRetries,
+        private readonly ClientInterface $client,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly string $endpoint,
+        private readonly string $contentType,
+        private readonly array $headers,
+        private readonly array $compression,
+        private readonly int $retryDelay,
+        private readonly int $maxRetries,
     ) {
     }
 

--- a/src/SDK/Common/Export/Http/PsrTransportFactory.php
+++ b/src/SDK/Common/Export/Http/PsrTransportFactory.php
@@ -17,9 +17,9 @@ use Psr\Http\Message\StreamFactoryInterface;
 final class PsrTransportFactory implements TransportFactoryInterface
 {
     public function __construct(
-        private ClientInterface $client,
-        private RequestFactoryInterface $requestFactory,
-        private StreamFactoryInterface $streamFactory,
+        private readonly ClientInterface $client,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
     ) {
     }
 

--- a/src/SDK/Common/Export/Http/PsrUtils.php
+++ b/src/SDK/Common/Export/Http/PsrUtils.php
@@ -116,11 +116,11 @@ final class PsrUtils
         if (!$compression) {
             return [];
         }
-        if (!str_contains($compression, ',')) {
+        if (!str_contains((string) $compression, ',')) {
             return [$compression];
         }
 
-        return array_map('trim', explode(',', $compression));
+        return array_map('trim', explode(',', (string) $compression));
     }
 
     private static function encoder(string $encoding): ?callable

--- a/src/SDK/Common/Export/Stream/StreamTransport.php
+++ b/src/SDK/Common/Export/Stream/StreamTransport.php
@@ -34,7 +34,7 @@ final class StreamTransport implements TransportInterface
      */
     public function __construct(
         private $stream,
-        private string $contentType,
+        private readonly string $contentType,
     ) {
     }
 

--- a/src/SDK/Common/Future/ErrorFuture.php
+++ b/src/SDK/Common/Future/ErrorFuture.php
@@ -12,11 +12,11 @@ use Throwable;
  */
 final class ErrorFuture implements FutureInterface
 {
-    public function __construct(private Throwable $throwable)
+    public function __construct(private readonly Throwable $throwable)
     {
     }
 
-    public function await()
+    public function await(): never
     {
         throw $this->throwable;
     }

--- a/src/SDK/Common/Http/Psr/Message/MessageFactory.php
+++ b/src/SDK/Common/Http/Psr/Message/MessageFactory.php
@@ -14,9 +14,9 @@ use Psr\Http\Message\ServerRequestInterface;
 final class MessageFactory implements MessageFactoryInterface
 {
     public function __construct(
-        private RequestFactoryInterface $requestFactory,
-        private ResponseFactoryInterface $responseFactory,
-        private ServerRequestFactoryInterface $serverRequestFactory,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly ServerRequestFactoryInterface $serverRequestFactory,
     ) {
     }
 

--- a/src/SDK/Common/Instrumentation/InstrumentationScope.php
+++ b/src/SDK/Common/Instrumentation/InstrumentationScope.php
@@ -12,10 +12,10 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 final class InstrumentationScope implements InstrumentationScopeInterface
 {
     public function __construct(
-        private string $name,
-        private ?string $version,
-        private ?string $schemaUrl,
-        private AttributesInterface $attributes,
+        private readonly string $name,
+        private readonly ?string $version,
+        private readonly ?string $schemaUrl,
+        private readonly AttributesInterface $attributes,
     ) {
     }
 

--- a/src/SDK/Common/Instrumentation/InstrumentationScopeFactory.php
+++ b/src/SDK/Common/Instrumentation/InstrumentationScopeFactory.php
@@ -8,7 +8,7 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesFactoryInterface;
 
 final class InstrumentationScopeFactory implements InstrumentationScopeFactoryInterface
 {
-    public function __construct(private AttributesFactoryInterface $attributesFactory)
+    public function __construct(private readonly AttributesFactoryInterface $attributesFactory)
     {
     }
 

--- a/src/SDK/Common/Time/StopWatch.php
+++ b/src/SDK/Common/Time/StopWatch.php
@@ -12,7 +12,7 @@ final class StopWatch implements StopWatchInterface
     private ?int $stopTime = null;
 
     public function __construct(
-        private ClockInterface $clock,
+        private readonly ClockInterface $clock,
         private ?int $initialStartTime = null,
     ) {
     }

--- a/src/SDK/Common/Time/StopWatchFactory.php
+++ b/src/SDK/Common/Time/StopWatchFactory.php
@@ -8,11 +8,11 @@ final class StopWatchFactory implements StopWatchFactoryInterface
 {
     private static ?StopWatchInterface $default = null;
 
-    private ClockInterface $clock;
+    private readonly ClockInterface $clock;
 
     public function __construct(
         ?ClockInterface $clock = null,
-        private ?int $initialStartTime = null,
+        private readonly ?int $initialStartTime = null,
     ) {
         $this->clock = $clock ?? ClockFactory::getDefault();
     }

--- a/src/SDK/Logs/Exporter/ConsoleExporter.php
+++ b/src/SDK/Logs/Exporter/ConsoleExporter.php
@@ -19,7 +19,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
  */
 class ConsoleExporter implements LogRecordExporterInterface
 {
-    public function __construct(private TransportInterface $transport)
+    public function __construct(private readonly TransportInterface $transport)
     {
     }
 

--- a/src/SDK/Logs/Exporter/InMemoryExporter.php
+++ b/src/SDK/Logs/Exporter/InMemoryExporter.php
@@ -12,11 +12,8 @@ use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
 
 class InMemoryExporter implements LogRecordExporterInterface
 {
-    private ArrayObject $storage;
-
-    public function __construct(?ArrayObject $storage = null)
+    public function __construct(private readonly ArrayObject $storage = new ArrayObject())
     {
-        $this->storage = $storage ?? new ArrayObject();
     }
 
     /**

--- a/src/SDK/Logs/LogRecordLimits.php
+++ b/src/SDK/Logs/LogRecordLimits.php
@@ -14,7 +14,7 @@ class LogRecordLimits
     /**
      * @internal Use {@see SpanLimitsBuilder} to create {@see SpanLimits} instance.
      */
-    public function __construct(private AttributesFactoryInterface $attributesFactory)
+    public function __construct(private readonly AttributesFactoryInterface $attributesFactory)
     {
     }
 

--- a/src/SDK/Logs/Logger.php
+++ b/src/SDK/Logs/Logger.php
@@ -17,8 +17,8 @@ use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 class Logger implements LoggerInterface
 {
     public function __construct(
-        private LoggerSharedState $loggerSharedState,
-        private InstrumentationScopeInterface $scope,
+        private readonly LoggerSharedState $loggerSharedState,
+        private readonly InstrumentationScopeInterface $scope,
     ) {
     }
 

--- a/src/SDK/Logs/LoggerProvider.php
+++ b/src/SDK/Logs/LoggerProvider.php
@@ -13,11 +13,11 @@ use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 
 class LoggerProvider implements LoggerProviderInterface
 {
-    private LoggerSharedState $loggerSharedState;
+    private readonly LoggerSharedState $loggerSharedState;
 
     public function __construct(
         LogRecordProcessorInterface $processor,
-        private InstrumentationScopeFactoryInterface $instrumentationScopeFactory,
+        private readonly InstrumentationScopeFactoryInterface $instrumentationScopeFactory,
         ?ResourceInfo $resource = null,
     ) {
         $this->loggerSharedState = new LoggerSharedState(

--- a/src/SDK/Logs/LoggerProviderBuilder.php
+++ b/src/SDK/Logs/LoggerProviderBuilder.php
@@ -12,9 +12,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 class LoggerProviderBuilder
 {
-    /**
-     * @var array<LogRecordProcessorInterface>
-     */
+    /** @var array<LogRecordProcessorInterface> */
     private array $processors = [];
     private ?ResourceInfo $resource = null;
 

--- a/src/SDK/Logs/LoggerSharedState.php
+++ b/src/SDK/Logs/LoggerSharedState.php
@@ -12,9 +12,9 @@ class LoggerSharedState
     private ?bool $shutdownResult = null;
 
     public function __construct(
-        private ResourceInfo $resource,
-        private LogRecordLimits $limits,
-        private LogRecordProcessorInterface $processor,
+        private readonly ResourceInfo $resource,
+        private readonly LogRecordLimits $limits,
+        private readonly LogRecordProcessorInterface $processor,
     ) {
     }
 

--- a/src/SDK/Logs/Processor/BatchLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/BatchLogRecordProcessor.php
@@ -54,13 +54,13 @@ class BatchLogRecordProcessor implements LogRecordProcessorInterface
     private bool $closed = false;
 
     public function __construct(
-        private LogRecordExporterInterface $exporter,
-        private ClockInterface $clock,
+        private readonly LogRecordExporterInterface $exporter,
+        private readonly ClockInterface $clock,
         int $maxQueueSize = self::DEFAULT_MAX_QUEUE_SIZE,
         int $scheduledDelayMillis = self::DEFAULT_SCHEDULE_DELAY,
         int $exportTimeoutMillis = self::DEFAULT_EXPORT_TIMEOUT,
         int $maxExportBatchSize = self::DEFAULT_MAX_EXPORT_BATCH_SIZE,
-        private bool $autoFlush = true,
+        private readonly bool $autoFlush = true,
         ?MeterProviderInterface $meterProvider = null,
     ) {
         if ($maxQueueSize <= 0) {

--- a/src/SDK/Logs/Processor/MultiLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/MultiLogRecordProcessor.php
@@ -11,7 +11,7 @@ use OpenTelemetry\SDK\Logs\ReadWriteLogRecord;
 
 class MultiLogRecordProcessor implements LogRecordProcessorInterface
 {
-    // @var LogRecordProcessorInterface[]
+    // @var list<LogRecordProcessorInterface>
     private array $processors = [];
 
     public function __construct(array $processors)

--- a/src/SDK/Logs/Processor/MultiLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/MultiLogRecordProcessor.php
@@ -11,7 +11,7 @@ use OpenTelemetry\SDK\Logs\ReadWriteLogRecord;
 
 class MultiLogRecordProcessor implements LogRecordProcessorInterface
 {
-    // @var list<LogRecordProcessorInterface>
+    /** @var list<LogRecordProcessorInterface> */
     private array $processors = [];
 
     public function __construct(array $processors)

--- a/src/SDK/Logs/Processor/SimpleLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/SimpleLogRecordProcessor.php
@@ -12,7 +12,7 @@ use OpenTelemetry\SDK\Logs\ReadWriteLogRecord;
 
 class SimpleLogRecordProcessor implements LogRecordProcessorInterface
 {
-    public function __construct(private LogRecordExporterInterface $exporter)
+    public function __construct(private readonly LogRecordExporterInterface $exporter)
     {
     }
 

--- a/src/SDK/Logs/ReadableLogRecord.php
+++ b/src/SDK/Logs/ReadableLogRecord.php
@@ -24,8 +24,8 @@ class ReadableLogRecord extends LogRecord
     protected SpanContextInterface $spanContext;
 
     public function __construct(
-        private InstrumentationScopeInterface $scope,
-        private LoggerSharedState $loggerSharedState,
+        private readonly InstrumentationScopeInterface $scope,
+        private readonly LoggerSharedState $loggerSharedState,
         LogRecord $logRecord,
     ) {
         parent::__construct($logRecord->body);

--- a/src/SDK/Logs/SimplePsrFileLogger.php
+++ b/src/SDK/Logs/SimplePsrFileLogger.php
@@ -30,7 +30,7 @@ class SimplePsrFileLogger implements LoggerInterface
      */
     public function log($level, $message, array $context = []): void
     {
-        $level = strtolower($level);
+        $level = strtolower((string) $level);
 
         if (!in_array($level, self::getLogLevels(), true)) {
             throw new InvalidArgumentException(

--- a/src/SDK/Logs/SimplePsrFileLogger.php
+++ b/src/SDK/Logs/SimplePsrFileLogger.php
@@ -20,8 +20,8 @@ class SimplePsrFileLogger implements LoggerInterface
     private static ?array $logLevels = null;
 
     public function __construct(
-        private string $filename,
-        private string $loggerName = self::DEFAULT_LOGGER_NAME,
+        private readonly string $filename,
+        private readonly string $loggerName = self::DEFAULT_LOGGER_NAME,
     ) {
     }
 

--- a/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramAggregation.php
+++ b/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramAggregation.php
@@ -137,23 +137,13 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
         );
     }
 
-    /**
-     * @param float|int $left
-     * @param float|int $right
-     * @return float|int
-     */
-    private static function min($left, $right)
+    private static function min(float|int $left, float|int $right): float|int
     {
         /** @noinspection PhpConditionAlreadyCheckedInspection */
         return $left <= $right ? $left : ($right <= $left ? $right : NAN);
     }
 
-    /**
-     * @param float|int $left
-     * @param float|int $right
-     * @return float|int
-     */
-    private static function max($left, $right)
+    private static function max(float|int $left, float|int $right): float|int
     {
         /** @noinspection PhpConditionAlreadyCheckedInspection */
         return $left >= $right ? $left : ($right >= $left ? $right : NAN);

--- a/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramAggregation.php
+++ b/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramAggregation.php
@@ -22,8 +22,7 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
      * @param list<float|int> $boundaries strictly ascending histogram bucket boundaries
      */
     public function __construct(
-        /** @readonly */
-        public array $boundaries,
+        public readonly array $boundaries,
     ) {
     }
 

--- a/src/SDK/Metrics/Aggregation/SumAggregation.php
+++ b/src/SDK/Metrics/Aggregation/SumAggregation.php
@@ -14,7 +14,7 @@ use OpenTelemetry\SDK\Metrics\Data;
  */
 final class SumAggregation implements AggregationInterface
 {
-    public function __construct(private bool $monotonic = false)
+    public function __construct(private readonly bool $monotonic = false)
     {
     }
 

--- a/src/SDK/Metrics/AttributeProcessor/FilteredAttributeProcessor.php
+++ b/src/SDK/Metrics/AttributeProcessor/FilteredAttributeProcessor.php
@@ -14,7 +14,7 @@ use OpenTelemetry\SDK\Metrics\AttributeProcessorInterface;
  */
 final class FilteredAttributeProcessor implements AttributeProcessorInterface
 {
-    public function __construct(private array $attributeKeys)
+    public function __construct(private readonly array $attributeKeys)
     {
     }
 

--- a/src/SDK/Metrics/Data/Exemplar.php
+++ b/src/SDK/Metrics/Data/Exemplar.php
@@ -9,7 +9,7 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 final class Exemplar
 {
     public function __construct(
-        private int|string $index,
+        private readonly int|string $index,
         /** @readonly */
         public float|int $value,
         /** @readonly */

--- a/src/SDK/Metrics/Data/Exemplar.php
+++ b/src/SDK/Metrics/Data/Exemplar.php
@@ -10,16 +10,11 @@ final class Exemplar
 {
     public function __construct(
         private readonly int|string $index,
-        /** @readonly */
-        public float|int $value,
-        /** @readonly */
-        public int $timestamp,
-        /** @readonly */
-        public AttributesInterface $attributes,
-        /** @readonly */
-        public ?string $traceId,
-        /** @readonly */
-        public ?string $spanId,
+        public readonly float|int $value,
+        public readonly int $timestamp,
+        public readonly AttributesInterface $attributes,
+        public readonly ?string $traceId,
+        public readonly ?string $spanId,
     ) {
     }
 

--- a/src/SDK/Metrics/Data/Gauge.php
+++ b/src/SDK/Metrics/Data/Gauge.php
@@ -11,8 +11,7 @@ final class Gauge implements DataInterface
      * @param iterable<NumberDataPoint> $dataPoints
      */
     public function __construct(
-        /** @readonly */
-        public iterable $dataPoints,
+        public readonly iterable $dataPoints,
     ) {
     }
 }

--- a/src/SDK/Metrics/Data/Histogram.php
+++ b/src/SDK/Metrics/Data/Histogram.php
@@ -10,10 +10,8 @@ final class Histogram implements DataInterface
      * @param iterable<HistogramDataPoint> $dataPoints
      */
     public function __construct(
-        /** @readonly */
-        public iterable $dataPoints,
-        /** @readonly */
-        public string|Temporality $temporality,
+        public readonly iterable $dataPoints,
+        public readonly string|Temporality $temporality,
     ) {
     }
 }

--- a/src/SDK/Metrics/Data/HistogramDataPoint.php
+++ b/src/SDK/Metrics/Data/HistogramDataPoint.php
@@ -13,26 +13,16 @@ final class HistogramDataPoint
      * @param list<float|int> $explicitBounds
      */
     public function __construct(
-        /** @readonly */
-        public int $count,
-        /** @readonly */
-        public float|int $sum,
-        /** @readonly */
-        public float|int $min,
-        /** @readonly */
-        public float|int $max,
-        /** @readonly */
-        public array $bucketCounts,
-        /** @readonly */
-        public array $explicitBounds,
-        /** @readonly */
-        public AttributesInterface $attributes,
-        /** @readonly */
-        public int $startTimestamp,
-        /** @readonly */
-        public int $timestamp,
-        /** @readonly */
-        public iterable $exemplars = [],
+        public readonly int $count,
+        public readonly float|int $sum,
+        public readonly float|int $min,
+        public readonly float|int $max,
+        public readonly array $bucketCounts,
+        public readonly array $explicitBounds,
+        public readonly AttributesInterface $attributes,
+        public readonly int $startTimestamp,
+        public readonly int $timestamp,
+        public readonly iterable $exemplars = [],
     ) {
     }
 }

--- a/src/SDK/Metrics/Data/Metric.php
+++ b/src/SDK/Metrics/Data/Metric.php
@@ -10,18 +10,12 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
 final class Metric
 {
     public function __construct(
-        /** @readonly */
-        public InstrumentationScopeInterface $instrumentationScope,
-        /** @readonly */
-        public ResourceInfo $resource,
-        /** @readonly */
-        public string $name,
-        /** @readonly */
-        public ?string $unit,
-        /** @readonly */
-        public ?string $description,
-        /** @readonly */
-        public DataInterface $data,
+        public readonly InstrumentationScopeInterface $instrumentationScope,
+        public readonly ResourceInfo $resource,
+        public readonly string $name,
+        public readonly ?string $unit,
+        public readonly ?string $description,
+        public readonly DataInterface $data,
     ) {
     }
 }

--- a/src/SDK/Metrics/Data/NumberDataPoint.php
+++ b/src/SDK/Metrics/Data/NumberDataPoint.php
@@ -9,16 +9,11 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 final class NumberDataPoint
 {
     public function __construct(
-        /** @readonly */
-        public float|int $value,
-        /** @readonly */
-        public AttributesInterface $attributes,
-        /** @readonly */
-        public int $startTimestamp,
-        /** @readonly */
-        public int $timestamp,
-        /** @readonly */
-        public iterable $exemplars = [],
+        public readonly float|int $value,
+        public readonly AttributesInterface $attributes,
+        public readonly int $startTimestamp,
+        public readonly int $timestamp,
+        public readonly iterable $exemplars = [],
     ) {
     }
 }

--- a/src/SDK/Metrics/Data/Sum.php
+++ b/src/SDK/Metrics/Data/Sum.php
@@ -10,12 +10,9 @@ final class Sum implements DataInterface
      * @param iterable<NumberDataPoint> $dataPoints
      */
     public function __construct(
-        /** @readonly */
-        public iterable $dataPoints,
-        /** @readonly */
-        public string|Temporality $temporality,
-        /** @readonly */
-        public bool $monotonic,
+        public readonly iterable $dataPoints,
+        public readonly string|Temporality $temporality,
+        public readonly bool $monotonic,
     ) {
     }
 }

--- a/src/SDK/Metrics/Exemplar/BucketEntry.php
+++ b/src/SDK/Metrics/Exemplar/BucketEntry.php
@@ -11,14 +11,8 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
  */
 final class BucketEntry
 {
-    /**
-     * @var int|string
-     */
-    public $index;
-    /**
-     * @var float|int
-     */
-    public $value;
+    public int|string $index;
+    public float|int $value;
     public int $timestamp;
     public AttributesInterface $attributes;
     public ?string $traceId = null;

--- a/src/SDK/Metrics/Exemplar/BucketStorage.php
+++ b/src/SDK/Metrics/Exemplar/BucketStorage.php
@@ -26,11 +26,7 @@ final class BucketStorage
         $this->buckets = array_fill(0, $size, null);
     }
 
-    /**
-     * @param int|string $index
-     * @param float|int $value
-     */
-    public function store(int $bucket, $index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
+    public function store(int $bucket, int|string $index, float|int $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         assert($bucket <= count($this->buckets));
 

--- a/src/SDK/Metrics/Exemplar/ExemplarFilterInterface.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilterInterface.php
@@ -13,8 +13,5 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
  */
 interface ExemplarFilterInterface
 {
-    /**
-     * @param float|int $value
-     */
-    public function accepts($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): bool;
+    public function accepts(float|int $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): bool;
 }

--- a/src/SDK/Metrics/Exemplar/ExemplarReservoirInterface.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarReservoirInterface.php
@@ -10,11 +10,7 @@ use OpenTelemetry\SDK\Metrics\Data\Exemplar;
 
 interface ExemplarReservoirInterface
 {
-    /**
-     * @param int|string $index
-     * @param float|int $value
-     */
-    public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void;
+    public function offer(int|string $index, float|int $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void;
 
     /**
      * @param array<AttributesInterface> $dataPointAttributes

--- a/src/SDK/Metrics/Exemplar/FilteredReservoir.php
+++ b/src/SDK/Metrics/Exemplar/FilteredReservoir.php
@@ -14,8 +14,8 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 final class FilteredReservoir implements ExemplarReservoirInterface
 {
     public function __construct(
-        private ExemplarReservoirInterface $reservoir,
-        private ExemplarFilterInterface $filter,
+        private readonly ExemplarReservoirInterface $reservoir,
+        private readonly ExemplarFilterInterface $filter,
     ) {
     }
 

--- a/src/SDK/Metrics/Exemplar/FixedSizeReservoir.php
+++ b/src/SDK/Metrics/Exemplar/FixedSizeReservoir.php
@@ -10,8 +10,8 @@ use function random_int;
 
 final class FixedSizeReservoir implements ExemplarReservoirInterface
 {
-    private BucketStorage $storage;
-    private int $size;
+    private readonly BucketStorage $storage;
+    private readonly int $size;
     private int $measurements = 0;
 
     public function __construct(int $size = 4)

--- a/src/SDK/Metrics/Exemplar/HistogramBucketReservoir.php
+++ b/src/SDK/Metrics/Exemplar/HistogramBucketReservoir.php
@@ -10,7 +10,7 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 
 final class HistogramBucketReservoir implements ExemplarReservoirInterface
 {
-    private BucketStorage $storage;
+    private readonly BucketStorage $storage;
     /**
      * @var list<float|int>
      */

--- a/src/SDK/Metrics/Instrument.php
+++ b/src/SDK/Metrics/Instrument.php
@@ -7,16 +7,11 @@ namespace OpenTelemetry\SDK\Metrics;
 final class Instrument
 {
     public function __construct(
-        /** @readonly */
-        public string|InstrumentType $type,
-        /** @readonly */
-        public string $name,
-        /** @readonly */
-        public ?string $unit,
-        /** @readonly */
-        public ?string $description,
-        /** @readonly */
-        public array $advisory = [],
+        public readonly string|InstrumentType $type,
+        public readonly string $name,
+        public readonly ?string $unit,
+        public readonly ?string $description,
+        public readonly array $advisory = [],
     ) {
     }
 }

--- a/src/SDK/Metrics/Meter.php
+++ b/src/SDK/Metrics/Meter.php
@@ -44,18 +44,18 @@ final class Meter implements MeterInterface
      * @param ArrayAccess<object, ObservableCallbackDestructor> $destructors
      */
     public function __construct(
-        private MetricFactoryInterface $metricFactory,
-        private ResourceInfo $resource,
-        private ClockInterface $clock,
-        private StalenessHandlerFactoryInterface $stalenessHandlerFactory,
-        private iterable $metricRegistries,
-        private ViewRegistryInterface $viewRegistry,
-        private ?ExemplarFilterInterface $exemplarFilter,
-        private MeterInstruments $instruments,
-        private InstrumentationScopeInterface $instrumentationScope,
-        private MetricRegistryInterface $registry,
-        private MetricWriterInterface $writer,
-        private ArrayAccess $destructors,
+        private readonly MetricFactoryInterface $metricFactory,
+        private readonly ResourceInfo $resource,
+        private readonly ClockInterface $clock,
+        private readonly StalenessHandlerFactoryInterface $stalenessHandlerFactory,
+        private readonly iterable $metricRegistries,
+        private readonly ViewRegistryInterface $viewRegistry,
+        private readonly ?ExemplarFilterInterface $exemplarFilter,
+        private readonly MeterInstruments $instruments,
+        private readonly InstrumentationScopeInterface $instrumentationScope,
+        private readonly MetricRegistryInterface $registry,
+        private readonly MetricWriterInterface $writer,
+        private readonly ArrayAccess $destructors,
     ) {
     }
 

--- a/src/SDK/Metrics/MeterProvider.php
+++ b/src/SDK/Metrics/MeterProvider.php
@@ -22,11 +22,11 @@ use WeakMap;
 
 final class MeterProvider implements MeterProviderInterface
 {
-    private MetricFactoryInterface $metricFactory;
-    private MeterInstruments $instruments;
-    private MetricRegistryInterface $registry;
-    private MetricWriterInterface $writer;
-    private ArrayAccess $destructors;
+    private readonly MetricFactoryInterface $metricFactory;
+    private readonly MeterInstruments $instruments;
+    private readonly MetricRegistryInterface $registry;
+    private readonly MetricWriterInterface $writer;
+    private readonly ArrayAccess $destructors;
 
     private bool $closed = false;
 
@@ -35,14 +35,14 @@ final class MeterProvider implements MeterProviderInterface
      */
     public function __construct(
         ?ContextStorageInterface $contextStorage,
-        private ResourceInfo $resource,
-        private ClockInterface $clock,
+        private readonly ResourceInfo $resource,
+        private readonly ClockInterface $clock,
         AttributesFactoryInterface $attributesFactory,
-        private InstrumentationScopeFactoryInterface $instrumentationScopeFactory,
-        private iterable $metricReaders,
-        private ViewRegistryInterface $viewRegistry,
-        private ?ExemplarFilterInterface $exemplarFilter,
-        private StalenessHandlerFactoryInterface $stalenessHandlerFactory,
+        private readonly InstrumentationScopeFactoryInterface $instrumentationScopeFactory,
+        private readonly iterable $metricReaders,
+        private readonly ViewRegistryInterface $viewRegistry,
+        private readonly ?ExemplarFilterInterface $exemplarFilter,
+        private readonly StalenessHandlerFactoryInterface $stalenessHandlerFactory,
         MetricFactoryInterface $metricFactory = null,
     ) {
         $this->metricFactory = $metricFactory ?? new StreamFactory();

--- a/src/SDK/Metrics/MeterProviderBuilder.php
+++ b/src/SDK/Metrics/MeterProviderBuilder.php
@@ -16,7 +16,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 
 class MeterProviderBuilder
 {
-    // @var list<MetricReaderInterface>
+    /** @var list<MetricReaderInterface> */
     private array $metricReaders = [];
     private ?ResourceInfo $resource = null;
     private ?ExemplarFilterInterface $exemplarFilter = null;

--- a/src/SDK/Metrics/MeterProviderBuilder.php
+++ b/src/SDK/Metrics/MeterProviderBuilder.php
@@ -16,7 +16,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 
 class MeterProviderBuilder
 {
-    // @var array<MetricReaderInterface>
+    // @var list<MetricReaderInterface>
     private array $metricReaders = [];
     private ?ResourceInfo $resource = null;
     private ?ExemplarFilterInterface $exemplarFilter = null;

--- a/src/SDK/Metrics/MeterProviderBuilder.php
+++ b/src/SDK/Metrics/MeterProviderBuilder.php
@@ -16,7 +16,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 
 class MeterProviderBuilder
 {
-    /** @var list<MetricReaderInterface> */
+    // @var array<MetricReaderInterface>
     private array $metricReaders = [];
     private ?ResourceInfo $resource = null;
     private ?ExemplarFilterInterface $exemplarFilter = null;

--- a/src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php
+++ b/src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php
@@ -18,16 +18,13 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
  */
 class ConsoleMetricExporter implements PushMetricExporterInterface, AggregationTemporalitySelectorInterface
 {
-    /**
-     * @param string|Temporality|null $temporality
-     */
-    public function __construct(private $temporality = null)
+    public function __construct(private readonly Temporality|string|null $temporality = null)
     {
     }
     /**
      * @inheritDoc
      */
-    public function temporality(MetricMetadataInterface $metric)
+    public function temporality(MetricMetadataInterface $metric): Temporality|string|null
     {
         return $this->temporality ?? $metric->temporality();
     }

--- a/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
+++ b/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
@@ -23,7 +23,7 @@ final class InMemoryExporter implements MetricExporterInterface, AggregationTemp
 
     private bool $closed = false;
 
-    public function __construct(private string|Temporality|null $temporality = null)
+    public function __construct(private readonly string|Temporality|null $temporality = null)
     {
     }
 

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSource.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSource.php
@@ -13,8 +13,8 @@ use OpenTelemetry\SDK\Metrics\MetricSourceInterface;
 final class StreamMetricSource implements MetricSourceInterface
 {
     public function __construct(
-        private StreamMetricSourceProvider $provider,
-        private int $reader,
+        private readonly StreamMetricSourceProvider $provider,
+        private readonly int $reader,
     ) {
     }
 

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
@@ -20,20 +20,13 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
 final class StreamMetricSourceProvider implements MetricSourceProviderInterface, MetricMetadataInterface
 {
     public function __construct(
-        /** @readonly */
-        public ViewProjection $view,
-        /** @readonly */
-        public Instrument $instrument,
-        /** @readonly */
-        public InstrumentationScopeInterface $instrumentationLibrary,
-        /** @readonly */
-        public ResourceInfo $resource,
-        /** @readonly */
-        public MetricStreamInterface $stream,
-        /** @readonly */
-        public MetricCollectorInterface $metricCollector,
-        /** @readonly */
-        public int $streamId,
+        public readonly ViewProjection $view,
+        public readonly Instrument $instrument,
+        public readonly InstrumentationScopeInterface $instrumentationLibrary,
+        public readonly ResourceInfo $resource,
+        public readonly MetricStreamInterface $stream,
+        public readonly MetricCollectorInterface $metricCollector,
+        public readonly int $streamId,
     ) {
     }
 

--- a/src/SDK/Metrics/MetricReader/ExportingReader.php
+++ b/src/SDK/Metrics/MetricReader/ExportingReader.php
@@ -34,7 +34,7 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
 
     private bool $closed = false;
 
-    public function __construct(private MetricExporterInterface $exporter)
+    public function __construct(private readonly MetricExporterInterface $exporter)
     {
     }
 

--- a/src/SDK/Metrics/MetricRegistration/MultiRegistryRegistration.php
+++ b/src/SDK/Metrics/MetricRegistration/MultiRegistryRegistration.php
@@ -19,8 +19,8 @@ final class MultiRegistryRegistration implements MetricRegistrationInterface
      * @param iterable<MetricSourceRegistryInterface> $registries
      */
     public function __construct(
-        private iterable $registries,
-        private StalenessHandlerInterface $stalenessHandler,
+        private readonly iterable $registries,
+        private readonly StalenessHandlerInterface $stalenessHandler,
     ) {
     }
 

--- a/src/SDK/Metrics/MetricRegistration/RegistryRegistration.php
+++ b/src/SDK/Metrics/MetricRegistration/RegistryRegistration.php
@@ -16,8 +16,8 @@ use OpenTelemetry\SDK\Metrics\StalenessHandlerInterface;
 final class RegistryRegistration implements MetricRegistrationInterface
 {
     public function __construct(
-        private MetricSourceRegistryInterface $registry,
-        private StalenessHandlerInterface $stalenessHandler,
+        private readonly MetricSourceRegistryInterface $registry,
+        private readonly StalenessHandlerInterface $stalenessHandler,
     ) {
     }
 

--- a/src/SDK/Metrics/MetricRegistry/MetricRegistry.php
+++ b/src/SDK/Metrics/MetricRegistry/MetricRegistry.php
@@ -40,9 +40,9 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
     private array $asynchronousCallbackArguments = [];
 
     public function __construct(
-        private ?ContextStorageInterface $contextStorage,
-        private AttributesFactoryInterface $attributesFactory,
-        private ClockInterface $clock,
+        private readonly ?ContextStorageInterface $contextStorage,
+        private readonly AttributesFactoryInterface $attributesFactory,
+        private readonly ClockInterface $clock,
     ) {
     }
 

--- a/src/SDK/Metrics/MetricRegistry/MultiObserver.php
+++ b/src/SDK/Metrics/MetricRegistry/MultiObserver.php
@@ -18,8 +18,8 @@ final class MultiObserver implements ObserverInterface
     public array $writers = [];
 
     public function __construct(
-        private AttributesFactoryInterface $attributesFactory,
-        private int $timestamp,
+        private readonly AttributesFactoryInterface $attributesFactory,
+        private readonly int $timestamp,
     ) {
     }
 

--- a/src/SDK/Metrics/ObservableCallback.php
+++ b/src/SDK/Metrics/ObservableCallback.php
@@ -14,10 +14,10 @@ use OpenTelemetry\SDK\Metrics\MetricRegistry\MetricWriterInterface;
 final class ObservableCallback implements ObservableCallbackInterface
 {
     public function __construct(
-        private MetricWriterInterface $writer,
-        private ReferenceCounterInterface $referenceCounter,
+        private readonly MetricWriterInterface $writer,
+        private readonly ReferenceCounterInterface $referenceCounter,
         private ?int $callbackId,
-        private ?ObservableCallbackDestructor $callbackDestructor,
+        private readonly ?ObservableCallbackDestructor $callbackDestructor,
         private ?object $target,
     ) {
     }

--- a/src/SDK/Metrics/ObservableCallbackDestructor.php
+++ b/src/SDK/Metrics/ObservableCallbackDestructor.php
@@ -20,7 +20,7 @@ final class ObservableCallbackDestructor
      */
     public function __construct(
         public ArrayAccess $destructors,
-        private MetricWriterInterface $writer,
+        private readonly MetricWriterInterface $writer,
     ) {
     }
 

--- a/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandler.php
+++ b/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandler.php
@@ -19,8 +19,8 @@ final class DelayedStalenessHandler implements StalenessHandlerInterface, Refere
     private int $count = 0;
 
     public function __construct(
-        private Closure $stale,
-        private Closure $freshen,
+        private readonly Closure $stale,
+        private readonly Closure $freshen,
     ) {
     }
 

--- a/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandlerFactory.php
+++ b/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandlerFactory.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\SDK\Metrics\StalenessHandler;
 
 use Closure;
 use OpenTelemetry\SDK\Common\Time\ClockInterface;
+use OpenTelemetry\SDK\Metrics\ReferenceCounterInterface;
 use OpenTelemetry\SDK\Metrics\StalenessHandlerFactoryInterface;
 use OpenTelemetry\SDK\Metrics\StalenessHandlerInterface;
 use WeakMap;
@@ -40,7 +41,7 @@ final class DelayedStalenessHandlerFactory implements StalenessHandlerFactoryInt
         $this->staleHandlers = new WeakMap();
     }
 
-    public function create(): StalenessHandlerInterface
+    public function create(): ReferenceCounterInterface&StalenessHandlerInterface
     {
         $this->triggerStaleHandlers();
 

--- a/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandlerFactory.php
+++ b/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandlerFactory.php
@@ -12,10 +12,10 @@ use WeakMap;
 
 final class DelayedStalenessHandlerFactory implements StalenessHandlerFactoryInterface
 {
-    private int $nanoDelay;
+    private readonly int $nanoDelay;
 
-    private Closure $stale;
-    private Closure $freshen;
+    private readonly Closure $stale;
+    private readonly Closure $freshen;
 
     /** @var WeakMap<DelayedStalenessHandler, int> */
     private WeakMap $staleHandlers;
@@ -25,7 +25,7 @@ final class DelayedStalenessHandlerFactory implements StalenessHandlerFactoryInt
      * @psalm-suppress PropertyTypeCoercion
      */
     public function __construct(
-        private ClockInterface $clock,
+        private readonly ClockInterface $clock,
         float $delay,
     ) {
         $this->nanoDelay = (int) ($delay * 1e9);

--- a/src/SDK/Metrics/StalenessHandler/ImmediateStalenessHandlerFactory.php
+++ b/src/SDK/Metrics/StalenessHandler/ImmediateStalenessHandlerFactory.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Metrics\StalenessHandler;
 
+use OpenTelemetry\SDK\Metrics\ReferenceCounterInterface;
 use OpenTelemetry\SDK\Metrics\StalenessHandlerFactoryInterface;
 use OpenTelemetry\SDK\Metrics\StalenessHandlerInterface;
 
 final class ImmediateStalenessHandlerFactory implements StalenessHandlerFactoryInterface
 {
-    public function create(): StalenessHandlerInterface
+    public function create(): ReferenceCounterInterface&StalenessHandlerInterface
     {
         return new ImmediateStalenessHandler();
     }

--- a/src/SDK/Metrics/StalenessHandler/MultiReferenceCounter.php
+++ b/src/SDK/Metrics/StalenessHandler/MultiReferenceCounter.php
@@ -14,7 +14,7 @@ final class MultiReferenceCounter implements ReferenceCounterInterface
     /**
      * @param list<ReferenceCounterInterface> $referenceCounters
      */
-    public function __construct(private array $referenceCounters)
+    public function __construct(private readonly array $referenceCounters)
     {
     }
 

--- a/src/SDK/Metrics/StalenessHandler/NoopStalenessHandlerFactory.php
+++ b/src/SDK/Metrics/StalenessHandler/NoopStalenessHandlerFactory.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Metrics\StalenessHandler;
 
+use OpenTelemetry\SDK\Metrics\ReferenceCounterInterface;
 use OpenTelemetry\SDK\Metrics\StalenessHandlerFactoryInterface;
 use OpenTelemetry\SDK\Metrics\StalenessHandlerInterface;
 
 final class NoopStalenessHandlerFactory implements StalenessHandlerFactoryInterface
 {
-    public function create(): StalenessHandlerInterface
+    public function create(): ReferenceCounterInterface&StalenessHandlerInterface
     {
         static $instance;
 

--- a/src/SDK/Metrics/StalenessHandlerFactoryInterface.php
+++ b/src/SDK/Metrics/StalenessHandlerFactoryInterface.php
@@ -6,8 +6,5 @@ namespace OpenTelemetry\SDK\Metrics;
 
 interface StalenessHandlerFactoryInterface
 {
-    /**
-     * @return StalenessHandlerInterface&ReferenceCounterInterface
-     */
-    public function create(): StalenessHandlerInterface;
+    public function create(): StalenessHandlerInterface&ReferenceCounterInterface;
 }

--- a/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
@@ -23,12 +23,12 @@ final class AsynchronousMetricStream implements MetricStreamInterface
 
     public function __construct(
         private readonly AggregationInterface $aggregation,
-        private int $startTimestamp,
+        private readonly int $startTimestamp,
     ) {
         $this->metric = new Metric([], [], $startTimestamp);
     }
 
-    public function temporality()
+    public function temporality(): Temporality|string
     {
         return Temporality::CUMULATIVE;
     }

--- a/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
@@ -22,7 +22,7 @@ final class AsynchronousMetricStream implements MetricStreamInterface
     private array $lastReads = [];
 
     public function __construct(
-        private AggregationInterface $aggregation,
+        private readonly AggregationInterface $aggregation,
         private int $startTimestamp,
     ) {
         $this->metric = new Metric([], [], $startTimestamp);

--- a/src/SDK/Metrics/Stream/DeltaStorage.php
+++ b/src/SDK/Metrics/Stream/DeltaStorage.php
@@ -16,7 +16,7 @@ final class DeltaStorage
 {
     private Delta $head;
 
-    public function __construct(private AggregationInterface $aggregation)
+    public function __construct(private readonly AggregationInterface $aggregation)
     {
         $this->head = new Delta(new Metric([], [], 0), 0);
 

--- a/src/SDK/Metrics/Stream/MetricAggregator.php
+++ b/src/SDK/Metrics/Stream/MetricAggregator.php
@@ -27,10 +27,7 @@ final class MetricAggregator implements MetricAggregatorInterface
     ) {
     }
 
-    /**
-     * @param float|int $value
-     */
-    public function record($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
+    public function record(float|int $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         $filteredAttributes = $this->attributeProcessor !== null
             ? $this->attributeProcessor->process($attributes, $context)

--- a/src/SDK/Metrics/Stream/MetricAggregator.php
+++ b/src/SDK/Metrics/Stream/MetricAggregator.php
@@ -21,9 +21,9 @@ final class MetricAggregator implements MetricAggregatorInterface
     private array $summaries = [];
 
     public function __construct(
-        private ?AttributeProcessorInterface $attributeProcessor,
-        private AggregationInterface $aggregation,
-        private ?ExemplarReservoirInterface $exemplarReservoir = null,
+        private readonly ?AttributeProcessorInterface $attributeProcessor,
+        private readonly AggregationInterface $aggregation,
+        private readonly ?ExemplarReservoirInterface $exemplarReservoir = null,
     ) {
     }
 

--- a/src/SDK/Metrics/Stream/MetricAggregatorFactory.php
+++ b/src/SDK/Metrics/Stream/MetricAggregatorFactory.php
@@ -13,8 +13,8 @@ use OpenTelemetry\SDK\Metrics\AttributeProcessorInterface;
 final class MetricAggregatorFactory implements MetricAggregatorFactoryInterface
 {
     public function __construct(
-        private ?AttributeProcessorInterface $attributeProcessor,
-        private AggregationInterface $aggregation,
+        private readonly ?AttributeProcessorInterface $attributeProcessor,
+        private readonly AggregationInterface $aggregation,
     ) {
     }
 

--- a/src/SDK/Metrics/Stream/SynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/SynchronousMetricStream.php
@@ -24,13 +24,13 @@ use function trigger_error;
  */
 final class SynchronousMetricStream implements MetricStreamInterface
 {
-    private DeltaStorage $delta;
+    private readonly DeltaStorage $delta;
     private int|GMP $readers = 0;
     private int|GMP $cumulative = 0;
 
     public function __construct(
-        private AggregationInterface $aggregation,
-        private int $timestamp,
+        private readonly AggregationInterface $aggregation,
+        private readonly int $timestamp,
     ) {
         $this->delta = new DeltaStorage($this->aggregation);
     }

--- a/src/SDK/Metrics/Stream/SynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/SynchronousMetricStream.php
@@ -28,14 +28,17 @@ final class SynchronousMetricStream implements MetricStreamInterface
     private int|GMP $readers = 0;
     private int|GMP $cumulative = 0;
 
+    /**
+     * @todo rector mistakenly makes $timestamp readonly, which conflicts with `self::push`. disabled in rector.php
+     */
     public function __construct(
         private readonly AggregationInterface $aggregation,
-        private readonly int $timestamp,
+        private int $timestamp,
     ) {
         $this->delta = new DeltaStorage($this->aggregation);
     }
 
-    public function temporality()
+    public function temporality(): Temporality|string
     {
         return Temporality::DELTA;
     }

--- a/src/SDK/Metrics/Stream/WritableMetricStreamInterface.php
+++ b/src/SDK/Metrics/Stream/WritableMetricStreamInterface.php
@@ -12,8 +12,5 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
  */
 interface WritableMetricStreamInterface
 {
-    /**
-     * @param float|int $value
-     */
-    public function record($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void;
+    public function record(float|int $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void;
 }

--- a/src/SDK/Metrics/View/SelectionCriteria/AllCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/AllCriteria.php
@@ -13,7 +13,7 @@ final class AllCriteria implements SelectionCriteriaInterface
     /**
      * @param iterable<SelectionCriteriaInterface> $criteria
      */
-    public function __construct(private iterable $criteria)
+    public function __construct(private readonly iterable $criteria)
     {
     }
 

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentNameCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentNameCriteria.php
@@ -14,7 +14,7 @@ use function strtr;
 
 final class InstrumentNameCriteria implements SelectionCriteriaInterface
 {
-    private string $pattern;
+    private readonly string $pattern;
 
     /**
      * @param non-empty-string $name

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentTypeCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentTypeCriteria.php
@@ -12,7 +12,7 @@ use OpenTelemetry\SDK\Metrics\View\SelectionCriteriaInterface;
 
 final class InstrumentTypeCriteria implements SelectionCriteriaInterface
 {
-    private array $instrumentTypes;
+    private readonly array $instrumentTypes;
 
     /**
      * @param string|InstrumentType|string[]|InstrumentType[] $instrumentType

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeNameCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeNameCriteria.php
@@ -10,7 +10,7 @@ use OpenTelemetry\SDK\Metrics\View\SelectionCriteriaInterface;
 
 final class InstrumentationScopeNameCriteria implements SelectionCriteriaInterface
 {
-    public function __construct(private string $name)
+    public function __construct(private readonly string $name)
     {
     }
 

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeSchemaUrlCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeSchemaUrlCriteria.php
@@ -10,7 +10,7 @@ use OpenTelemetry\SDK\Metrics\View\SelectionCriteriaInterface;
 
 final class InstrumentationScopeSchemaUrlCriteria implements SelectionCriteriaInterface
 {
-    public function __construct(private ?string $schemaUrl)
+    public function __construct(private readonly ?string $schemaUrl)
     {
     }
 

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeVersionCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeVersionCriteria.php
@@ -10,7 +10,7 @@ use OpenTelemetry\SDK\Metrics\View\SelectionCriteriaInterface;
 
 final class InstrumentationScopeVersionCriteria implements SelectionCriteriaInterface
 {
-    public function __construct(private ?string $version)
+    public function __construct(private readonly ?string $version)
     {
     }
 

--- a/src/SDK/Metrics/View/ViewTemplate.php
+++ b/src/SDK/Metrics/View/ViewTemplate.php
@@ -12,9 +12,7 @@ final class ViewTemplate
 {
     private ?string $name = null;
     private ?string $description = null;
-    /**
-     * @var list<string>
-     */
+    /** @var list<string> */
     private ?array $attributeKeys = null;
     private ?AggregationInterface $aggregation = null;
 

--- a/src/SDK/Metrics/ViewProjection.php
+++ b/src/SDK/Metrics/ViewProjection.php
@@ -10,16 +10,11 @@ final class ViewProjection
      * @param list<string>|null $attributeKeys
      */
     public function __construct(
-        /** @readonly */
-        public string $name,
-        /** @readonly */
-        public ?string $unit,
-        /** @readonly */
-        public ?string $description,
-        /** @readonly */
-        public ?array $attributeKeys,
-        /** @readonly */
-        public ?AggregationInterface $aggregation,
+        public readonly string $name,
+        public readonly ?string $unit,
+        public readonly ?string $description,
+        public readonly ?array $attributeKeys,
+        public readonly ?AggregationInterface $aggregation,
     ) {
     }
 }

--- a/src/SDK/Resource/Detectors/Composite.php
+++ b/src/SDK/Resource/Detectors/Composite.php
@@ -13,7 +13,7 @@ final class Composite implements ResourceDetectorInterface
     /**
      * @param iterable<ResourceDetectorInterface> $resourceDetectors
      */
-    public function __construct(private iterable $resourceDetectors)
+    public function __construct(private readonly iterable $resourceDetectors)
     {
     }
 

--- a/src/SDK/Resource/Detectors/Constant.php
+++ b/src/SDK/Resource/Detectors/Constant.php
@@ -9,7 +9,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 final class Constant implements ResourceDetectorInterface
 {
-    public function __construct(private ResourceInfo $resourceInfo)
+    public function __construct(private readonly ResourceInfo $resourceInfo)
     {
     }
 

--- a/src/SDK/Sdk.php
+++ b/src/SDK/Sdk.php
@@ -16,10 +16,10 @@ class Sdk
     private const OTEL_PHP_DISABLED_INSTRUMENTATIONS_ALL = 'all';
 
     public function __construct(
-        private TracerProviderInterface $tracerProvider,
-        private MeterProviderInterface $meterProvider,
-        private LoggerProviderInterface $loggerProvider,
-        private TextMapPropagatorInterface $propagator,
+        private readonly TracerProviderInterface $tracerProvider,
+        private readonly MeterProviderInterface $meterProvider,
+        private readonly LoggerProviderInterface $loggerProvider,
+        private readonly TextMapPropagatorInterface $propagator,
     ) {
     }
 

--- a/src/SDK/SdkAutoloader.php
+++ b/src/SDK/SdkAutoloader.php
@@ -46,9 +46,9 @@ class SdkAutoloader
 
             $loggerProvider = (new LoggerProviderFactory())->create($emitMetrics ? $meterProvider : null, $resource);
 
-            ShutdownHandler::register([$tracerProvider, 'shutdown']);
-            ShutdownHandler::register([$meterProvider, 'shutdown']);
-            ShutdownHandler::register([$loggerProvider, 'shutdown']);
+            ShutdownHandler::register($tracerProvider->shutdown(...));
+            ShutdownHandler::register($meterProvider->shutdown(...));
+            ShutdownHandler::register($loggerProvider->shutdown(...));
 
             return $configurator
                 ->withTracerProvider($tracerProvider)
@@ -77,7 +77,7 @@ class SdkAutoloader
             return false;
         }
         foreach ($ignoreUrls as $ignore) {
-            if (preg_match(sprintf('|%s|', $ignore), $url) === 1) {
+            if (preg_match(sprintf('|%s|', $ignore), (string) $url) === 1) {
                 return true;
             }
         }
@@ -116,7 +116,7 @@ class SdkAutoloader
             return false;
         }
         foreach ($excludedUrls as $excludedUrl) {
-            if (preg_match(sprintf('|%s|', $excludedUrl), $url) === 1) {
+            if (preg_match(sprintf('|%s|', $excludedUrl), (string) $url) === 1) {
                 return true;
             }
         }

--- a/src/SDK/SdkAutoloader.php
+++ b/src/SDK/SdkAutoloader.php
@@ -19,6 +19,9 @@ use OpenTelemetry\SDK\Trace\SamplerFactory;
 use OpenTelemetry\SDK\Trace\SpanProcessorFactory;
 use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
 
+/**
+ * @psalm-suppress RedundantCast
+ */
 class SdkAutoloader
 {
     public static function autoload(): bool

--- a/src/SDK/SdkBuilder.php
+++ b/src/SDK/SdkBuilder.php
@@ -70,9 +70,9 @@ class SdkBuilder
         $loggerProvider = $this->loggerProvider ?? new NoopLoggerProvider();
         if ($this->autoShutdown) {
             // rector rule disabled in config, because ShutdownHandler::register() does not keep a strong reference to $this
-            ShutdownHandler::register([$tracerProvider, 'shutdown']);
-            ShutdownHandler::register([$meterProvider, 'shutdown']);
-            ShutdownHandler::register([$loggerProvider, 'shutdown']);
+            ShutdownHandler::register($tracerProvider->shutdown(...));
+            ShutdownHandler::register($meterProvider->shutdown(...));
+            ShutdownHandler::register($loggerProvider->shutdown(...));
         }
 
         return new Sdk(

--- a/src/SDK/Trace/Event.php
+++ b/src/SDK/Trace/Event.php
@@ -10,9 +10,9 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 final class Event implements EventInterface
 {
     public function __construct(
-        private string $name,
-        private int $timestamp,
-        private AttributesInterface $attributes,
+        private readonly string $name,
+        private readonly int $timestamp,
+        private readonly AttributesInterface $attributes,
     ) {
     }
 

--- a/src/SDK/Trace/ImmutableSpan.php
+++ b/src/SDK/Trace/ImmutableSpan.php
@@ -21,15 +21,15 @@ final class ImmutableSpan implements SpanDataInterface
      * @param list<EventInterface> $events
      */
     public function __construct(
-        private Span $span,
-        private string $name,
-        private array $links,
-        private array $events,
-        private AttributesInterface $attributes,
-        private int $totalRecordedEvents,
-        private StatusDataInterface $status,
-        private int $endEpochNanos,
-        private bool $hasEnded,
+        private readonly Span $span,
+        private readonly string $name,
+        private readonly array $links,
+        private readonly array $events,
+        private readonly AttributesInterface $attributes,
+        private readonly int $totalRecordedEvents,
+        private readonly StatusDataInterface $status,
+        private readonly int $endEpochNanos,
+        private readonly bool $hasEnded,
     ) {
     }
 

--- a/src/SDK/Trace/Link.php
+++ b/src/SDK/Trace/Link.php
@@ -10,8 +10,8 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 final class Link implements LinkInterface
 {
     public function __construct(
-        private API\SpanContextInterface $context,
-        private AttributesInterface $attributes,
+        private readonly API\SpanContextInterface $context,
+        private readonly AttributesInterface $attributes,
     ) {
     }
 

--- a/src/SDK/Trace/Sampler/ParentBased.php
+++ b/src/SDK/Trace/Sampler/ParentBased.php
@@ -29,22 +29,31 @@ use OpenTelemetry\SDK\Trace\Span;
  */
 class ParentBased implements SamplerInterface
 {
+    private readonly SamplerInterface $remoteParentSampler;
+    private readonly SamplerInterface $remoteParentNotSampler;
+    private readonly SamplerInterface $localParentSampler;
+    private readonly SamplerInterface $localParentNotSampler;
+
     /**
      * ParentBased sampler delegates the sampling decision based on the parent context.
      *
      * @param SamplerInterface $root Sampler called for the span with no parent (root span).
-     * @param SamplerInterface $remoteParentSampler Sampler called for the span with the remote sampled parent. When null, `AlwaysOnSampler` is used.
-     * @param SamplerInterface $remoteParentNotSampler Sampler called for the span with the remote not sampled parent. When null, `AlwaysOffSampler` is used.
-     * @param SamplerInterface $localParentSampler Sampler called for the span with local the sampled parent. When null, `AlwaysOnSampler` is used.
-     * @param SamplerInterface $localParentNotSampler Sampler called for the span with the local not sampled parent. When null, `AlwaysOffSampler` is used.
+     * @param SamplerInterface|null $remoteParentSampler Sampler called for the span with the remote sampled parent. When null, `AlwaysOnSampler` is used.
+     * @param SamplerInterface|null $remoteParentNotSampler Sampler called for the span with the remote not sampled parent. When null, `AlwaysOffSampler` is used.
+     * @param SamplerInterface|null $localParentSampler Sampler called for the span with local the sampled parent. When null, `AlwaysOnSampler` is used.
+     * @param SamplerInterface|null $localParentNotSampler Sampler called for the span with the local not sampled parent. When null, `AlwaysOffSampler` is used.
      */
     public function __construct(
         private readonly SamplerInterface $root,
-        private readonly SamplerInterface $remoteParentSampler = new AlwaysOnSampler(),
-        private readonly SamplerInterface $remoteParentNotSampler = new AlwaysOffSampler(),
-        private readonly SamplerInterface $localParentSampler = new AlwaysOnSampler(),
-        private readonly SamplerInterface $localParentNotSampler = new AlwaysOffSampler(),
+        ?SamplerInterface $remoteParentSampler = null,
+        ?SamplerInterface $remoteParentNotSampler = null,
+        ?SamplerInterface $localParentSampler = null,
+        ?SamplerInterface $localParentNotSampler = null,
     ) {
+        $this->remoteParentSampler = $remoteParentSampler ?? new AlwaysOnSampler();
+        $this->remoteParentNotSampler = $remoteParentNotSampler ?? new AlwaysOffSampler();
+        $this->localParentSampler = $localParentSampler ?? new AlwaysOnSampler();
+        $this->localParentNotSampler = $localParentNotSampler ?? new AlwaysOffSampler();
     }
 
     /**

--- a/src/SDK/Trace/Sampler/ParentBased.php
+++ b/src/SDK/Trace/Sampler/ParentBased.php
@@ -29,14 +29,6 @@ use OpenTelemetry\SDK\Trace\Span;
  */
 class ParentBased implements SamplerInterface
 {
-    private SamplerInterface $remoteParentSampler;
-
-    private SamplerInterface $remoteParentNotSampler;
-
-    private SamplerInterface $localParentSampler;
-
-    private SamplerInterface $localParentNotSampler;
-
     /**
      * ParentBased sampler delegates the sampling decision based on the parent context.
      *
@@ -46,17 +38,8 @@ class ParentBased implements SamplerInterface
      * @param SamplerInterface|null $localParentSampler Sampler called for the span with local the sampled parent. When null, `AlwaysOnSampler` is used.
      * @param SamplerInterface|null $localParentNotSampler Sampler called for the span with the local not sampled parent. When null, `AlwaysOffSampler` is used.
      */
-    public function __construct(
-        private SamplerInterface $root,
-        ?SamplerInterface $remoteParentSampler = null,
-        ?SamplerInterface $remoteParentNotSampler = null,
-        ?SamplerInterface $localParentSampler = null,
-        ?SamplerInterface $localParentNotSampler = null,
-    ) {
-        $this->remoteParentSampler = $remoteParentSampler ?? new AlwaysOnSampler();
-        $this->remoteParentNotSampler = $remoteParentNotSampler ?? new AlwaysOffSampler();
-        $this->localParentSampler = $localParentSampler ?? new AlwaysOnSampler();
-        $this->localParentNotSampler = $localParentNotSampler ?? new AlwaysOffSampler();
+    public function __construct(private readonly SamplerInterface $root, private readonly SamplerInterface $remoteParentSampler = new AlwaysOnSampler(), private readonly SamplerInterface $remoteParentNotSampler = new AlwaysOffSampler(), private readonly SamplerInterface $localParentSampler = new AlwaysOnSampler(), private readonly SamplerInterface $localParentNotSampler = new AlwaysOffSampler())
+    {
     }
 
     /**

--- a/src/SDK/Trace/Sampler/ParentBased.php
+++ b/src/SDK/Trace/Sampler/ParentBased.php
@@ -33,13 +33,18 @@ class ParentBased implements SamplerInterface
      * ParentBased sampler delegates the sampling decision based on the parent context.
      *
      * @param SamplerInterface $root Sampler called for the span with no parent (root span).
-     * @param SamplerInterface|null $remoteParentSampler Sampler called for the span with the remote sampled parent. When null, `AlwaysOnSampler` is used.
-     * @param SamplerInterface|null $remoteParentNotSampler Sampler called for the span with the remote not sampled parent. When null, `AlwaysOffSampler` is used.
-     * @param SamplerInterface|null $localParentSampler Sampler called for the span with local the sampled parent. When null, `AlwaysOnSampler` is used.
-     * @param SamplerInterface|null $localParentNotSampler Sampler called for the span with the local not sampled parent. When null, `AlwaysOffSampler` is used.
+     * @param SamplerInterface $remoteParentSampler Sampler called for the span with the remote sampled parent. When null, `AlwaysOnSampler` is used.
+     * @param SamplerInterface $remoteParentNotSampler Sampler called for the span with the remote not sampled parent. When null, `AlwaysOffSampler` is used.
+     * @param SamplerInterface $localParentSampler Sampler called for the span with local the sampled parent. When null, `AlwaysOnSampler` is used.
+     * @param SamplerInterface $localParentNotSampler Sampler called for the span with the local not sampled parent. When null, `AlwaysOffSampler` is used.
      */
-    public function __construct(private readonly SamplerInterface $root, private readonly SamplerInterface $remoteParentSampler = new AlwaysOnSampler(), private readonly SamplerInterface $remoteParentNotSampler = new AlwaysOffSampler(), private readonly SamplerInterface $localParentSampler = new AlwaysOnSampler(), private readonly SamplerInterface $localParentNotSampler = new AlwaysOffSampler())
-    {
+    public function __construct(
+        private readonly SamplerInterface $root,
+        private readonly SamplerInterface $remoteParentSampler = new AlwaysOnSampler(),
+        private readonly SamplerInterface $remoteParentNotSampler = new AlwaysOffSampler(),
+        private readonly SamplerInterface $localParentSampler = new AlwaysOnSampler(),
+        private readonly SamplerInterface $localParentNotSampler = new AlwaysOffSampler(),
+    ) {
     }
 
     /**

--- a/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -21,7 +21,7 @@ use OpenTelemetry\SDK\Trace\Span;
  */
 class TraceIdRatioBasedSampler implements SamplerInterface
 {
-    private float $probability;
+    private readonly float $probability;
 
     /**
      * @param float $probability Probability float value between 0.0 and 1.0.

--- a/src/SDK/Trace/SamplingResult.php
+++ b/src/SDK/Trace/SamplingResult.php
@@ -27,9 +27,9 @@ final class SamplingResult
      * @param ?API\TraceStateInterface $traceState A Tracestate that will be associated with the Span through the new SpanContext.
      */
     public function __construct(
-        private int $decision,
-        private iterable $attributes = [],
-        private ?API\TraceStateInterface $traceState = null,
+        private readonly int $decision,
+        private readonly iterable $attributes = [],
+        private readonly ?API\TraceStateInterface $traceState = null,
     ) {
     }
 

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -31,26 +31,26 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     private function __construct(
         private string $name,
         /** @readonly */
-        private API\SpanContextInterface $context,
+        private readonly API\SpanContextInterface $context,
         /** @readonly */
-        private InstrumentationScopeInterface $instrumentationScope,
+        private readonly InstrumentationScopeInterface $instrumentationScope,
         /** @readonly */
-        private int $kind,
+        private readonly int $kind,
         /** @readonly */
-        private API\SpanContextInterface $parentSpanContext,
+        private readonly API\SpanContextInterface $parentSpanContext,
         /** @readonly */
-        private SpanLimits $spanLimits,
+        private readonly SpanLimits $spanLimits,
         /** @readonly */
-        private SpanProcessorInterface $spanProcessor,
+        private readonly SpanProcessorInterface $spanProcessor,
         /** @readonly */
-        private ResourceInfo $resource,
+        private readonly ResourceInfo $resource,
         private AttributesBuilderInterface $attributesBuilder,
         /** @readonly */
-        private array $links,
+        private readonly array $links,
         /** @readonly */
-        private int $totalRecordedLinks,
+        private readonly int $totalRecordedLinks,
         /** @readonly */
-        private int $startEpochNanos,
+        private readonly int $startEpochNanos,
     ) {
         $this->status = StatusData::unset();
     }

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -30,26 +30,16 @@ final class Span extends API\Span implements ReadWriteSpanInterface
      */
     private function __construct(
         private string $name,
-        /** @readonly */
         private readonly API\SpanContextInterface $context,
-        /** @readonly */
         private readonly InstrumentationScopeInterface $instrumentationScope,
-        /** @readonly */
         private readonly int $kind,
-        /** @readonly */
         private readonly API\SpanContextInterface $parentSpanContext,
-        /** @readonly */
         private readonly SpanLimits $spanLimits,
-        /** @readonly */
         private readonly SpanProcessorInterface $spanProcessor,
-        /** @readonly */
         private readonly ResourceInfo $resource,
         private AttributesBuilderInterface $attributesBuilder,
-        /** @readonly */
         private readonly array $links,
-        /** @readonly */
         private readonly int $totalRecordedLinks,
-        /** @readonly */
         private readonly int $startEpochNanos,
     ) {
         $this->status = StatusData::unset();

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -29,11 +29,8 @@ final class SpanBuilder implements API\SpanBuilderInterface
 
     /** @param non-empty-string $spanName */
     public function __construct(
-        /** @readonly */
         private readonly string $spanName,
-        /** @readonly */
         private readonly InstrumentationScopeInterface $instrumentationScope,
-        /** @readonly */
         private readonly TracerSharedState $tracerSharedState,
     ) {
         $this->attributesBuilder = $this->tracerSharedState->getSpanLimits()->getAttributesFactory()->builder();

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -30,11 +30,11 @@ final class SpanBuilder implements API\SpanBuilderInterface
     /** @param non-empty-string $spanName */
     public function __construct(
         /** @readonly */
-        private string $spanName,
+        private readonly string $spanName,
         /** @readonly */
-        private InstrumentationScopeInterface $instrumentationScope,
+        private readonly InstrumentationScopeInterface $instrumentationScope,
         /** @readonly */
-        private TracerSharedState $tracerSharedState,
+        private readonly TracerSharedState $tracerSharedState,
     ) {
         $this->attributesBuilder = $this->tracerSharedState->getSpanLimits()->getAttributesFactory()->builder();
     }

--- a/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php
+++ b/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php
@@ -19,7 +19,7 @@ class ConsoleSpanExporter implements SpanExporterInterface
     use LogsMessagesTrait;
 
     public function __construct(
-        private TransportInterface $transport,
+        private readonly TransportInterface $transport,
         ?SpanConverterInterface $converter = null,
     ) {
         $this->setSpanConverter($converter ?? new FriendlySpanConverter());

--- a/src/SDK/Trace/SpanExporter/InMemoryExporter.php
+++ b/src/SDK/Trace/SpanExporter/InMemoryExporter.php
@@ -12,7 +12,7 @@ class InMemoryExporter implements SpanExporterInterface
 {
     use SpanExporterTrait;
 
-    public function __construct(private ArrayObject $storage = new ArrayObject())
+    public function __construct(private readonly ArrayObject $storage = new ArrayObject())
     {
     }
 

--- a/src/SDK/Trace/SpanExporter/InMemoryExporter.php
+++ b/src/SDK/Trace/SpanExporter/InMemoryExporter.php
@@ -12,11 +12,8 @@ class InMemoryExporter implements SpanExporterInterface
 {
     use SpanExporterTrait;
 
-    private ArrayObject $storage;
-
-    public function __construct(?ArrayObject $storage = null)
+    public function __construct(private ArrayObject $storage = new ArrayObject())
     {
-        $this->storage = $storage ?? new ArrayObject();
     }
 
     protected function doExport(iterable $spans): bool

--- a/src/SDK/Trace/SpanLimits.php
+++ b/src/SDK/Trace/SpanLimits.php
@@ -46,11 +46,11 @@ final class SpanLimits
      * @internal Use {@see SpanLimitsBuilder} to create {@see SpanLimits} instance.
      */
     public function __construct(
-        private AttributesFactoryInterface $attributesFactory,
-        private AttributesFactoryInterface $eventAttributesFactory,
-        private AttributesFactoryInterface $linkAttributesFactory,
-        private int $eventCountLimit,
-        private int $linkCountLimit,
+        private readonly AttributesFactoryInterface $attributesFactory,
+        private readonly AttributesFactoryInterface $eventAttributesFactory,
+        private readonly AttributesFactoryInterface $linkAttributesFactory,
+        private readonly int $eventCountLimit,
+        private readonly int $linkCountLimit,
     ) {
     }
 }

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -59,13 +59,13 @@ class BatchSpanProcessor implements SpanProcessorInterface
     private bool $closed = false;
 
     public function __construct(
-        private SpanExporterInterface $exporter,
-        private ClockInterface $clock,
+        private readonly SpanExporterInterface $exporter,
+        private readonly ClockInterface $clock,
         int $maxQueueSize = self::DEFAULT_MAX_QUEUE_SIZE,
         int $scheduledDelayMillis = self::DEFAULT_SCHEDULE_DELAY,
         int $exportTimeoutMillis = self::DEFAULT_EXPORT_TIMEOUT,
         int $maxExportBatchSize = self::DEFAULT_MAX_EXPORT_BATCH_SIZE,
-        private bool $autoFlush = true,
+        private readonly bool $autoFlush = true,
         ?MeterProviderInterface $meterProvider = null,
     ) {
         if ($maxQueueSize <= 0) {

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessorBuilder.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessorBuilder.php
@@ -12,7 +12,7 @@ class BatchSpanProcessorBuilder
 {
     private ?MeterProviderInterface $meterProvider = null;
 
-    public function __construct(private SpanExporterInterface $exporter)
+    public function __construct(private readonly SpanExporterInterface $exporter)
     {
     }
 

--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -28,7 +28,7 @@ class SimpleSpanProcessor implements SpanProcessorInterface
 
     private bool $closed = false;
 
-    public function __construct(private SpanExporterInterface $exporter)
+    public function __construct(private readonly SpanExporterInterface $exporter)
     {
         $this->exportContext = Context::getCurrent();
         $this->queue = new SplQueue();

--- a/src/SDK/Trace/StatusData.php
+++ b/src/SDK/Trace/StatusData.php
@@ -14,8 +14,8 @@ final class StatusData implements StatusDataInterface
 
     /** @psalm-param API\StatusCode::STATUS_* $code */
     public function __construct(
-        private string $code,
-        private string $description,
+        private readonly string $code,
+        private readonly string $description,
     ) {
     }
 

--- a/src/SDK/Trace/Tracer.php
+++ b/src/SDK/Trace/Tracer.php
@@ -14,9 +14,7 @@ class Tracer implements API\TracerInterface
     public const FALLBACK_SPAN_NAME = 'empty';
 
     public function __construct(
-        /** @readonly */
         private readonly TracerSharedState $tracerSharedState,
-        /** @readonly */
         private readonly InstrumentationScopeInterface $instrumentationScope,
     ) {
     }

--- a/src/SDK/Trace/Tracer.php
+++ b/src/SDK/Trace/Tracer.php
@@ -15,9 +15,9 @@ class Tracer implements API\TracerInterface
 
     public function __construct(
         /** @readonly */
-        private TracerSharedState $tracerSharedState,
+        private readonly TracerSharedState $tracerSharedState,
         /** @readonly */
-        private InstrumentationScopeInterface $instrumentationScope,
+        private readonly InstrumentationScopeInterface $instrumentationScope,
     ) {
     }
 

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -18,7 +18,6 @@ use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
 
 final class TracerProvider implements TracerProviderInterface
 {
-    /** @readonly */
     private readonly TracerSharedState $tracerSharedState;
     private readonly InstrumentationScopeFactoryInterface $instrumentationScopeFactory;
 

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -19,8 +19,8 @@ use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
 final class TracerProvider implements TracerProviderInterface
 {
     /** @readonly */
-    private TracerSharedState $tracerSharedState;
-    private InstrumentationScopeFactoryInterface $instrumentationScopeFactory;
+    private readonly TracerSharedState $tracerSharedState;
+    private readonly InstrumentationScopeFactoryInterface $instrumentationScopeFactory;
 
     /** @param list<SpanProcessorInterface>|SpanProcessorInterface|null $spanProcessors */
     public function __construct(

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -24,17 +24,14 @@ final class TracerProvider implements TracerProviderInterface
 
     /** @param list<SpanProcessorInterface>|SpanProcessorInterface|null $spanProcessors */
     public function __construct(
-        $spanProcessors = [],
+        SpanProcessorInterface|array|null $spanProcessors = [],
         SamplerInterface $sampler = null,
         ResourceInfo $resource = null,
         SpanLimits $spanLimits = null,
         IdGeneratorInterface $idGenerator = null,
         ?InstrumentationScopeFactoryInterface $instrumentationScopeFactory = null,
     ) {
-        if (null === $spanProcessors) {
-            $spanProcessors = [];
-        }
-
+        $spanProcessors ??= [];
         $spanProcessors = is_array($spanProcessors) ? $spanProcessors : [$spanProcessors];
         $resource ??= ResourceInfoFactory::defaultResource();
         $sampler ??= new ParentBased(new AlwaysOnSampler());

--- a/src/SDK/Trace/TracerProviderFactory.php
+++ b/src/SDK/Trace/TracerProviderFactory.php
@@ -11,18 +11,11 @@ final class TracerProviderFactory
 {
     use LogsMessagesTrait;
 
-    private ExporterFactory $exporterFactory;
-    private SamplerFactory $samplerFactory;
-    private SpanProcessorFactory $spanProcessorFactory;
-
     public function __construct(
-        ?ExporterFactory $exporterFactory = null,
-        ?SamplerFactory $samplerFactory = null,
-        ?SpanProcessorFactory $spanProcessorFactory = null,
+        private readonly ExporterFactory $exporterFactory = new ExporterFactory(),
+        private readonly SamplerFactory $samplerFactory = new SamplerFactory(),
+        private readonly SpanProcessorFactory $spanProcessorFactory = new SpanProcessorFactory(),
     ) {
-        $this->exporterFactory = $exporterFactory ?: new ExporterFactory();
-        $this->samplerFactory = $samplerFactory ?: new SamplerFactory();
-        $this->spanProcessorFactory = $spanProcessorFactory ?: new SpanProcessorFactory();
     }
 
     public function create(): TracerProviderInterface

--- a/src/SDK/Trace/TracerSharedState.php
+++ b/src/SDK/Trace/TracerSharedState.php
@@ -15,7 +15,6 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\NoopSpanProcessor;
  */
 final class TracerSharedState
 {
-    /** @readonly */
     private readonly SpanProcessorInterface $spanProcessor;
 
     private ?bool $shutdownResult = null;

--- a/src/SDK/Trace/TracerSharedState.php
+++ b/src/SDK/Trace/TracerSharedState.php
@@ -16,19 +16,19 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\NoopSpanProcessor;
 final class TracerSharedState
 {
     /** @readonly */
-    private SpanProcessorInterface $spanProcessor;
+    private readonly SpanProcessorInterface $spanProcessor;
 
     private ?bool $shutdownResult = null;
 
     public function __construct(
         /** @readonly */
-        private IdGeneratorInterface $idGenerator,
+        private readonly IdGeneratorInterface $idGenerator,
         /** @readonly */
-        private ResourceInfo $resource,
+        private readonly ResourceInfo $resource,
         /** @readonly */
-        private SpanLimits $spanLimits,
+        private readonly SpanLimits $spanLimits,
         /** @readonly */
-        private SamplerInterface $sampler,
+        private readonly SamplerInterface $sampler,
         array $spanProcessors,
     ) {
         $this->spanProcessor = match (count($spanProcessors)) {

--- a/src/SDK/Trace/TracerSharedState.php
+++ b/src/SDK/Trace/TracerSharedState.php
@@ -21,13 +21,9 @@ final class TracerSharedState
     private ?bool $shutdownResult = null;
 
     public function __construct(
-        /** @readonly */
         private readonly IdGeneratorInterface $idGenerator,
-        /** @readonly */
         private readonly ResourceInfo $resource,
-        /** @readonly */
         private readonly SpanLimits $spanLimits,
-        /** @readonly */
         private readonly SamplerInterface $sampler,
         array $spanProcessors,
     ) {

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "open-telemetry/api": "^1.0",
         "open-telemetry/context": "^1.0",

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -29,7 +29,6 @@
         "psr/http-message": "^1.0.1|^2.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/polyfill-mbstring": "^1.23",
-        "symfony/polyfill-php81": "^1.26",
         "symfony/polyfill-php82": "^1.26"
     },
     "autoload": {

--- a/src/SemConv/composer.json
+++ b/src/SemConv/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integration/SDK/ParentBasedTest.php
+++ b/tests/Integration/SDK/ParentBasedTest.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Integration\SDK;
 
 use OpenTelemetry\API\Trace as API;
-use OpenTelemetry\API\Trace\NonRecordingSpan;
-use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
@@ -33,92 +30,6 @@ class ParentBasedTest extends TestCase
             Attributes::create([]),
             [],
         );
-    }
-
-    /**
-     * @dataProvider parentContextData
-     */
-    public function test_parent_based(
-        ContextInterface $parentContext,
-        ?SamplerInterface $remoteParentSampled = null,
-        ?SamplerInterface $remoteParentNotSampled = null,
-        ?SamplerInterface $localParentSampled = null,
-        ?SamplerInterface $localParentNotSampled = null,
-        ?int $expectedDecision = null,
-    ): void {
-        $rootSampler = $this->createMockSamplerNeverInvoked();
-
-        $sampler = new ParentBased($rootSampler, $remoteParentSampled, $remoteParentNotSampled, $localParentSampled, $localParentNotSampled);
-        $decision = $sampler->shouldSample(
-            $parentContext,
-            '4bf92f3577b34da6a3ce929d0e0e4736',
-            'test.opentelemetry.io',
-            API\SpanKind::KIND_INTERNAL,
-            Attributes::create([]),
-            [],
-        );
-        $this->assertEquals($expectedDecision, $decision->getDecision());
-    }
-
-    public function parentContextData(): array
-    {
-        return [
-            // remote, sampled, default sampler
-            [$this->createParentContext(true, true), null, null, null, null, SamplingResult::RECORD_AND_SAMPLE],
-            // remote, not sampled, default sampler
-            [$this->createParentContext(false, true), null, null, null, null, SamplingResult::DROP],
-            // local, sampled, default sampler
-            [$this->createParentContext(true, false), null, null, null, null, SamplingResult::RECORD_AND_SAMPLE],
-            // local, not sampled, default sampler
-            [$this->createParentContext(false, false), null, null, null, null, SamplingResult::DROP],
-            // remote, sampled
-            [$this->createParentContext(true, true), $this->createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE), null, null, null, SamplingResult::RECORD_AND_SAMPLE],
-            // remote, not sampled
-            [$this->createParentContext(false, true), null, $this->createMockSamplerInvokedOnce(SamplingResult::DROP), null, null, SamplingResult::DROP],
-            // local, sampled
-            [$this->createParentContext(true, false), null, null, $this->createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE), null, SamplingResult::RECORD_AND_SAMPLE],
-            // local, not sampled
-            [$this->createParentContext(false, false), null, null, null, $this->createMockSamplerInvokedOnce(SamplingResult::DROP), SamplingResult::DROP],
-        ];
-    }
-
-    public function test_parent_based_description(): void
-    {
-        $rootSampler = $this->createMock(SamplerInterface::class);
-        $rootSampler->expects($this->once())->method('getDescription')->willReturn('Foo');
-        $sampler = new ParentBased($rootSampler);
-        $this->assertEquals('ParentBased+Foo', $sampler->getDescription());
-    }
-
-    private function createParentContext(bool $sampled, bool $isRemote, ?API\TraceStateInterface $traceState = null): ContextInterface
-    {
-        $traceFlag = $sampled ? API\TraceFlags::SAMPLED : API\TraceFlags::DEFAULT;
-
-        if ($isRemote) {
-            $spanContext = SpanContext::createFromRemoteParent(
-                '4bf92f3577b34da6a3ce929d0e0e4736',
-                '00f067aa0ba902b7',
-                $traceFlag,
-                $traceState
-            );
-        } else {
-            $spanContext = SpanContext::create(
-                '4bf92f3577b34da6a3ce929d0e0e4736',
-                '00f067aa0ba902b7',
-                $traceFlag,
-                $traceState
-            );
-        }
-
-        return Context::getRoot()->withContextValue(new NonRecordingSpan($spanContext));
-    }
-
-    private function createMockSamplerNeverInvoked(): SamplerInterface
-    {
-        $sampler = $this->createMock(SamplerInterface::class);
-        $sampler->expects($this->never())->method('shouldSample');
-
-        return $sampler;
     }
 
     private function createMockSamplerInvokedOnce(int $resultDecision): SamplerInterface

--- a/tests/Unit/SDK/Trace/Sampler/ParentBasedTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/ParentBasedTest.php
@@ -66,15 +66,12 @@ class ParentBasedTest extends MockeryTestCase
      */
     public function test_should_sample_parent_based(
         $parentContext,
-        ?SamplerInterface $remoteParentSampled = null,
-        ?SamplerInterface $remoteParentNotSampled = null,
-        ?SamplerInterface $localParentSampled = null,
-        ?SamplerInterface $localParentNotSampled = null,
+        array $args = [],
         ?int $expectedDecision = null,
     ): void {
-        $rootSampler = $this->createMockSamplerNeverInvoked();
+        $args['root'] = $this->createMockSamplerNeverInvoked();
+        $sampler = new ParentBased(...$args);
 
-        $sampler = new ParentBased($rootSampler, $remoteParentSampled, $remoteParentNotSampled, $localParentSampled, $localParentNotSampled);
         $decision = $sampler->shouldSample(
             $parentContext,
             '4bf92f3577b34da6a3ce929d0e0e4736',
@@ -89,14 +86,46 @@ class ParentBasedTest extends MockeryTestCase
     public static function parentContextProvider(): array
     {
         return [
-            'remote, sampled, default sampler' => [self::createParentContext(true, true), null, null, null, null, SamplingResult::RECORD_AND_SAMPLE],
-            'remote, not sampled, default sampler' => [self::createParentContext(false, true), null, null, null, null, SamplingResult::DROP],
-            'local, sampled, default sampler' => [self::createParentContext(true, false), null, null, null, null, SamplingResult::RECORD_AND_SAMPLE],
-            'local, not sampled, default sampler' => [self::createParentContext(false, false), null, null, null, null, SamplingResult::DROP],
-            'remote, sampled' => [self::createParentContext(true, true), self::createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE), null, null, null, SamplingResult::RECORD_AND_SAMPLE],
-            'remote, not sampled' => [self::createParentContext(false, true), null, self::createMockSamplerInvokedOnce(SamplingResult::DROP), null, null, SamplingResult::DROP],
-            'local, sampled' => [self::createParentContext(true, false), null, null, self::createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE), null, SamplingResult::RECORD_AND_SAMPLE],
-            'local, not sampled' => [self::createParentContext(false, false), null, null, null, self::createMockSamplerInvokedOnce(SamplingResult::DROP), SamplingResult::DROP],
+            'remote, sampled, default sampler' => [
+                self::createParentContext(true, true),
+                [],
+                SamplingResult::RECORD_AND_SAMPLE,
+            ],
+            'remote, not sampled, default sampler' => [
+                self::createParentContext(false, true),
+                [],
+                SamplingResult::DROP,
+            ],
+            'local, sampled, default sampler' => [
+                self::createParentContext(true, false),
+                [],
+                SamplingResult::RECORD_AND_SAMPLE,
+            ],
+            'local, not sampled, default sampler' => [
+                self::createParentContext(false, false),
+                [],
+                SamplingResult::DROP,
+            ],
+            'remote, sampled' => [
+                self::createParentContext(true, true),
+                ['remoteParentSampler' => self::createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE)],
+                SamplingResult::RECORD_AND_SAMPLE,
+            ],
+            'remote, not sampled' => [
+                self::createParentContext(false, true),
+                ['remoteParentNotSampler' => self::createMockSamplerInvokedOnce(SamplingResult::DROP)],
+                SamplingResult::DROP,
+            ],
+            'local, sampled' => [
+                self::createParentContext(true, false),
+                ['localParentSampler' => self::createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE)],
+                SamplingResult::RECORD_AND_SAMPLE,
+            ],
+            'local, not sampled' => [
+                self::createParentContext(false, false),
+                ['localParentNotSampler' => self::createMockSamplerInvokedOnce(SamplingResult::DROP)],
+                SamplingResult::DROP,
+            ],
         ];
     }
 

--- a/tests/Unit/SDK/Trace/Sampler/ParentBasedTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/ParentBasedTest.php
@@ -66,12 +66,15 @@ class ParentBasedTest extends MockeryTestCase
      */
     public function test_should_sample_parent_based(
         $parentContext,
-        array $args = [],
+        ?SamplerInterface $remoteParentSampled = null,
+        ?SamplerInterface $remoteParentNotSampled = null,
+        ?SamplerInterface $localParentSampled = null,
+        ?SamplerInterface $localParentNotSampled = null,
         ?int $expectedDecision = null,
     ): void {
-        $args['root'] = $this->createMockSamplerNeverInvoked();
-        $sampler = new ParentBased(...$args);
+        $rootSampler = $this->createMockSamplerNeverInvoked();
 
+        $sampler = new ParentBased($rootSampler, $remoteParentSampled, $remoteParentNotSampled, $localParentSampled, $localParentNotSampled);
         $decision = $sampler->shouldSample(
             $parentContext,
             '4bf92f3577b34da6a3ce929d0e0e4736',
@@ -86,46 +89,14 @@ class ParentBasedTest extends MockeryTestCase
     public static function parentContextProvider(): array
     {
         return [
-            'remote, sampled, default sampler' => [
-                self::createParentContext(true, true),
-                [],
-                SamplingResult::RECORD_AND_SAMPLE,
-            ],
-            'remote, not sampled, default sampler' => [
-                self::createParentContext(false, true),
-                [],
-                SamplingResult::DROP,
-            ],
-            'local, sampled, default sampler' => [
-                self::createParentContext(true, false),
-                [],
-                SamplingResult::RECORD_AND_SAMPLE,
-            ],
-            'local, not sampled, default sampler' => [
-                self::createParentContext(false, false),
-                [],
-                SamplingResult::DROP,
-            ],
-            'remote, sampled' => [
-                self::createParentContext(true, true),
-                ['remoteParentSampler' => self::createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE)],
-                SamplingResult::RECORD_AND_SAMPLE,
-            ],
-            'remote, not sampled' => [
-                self::createParentContext(false, true),
-                ['remoteParentNotSampler' => self::createMockSamplerInvokedOnce(SamplingResult::DROP)],
-                SamplingResult::DROP,
-            ],
-            'local, sampled' => [
-                self::createParentContext(true, false),
-                ['localParentSampler' => self::createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE)],
-                SamplingResult::RECORD_AND_SAMPLE,
-            ],
-            'local, not sampled' => [
-                self::createParentContext(false, false),
-                ['localParentNotSampler' => self::createMockSamplerInvokedOnce(SamplingResult::DROP)],
-                SamplingResult::DROP,
-            ],
+            'remote, sampled, default sampler' => [self::createParentContext(true, true), null, null, null, null, SamplingResult::RECORD_AND_SAMPLE],
+            'remote, not sampled, default sampler' => [self::createParentContext(false, true), null, null, null, null, SamplingResult::DROP],
+            'local, sampled, default sampler' => [self::createParentContext(true, false), null, null, null, null, SamplingResult::RECORD_AND_SAMPLE],
+            'local, not sampled, default sampler' => [self::createParentContext(false, false), null, null, null, null, SamplingResult::DROP],
+            'remote, sampled' => [self::createParentContext(true, true), self::createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE), null, null, null, SamplingResult::RECORD_AND_SAMPLE],
+            'remote, not sampled' => [self::createParentContext(false, true), null, self::createMockSamplerInvokedOnce(SamplingResult::DROP), null, null, SamplingResult::DROP],
+            'local, sampled' => [self::createParentContext(true, false), null, null, self::createMockSamplerInvokedOnce(SamplingResult::RECORD_AND_SAMPLE), null, SamplingResult::RECORD_AND_SAMPLE],
+            'local, not sampled' => [self::createParentContext(false, false), null, null, null, self::createMockSamplerInvokedOnce(SamplingResult::DROP), SamplingResult::DROP],
         ];
     }
 


### PR DESCRIPTION
these are mostly automated changes from rector, applying 8.1 syntax updates.
also, apply some manual type-hint updates and readonly properties that rector missed.

after this is merged, we can separate create PRs to:
- upgrade phpunit to v10
- replace some interfaces/classes with enums