### PR TITLE
Fix `weaken` for PHP8.4 closure names

### DIFF
--- a/src/SDK/Common/Util/functions.php
+++ b/src/SDK/Common/Util/functions.php
@@ -8,6 +8,7 @@ use Closure;
 use ReflectionFunction;
 use stdClass;
 use WeakReference;
+use function str_starts_with;
 
 /**
  * @internal
@@ -30,7 +31,7 @@ function weaken(Closure $closure, ?object &$target = null): Closure
 
     $scope = $reflection->getClosureScopeClass();
     $name = $reflection->getShortName();
-    if ($name !== '{closure}') {
+    if (!str_starts_with($name, '{closure')) {
         /** @psalm-suppress InvalidScope @phpstan-ignore-next-line @phan-suppress-next-line PhanUndeclaredThis */
         $closure = fn (...$args) => $this->$name(...$args);
         if ($scope !== null) {

--- a/src/SDK/Common/Util/functions.php
+++ b/src/SDK/Common/Util/functions.php
@@ -7,8 +7,8 @@ namespace OpenTelemetry\SDK\Common\Util;
 use Closure;
 use ReflectionFunction;
 use stdClass;
-use WeakReference;
 use function str_starts_with;
+use WeakReference;
 
 /**
  * @internal


### PR DESCRIPTION
PHP8.4 non-first-class-callables include source information in their name -> checking for `{closure}` fails.
> Error: Call to undefined method OpenTelemetry\SDK\Logs\Processor\BatchLogRecordProcessor::{closure:OpenTelemetry\SDK\Logs\Processor\BatchLogRecordProcessor::__construct():100}()