### PR TITLE
Add host.id for non-containerized systems

### DIFF
--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -63,7 +63,7 @@ final class Host implements ResourceDetectorInterface
                 }
         }
 
-        return '';
+        return null;
     }
 
     private function getLinuxId(): string
@@ -76,7 +76,7 @@ final class Host implements ResourceDetectorInterface
             }
         }
 
-        return '';
+        return null;
     }
 
     private function getBsdId(): string
@@ -91,7 +91,7 @@ final class Host implements ResourceDetectorInterface
             return $out;
         }
 
-        return '';
+        return null;
     }
 
     private function getMacOsId(): string
@@ -102,7 +102,7 @@ final class Host implements ResourceDetectorInterface
             return $out;
         }
 
-        return '';
+        return null;
     }
 
     private function getWindowsId(): string
@@ -113,7 +113,7 @@ final class Host implements ResourceDetectorInterface
             return $out;
         }
 
-        return '';
+        return null;
     }
 
     public static function parseMacOsId(string $out): string
@@ -128,7 +128,7 @@ final class Host implements ResourceDetectorInterface
             }
         }
 
-        return '';
+        return null;
     }
 
     public static function parseWindowsId(string $out): string

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -126,7 +126,7 @@ final class Host implements ResourceDetectorInterface
             if (str_contains($line, 'IOPlatformUUID')) {
                 $parts = explode('=', $line);
 
-                return trim($parts[1]);
+                return trim(str_replace('"', '', $parts[1]));
             }
         }
 

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -17,11 +17,14 @@ final class Host implements ResourceDetectorInterface
 {
     private const PATH_ETC_MACHINEID = 'etc/machine-id';
     private const PATH_VAR_LIB_DBUS_MACHINEID = 'var/lib/dbus/machine-id';
+    private const PATH_ETC_HOSTID = 'etc/hostid';
     private readonly string $dir;
+    private readonly string $os;
 
-    public function __construct(string $dir = '/')
+    public function __construct(string $dir = '/', string $os = PHP_OS_FAMILY)
     {
         $this->dir = $dir;
+        $this->os = $os;
     }
 
     public function getResource(): ResourceInfo
@@ -37,7 +40,7 @@ final class Host implements ResourceDetectorInterface
 
     private function getMachineId()
     {
-        switch (strtolower(PHP_OS_FAMILY)) {
+        switch (strtolower($this->os)) {
             case 'linux':
                 {
                     return $this->getLinuxId();
@@ -80,8 +83,8 @@ final class Host implements ResourceDetectorInterface
 
     private function getBsdId(): string
     {
-        if (file_exists('/etc/hostid')) {
-            return trim(file_get_contents('/etc/hostid'));
+        if (file_exists($this->dir . self::PATH_ETC_HOSTID)) {
+            return trim(file_get_contents($this->dir . self::PATH_ETC_HOSTID));
         }
 
         $out = exec('kenv -q smbios.system.uuid');

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -109,7 +109,7 @@ final class Host implements ResourceDetectorInterface
 
     private function getWindowsId(): string
     {
-        $out = exec('%windir%\System32\REG.exe QUERY HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography /v MachineGuid');
+        $out = exec('powershell.exe -Command "Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\Cryptography -Name MachineGuid"');
 
         if ($out != false) {
             return $out;

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -38,7 +38,7 @@ final class Host implements ResourceDetectorInterface
         return ResourceInfo::create(Attributes::create($attributes), ResourceAttributes::SCHEMA_URL);
     }
 
-    private function getMachineId()
+    private function getMachineId(): ?string
     {
         switch ($this->os) {
             case 'Linux':
@@ -62,7 +62,7 @@ final class Host implements ResourceDetectorInterface
         return null;
     }
 
-    private function getLinuxId(): string
+    private function getLinuxId(): ?string
     {
         $paths = [self::PATH_ETC_MACHINEID, self::PATH_VAR_LIB_DBUS_MACHINEID];
 
@@ -75,7 +75,7 @@ final class Host implements ResourceDetectorInterface
         return null;
     }
 
-    private function getBsdId(): string
+    private function getBsdId(): ?string
     {
         if (file_exists($this->dir . self::PATH_ETC_HOSTID)) {
             return trim(file_get_contents($this->dir . self::PATH_ETC_HOSTID));
@@ -90,7 +90,7 @@ final class Host implements ResourceDetectorInterface
         return null;
     }
 
-    private function getMacOsId(): string
+    private function getMacOsId(): ?string
     {
         $out = exec('ioreg -rd1 -c IOPlatformExpertDevice | awk \'/IOPlatformUUID/ { split($0, line, "\""); printf("%s\n", line[4]); }\'');
 
@@ -101,7 +101,7 @@ final class Host implements ResourceDetectorInterface
         return null;
     }
 
-    private function getWindowsId(): string
+    private function getWindowsId(): ?string
     {
         $out = exec('powershell.exe -Command "Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\Cryptography -Name MachineGuid"');
 

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -57,9 +57,7 @@ final class Host implements ResourceDetectorInterface
                 }
             case 'Windows':
                 {
-                    $out = $this->getWindowsId();
-
-                    return self::parseWindowsId($out);
+                    return $this->getWindowsId();
                 }
         }
 
@@ -129,12 +127,5 @@ final class Host implements ResourceDetectorInterface
         }
 
         return null;
-    }
-
-    public static function parseWindowsId(string $out): string
-    {
-        $parts = explode('REG_SZ', $out);
-
-        return trim($parts[1]);
     }
 }

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -8,6 +8,7 @@ use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SemConv\ResourceAttributes;
+use MachineIdSource;
 use function php_uname;
 
 /**
@@ -15,13 +16,128 @@ use function php_uname;
  */
 final class Host implements ResourceDetectorInterface
 {
+    private string $dir;
+
+    public function __construct(string $dir = '/')
+    {
+        $this->dir = $dir;
+    }
+
     public function getResource(): ResourceInfo
     {
         $attributes = [
             ResourceAttributes::HOST_NAME => php_uname('n'),
             ResourceAttributes::HOST_ARCH => php_uname('m'),
+            ResourceAttributes::HOST_ID => $this->getMachineId(),
         ];
 
         return ResourceInfo::create(Attributes::create($attributes), ResourceAttributes::SCHEMA_URL);
+    }
+
+    private function getMachineId()
+    {
+        switch (strtolower(PHP_OS_FAMILY))
+        {
+            case 'linux':
+            {
+                return $this->getLinuxId();
+            }
+            case 'freebsd':
+            case 'netbsd':
+            case 'openbsd':
+            {
+                return $this->getBsdId();
+            }
+            case 'darwin':
+            {
+                $out = $this->getMacOsId();
+                return Host::parseMacOsId($out);
+            }
+            case 'windows':
+            {
+                $out = $this->getWindowsId();
+                return Host::parseWindowsId($out);
+            }
+        }
+
+        return '';
+    }
+
+    private function getLinuxId(): string
+    {
+        $paths = ['etc/machine-id', 'var/lib/dbus/machine-id'];
+
+        foreach ($paths as $path)
+        {
+            if (file_exists($this->dir . $path))
+            {
+                return trim(file_get_contents($this->dir . $path));
+            }
+        }
+
+        return '';
+    }
+
+    private function getBsdId(): string
+    {
+        if (file_exists('/etc/hostid'))
+        {
+            return trim(file_get_contents('/etc/hostid'));
+        }
+
+        $out = exec('kenv -q smbios.system.uuid');
+
+        if ($out != FALSE)
+        {
+            return $out;
+        }
+
+        return '';
+    }
+
+    private function getMacOsId(): string
+    {
+        $out = exec('ioreg -rd1 -c "IOPlatformExpertDevice"');
+
+        if ($out != FALSE)
+        {
+            return $out;
+        }
+
+        return '';
+    }
+
+    private function getWindowsId(): string
+    {
+        $out = exec('%windir%\System32\REG.exe QUERY HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography /v MachineGuid');
+
+        if ($out != FALSE)
+        {
+            return $out;
+        }
+
+        return '';
+    }
+
+    public static function parseMacOsId(string $out): string
+    {
+        $lines = explode("\n", $out);
+
+        foreach ($lines as $line)
+        {
+            if (strpos($line, 'IOPlatformUUID') !== FALSE)
+            {
+                $parts = explode('=', $line);
+                return trim($parts[1]);
+            }
+        }
+
+        return '';
+    }
+
+    public static function parseWindowsId(string $out): string
+    {
+        $parts = explode('REG_SZ', $out);
+        return trim($parts[1]);
     }
 }

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -37,26 +37,13 @@ final class Host implements ResourceDetectorInterface
 
     private function getMachineId(): ?string
     {
-        switch ($this->os) {
-            case 'Linux':
-                {
-                    return $this->getLinuxId();
-                }
-            case 'BSD':
-                {
-                    return $this->getBsdId();
-                }
-            case 'Darwin':
-                {
-                    return $this->getMacOsId();
-                }
-            case 'Windows':
-                {
-                    return $this->getWindowsId();
-                }
-        }
-
-        return null;
+        return match ($this->os) {
+            'Linux' => $this->getLinuxId(),
+            'BSD' => $this->getBsdId(),
+            'Darwin' => $this->getMacOsId(),
+            'Windows' => $this->getWindowsId(),
+            default => null,
+        };
     }
 
     private function getLinuxId(): ?string

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -40,24 +40,22 @@ final class Host implements ResourceDetectorInterface
 
     private function getMachineId()
     {
-        switch (strtolower($this->os)) {
-            case 'linux':
+        switch ($this->os) {
+            case 'Linux':
                 {
                     return $this->getLinuxId();
                 }
-            case 'freebsd':
-            case 'netbsd':
-            case 'openbsd':
+            case 'BSD':
                 {
                     return $this->getBsdId();
                 }
-            case 'darwin':
+            case 'Darwin':
                 {
                     $out = $this->getMacOsId();
 
                     return self::parseMacOsId($out);
                 }
-            case 'windows':
+            case 'Windows':
                 {
                     $out = $this->getWindowsId();
 

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -15,6 +15,8 @@ use function php_uname;
  */
 final class Host implements ResourceDetectorInterface
 {
+    private const PATH_ETC_MACHINEID = 'etc/machine-id';
+    private const PATH_VAR_LIB_DBUS_MACHINEID = 'var/lib/dbus/machine-id';
     private readonly string $dir;
 
     public function __construct(string $dir = '/')
@@ -65,7 +67,7 @@ final class Host implements ResourceDetectorInterface
 
     private function getLinuxId(): string
     {
-        $paths = ['etc/machine-id', 'var/lib/dbus/machine-id'];
+        $paths = [self::PATH_ETC_MACHINEID, self::PATH_VAR_LIB_DBUS_MACHINEID];
 
         foreach ($paths as $path) {
             if (file_exists($this->dir . $path)) {

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -51,9 +51,7 @@ final class Host implements ResourceDetectorInterface
                 }
             case 'Darwin':
                 {
-                    $out = $this->getMacOsId();
-
-                    return self::parseMacOsId($out);
+                    return $this->getMacOsId();
                 }
             case 'Windows':
                 {
@@ -94,7 +92,7 @@ final class Host implements ResourceDetectorInterface
 
     private function getMacOsId(): string
     {
-        $out = exec('ioreg -rd1 -c "IOPlatformExpertDevice"');
+        $out = exec('ioreg -rd1 -c IOPlatformExpertDevice | awk \'/IOPlatformUUID/ { split($0, line, "\""); printf("%s\n", line[4]); }\'');
 
         if ($out != false) {
             return $out;
@@ -109,21 +107,6 @@ final class Host implements ResourceDetectorInterface
 
         if ($out != false) {
             return $out;
-        }
-
-        return null;
-    }
-
-    public static function parseMacOsId(string $out): string
-    {
-        $lines = explode(PHP_EOL, $out);
-
-        foreach ($lines as $line) {
-            if (str_contains($line, 'IOPlatformUUID')) {
-                $parts = explode('=', $line);
-
-                return trim(str_replace('"', '', $parts[1]));
-            }
         }
 
         return null;

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -18,6 +18,7 @@ final class Host implements ResourceDetectorInterface
     private const PATH_ETC_MACHINEID = 'etc/machine-id';
     private const PATH_VAR_LIB_DBUS_MACHINEID = 'var/lib/dbus/machine-id';
     private const PATH_ETC_HOSTID = 'etc/hostid';
+
     public function __construct(
         private readonly string $dir = '/',
         private readonly string $os = PHP_OS_FAMILY,

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -51,12 +51,12 @@ final class Host implements ResourceDetectorInterface
             case 'darwin':
             {
                 $out = $this->getMacOsId();
-                return Host::parseMacOsId($out);
+                return self::parseMacOsId($out);
             }
             case 'windows':
             {
                 $out = $this->getWindowsId();
-                return Host::parseWindowsId($out);
+                return self::parseWindowsId($out);
             }
         }
 
@@ -125,7 +125,7 @@ final class Host implements ResourceDetectorInterface
 
         foreach ($lines as $line)
         {
-            if (strpos($line, 'IOPlatformUUID') !== FALSE)
+            if (str_contains($line, 'IOPlatformUUID') !== FALSE)
             {
                 $parts = explode('=', $line);
                 return trim($parts[1]);

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -8,7 +8,6 @@ use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SemConv\ResourceAttributes;
-use MachineIdSource;
 use function php_uname;
 
 /**
@@ -16,7 +15,7 @@ use function php_uname;
  */
 final class Host implements ResourceDetectorInterface
 {
-    private string $dir;
+    private readonly string $dir;
 
     public function __construct(string $dir = '/')
     {
@@ -36,28 +35,29 @@ final class Host implements ResourceDetectorInterface
 
     private function getMachineId()
     {
-        switch (strtolower(PHP_OS_FAMILY))
-        {
+        switch (strtolower(PHP_OS_FAMILY)) {
             case 'linux':
-            {
-                return $this->getLinuxId();
-            }
+                {
+                    return $this->getLinuxId();
+                }
             case 'freebsd':
             case 'netbsd':
             case 'openbsd':
-            {
-                return $this->getBsdId();
-            }
+                {
+                    return $this->getBsdId();
+                }
             case 'darwin':
-            {
-                $out = $this->getMacOsId();
-                return self::parseMacOsId($out);
-            }
+                {
+                    $out = $this->getMacOsId();
+
+                    return self::parseMacOsId($out);
+                }
             case 'windows':
-            {
-                $out = $this->getWindowsId();
-                return self::parseWindowsId($out);
-            }
+                {
+                    $out = $this->getWindowsId();
+
+                    return self::parseWindowsId($out);
+                }
         }
 
         return '';
@@ -67,10 +67,8 @@ final class Host implements ResourceDetectorInterface
     {
         $paths = ['etc/machine-id', 'var/lib/dbus/machine-id'];
 
-        foreach ($paths as $path)
-        {
-            if (file_exists($this->dir . $path))
-            {
+        foreach ($paths as $path) {
+            if (file_exists($this->dir . $path)) {
                 return trim(file_get_contents($this->dir . $path));
             }
         }
@@ -80,15 +78,13 @@ final class Host implements ResourceDetectorInterface
 
     private function getBsdId(): string
     {
-        if (file_exists('/etc/hostid'))
-        {
+        if (file_exists('/etc/hostid')) {
             return trim(file_get_contents('/etc/hostid'));
         }
 
         $out = exec('kenv -q smbios.system.uuid');
 
-        if ($out != FALSE)
-        {
+        if ($out != false) {
             return $out;
         }
 
@@ -99,8 +95,7 @@ final class Host implements ResourceDetectorInterface
     {
         $out = exec('ioreg -rd1 -c "IOPlatformExpertDevice"');
 
-        if ($out != FALSE)
-        {
+        if ($out != false) {
             return $out;
         }
 
@@ -111,8 +106,7 @@ final class Host implements ResourceDetectorInterface
     {
         $out = exec('%windir%\System32\REG.exe QUERY HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography /v MachineGuid');
 
-        if ($out != FALSE)
-        {
+        if ($out != false) {
             return $out;
         }
 
@@ -123,11 +117,10 @@ final class Host implements ResourceDetectorInterface
     {
         $lines = explode("\n", $out);
 
-        foreach ($lines as $line)
-        {
-            if (str_contains($line, 'IOPlatformUUID') !== FALSE)
-            {
+        foreach ($lines as $line) {
+            if (str_contains($line, 'IOPlatformUUID')) {
                 $parts = explode('=', $line);
+
                 return trim($parts[1]);
             }
         }
@@ -138,6 +131,7 @@ final class Host implements ResourceDetectorInterface
     public static function parseWindowsId(string $out): string
     {
         $parts = explode('REG_SZ', $out);
+
         return trim($parts[1]);
     }
 }

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -117,7 +117,7 @@ final class Host implements ResourceDetectorInterface
 
     public static function parseMacOsId(string $out): string
     {
-        $lines = explode("\n", $out);
+        $lines = explode(PHP_EOL, $out);
 
         foreach ($lines as $line) {
             if (str_contains($line, 'IOPlatformUUID')) {

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -18,13 +18,10 @@ final class Host implements ResourceDetectorInterface
     private const PATH_ETC_MACHINEID = 'etc/machine-id';
     private const PATH_VAR_LIB_DBUS_MACHINEID = 'var/lib/dbus/machine-id';
     private const PATH_ETC_HOSTID = 'etc/hostid';
-    private readonly string $dir;
-    private readonly string $os;
-
-    public function __construct(string $dir = '/', string $os = PHP_OS_FAMILY)
-    {
-        $this->dir = $dir;
-        $this->os = $os;
+    public function __construct(
+        private readonly string $dir = '/',
+        private readonly string $os = PHP_OS_FAMILY,
+    ) {
     }
 
     public function getResource(): ResourceInfo

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -44,10 +44,10 @@ class HostTest extends TestCase
     /**
      * @dataProvider hostIdData
      */
-    public function test_host_id_linux(array $files, string $expectedId): void
+    public function test_host_id_filesystem(string $os, array $files, string $expectedId): void
     {
         $root = vfsStream::setup('/', null, $files);
-        $resouceDetector = new Detectors\Host($root->url());
+        $resouceDetector = new Detectors\Host($root->url(), $os);
         $resource = $resouceDetector->getResource();
         $hostId = $resource->getAttributes()->get(ResourceAttributes::HOST_ID);
         $this->assertIsString($hostId);
@@ -56,7 +56,7 @@ class HostTest extends TestCase
 
     public static function hostIdData(): array
     {
-        $etc = [
+        $etc_machineid = [
             'etc' => [
               'machine-id' => '1234567890',
             ],
@@ -70,12 +70,19 @@ class HostTest extends TestCase
                 ],
             ],
         ];
+        $etc_hostid = [
+            'etc' => [
+              'hostid' => '1234567890',
+            ],
+        ];
 
         return [
-            [[], ''],
-            [$etc, '1234567890'],
-            [array_merge($etc, $varLibDbus), '1234567890'],
-            [$varLibDbus, '0987654321'],
+            ['Linux', [], ''],
+            ['Linux', $etc_machineid, '1234567890'],
+            ['Linux', array_merge($etc_machineid, $varLibDbus), '1234567890'],
+            ['Linux', $etc_machineid, '1234567890'],
+            ['OpenBSD', [], ''],
+            ['OpenBSD', $etc_hostid, '1234567890'],
         ];
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -22,17 +22,22 @@ class HostTest extends TestCase
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_NAME));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_ARCH));
-        $this->assertTrue($resource->getAttributes()->has(ResourceAttributes::HOST_ID));
     }
 
     /**
      * @dataProvider hostIdData
      */
-    public function test_host_id_filesystem(string $os, array $files, string $expectedId): void
+    public function test_host_id_filesystem(string $os, array $files, ?string $expectedId): void
     {
         $root = vfsStream::setup('/', null, $files);
         $resouceDetector = new Detectors\Host($root->url(), $os);
         $resource = $resouceDetector->getResource();
+        
+        if ($expectedId === null) {
+            $this->assertFalse($resource->getAttributes()->has(ResourceAttributes::HOST_ID));
+            return;
+        }
+
         $hostId = $resource->getAttributes()->get(ResourceAttributes::HOST_ID);
         $this->assertIsString($hostId);
         $this->assertSame($expectedId, $hostId);
@@ -61,12 +66,12 @@ class HostTest extends TestCase
         ];
 
         return [
-            ['Linux', [], ''],
+            ['Linux', [], null],
             ['Linux', $etc_machineid, '1234567890'],
             ['Linux', array_merge($etc_machineid, $varLibDbus), '1234567890'],
             ['Linux', $etc_machineid, '1234567890'],
-            ['OpenBSD', [], ''],
-            ['OpenBSD', $etc_hostid, '1234567890'],
+            ['BSD', [], null],
+            ['BSD', $etc_hostid, '1234567890'],
         ];
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -32,9 +32,10 @@ class HostTest extends TestCase
         $root = vfsStream::setup('/', null, $files);
         $resouceDetector = new Detectors\Host($root->url(), $os);
         $resource = $resouceDetector->getResource();
-        
+
         if ($expectedId === null) {
             $this->assertFalse($resource->getAttributes()->has(ResourceAttributes::HOST_ID));
+
             return;
         }
 

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -25,43 +25,6 @@ class HostTest extends TestCase
         $this->assertTrue($resource->getAttributes()->has(ResourceAttributes::HOST_ID));
     }
 
-    public function test_host_parse_macos_id(): void
-    {
-        $out = <<<END
-        +-o J293AP  <class IOPlatformExpertDevice, id 0x100000227, registered, matched,$
-        {
-          "IOPolledInterface" = "AppleARMWatchdogTimerHibernateHandler is not seria$
-          "#address-cells" = <02000000>
-          "AAPL,phandle" = <01000000>
-          "serial-number" = <432123465233514651303544000000000000000000000000000000$
-          "IOBusyInterest" = "IOCommand is not serializable"
-          "target-type" = <"J293">
-          "platform-name" = <743831303300000000000000000000000000000000000000000000$
-          "secure-root-prefix" = <"md">
-          "name" = <"device-tree">
-          "region-info" = <4c4c2f41000000000000000000000000000000000000000000000000$
-          "manufacturer" = <"Apple Inc.">
-          "compatible" = <"J293AP","MacBookPro17,1","AppleARM">
-          "config-number" = <000000000000000000000000000000000000000000000000000000$
-          "IOPlatformSerialNumber" = "A01BC3QFQ05D"
-          "regulatory-model-number" = <41323333380000000000000000000000000000000000$
-          "time-stamp" = <"Mon Jun 27 20:12:10 PDT 2022">
-          "clock-frequency" = <00366e01>
-          "model" = <"MacBookPro17,1">
-          "mlb-serial-number" = <432123413230363030455151384c4c314a0000000000000000$
-          "model-number" = <4d59443832000000000000000000000000000000000000000000000$
-          "IONWInterrupts" = "IONWInterrupts"
-          "model-config" = <"SUNWAY;MoPED=0x803914B08BE6C5AF0E6C990D7D8240DA4CAC2FF$
-          "device_type" = <"bootrom">
-          "#size-cells" = <02000000>
-          "IOPlatformUUID" = "1AB2345C-03E4-57D4-A375-1234D48DE123"
-        }
-END;
-        $hostId = Detectors\Host::parseMacOsId($out);
-        $this->assertIsString($hostId);
-        $this->assertSame('1AB2345C-03E4-57D4-A375-1234D48DE123', $hostId);
-    }
-
     /**
      * @dataProvider hostIdData
      */

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -56,7 +56,7 @@ class HostTest extends TestCase
           "#size-cells" = <02000000>
           "IOPlatformUUID" = "1AB2345C-03E4-57D4-A375-1234D48DE123"
         }
-END;    
+END;
         $hostId = Detectors\Host::parseMacOsId($out);
         $this->assertIsString($hostId);
         $this->assertSame('1AB2345C-03E4-57D4-A375-1234D48DE123', $hostId);
@@ -87,7 +87,7 @@ END;
     {
         $etc_machineid = [
             'etc' => [
-              'machine-id' => '1234567890',
+                'machine-id' => '1234567890',
             ],
         ];
         $varLibDbus = [
@@ -101,7 +101,7 @@ END;
         ];
         $etc_hostid = [
             'etc' => [
-              'hostid' => '1234567890',
+                'hostid' => '1234567890',
             ],
         ];
 

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -27,10 +27,39 @@ class HostTest extends TestCase
 
     public function test_host_parse_macos_id(): void
     {
-        $out = 'IOPlatformUUID=1234567890';
+        $out = <<<END
+        +-o J293AP  <class IOPlatformExpertDevice, id 0x100000227, registered, matched,$
+        {
+          "IOPolledInterface" = "AppleARMWatchdogTimerHibernateHandler is not seria$
+          "#address-cells" = <02000000>
+          "AAPL,phandle" = <01000000>
+          "serial-number" = <432123465233514651303544000000000000000000000000000000$
+          "IOBusyInterest" = "IOCommand is not serializable"
+          "target-type" = <"J293">
+          "platform-name" = <743831303300000000000000000000000000000000000000000000$
+          "secure-root-prefix" = <"md">
+          "name" = <"device-tree">
+          "region-info" = <4c4c2f41000000000000000000000000000000000000000000000000$
+          "manufacturer" = <"Apple Inc.">
+          "compatible" = <"J293AP","MacBookPro17,1","AppleARM">
+          "config-number" = <000000000000000000000000000000000000000000000000000000$
+          "IOPlatformSerialNumber" = "A01BC3QFQ05D"
+          "regulatory-model-number" = <41323333380000000000000000000000000000000000$
+          "time-stamp" = <"Mon Jun 27 20:12:10 PDT 2022">
+          "clock-frequency" = <00366e01>
+          "model" = <"MacBookPro17,1">
+          "mlb-serial-number" = <432123413230363030455151384c4c314a0000000000000000$
+          "model-number" = <4d59443832000000000000000000000000000000000000000000000$
+          "IONWInterrupts" = "IONWInterrupts"
+          "model-config" = <"SUNWAY;MoPED=0x803914B08BE6C5AF0E6C990D7D8240DA4CAC2FF$
+          "device_type" = <"bootrom">
+          "#size-cells" = <02000000>
+          "IOPlatformUUID" = "1AB2345C-03E4-57D4-A375-1234D48DE123"
+        }
+END;    
         $hostId = Detectors\Host::parseMacOsId($out);
         $this->assertIsString($hostId);
-        $this->assertSame('1234567890', $hostId);
+        $this->assertSame('1AB2345C-03E4-57D4-A375-1234D48DE123', $hostId);
     }
 
     public function test_host_parse_windows_id(): void

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -59,7 +59,7 @@ class HostTest extends TestCase
         $etc = [
             'etc' => [
               'machine-id' => '1234567890',
-            ]
+            ],
         ];
         $varLibDbus = [
             'var' => [

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -22,7 +22,7 @@ class HostTest extends TestCase
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_NAME));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_ARCH));
-        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_ID));
+        $this->assertTrue($resource->getAttributes()->has(ResourceAttributes::HOST_ID));
     }
 
     public function test_host_parse_macos_id(): void

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -62,14 +62,6 @@ END;
         $this->assertSame('1AB2345C-03E4-57D4-A375-1234D48DE123', $hostId);
     }
 
-    public function test_host_parse_windows_id(): void
-    {
-        $out = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid    REG_SZ    1234567890';
-        $hostId = Detectors\Host::parseWindowsId($out);
-        $this->assertIsString($hostId);
-        $this->assertSame('1234567890', $hostId);
-    }
-
     /**
      * @dataProvider hostIdData
      */

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
 
 use OpenTelemetry\SDK\Resource\Detectors;
 use OpenTelemetry\SemConv\ResourceAttributes;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,5 +22,60 @@ class HostTest extends TestCase
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_NAME));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_ARCH));
+        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::HOST_ID));
+    }
+
+    public function test_host_parse_macos_id(): void
+    {
+        $out = 'IOPlatformUUID=1234567890';
+        $hostId = Detectors\Host::parseMacOsId($out);
+        $this->assertIsString($hostId);
+        $this->assertSame('1234567890', $hostId);
+    }
+
+    public function test_host_parse_windows_id(): void
+    {
+        $out = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\MachineGuid    REG_SZ    1234567890';
+        $hostId = Detectors\Host::parseWindowsId($out);
+        $this->assertIsString($hostId);
+        $this->assertSame('1234567890', $hostId);
+    }
+
+    /**
+     * @dataProvider hostIdData
+     */
+    public function test_host_id_linux(array $files, string $expectedId): void
+    {
+        $root = vfsStream::setup('/', null, $files);
+        $resouceDetector = new Detectors\Host($root->url());
+        $resource = $resouceDetector->getResource();
+        $hostId = $resource->getAttributes()->get(ResourceAttributes::HOST_ID);
+        $this->assertIsString($hostId);
+        $this->assertSame($expectedId, $hostId);
+    }
+
+    public static function hostIdData(): array
+    {
+        $etc = [
+            'etc' => [
+              'machine-id' => '1234567890',
+            ]
+        ];
+        $varLibDbus = [
+            'var' => [
+                'lib' => [
+                    'dbus' => [
+                        'machine-id' => '0987654321',
+                    ],
+                ],
+            ],
+        ];
+
+        return [
+            [[], ''],
+            [$etc, '1234567890'],
+            [array_merge($etc, $varLibDbus), '1234567890'],
+            [$varLibDbus, '0987654321'],
+        ];
     }
 }


### PR DESCRIPTION
Fixes #1263 

Only mocked the file system for Linux.

BSD, MacOS, and Windows all shell out to get the ID. I've added tests covering parsing the output on MacOS and Windows.

Any and all feedback is welcome, I haven't written PHP in a long time.