### PR TITLE
use codecov action

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -131,7 +131,12 @@ jobs:
       run: vendor/bin/phpunit --testsuite integration
 
     - name: Code Coverage
-      run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.php-version }}
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.clover
+        flags: unittests
+        verbose: true
 
   packages:
     uses: opentelemetry-php/gh-workflows/.github/workflows/validate-packages.yml@main

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -135,8 +135,8 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.clover
-        flags: unittests
-        verbose: true
+        flags: ${{ matrix.php-version }}
+        verbose: false
 
   packages:
     uses: opentelemetry-php/gh-workflows/.github/workflows/validate-packages.yml@main


### PR DESCRIPTION
our previous method of uploading to codecov.io is suffering from throttling and taking 5+ hours, a post in the opentelemetry maintainers channel suggests this is the way to do it now