### PR TITLE
Add `Span::addLink()` and `Meter::createGauge()`

### DIFF
--- a/src/API/Metrics/GaugeInterface.php
+++ b/src/API/Metrics/GaugeInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Metrics;
+
+use OpenTelemetry\Context\ContextInterface;
+
+/**
+ * A synchronous instrument which can be used to record non-additive values.
+ *
+ * @see https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge
+ *
+ * @experimental
+ */
+interface GaugeInterface
+{
+
+    /**
+     * @param float|int $amount current absolute value
+     * @param iterable<non-empty-string, string|bool|float|int|array|null> $attributes
+     *        attributes of the data point
+     * @param ContextInterface|false|null $context execution context
+     *
+     * @see https://opentelemetry.io/docs/specs/otel/metrics/api/#record-1
+     */
+    public function record(float|int $amount, iterable $attributes = [], ContextInterface|false|null $context = null): void;
+}

--- a/src/API/Metrics/MeterInterface.php
+++ b/src/API/Metrics/MeterInterface.php
@@ -100,6 +100,26 @@ interface MeterInterface
     ): HistogramInterface;
 
     /**
+     * Creates a `Gauge`.
+     *
+     * @param string $name name of the instrument
+     * @param string|null $unit unit of measure
+     * @param string|null $description description of the instrument
+     * @param array $advisory an optional set of recommendations
+     * @return GaugeInterface created instrument
+     *
+     * @see https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge-creation
+     *
+     * @experimental
+     */
+    public function createGauge(
+        string $name,
+        ?string $unit = null,
+        ?string $description = null,
+        array $advisory = [],
+    ): GaugeInterface;
+
+    /**
      * Creates an `ObservableGauge`.
      *
      * @param string $name name of the instrument

--- a/src/API/Metrics/Noop/NoopGauge.php
+++ b/src/API/Metrics/Noop/NoopGauge.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Metrics\Noop;
+
+use OpenTelemetry\API\Metrics\GaugeInterface;
+
+/**
+ * @internal
+ */
+final class NoopGauge implements GaugeInterface
+{
+    public function record(float|int $amount, iterable $attributes = [], $context = null): void
+    {
+        // no-op
+    }
+}

--- a/src/API/Metrics/Noop/NoopMeter.php
+++ b/src/API/Metrics/Noop/NoopMeter.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\API\Metrics\Noop;
 
 use OpenTelemetry\API\Metrics\AsynchronousInstrument;
 use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\GaugeInterface;
 use OpenTelemetry\API\Metrics\HistogramInterface;
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Metrics\ObservableCallbackInterface;
@@ -34,6 +35,11 @@ final class NoopMeter implements MeterInterface
     public function createHistogram(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): HistogramInterface
     {
         return new NoopHistogram();
+    }
+
+    public function createGauge(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): GaugeInterface
+    {
+        return new NoopGauge();
     }
 
     public function createObservableGauge(string $name, ?string $unit = null, ?string $description = null, $advisory = [], callable ...$callbacks): ObservableGaugeInterface

--- a/src/API/Trace/NonRecordingSpan.php
+++ b/src/API/Trace/NonRecordingSpan.php
@@ -41,6 +41,11 @@ final class NonRecordingSpan extends Span
         return $this;
     }
 
+    public function addLink(SpanContextInterface $context, iterable $attributes = []): SpanInterface
+    {
+        return $this;
+    }
+
     /** @inheritDoc */
     public function addEvent(string $name, iterable $attributes = [], int $timestamp = null): SpanInterface
     {

--- a/src/API/Trace/SpanInterface.php
+++ b/src/API/Trace/SpanInterface.php
@@ -66,6 +66,21 @@ interface SpanInterface extends ImplicitContextKeyedInterface
     public function setAttributes(iterable $attributes): SpanInterface;
 
     /**
+     * Records a link to another `SpanContext`.
+     *
+     * Adding links at span creation via {@link SpanBuilderInterface::addLink()} is preferred to calling
+     * {@link SpanInterface::addLink()} later, for contexts that are available during span creation, because head
+     * sampling decisions can only consider information present during span creation.
+     *
+     * @param SpanContextInterface $context span context to link
+     * @param iterable $attributes attributes to associate with the link
+     * @return SpanInterface this span
+     *
+     * @see https://opentelemetry.io/docs/specs/otel/trace/api/#add-link
+     */
+    public function addLink(SpanContextInterface $context, iterable $attributes = []): SpanInterface;
+
+    /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.1/specification/trace/api.md#add-events
      */
     public function addEvent(string $name, iterable $attributes = [], int $timestamp = null): SpanInterface;

--- a/src/API/composer.json
+++ b/src/API/composer.json
@@ -23,7 +23,7 @@
         "symfony/polyfill-php82": "^1.26"
     },
     "conflict": {
-        "open-telemetry/sdk": "<=1.0.4"
+        "open-telemetry/sdk": "<=1.0.8"
     },
     "autoload": {
         "psr-4": {
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.0.x-dev"
+            "dev-main": "1.1.x-dev"
         }
     }
 }

--- a/src/SDK/Metrics/DefaultAggregationProviderTrait.php
+++ b/src/SDK/Metrics/DefaultAggregationProviderTrait.php
@@ -12,7 +12,7 @@ trait DefaultAggregationProviderTrait
             InstrumentType::COUNTER, InstrumentType::ASYNCHRONOUS_COUNTER => new Aggregation\SumAggregation(true),
             InstrumentType::UP_DOWN_COUNTER, InstrumentType::ASYNCHRONOUS_UP_DOWN_COUNTER => new Aggregation\SumAggregation(),
             InstrumentType::HISTOGRAM => new Aggregation\ExplicitBucketHistogramAggregation($advisory['ExplicitBucketBoundaries'] ?? [0, 5, 10, 25, 50, 75, 100, 250, 500, 1000]),
-            InstrumentType::ASYNCHRONOUS_GAUGE => new Aggregation\LastValueAggregation(),
+            InstrumentType::GAUGE, InstrumentType::ASYNCHRONOUS_GAUGE => new Aggregation\LastValueAggregation(),
             default => null,
         };
         // @codeCoverageIgnoreEnd

--- a/src/SDK/Metrics/Gauge.php
+++ b/src/SDK/Metrics/Gauge.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Metrics;
+
+use OpenTelemetry\API\Metrics\GaugeInterface;
+
+/**
+ * @internal
+ */
+final class Gauge implements GaugeInterface, InstrumentHandle
+{
+    use SynchronousInstrumentTrait { write as record; }
+}

--- a/src/SDK/Metrics/InstrumentType.php
+++ b/src/SDK/Metrics/InstrumentType.php
@@ -14,6 +14,8 @@ final class InstrumentType
     public const COUNTER = 'Counter';
     public const UP_DOWN_COUNTER = 'UpDownCounter';
     public const HISTOGRAM = 'Histogram';
+    /** @experimental */
+    public const GAUGE = 'Gauge';
 
     public const ASYNCHRONOUS_COUNTER = 'AsynchronousCounter';
     public const ASYNCHRONOUS_UP_DOWN_COUNTER = 'AsynchronousUpDownCounter';

--- a/src/SDK/Metrics/Meter.php
+++ b/src/SDK/Metrics/Meter.php
@@ -11,6 +11,7 @@ use function is_callable;
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\API\Metrics\AsynchronousInstrument;
 use OpenTelemetry\API\Metrics\CounterInterface;
+use OpenTelemetry\API\Metrics\GaugeInterface;
 use OpenTelemetry\API\Metrics\HistogramInterface;
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Metrics\ObservableCallbackInterface;
@@ -151,6 +152,19 @@ final class Meter implements MeterInterface
         );
 
         return new Histogram($this->writer, $instrument, $referenceCounter);
+    }
+
+    public function createGauge(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): GaugeInterface
+    {
+        [$instrument, $referenceCounter] = $this->createSynchronousWriter(
+            InstrumentType::GAUGE,
+            $name,
+            $unit,
+            $description,
+            $advisory,
+        );
+
+        return new Gauge($this->writer, $instrument, $referenceCounter);
     }
 
     public function createObservableGauge(string $name, ?string $unit = null, ?string $description = null, $advisory = [], callable ...$callbacks): ObservableGaugeInterface

--- a/src/SDK/Trace/ImmutableSpan.php
+++ b/src/SDK/Trace/ImmutableSpan.php
@@ -26,6 +26,7 @@ final class ImmutableSpan implements SpanDataInterface
         private readonly array $links,
         private readonly array $events,
         private readonly AttributesInterface $attributes,
+        private readonly int $totalRecordedLinks,
         private readonly int $totalRecordedEvents,
         private readonly StatusDataInterface $status,
         private readonly int $endEpochNanos,
@@ -112,7 +113,7 @@ final class ImmutableSpan implements SpanDataInterface
 
     public function getTotalDroppedLinks(): int
     {
-        return max(0, $this->span->getTotalRecordedLinks() - count($this->links));
+        return max(0, $this->totalRecordedLinks - count($this->links));
     }
 
     public function getStatus(): StatusDataInterface

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Trace;
 
 use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesBuilderInterface;
 use OpenTelemetry\SDK\Common\Dev\Compatibility\Util as BcUtil;
@@ -38,8 +39,8 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         private readonly SpanProcessorInterface $spanProcessor,
         private readonly ResourceInfo $resource,
         private AttributesBuilderInterface $attributesBuilder,
-        private readonly array $links,
-        private readonly int $totalRecordedLinks,
+        private array $links,
+        private int $totalRecordedLinks,
         private readonly int $startEpochNanos,
     ) {
         $this->status = StatusData::unset();
@@ -138,6 +139,29 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         foreach ($attributes as $key => $value) {
             $this->attributesBuilder[$key] = $value;
         }
+
+        return $this;
+    }
+
+    public function addLink(SpanContextInterface $context, iterable $attributes = []): self
+    {
+        if ($this->hasEnded) {
+            return $this;
+        }
+        if (!$context->isValid()) {
+            return $this;
+        }
+        if (++$this->totalRecordedLinks > $this->spanLimits->getLinkCountLimit()) {
+            return $this;
+        }
+
+        $this->links[] = new Link(
+            $context,
+            $this->spanLimits
+                ->getLinkAttributesFactory()
+                ->builder($attributes)
+                ->build(),
+        );
 
         return $this;
     }
@@ -260,6 +284,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
             $this->links,
             $this->events,
             $this->attributesBuilder->build(),
+            $this->totalRecordedLinks,
             $this->totalRecordedEvents,
             $this->status,
             $this->endEpochNanos,

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "open-telemetry/api": "^1.0",
+        "open-telemetry/api": "~1.0 || ~1.1",
         "open-telemetry/context": "^1.0",
         "open-telemetry/sem-conv": "^1.0",
         "php-http/discovery": "^1.14",

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -68,6 +68,22 @@ class SpanBuilderTest extends MockeryTestCase
         $this->assertCount(2, $span->toSpanData()->getLinks());
     }
 
+    /**
+     * @group trace-compliance
+     */
+    public function test_add_link_after_span_creation(): void
+    {
+        /** @var Span $span */
+        $span = $this
+            ->tracer
+            ->spanBuilder(self::SPAN_NAME)
+            ->addLink($this->sampledSpanContext)
+            ->startSpan()
+            ->addLink($this->sampledSpanContext);
+
+        $this->assertCount(2, $span->toSpanData()->getLinks());
+    }
+
     public function test_add_link_invalid(): void
     {
         /** @var Span $span */

--- a/tests/Unit/SDK/Metrics/MeterTest.php
+++ b/tests/Unit/SDK/Metrics/MeterTest.php
@@ -100,6 +100,26 @@ final class MeterTest extends TestCase
         );
     }
 
+    public function test_create_gauge(): void
+    {
+        $metricFactory = $this->createMock(MetricFactoryInterface::class);
+        $metricFactory->expects($this->once())->method('createSynchronousWriter')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                new InstrumentationScope('test', null, null, Attributes::create([])),
+                new Instrument(InstrumentType::GAUGE, 'name', 'unit', 'description'),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+            )
+            ->willReturn([]);
+
+        $meterProvider = $this->createMeterProviderForMetricFactory($metricFactory);
+        $meter = $meterProvider->getMeter('test');
+        $meter->createGauge('name', 'unit', 'description');
+    }
+
     public function test_create_up_down_counter(): void
     {
         $metricFactory = $this->createMock(MetricFactoryInterface::class);

--- a/tests/Unit/SDK/Metrics/MetricReader/ExportingReaderTest.php
+++ b/tests/Unit/SDK/Metrics/MetricReader/ExportingReaderTest.php
@@ -50,6 +50,7 @@ final class ExportingReaderTest extends TestCase
         $this->assertEquals(new SumAggregation(), $reader->defaultAggregation(InstrumentType::UP_DOWN_COUNTER));
         $this->assertEquals(new SumAggregation(), $reader->defaultAggregation(InstrumentType::ASYNCHRONOUS_UP_DOWN_COUNTER));
         $this->assertEquals(new ExplicitBucketHistogramAggregation([0, 5, 10, 25, 50, 75, 100, 250, 500, 1000]), $reader->defaultAggregation(InstrumentType::HISTOGRAM));
+        $this->assertEquals(new LastValueAggregation(), $reader->defaultAggregation(InstrumentType::GAUGE));
         $this->assertEquals(new LastValueAggregation(), $reader->defaultAggregation(InstrumentType::ASYNCHRONOUS_GAUGE));
     }
 

--- a/tests/Unit/SDK/Trace/ImmutableSpanTest.php
+++ b/tests/Unit/SDK/Trace/ImmutableSpanTest.php
@@ -66,6 +66,7 @@ class ImmutableSpanTest extends TestCase
             [],
             [],
             $this->attributes,
+            $this->totalRecordedLinks,
             $this->totalRecordedEvents,
             $this->status,
             $this->endEpochNanos,


### PR DESCRIPTION
Updates traces and metrics API to match spec version 1.32.0.

Not included in this PR are changes to the events API; there were breaking changes to `EventLogger` in v1.28.0, non-breaking changes in v1.31.0.