### PR TITLE
Add infection test tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ psalm-info: ## Run psalm and show info
 	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor-bin/psalm/vendor/bin/psalm --show-info=true --threads=1
 phpstan: ## Run phpstan
 	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=256M
+infection: ## Run infection (mutation testing)
+	$(DC_RUN_PHP) env XDEBUG_MODE=coverage php -d memory_limit=1024M vendor-bin/infection/vendor/bin/infection --threads=$(shell nproc)
 packages-composer: ## Validate composer packages
 	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/otel packages:composer:validate
 benchmark: ## Run phpbench

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://raw.githubusercontent.com/infection/infection/0.28.1/resources/schema.json",
+    "source": {
+        "directories": [
+            "src"
+        ],
+        "excludes": [
+            "Composer"
+        ]
+    },
+    "logs": {
+        "text": "var/infection/infection.log",
+        "html": "var/infection/infection.html",
+    },
+    "timeout": 1,
+    "mutators": {
+        "@default": true
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
     bootstrap="./tests/bootstrap.php"
     cacheResult="false"
     colors="false"
+    executionOrder="random"
     processIsolation="false"
     stopOnError="false"
     stopOnFailure="false"

--- a/src/API/Behavior/Internal/Logging.php
+++ b/src/API/Behavior/Internal/Logging.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\API\Behavior\Internal;
 
 use OpenTelemetry\API\Behavior\Internal\LogWriter\LogWriterInterface;
+use OpenTelemetry\API\Behavior\Internal\LogWriter\NoopLogWriter;
 use Psr\Log\LogLevel;
 
 /**
@@ -86,5 +87,10 @@ class Logging
     {
         self::$logLevel = null;
         self::$writer = null;
+    }
+
+    public static function disable(): void
+    {
+        self::$writer = new NoopLogWriter();
     }
 }

--- a/src/API/LoggerHolder.php
+++ b/src/API/LoggerHolder.php
@@ -38,6 +38,9 @@ final class LoggerHolder
         return null !== self::$logger;
     }
 
+    /**
+     * @internal
+     */
     public static function unset(): void
     {
         self::$logger = null;
@@ -45,6 +48,7 @@ final class LoggerHolder
 
     /**
      * Disable psr-3 logging
+     * @internal
      */
     public static function disable(): void
     {

--- a/tests/Unit/API/Behavior/Internal/LogWriterFactoryTest.php
+++ b/tests/Unit/API/Behavior/Internal/LogWriterFactoryTest.php
@@ -21,6 +21,11 @@ class LogWriterFactoryTest extends TestCase
 {
     use EnvironmentVariables;
 
+    public function setUp(): void
+    {
+        LoggerHolder::unset();
+    }
+
     public function tearDown(): void
     {
         self::restoreEnvironmentVariables();

--- a/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
@@ -23,6 +23,7 @@ class LogsMessagesTraitTest extends TestCase
 
     public function setUp(): void
     {
+        Logging::reset();
         $this->writer = $this->createMock(LogWriterInterface::class);
         Logging::setLogWriter($this->writer);
     }

--- a/tests/Unit/API/Common/Time/ClockTest.php
+++ b/tests/Unit/API/Common/Time/ClockTest.php
@@ -14,6 +14,16 @@ use PHPUnit\Framework\TestCase;
  */
 class ClockTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Clock::reset();
+    }
+
+    public function tearDown(): void
+    {
+        Clock::reset();
+    }
+
     public function test_default_is_system_clock(): void
     {
         $this->assertInstanceOf(SystemClock::class, Clock::getDefault());

--- a/tests/Unit/API/Instrumentation/InstrumentationTest.php
+++ b/tests/Unit/API/Instrumentation/InstrumentationTest.php
@@ -33,6 +33,11 @@ use PHPUnit\Framework\TestCase;
  */
 final class InstrumentationTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Globals::reset();
+    }
+
     public function tearDown(): void
     {
         Globals::reset();

--- a/tests/Unit/API/LoggerHolderTest.php
+++ b/tests/Unit/API/LoggerHolderTest.php
@@ -19,6 +19,11 @@ class LoggerHolderTest extends TestCase
         LoggerHolder::unset();
     }
 
+    public function setUp(): void
+    {
+        LoggerHolder::unset();
+    }
+
     public function test_constructor(): void
     {
         $logger = $this->createMock(LoggerInterface::class);

--- a/tests/Unit/API/Trace/Propagation/TraceContextPropagatorTest.php
+++ b/tests/Unit/API/Trace/Propagation/TraceContextPropagatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\API\Trace\Propagation;
 
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\API\LoggerHolder;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\SpanContext;
@@ -35,7 +36,7 @@ class TraceContextPropagatorTest extends TestCase
 
     protected function setUp(): void
     {
-        LoggerHolder::set(new NullLogger());
+        Logging::disable();
         $this->traceContextPropagator = TraceContextPropagator::getInstance();
         $this->traceState = (new TraceState())->with('bar', 'baz')->with('foo', 'bar');
     }

--- a/tests/Unit/Contrib/Otlp/LogsExporterTest.php
+++ b/tests/Unit/Contrib/Otlp/LogsExporterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\Contrib\Otlp;
 
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\Contrib\Otlp\LogsExporter;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;
@@ -24,6 +25,7 @@ class LogsExporterTest extends TestCase
         $this->transport = $this->createMock(TransportInterface::class);
         $this->transport->method('contentType')->willReturn('application/x-protobuf');
         $this->exporter = new LogsExporter($this->transport);
+        Logging::disable();
     }
 
     public function test_export_with_transport_failure(): void

--- a/tests/Unit/Contrib/Otlp/SpanExporterTest.php
+++ b/tests/Unit/Contrib/Otlp/SpanExporterTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\Contrib\Otlp;
 
+use OpenTelemetry\API\Behavior\Internal\Logging;
+use OpenTelemetry\API\LoggerHolder;
+use Psr\Log\LoggerInterface;
 use function fseek;
 use OpenTelemetry\API\Trace\SpanContext;
 use OpenTelemetry\Contrib\Otlp\SpanExporter;
@@ -26,6 +29,7 @@ class SpanExporterTest extends TestCase
 
     public function setUp(): void
     {
+        Logging::disable();
         $this->transport = $this->createMock(TransportInterface::class);
         $this->transport->method('contentType')->willReturn('application/x-protobuf');
         $this->exporter = new SpanExporter($this->transport);

--- a/tests/Unit/SDK/Metrics/MeterProviderFactoryTest.php
+++ b/tests/Unit/SDK/Metrics/MeterProviderFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\API\LoggerHolder;
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues;
@@ -22,7 +23,7 @@ class MeterProviderFactoryTest extends TestCase
 
     public function setUp(): void
     {
-        LoggerHolder::set(new NullLogger());
+        Logging::disable();
     }
 
     public function tearDown(): void

--- a/tests/Unit/SDK/Metrics/Stream/MetricStreamTest.php
+++ b/tests/Unit/SDK/Metrics/Stream/MetricStreamTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics\Stream;
 
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use function current;
 use function extension_loaded;
 use OpenTelemetry\Context\Context;
@@ -44,6 +45,11 @@ use PHPUnit\Framework\TestCase;
  */
 final class MetricStreamTest extends TestCase
 {
+    public function setUp(): void
+    {
+        Logging::disable();
+    }
+
     public function test_asynchronous_single_data_point(): void
     {
         $s = new AsynchronousMetricStream(new SumAggregation(), 3);

--- a/tests/Unit/SDK/Propagation/PropagatorFactoryTest.php
+++ b/tests/Unit/SDK/Propagation/PropagatorFactoryTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK\Propagation;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use OpenTelemetry\API\Baggage\Propagation\BaggagePropagator;
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\API\LoggerHolder;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\Context\Propagation\MultiTextMapPropagator;
@@ -29,7 +30,8 @@ class PropagatorFactoryTest extends TestCase
 
     public function setUp(): void
     {
-        LoggerHolder::set(new NullLogger());
+        LoggerHolder::disable();
+        Logging::disable();
     }
 
     public function tearDown(): void

--- a/tests/Unit/SDK/Resource/ResourceInfoTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoTest.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Tests\Unit\SDK\Resource;
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
 use Composer\InstalledVersions;
 use Generator;
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\API\LoggerHolder;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\Detectors;
@@ -25,7 +26,7 @@ class ResourceInfoTest extends TestCase
 
     public function setUp(): void
     {
-        LoggerHolder::set(new NullLogger());
+        Logging::disable();
     }
 
     public function tearDown(): void

--- a/tests/Unit/SDK/SdkAutoloaderTest.php
+++ b/tests/Unit/SDK/SdkAutoloaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\SDK;
 
 use AssertWell\PHPUnitGlobalState\EnvironmentVariables;
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\LoggerHolder;
 use OpenTelemetry\API\Logs\NoopEventLoggerProvider;
@@ -26,7 +27,7 @@ class SdkAutoloaderTest extends TestCase
 
     public function setUp(): void
     {
-        LoggerHolder::set(new NullLogger());
+        Logging::disable();
         Globals::reset();
     }
 

--- a/tests/Unit/SDK/Trace/SpanExporter/AbstractExporterTestCase.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/AbstractExporterTestCase.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Unit\SDK\Trace\SpanExporter;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use OpenTelemetry\API\Behavior\Internal\Logging;
 use OpenTelemetry\API\LoggerHolder;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;
@@ -25,7 +26,7 @@ abstract class AbstractExporterTestCase extends MockeryTestCase
 
     public function setUp(): void
     {
-        LoggerHolder::set(new NullLogger());
+        Logging::disable();
         $this->future = Mockery::mock(FutureInterface::class);
         $this->future->allows([
             'map' => $this->future,

--- a/vendor-bin/infection/composer.json
+++ b/vendor-bin/infection/composer.json
@@ -1,0 +1,10 @@
+{
+    "require-dev": {
+        "infection/infection": "^0.28.1"
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
+    }
+}


### PR DESCRIPTION
- run unit tests in random order
running in random order highlights some interference between tests (mostly logging being enabled), and is a requirement for
mutation testing (ie, all tests must pass when executed in a random order). Fix the failing tests so that everything consistently passes when tests are run in random order.
- adding infection mutation testing
this adds the ability to run infection. It generates a lot of output, which is an exercise for another PR...