### PR TITLE
Include schema_url in FriendlySpanConverter

### DIFF
--- a/src/SDK/Trace/SpanExporter/FriendlySpanConverter.php
+++ b/src/SDK/Trace/SpanExporter/FriendlySpanConverter.php
@@ -35,6 +35,7 @@ class FriendlySpanConverter implements SpanConverterInterface
     private const EVENTS_ATTR = 'events';
     private const TIMESTAMP_ATTR = 'timestamp';
     private const LINKS_ATTR = 'links';
+    private const SCHEMA_URL_ATTR = 'schema_url';
 
     public function convert(iterable $spans): array
     {
@@ -63,6 +64,7 @@ class FriendlySpanConverter implements SpanConverterInterface
             self::STATUS_ATTR => $this->covertStatus($span->getStatus()),
             self::EVENTS_ATTR => $this->convertEvents($span->getEvents()),
             self::LINKS_ATTR => $this->convertLinks($span->getLinks()),
+            self::SCHEMA_URL_ATTR => $this->convertSchemaUrl($span->getInstrumentationScope()->getSchemaUrl()),
         ];
     }
 
@@ -143,5 +145,13 @@ class FriendlySpanConverter implements SpanConverterInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @param string|null $schemaUrl
+     */
+    private function convertSchemaUrl(?string $schemaUrl): string
+    {
+        return $schemaUrl ?? '';
     }
 }

--- a/tests/Unit/SDK/Trace/SpanExporter/FriendlySpanConverterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/FriendlySpanConverterTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\TraceStateInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
+use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\EventInterface;
 use OpenTelemetry\SDK\Trace\LinkInterface;
@@ -78,6 +79,7 @@ class FriendlySpanConverterTest extends TestCase
                 'foz' => 'baz',
             ], ],
         ],
+        'schema_url' => 'https://opentelemetry.io/schemas/1.25.0',
     ];
 
     public function test_convert(): void
@@ -160,9 +162,23 @@ class FriendlySpanConverterTest extends TestCase
         }
         $mock->method('getLinks')->willReturn($links);
 
+        $mock->method('getInstrumentationScope')
+            ->willReturn(
+                $this->createInstrumentationScopeMock()
+            );
+
         return $mock;
     }
 
+    private function createInstrumentationScopeMock(): InstrumentationScopeInterface
+    {
+        $mock = $this->createMock(InstrumentationScopeInterface::class);
+
+        $mock->method('getSchemaUrl')
+            ->willReturn($this->createSchemaUrlMock());
+
+        return $mock;
+    }
     private function createSpanContextMock(string $spanId, string $traceId = '0', string $traceState = null): SpanContextInterface
     {
         $mock = $this->createMock(SpanContextInterface::class);
@@ -248,5 +264,10 @@ class FriendlySpanConverterTest extends TestCase
         $mock->method('getAttributes')->willReturn($attributes);
 
         return $mock;
+    }
+
+    public function createSchemaUrlMock(): string
+    {
+        return self::TEST_DATA['schema_url'];
     }
 }


### PR DESCRIPTION
Regarding this issue: https://github.com/open-telemetry/opentelemetry-php/issues/1290

I believe this is the expected way to communicate the scheme used to a collector or downstream system attempting to analyze the telemetry, based on the [documentation](https://opentelemetry.io/docs/specs/otel/schemas/#otlp-support) on the OpenTelemetry website.

Closes: https://github.com/open-telemetry/opentelemetry-php/issues/1290