### PR TITLE
Experiment: Register instrumentation with SPI.

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -77,6 +77,10 @@ deptrac:
           collectors:
               - type: className
                 regex: ^Composer\\*
+      -   name: SPI
+          collectors:
+              - type: className
+                regex: ^Nevay\\SPI\\*
 
     ruleset:
       Context:
@@ -91,6 +95,7 @@ deptrac:
           - PsrHttp
           - HttpPlug
           - Composer
+          - SPI
       Contrib:
           - +SDK
           - +OtelProto

--- a/src/SDK/Common/Instrumentation/AutoInstrument.php
+++ b/src/SDK/Common/Instrumentation/AutoInstrument.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Instrumentation;
+
+use Nevay\SPI\ServiceLoader;
+use OpenTelemetry\API\Instrumentation\InstrumentationInterface;
+use Throwable;
+
+/**
+ * @internal
+ * @phan-file-suppress PhanUndeclaredClassMethod
+ */
+final class AutoInstrument
+{
+    public static function bootstrap(): void
+    {
+        /** @var InstrumentationInterface $instrumentation */
+        foreach (ServiceLoader::load(InstrumentationInterface::class) as $instrumentation) {
+            try {
+                if ($instrumentation->init()) {
+                    $instrumentation->activate();
+                }
+            } catch (Throwable $e) {
+                trigger_error("Error during opentelemetry auto-instrumentation: {$e->getMessage()}", E_USER_WARNING);
+            }
+        }
+    }
+}

--- a/src/SDK/SdkAutoloader.php
+++ b/src/SDK/SdkAutoloader.php
@@ -9,6 +9,7 @@ use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
+use OpenTelemetry\SDK\Common\Instrumentation\AutoInstrument;
 use OpenTelemetry\SDK\Common\Util\ShutdownHandler;
 use OpenTelemetry\SDK\Logs\LoggerProviderFactory;
 use OpenTelemetry\SDK\Metrics\MeterProviderFactory;
@@ -29,6 +30,9 @@ class SdkAutoloader
         if (!self::isEnabled() || self::isExcludedUrl()) {
             return false;
         }
+
+        AutoInstrument::bootstrap();
+
         Globals::registerInitializer(function (Configurator $configurator) {
             $propagator = (new PropagatorFactory())->create();
             if (Sdk::isDisabled()) {

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -29,7 +29,8 @@
         "psr/http-message": "^1.0.1|^2.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "symfony/polyfill-mbstring": "^1.23",
-        "symfony/polyfill-php82": "^1.26"
+        "symfony/polyfill-php82": "^1.26",
+        "tbachert/spi": "^0.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# :warning: :construction: Experimental :construction_worker: 

Just toying around with the SPI package as an alternative way to register auto-instrumentation.

Though it uses the `InstrumentationInterface` as a proof-of-concept, I think we should possibly create a more purposeful interface that fits our needs a little better. eg. the `get***Provider()`s can be resolved lazily later.

---

## References:

 - https://getcomposer.org/doc/04-schema.md#files
   - autoload file inclusion order is impacted by dependencies
   - if an auto-instrumentation package has the SDK as an explicit dependency, then `SdkAutoloader` would run first via `_autoload`.

 - https://getcomposer.org/doc/articles/plugins.md#plugin-optional
   - can affect service loading based on above