### PR TITLE
Clean up shell scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: Shellcheck
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt update && sudo apt install --assume-yes shellcheck
+
+      - name: Run shellcheck
+        run: find . -name \*.sh | xargs shellcheck --severity=warning

--- a/script/proto_gen.sh
+++ b/script/proto_gen.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 DESTINATION_DIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")")/../proto/otel
 GPBMETA_DIR="GPBMetadata"
 OTEL_DIR="Opentelemetry"
@@ -12,7 +14,7 @@ git clone https://github.com/open-telemetry/${REPO_DIR}
   cd ${REPO_DIR}
   git config --add advice.detachedHead false
   TAG=$(
-      TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+      TAG=$(git describe --tags "`git rev-list --tags --max-count=1`")
 
       git checkout "${TAG}"
 

--- a/script/semantic-conventions/semconv.sh
+++ b/script/semantic-conventions/semconv.sh
@@ -9,6 +9,7 @@
 # Source repositories:
 #  - https://github.com/open-telemetry/semantic-conventions/releases
 #  - https://github.com/open-telemetry/build-tools/releases
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
@@ -21,18 +22,18 @@ SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.23.0
 
-cd "${SCRIPT_DIR}" || exit
+cd "${SCRIPT_DIR}"
 
-rm -rf "${SPEC_DIR}" || true
+rm -rf "${SPEC_DIR}"
 mkdir "${SPEC_DIR}"
-cd "${SPEC_DIR}" || exit
+cd "${SPEC_DIR}"
 
 git init -b main
 git remote add origin https://github.com/open-telemetry/semantic-conventions.git
 git fetch origin "$SPEC_VERSION"
 git reset --hard FETCH_HEAD
 
-cd "${SCRIPT_DIR}" || exit
+cd "${SCRIPT_DIR}"
 
 mkdir -p "${CODE_DIR}"
 find "${CODE_DIR}" -name "*.php" -exec rm -f {} \;
@@ -101,4 +102,4 @@ docker run --rm \
   -Dclass="Resource" \
   -DschemaUrl=$SCHEMA_URL
 
-rm -rf "${SPEC_DIR}" || true
+rm -rf "${SPEC_DIR}"

--- a/tests/TraceContext/W3CTestService/trace-context-test.sh
+++ b/tests/TraceContext/W3CTestService/trace-context-test.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -x
+set -e
 
 function install_symfony() {
     curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.alpine.sh' | bash >/dev/null
     apk add symfony-cli
 }
 
-cd "tests/TraceContext/W3CTestService" || { echo "error: could not cd into the W3CTestService directory."; exit 1; }
+cd "tests/TraceContext/W3CTestService"
 
 # Install Symfony: we will use the Symfony server as the built-in PHP server doesn't play well with duplicate headers
 install_symfony


### PR DESCRIPTION
- Use `set -e` rather than repeatedly checking for errors
- Apply suggestion from `shellcheck --severity=warning` to properly quote backtick result
- Add CI step to run `shellcheck --severity=warning`