### PR TITLE
update semconv to 1.26.0

### DIFF
--- a/script/semantic-conventions/README.md
+++ b/script/semantic-conventions/README.md
@@ -32,6 +32,13 @@ diff <(grep "public const" src/SemConv/TraceAttributes.php | sort -u) \
 
 Use this output as a basis for updating the relevant deprecations file and generate a second time to include them in the final output.
 
+Note that some previously-removed semconv entries have been added back in recent versions, so may need to be removed from the
+deprecations partials.
+
+## Add to SemConv/Version
+
+Add an entry to `src/SemConv/Version.php` for the new version.
+
 ## Update tests
 
 Update `tests/Integration/Config/configurations/kitchen-sink.yaml`'s `resource.schema_url` value to the latest, as merging resources

--- a/script/semantic-conventions/semconv.sh
+++ b/script/semantic-conventions/semconv.sh
@@ -17,7 +17,7 @@ SPEC_DIR="${ROOT_DIR}/var/semantic-conventions"
 CODE_DIR="${ROOT_DIR}/src/SemConv"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=${SEMCONV_VERSION:=1.25.0}
+SEMCONV_VERSION=${SEMCONV_VERSION:=1.26.0}
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.24.0

--- a/script/semantic-conventions/templates/resource_deprecations.php.partial
+++ b/script/semantic-conventions/templates/resource_deprecations.php.partial
@@ -19,11 +19,11 @@
     public const CONTAINER_IMAGE_TAG = 'container.image.tag';
 
     /**
-     * @deprecated
+     * @deprecated Use `otel.scope.name`
      */
     public const OTEL_LIBRARY_NAME = 'otel.library.name';
 
     /**
-     * @deprecated
+     * @deprecated Use `otel.scope.version`
      */
     public const OTEL_LIBRARY_VERSION = 'otel.library.version';

--- a/script/semantic-conventions/templates/resource_deprecations.php.partial
+++ b/script/semantic-conventions/templates/resource_deprecations.php.partial
@@ -17,3 +17,13 @@
      * @deprecated Use CONTAINER_IMAGE_TAGS
      */
     public const CONTAINER_IMAGE_TAG = 'container.image.tag';
+
+    /**
+     * @deprecated
+     */
+    public const OTEL_LIBRARY_NAME = 'otel.library.name';
+
+    /**
+     * @deprecated
+     */
+    public const OTEL_LIBRARY_VERSION = 'otel.library.version';

--- a/script/semantic-conventions/templates/trace_deprecations.php.partial
+++ b/script/semantic-conventions/templates/trace_deprecations.php.partial
@@ -6,27 +6,7 @@
     /**
      * @deprecated
      */
-    public const HTTP_HOST = 'http.host';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = 'http.request_content_length_uncompressed';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = 'http.response_content_length_uncompressed';
-
-    /**
-     * @deprecated
-     */
     public const HTTP_RETRY_COUNT = 'http.retry_count';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_SERVER_NAME = 'http.server_name';
 
     /**
      * @deprecated
@@ -72,21 +52,6 @@
      * @deprecated
      */
     public const MESSAGING_URL = 'messaging.url';
-
-    /**
-     * @deprecated
-     */
-    public const NET_HOST_IP = 'net.host.ip';
-
-    /**
-     * @deprecated
-     */
-    public const NET_PEER_IP = 'net.peer.ip';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_CLIENT_IP = 'http.client_ip';
 
     /**
      * @deprecated

--- a/src/SemConv/ResourceAttributeValues.php
+++ b/src/SemConv/ResourceAttributeValues.php
@@ -11,7 +11,7 @@ interface ResourceAttributeValues
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.25.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.26.0';
     /**
      * @see ResourceAttributes::AWS_ECS_LAUNCHTYPE ec2
      */

--- a/src/SemConv/ResourceAttributes.php
+++ b/src/SemConv/ResourceAttributes.php
@@ -1042,12 +1042,12 @@ interface ResourceAttributes
     public const CONTAINER_IMAGE_TAG = 'container.image.tag';
 
     /**
-     * @deprecated
+     * @deprecated Use `otel.scope.name`
      */
     public const OTEL_LIBRARY_NAME = 'otel.library.name';
 
     /**
-     * @deprecated
+     * @deprecated Use `otel.scope.version`
      */
     public const OTEL_LIBRARY_VERSION = 'otel.library.version';
 }

--- a/src/SemConv/ResourceAttributes.php
+++ b/src/SemConv/ResourceAttributes.php
@@ -11,7 +11,7 @@ interface ResourceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.25.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.26.0';
 
     /**
      * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found here.
@@ -254,7 +254,7 @@ interface ResourceAttributes
      *
      * Docker defines a sha256 of the image id; `container.image.id` corresponds to the `Image` field from the Docker container inspect API endpoint.
      * K8s defines a link to the container registry repository with digest `"imageID": "registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625"`.
-     * The ID is assinged by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
+     * The ID is assigned by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
      *
      * @example sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f
      */
@@ -625,10 +625,16 @@ interface ResourceAttributes
 
     /**
      * Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec.
-     *
-     * @example 2
      */
     public const K8S_CONTAINER_RESTART_COUNT = 'k8s.container.restart_count';
+
+    /**
+     * Last terminated reason of the Container.
+     *
+     * @example Evicted
+     * @example Error
+     */
+    public const K8S_CONTAINER_STATUS_LAST_TERMINATED_REASON = 'k8s.container.status.last_terminated_reason';
 
     /**
      * The name of the CronJob.
@@ -797,24 +803,6 @@ interface ResourceAttributes
      * @example 18.04.1
      */
     public const OS_VERSION = 'os.version';
-
-    /**
-     * None.
-     *
-     * @deprecated use the `otel.scope.name` attribute.
-     *
-     * @example io.opentelemetry.contrib.mongodb
-     */
-    public const OTEL_LIBRARY_NAME = 'otel.library.name';
-
-    /**
-     * None.
-     *
-     * @deprecated use the `otel.scope.version` attribute.
-     *
-     * @example 1.0.0
-     */
-    public const OTEL_LIBRARY_VERSION = 'otel.library.version';
 
     /**
      * The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
@@ -1052,4 +1040,14 @@ interface ResourceAttributes
      * @deprecated Use CONTAINER_IMAGE_TAGS
      */
     public const CONTAINER_IMAGE_TAG = 'container.image.tag';
+
+    /**
+     * @deprecated
+     */
+    public const OTEL_LIBRARY_NAME = 'otel.library.name';
+
+    /**
+     * @deprecated
+     */
+    public const OTEL_LIBRARY_VERSION = 'otel.library.version';
 }

--- a/src/SemConv/TraceAttributeValues.php
+++ b/src/SemConv/TraceAttributeValues.php
@@ -11,7 +11,7 @@ interface TraceAttributeValues
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.25.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.26.0';
     /**
      * @see TraceAttributes::ANDROID_STATE Any time before Activity.onResume() or, if the app has no Activity, Context.startService() has been called in the app for the first time
      */
@@ -26,6 +26,26 @@ interface TraceAttributeValues
      * @see TraceAttributes::ANDROID_STATE Any time after Activity.onResume() or, if the app has no Activity, Context.startService() has been called when the app was in either the created or background states
      */
     public const ANDROID_STATE_FOREGROUND = 'foreground';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT Exception was handled by the exception handling middleware
+     */
+    public const ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT_HANDLED = 'handled';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT Exception was not handled by the exception handling middleware
+     */
+    public const ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT_UNHANDLED = 'unhandled';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT Exception handling was skipped because the response had started
+     */
+    public const ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT_SKIPPED = 'skipped';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT Exception handling didn&#39;t run because the request was aborted
+     */
+    public const ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT_ABORTED = 'aborted';
 
     /**
      * @see TraceAttributes::ASPNETCORE_RATE_LIMITING_RESULT Lease was acquired
@@ -46,6 +66,26 @@ interface TraceAttributeValues
      * @see TraceAttributes::ASPNETCORE_RATE_LIMITING_RESULT Lease request was canceled
      */
     public const ASPNETCORE_RATE_LIMITING_RESULT_REQUEST_CANCELED = 'request_canceled';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_ROUTING_MATCH_STATUS Match succeeded
+     */
+    public const ASPNETCORE_ROUTING_MATCH_STATUS_SUCCESS = 'success';
+
+    /**
+     * @see TraceAttributes::ASPNETCORE_ROUTING_MATCH_STATUS Match failed
+     */
+    public const ASPNETCORE_ROUTING_MATCH_STATUS_FAILURE = 'failure';
+
+    /**
+     * @see TraceAttributes::AWS_ECS_LAUNCHTYPE ec2
+     */
+    public const AWS_ECS_LAUNCHTYPE_EC2 = 'ec2';
+
+    /**
+     * @see TraceAttributes::AWS_ECS_LAUNCHTYPE fargate
+     */
+    public const AWS_ECS_LAUNCHTYPE_FARGATE = 'fargate';
 
     /**
      * @see TraceAttributes::CLOUD_PLATFORM Alibaba Cloud Elastic Compute Service
@@ -291,6 +331,16 @@ interface TraceAttributeValues
      * @see TraceAttributes::DB_CASSANDRA_CONSISTENCY_LEVEL local_serial
      */
     public const DB_CASSANDRA_CONSISTENCY_LEVEL_LOCAL_SERIAL = 'local_serial';
+
+    /**
+     * @see TraceAttributes::DB_CLIENT_CONNECTIONS_STATE idle
+     */
+    public const DB_CLIENT_CONNECTIONS_STATE_IDLE = 'idle';
+
+    /**
+     * @see TraceAttributes::DB_CLIENT_CONNECTIONS_STATE used
+     */
+    public const DB_CLIENT_CONNECTIONS_STATE_USED = 'used';
 
     /**
      * @see TraceAttributes::DB_COSMOSDB_CONNECTION_MODE Gateway (HTTP) connections mode
@@ -718,6 +768,11 @@ interface TraceAttributeValues
     public const FAAS_TRIGGER_OTHER = 'other';
 
     /**
+     * @see TraceAttributes::GEN_AI_SYSTEM OpenAI
+     */
+    public const GEN_AI_SYSTEM_OPENAI = 'openai';
+
+    /**
      * @see TraceAttributes::GRAPHQL_OPERATION_TYPE GraphQL query
      */
     public const GRAPHQL_OPERATION_TYPE_QUERY = 'query';
@@ -898,6 +953,36 @@ interface TraceAttributeValues
     public const JVM_MEMORY_TYPE_NON_HEAP = 'non_heap';
 
     /**
+     * @see TraceAttributes::JVM_THREAD_STATE A thread that has not yet started is in this state
+     */
+    public const JVM_THREAD_STATE_NEW = 'new';
+
+    /**
+     * @see TraceAttributes::JVM_THREAD_STATE A thread executing in the Java virtual machine is in this state
+     */
+    public const JVM_THREAD_STATE_RUNNABLE = 'runnable';
+
+    /**
+     * @see TraceAttributes::JVM_THREAD_STATE A thread that is blocked waiting for a monitor lock is in this state
+     */
+    public const JVM_THREAD_STATE_BLOCKED = 'blocked';
+
+    /**
+     * @see TraceAttributes::JVM_THREAD_STATE A thread that is waiting indefinitely for another thread to perform a particular action is in this state
+     */
+    public const JVM_THREAD_STATE_WAITING = 'waiting';
+
+    /**
+     * @see TraceAttributes::JVM_THREAD_STATE A thread that is waiting for another thread to perform an action for up to a specified waiting time is in this state
+     */
+    public const JVM_THREAD_STATE_TIMED_WAITING = 'timed_waiting';
+
+    /**
+     * @see TraceAttributes::JVM_THREAD_STATE A thread that has exited is in this state
+     */
+    public const JVM_THREAD_STATE_TERMINATED = 'terminated';
+
+    /**
      * @see TraceAttributes::LOG_IOSTREAM Logs from stdout stream
      */
     public const LOG_IOSTREAM_STDOUT = 'stdout';
@@ -918,29 +1003,29 @@ interface TraceAttributeValues
     public const MESSAGE_TYPE_RECEIVED = 'RECEIVED';
 
     /**
-     * @see TraceAttributes::MESSAGING_OPERATION One or more messages are provided for publishing to an intermediary. If a single message is published, the context of the &#34;Publish&#34; span can be used as the creation context and no &#34;Create&#34; span needs to be created
+     * @see TraceAttributes::MESSAGING_OPERATION_TYPE One or more messages are provided for publishing to an intermediary. If a single message is published, the context of the &#34;Publish&#34; span can be used as the creation context and no &#34;Create&#34; span needs to be created
      */
-    public const MESSAGING_OPERATION_PUBLISH = 'publish';
+    public const MESSAGING_OPERATION_TYPE_PUBLISH = 'publish';
 
     /**
-     * @see TraceAttributes::MESSAGING_OPERATION A message is created. &#34;Create&#34; spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios
+     * @see TraceAttributes::MESSAGING_OPERATION_TYPE A message is created. &#34;Create&#34; spans always refer to a single message and are used to provide a unique creation context for messages in batch publishing scenarios
      */
-    public const MESSAGING_OPERATION_CREATE = 'create';
+    public const MESSAGING_OPERATION_TYPE_CREATE = 'create';
 
     /**
-     * @see TraceAttributes::MESSAGING_OPERATION One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages
+     * @see TraceAttributes::MESSAGING_OPERATION_TYPE One or more messages are requested by a consumer. This operation refers to pull-based scenarios, where consumers explicitly call methods of messaging SDKs to receive messages
      */
-    public const MESSAGING_OPERATION_RECEIVE = 'receive';
+    public const MESSAGING_OPERATION_TYPE_RECEIVE = 'receive';
 
     /**
-     * @see TraceAttributes::MESSAGING_OPERATION One or more messages are delivered to or processed by a consumer
+     * @see TraceAttributes::MESSAGING_OPERATION_TYPE One or more messages are delivered to or processed by a consumer
      */
-    public const MESSAGING_OPERATION_DELIVER = 'process';
+    public const MESSAGING_OPERATION_TYPE_DELIVER = 'process';
 
     /**
-     * @see TraceAttributes::MESSAGING_OPERATION One or more messages are settled
+     * @see TraceAttributes::MESSAGING_OPERATION_TYPE One or more messages are settled
      */
-    public const MESSAGING_OPERATION_SETTLE = 'settle';
+    public const MESSAGING_OPERATION_TYPE_SETTLE = 'settle';
 
     /**
      * @see TraceAttributes::MESSAGING_ROCKETMQ_CONSUMPTION_MODEL Clustering consumption model
@@ -1330,6 +1415,16 @@ interface TraceAttributeValues
     public const OTEL_STATUS_CODE_ERROR = 'ERROR';
 
     /**
+     * @see TraceAttributes::PROCESS_CONTEXT_SWITCH_TYPE voluntary
+     */
+    public const PROCESS_CONTEXT_SWITCH_TYPE_VOLUNTARY = 'voluntary';
+
+    /**
+     * @see TraceAttributes::PROCESS_CONTEXT_SWITCH_TYPE involuntary
+     */
+    public const PROCESS_CONTEXT_SWITCH_TYPE_INVOLUNTARY = 'involuntary';
+
+    /**
      * @see TraceAttributes::PROCESS_CPU_STATE system
      */
     public const PROCESS_CPU_STATE_SYSTEM = 'system';
@@ -1343,6 +1438,16 @@ interface TraceAttributeValues
      * @see TraceAttributes::PROCESS_CPU_STATE wait
      */
     public const PROCESS_CPU_STATE_WAIT = 'wait';
+
+    /**
+     * @see TraceAttributes::PROCESS_PAGING_FAULT_TYPE major
+     */
+    public const PROCESS_PAGING_FAULT_TYPE_MAJOR = 'major';
+
+    /**
+     * @see TraceAttributes::PROCESS_PAGING_FAULT_TYPE minor
+     */
+    public const PROCESS_PAGING_FAULT_TYPE_MINOR = 'minor';
 
     /**
      * @see TraceAttributes::RPC_CONNECT_RPC_ERROR_CODE cancelled
@@ -1508,6 +1613,16 @@ interface TraceAttributeValues
      * @see TraceAttributes::RPC_GRPC_STATUS_CODE UNAUTHENTICATED
      */
     public const RPC_GRPC_STATUS_CODE_UNAUTHENTICATED = '16';
+
+    /**
+     * @see TraceAttributes::RPC_MESSAGE_TYPE sent
+     */
+    public const RPC_MESSAGE_TYPE_SENT = 'SENT';
+
+    /**
+     * @see TraceAttributes::RPC_MESSAGE_TYPE received
+     */
+    public const RPC_MESSAGE_TYPE_RECEIVED = 'RECEIVED';
 
     /**
      * @see TraceAttributes::RPC_SYSTEM gRPC

--- a/src/SemConv/TraceAttributes.php
+++ b/src/SemConv/TraceAttributes.php
@@ -11,7 +11,7 @@ interface TraceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.25.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.26.0';
 
     /**
      * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found here.
@@ -22,11 +22,19 @@ interface TraceAttributes
     public const ANDROID_OS_API_LEVEL = 'android.os.api_level';
 
     /**
-     * This attribute represents the state the application has transitioned into at the occurrence of the event.
+     * Deprecated use the `device.app.lifecycle` event definition including `android.state` as a payload field instead.
      *
      * The Android lifecycle states are defined in Activity lifecycle callbacks, and from which the `OS identifiers` are derived.
      */
     public const ANDROID_STATE = 'android.state';
+
+    /**
+     * ASP.NET Core exception middleware handling result.
+     *
+     * @example handled
+     * @example unhandled
+     */
+    public const ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT = 'aspnetcore.diagnostics.exception.result';
 
     /**
      * Full type name of the `IExceptionHandler` implementation that handled the exception.
@@ -65,6 +73,14 @@ interface TraceAttributes
      * @example True
      */
     public const ASPNETCORE_ROUTING_IS_FALLBACK = 'aspnetcore.routing.is_fallback';
+
+    /**
+     * Match result - success or failure.
+     *
+     * @example success
+     * @example failure
+     */
+    public const ASPNETCORE_ROUTING_MATCH_STATUS = 'aspnetcore.routing.match_status';
 
     /**
      * The JSON-serialized value of each item in the `AttributeDefinitions` request field.
@@ -225,6 +241,63 @@ interface TraceAttributes
     public const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
 
     /**
+     * The ARN of an ECS cluster.
+     *
+     * @example arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
+     */
+    public const AWS_ECS_CLUSTER_ARN = 'aws.ecs.cluster.arn';
+
+    /**
+     * The Amazon Resource Name (ARN) of an ECS container instance.
+     *
+     * @example arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9
+     */
+    public const AWS_ECS_CONTAINER_ARN = 'aws.ecs.container.arn';
+
+    /**
+     * The launch type for an ECS task.
+     */
+    public const AWS_ECS_LAUNCHTYPE = 'aws.ecs.launchtype';
+
+    /**
+     * The ARN of a running ECS task.
+     *
+     * @example arn:aws:ecs:us-west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b
+     * @example arn:aws:ecs:us-west-1:123456789123:task/my-cluster/task-id/23ebb8ac-c18f-46c6-8bbe-d55d0e37cfbd
+     */
+    public const AWS_ECS_TASK_ARN = 'aws.ecs.task.arn';
+
+    /**
+     * The family name of the ECS task definition used to create the ECS task.
+     *
+     * @example opentelemetry-family
+     */
+    public const AWS_ECS_TASK_FAMILY = 'aws.ecs.task.family';
+
+    /**
+     * The ID of a running ECS task. The ID MUST be extracted from `task.arn`.
+     *
+     * @example 10838bed-421f-43ef-870a-f43feacbbb5b
+     * @example 23ebb8ac-c18f-46c6-8bbe-d55d0e37cfbd
+     */
+    public const AWS_ECS_TASK_ID = 'aws.ecs.task.id';
+
+    /**
+     * The revision for the task definition used to create the ECS task.
+     *
+     * @example 8
+     * @example 26
+     */
+    public const AWS_ECS_TASK_REVISION = 'aws.ecs.task.revision';
+
+    /**
+     * The ARN of an EKS cluster.
+     *
+     * @example arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
+     */
+    public const AWS_EKS_CLUSTER_ARN = 'aws.eks.cluster.arn';
+
+    /**
      * The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
      *
      * This may be different from `cloud.resource_id` if an alias is involved.
@@ -232,6 +305,41 @@ interface TraceAttributes
      * @example arn:aws:lambda:us-east-1:123456:function:myfunction:myalias
      */
     public const AWS_LAMBDA_INVOKED_ARN = 'aws.lambda.invoked_arn';
+
+    /**
+     * The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+     *
+     * See the log group ARN format documentation.
+     *
+     * @example arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*
+     */
+    public const AWS_LOG_GROUP_ARNS = 'aws.log.group.arns';
+
+    /**
+     * The name(s) of the AWS log group(s) an application is writing to.
+     *
+     * Multiple log groups must be supported for cases like multi-container applications, where a single application has sidecar containers, and each write to their own log group.
+     *
+     * @example /aws/lambda/my-function
+     * @example opentelemetry-service
+     */
+    public const AWS_LOG_GROUP_NAMES = 'aws.log.group.names';
+
+    /**
+     * The ARN(s) of the AWS log stream(s).
+     *
+     * See the log stream ARN format documentation. One log group can contain several log streams, so these ARNs necessarily identify both a log group and a log stream.
+     *
+     * @example arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b
+     */
+    public const AWS_LOG_STREAM_ARNS = 'aws.log.stream.arns';
+
+    /**
+     * The name(s) of the AWS log stream(s) an application is writing to.
+     *
+     * @example logs/main/10838bed-421f-43ef-870a-f43feacbbb5b
+     */
+    public const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
 
     /**
      * The AWS request ID as returned in the response headers `x-amz-request-id` or `x-amz-requestid`.
@@ -579,7 +687,7 @@ interface TraceAttributes
      *
      * Docker defines a sha256 of the image id; `container.image.id` corresponds to the `Image` field from the Docker container inspect API endpoint.
      * K8s defines a link to the container registry repository with digest `"imageID": "registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625"`.
-     * The ID is assinged by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
+     * The ID is assigned by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
      *
      * @example sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f
      */
@@ -665,13 +773,38 @@ interface TraceAttributes
     public const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = 'db.cassandra.speculative_execution_count';
 
     /**
-     * The name of the primary Cassandra table that the operation is acting upon, including the keyspace name (if applicable).
+     * Deprecated, use `db.collection.name` instead.
      *
-     * This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+     * @deprecated Replaced by `db.collection.name`.
      *
      * @example mytable
      */
     public const DB_CASSANDRA_TABLE = 'db.cassandra.table';
+
+    /**
+     * The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`.
+     *
+     * @example myDataSource
+     */
+    public const DB_CLIENT_CONNECTIONS_POOL_NAME = 'db.client.connections.pool.name';
+
+    /**
+     * The state of a connection in the pool.
+     *
+     * @example idle
+     */
+    public const DB_CLIENT_CONNECTIONS_STATE = 'db.client.connections.state';
+
+    /**
+     * The name of a collection (table, container) within the database.
+     *
+     * If the collection name is parsed from the query, it SHOULD match the value provided in the query and may be qualified with the schema and database name.
+     * It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
+     *
+     * @example public.users
+     * @example customers
+     */
+    public const DB_COLLECTION_NAME = 'db.collection.name';
 
     /**
      * Deprecated, use `server.address`, `server.port` attributes instead.
@@ -695,9 +828,11 @@ interface TraceAttributes
     public const DB_COSMOSDB_CONNECTION_MODE = 'db.cosmosdb.connection_mode';
 
     /**
-     * Cosmos DB container name.
+     * Deprecated, use `db.collection.name` instead.
      *
-     * @example anystring
+     * @deprecated Replaced by `db.collection.name`.
+     *
+     * @example mytable
      */
     public const DB_COSMOSDB_CONTAINER = 'db.cosmosdb.container';
 
@@ -743,16 +878,16 @@ interface TraceAttributes
     public const DB_ELASTICSEARCH_CLUSTER_NAME = 'db.elasticsearch.cluster.name';
 
     /**
-     * Deprecated, use `db.instance.id` instead.
-     *
-     * @deprecated Replaced by `db.instance.id`.
+     * Represents the human-readable identifier of the node/instance to which a request was routed.
      *
      * @example instance-0000000001
      */
     public const DB_ELASTICSEARCH_NODE_NAME = 'db.elasticsearch.node.name';
 
     /**
-     * An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`.
+     * Deprecated, no general replacement at this time. For Elasticsearch, use `db.elasticsearch.node.name` instead.
+     *
+     * @deprecated Deprecated, no general replacement at this time. For Elasticsearch, use `db.elasticsearch.node.name` instead.
      *
      * @example mysql-e26b99z.example.com
      */
@@ -769,26 +904,27 @@ interface TraceAttributes
     public const DB_JDBC_DRIVER_CLASSNAME = 'db.jdbc.driver_classname';
 
     /**
-     * The MongoDB collection being accessed within the database stated in `db.name`.
+     * Deprecated, use `db.collection.name` instead.
      *
-     * @example customers
-     * @example products
+     * @deprecated Replaced by `db.collection.name`.
+     *
+     * @example mytable
      */
     public const DB_MONGODB_COLLECTION = 'db.mongodb.collection';
 
     /**
-     * The Microsoft SQL Server instance name connecting to. This name is used to determine the port of a named instance.
+     * Deprecated, SQL Server instance is now populated as a part of `db.namespace` attribute.
      *
-     * If setting a `db.mssql.instance_name`, `server.port` is no longer required (but still recommended if non-standard).
+     * @deprecated Deprecated, no replacement at this time.
      *
      * @example MSSQLSERVER
      */
     public const DB_MSSQL_INSTANCE_NAME = 'db.mssql.instance_name';
 
     /**
-     * This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails).
+     * Deprecated, use `db.namespace` instead.
      *
-     * In some SQL databases, the database name to be used is called &quot;schema name&quot;. In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name).
+     * @deprecated Replaced by `db.namespace`.
      *
      * @example customers
      * @example main
@@ -796,9 +932,21 @@ interface TraceAttributes
     public const DB_NAME = 'db.name';
 
     /**
-     * The name of the operation being executed, e.g. the MongoDB command name such as `findAndModify`, or the SQL keyword.
+     * The name of the database, fully qualified within the server address and port.
      *
-     * When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+     * If a database system has multiple namespace components, they SHOULD be concatenated (potentially using database system specific conventions) from most general to most specific namespace component, and more specific namespaces SHOULD NOT be captured without the more general namespaces, to ensure that &quot;startswith&quot; queries for the more general namespaces will be valid.
+     * Semantic conventions for individual database systems SHOULD document what `db.namespace` means in the context of that system.
+     * It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
+     *
+     * @example customers
+     * @example test.users
+     */
+    public const DB_NAMESPACE = 'db.namespace';
+
+    /**
+     * Deprecated, use `db.operation.name` instead.
+     *
+     * @deprecated Replaced by `db.operation.name`.
      *
      * @example findAndModify
      * @example HMSET
@@ -807,7 +955,28 @@ interface TraceAttributes
     public const DB_OPERATION = 'db.operation';
 
     /**
-     * The index of the database being accessed as used in the `SELECT` command, provided as an integer. To be used instead of the generic `db.name` attribute.
+     * The name of the operation or command being executed.
+     *
+     * It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
+     *
+     * @example findAndModify
+     * @example HMSET
+     * @example SELECT
+     */
+    public const DB_OPERATION_NAME = 'db.operation.name';
+
+    /**
+     * The database query being executed.
+     *
+     * @example SELECT * FROM wuser_table where username = ?
+     * @example SET mykey "WuValue"
+     */
+    public const DB_QUERY_TEXT = 'db.query.text';
+
+    /**
+     * Deprecated, use `db.namespace` instead.
+     *
+     * @deprecated Replaced by `db.namespace`.
      *
      * @example 1
      * @example 15
@@ -815,17 +984,18 @@ interface TraceAttributes
     public const DB_REDIS_DATABASE_INDEX = 'db.redis.database_index';
 
     /**
-     * The name of the primary table that the operation is acting upon, including the database name (if applicable).
+     * Deprecated, use `db.collection.name` instead.
      *
-     * It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+     * @deprecated Replaced by `db.collection.name`.
      *
-     * @example public.users
-     * @example customers
+     * @example mytable
      */
     public const DB_SQL_TABLE = 'db.sql.table';
 
     /**
      * The database statement being executed.
+     *
+     * @deprecated Replaced by `db.query.text`.
      *
      * @example SELECT * FROM wuser_table
      * @example SET mykey "WuValue"
@@ -833,12 +1003,16 @@ interface TraceAttributes
     public const DB_STATEMENT = 'db.statement';
 
     /**
-     * An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
+     * The database management system (DBMS) product as identified by the client instrumentation.
+     *
+     * The actual DBMS may differ from the one identified by the client. For example, when using PostgreSQL client libraries to connect to a CockroachDB, the `db.system` is set to `postgresql` based on the instrumentation's best knowledge.
      */
     public const DB_SYSTEM = 'db.system';
 
     /**
-     * Username for accessing the database.
+     * Deprecated, no replacement at this time.
+     *
+     * @deprecated No replacement at this time.
      *
      * @example readonly_user
      * @example reporting_user
@@ -960,14 +1134,7 @@ interface TraceAttributes
     /**
      * Describes a class of error the operation ended with.
      *
-     * If the request fails with an error before response status code was sent or received,
-     * `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
-     * or a component-specific low cardinality error identifier.If response status code was sent or received and status indicates an error according to HTTP span status definition,
-     * `error.type` SHOULD be set to the status code number (represented as a string), an exception type (if thrown) or a component-specific error identifier.The `error.type` value SHOULD be predictable and SHOULD have low cardinality.
-     * Instrumentations SHOULD document the list of errors they report.The cardinality of `error.type` within one instrumentation library SHOULD be low, but
-     * telemetry consumers that aggregate data from multiple instrumentation libraries and applications
-     * should be prepared for `error.type` to have high cardinality at query time, when no
-     * additional filters are applied.If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
+     * The `error.type` SHOULD match the error code returned by the database or the client library, the canonical name of exception that occurred, or another low-cardinality error identifier. Instrumentations SHOULD document the list of errors they report.
      *
      * @example timeout
      * @example java.net.UnknownHostException
@@ -1272,6 +1439,95 @@ interface TraceAttributes
     public const GCP_GCE_INSTANCE_NAME = 'gcp.gce.instance.name';
 
     /**
+     * The full response received from the LLM.
+     *
+     * It's RECOMMENDED to format completions as JSON string matching OpenAI messages format
+     *
+     * @example [{'role': 'assistant', 'content': 'The capital of France is Paris.'}]
+     */
+    public const GEN_AI_COMPLETION = 'gen_ai.completion';
+
+    /**
+     * The full prompt sent to an LLM.
+     *
+     * It's RECOMMENDED to format prompts as JSON string matching OpenAI messages format
+     *
+     * @example [{'role': 'user', 'content': 'What is the capital of France?'}]
+     */
+    public const GEN_AI_PROMPT = 'gen_ai.prompt';
+
+    /**
+     * The maximum number of tokens the LLM generates for a request.
+     *
+     * @example 100
+     */
+    public const GEN_AI_REQUEST_MAX_TOKENS = 'gen_ai.request.max_tokens';
+
+    /**
+     * The name of the LLM a request is being made to.
+     *
+     * @example gpt-4
+     */
+    public const GEN_AI_REQUEST_MODEL = 'gen_ai.request.model';
+
+    /**
+     * The temperature setting for the LLM request.
+     *
+     */
+    public const GEN_AI_REQUEST_TEMPERATURE = 'gen_ai.request.temperature';
+
+    /**
+     * The top_p sampling setting for the LLM request.
+     *
+     * @example 1.0
+     */
+    public const GEN_AI_REQUEST_TOP_P = 'gen_ai.request.top_p';
+
+    /**
+     * Array of reasons the model stopped generating tokens, corresponding to each generation received.
+     *
+     * @example stop
+     */
+    public const GEN_AI_RESPONSE_FINISH_REASONS = 'gen_ai.response.finish_reasons';
+
+    /**
+     * The unique identifier for the completion.
+     *
+     * @example chatcmpl-123
+     */
+    public const GEN_AI_RESPONSE_ID = 'gen_ai.response.id';
+
+    /**
+     * The name of the LLM a response was generated from.
+     *
+     * @example gpt-4-0613
+     */
+    public const GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model';
+
+    /**
+     * The Generative AI product as identified by the client instrumentation.
+     *
+     * The actual GenAI product may differ from the one identified by the client. For example, when using OpenAI client libraries to communicate with Mistral, the `gen_ai.system` is set to `openai` based on the instrumentation's best knowledge.
+     *
+     * @example openai
+     */
+    public const GEN_AI_SYSTEM = 'gen_ai.system';
+
+    /**
+     * The number of tokens used in the LLM response (completion).
+     *
+     * @example 180
+     */
+    public const GEN_AI_USAGE_COMPLETION_TOKENS = 'gen_ai.usage.completion_tokens';
+
+    /**
+     * The number of tokens used in the LLM prompt.
+     *
+     * @example 100
+     */
+    public const GEN_AI_USAGE_PROMPT_TOKENS = 'gen_ai.usage.prompt_tokens';
+
+    /**
      * The GraphQL document being executed.
      *
      * The value may be sanitized to exclude sensitive information.
@@ -1295,6 +1551,27 @@ interface TraceAttributes
      * @example subscription
      */
     public const GRAPHQL_OPERATION_TYPE = 'graphql.operation.type';
+
+    /**
+     * Unique identifier for the application.
+     *
+     * @example 2daa2797-e42b-4624-9322-ec3f968df4da
+     */
+    public const HEROKU_APP_ID = 'heroku.app.id';
+
+    /**
+     * Commit hash for the current release.
+     *
+     * @example e6134959463efd8966b20e75b913cafe3f5ec
+     */
+    public const HEROKU_RELEASE_COMMIT = 'heroku.release.commit';
+
+    /**
+     * Time and date the release was created.
+     *
+     * @example 2022-10-23T18:00:42Z
+     */
+    public const HEROKU_RELEASE_CREATION_TIMESTAMP = 'heroku.release.creation_timestamp';
 
     /**
      * The CPU architecture the host system is running on.
@@ -1412,6 +1689,15 @@ interface TraceAttributes
     public const HOST_TYPE = 'host.type';
 
     /**
+     * Deprecated, use `client.address` instead.
+     *
+     * @deprecated Replaced by `client.address`.
+     *
+     * @example 83.164.160.102
+     */
+    public const HTTP_CLIENT_IP = 'http.client_ip';
+
+    /**
      * State of the HTTP connection in the HTTP connection pool.
      *
      * @example active
@@ -1425,6 +1711,15 @@ interface TraceAttributes
      * @deprecated Replaced by `network.protocol.name`.
      */
     public const HTTP_FLAVOR = 'http.flavor';
+
+    /**
+     * Deprecated, use one of `server.address`, `client.address` or `http.request.header.host` instead, depending on the usage.
+     *
+     * @deprecated Replaced by one of `server.address`, `client.address` or `http.request.header.host`, depending on the usage.
+     *
+     * @example www.example.org
+     */
+    public const HTTP_HOST = 'http.host';
 
     /**
      * Deprecated, use `http.request.method` instead.
@@ -1497,6 +1792,15 @@ interface TraceAttributes
     public const HTTP_REQUEST_CONTENT_LENGTH = 'http.request_content_length';
 
     /**
+     * Deprecated, use `http.request.body.size` instead.
+     *
+     * @deprecated Replaced by `http.request.body.size`.
+     *
+     * @example 5493
+     */
+    public const HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = 'http.request_content_length_uncompressed';
+
+    /**
      * The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.
      *
      * @example 3495
@@ -1527,6 +1831,15 @@ interface TraceAttributes
     public const HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length';
 
     /**
+     * Deprecated, use `http.response.body.size` instead.
+     *
+     * @deprecated Replace by `http.response.body.size`.
+     *
+     * @example 5493
+     */
+    public const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = 'http.response_content_length_uncompressed';
+
+    /**
      * The matched route, that is, the path template in the format used by the respective server framework.
      *
      * MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
@@ -1546,6 +1859,15 @@ interface TraceAttributes
      * @example https
      */
     public const HTTP_SCHEME = 'http.scheme';
+
+    /**
+     * Deprecated, use `server.address` instead.
+     *
+     * @deprecated Replaced by `server.address`.
+     *
+     * @example example.com
+     */
+    public const HTTP_SERVER_NAME = 'http.server_name';
 
     /**
      * Deprecated, use `http.response.status_code` instead.
@@ -1585,9 +1907,11 @@ interface TraceAttributes
     public const HTTP_USER_AGENT = 'http.user_agent';
 
     /**
-     * This attribute represents the state the application has transitioned into at the occurrence of the event.
+     * Deprecated use the `device.app.lifecycle` event definition including `ios.state` as a payload field instead.
      *
      * The iOS lifecycle states are defined in the UIApplicationDelegate documentation, and from which the `OS terminology` column values are derived.
+     *
+     * @deprecated Moved to a payload field of `device.app.lifecycle`.
      */
     public const IOS_STATE = 'ios.state';
 
@@ -1600,6 +1924,26 @@ interface TraceAttributes
      * @example direct
      */
     public const JVM_BUFFER_POOL_NAME = 'jvm.buffer.pool.name';
+
+    /**
+     * Name of the garbage collector action.
+     *
+     * Garbage collector action is generally obtained via GarbageCollectionNotificationInfo#getGcAction().
+     *
+     * @example end of minor GC
+     * @example end of major GC
+     */
+    public const JVM_GC_ACTION = 'jvm.gc.action';
+
+    /**
+     * Name of the garbage collector.
+     *
+     * Garbage collector name is generally obtained via GarbageCollectionNotificationInfo#getGcName().
+     *
+     * @example G1 Young Generation
+     * @example G1 Old Generation
+     */
+    public const JVM_GC_NAME = 'jvm.gc.name';
 
     /**
      * Name of the memory pool.
@@ -1619,6 +1963,19 @@ interface TraceAttributes
      * @example non_heap
      */
     public const JVM_MEMORY_TYPE = 'jvm.memory.type';
+
+    /**
+     * Whether the thread is daemon or not.
+     */
+    public const JVM_THREAD_DAEMON = 'jvm.thread.daemon';
+
+    /**
+     * State of the thread.
+     *
+     * @example runnable
+     * @example blocked
+     */
+    public const JVM_THREAD_STATE = 'jvm.thread.state';
 
     /**
      * The name of the cluster.
@@ -1661,10 +2018,16 @@ interface TraceAttributes
 
     /**
      * Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec.
-     *
-     * @example 2
      */
     public const K8S_CONTAINER_RESTART_COUNT = 'k8s.container.restart_count';
+
+    /**
+     * Last terminated reason of the Container.
+     *
+     * @example Evicted
+     * @example Error
+     */
+    public const K8S_CONTAINER_STATUS_LAST_TERMINATED_REASON = 'k8s.container.status.last_terminated_reason';
 
     /**
      * The name of the CronJob.
@@ -1829,24 +2192,30 @@ interface TraceAttributes
     public const LOG_RECORD_UID = 'log.record.uid';
 
     /**
-     * Compressed size of the message in bytes.
+     * Deprecated, use `rpc.message.compressed_size` instead.
+     *
+     * @deprecated Replaced by `rpc.message.compressed_size`.
      */
     public const MESSAGE_COMPRESSED_SIZE = 'message.compressed_size';
 
     /**
-     * MUST be calculated as two different counters starting from `1` one for sent messages and one for received message.
+     * Deprecated, use `rpc.message.id` instead.
      *
-     * This way we guarantee that the values will be consistent between different implementations.
+     * @deprecated Replaced by `rpc.message.id`.
      */
     public const MESSAGE_ID = 'message.id';
 
     /**
-     * Whether this is a received or sent message.
+     * Deprecated, use `rpc.message.type` instead.
+     *
+     * @deprecated Replaced by `rpc.message.type`.
      */
     public const MESSAGE_TYPE = 'message.type';
 
     /**
-     * Uncompressed size of the message in bytes.
+     * Deprecated, use `rpc.message.uncompressed_size` instead.
+     *
+     * @deprecated Replaced by `rpc.message.uncompressed_size`.
      */
     public const MESSAGE_UNCOMPRESSED_SIZE = 'message.uncompressed_size';
 
@@ -1866,7 +2235,7 @@ interface TraceAttributes
      * @example client-5
      * @example myhost@8742@s8083jm
      */
-    public const MESSAGING_CLIENT_ID = 'messaging.client_id';
+    public const MESSAGING_CLIENT_ID = 'messaging.client.id';
 
     /**
      * A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).
@@ -1936,6 +2305,27 @@ interface TraceAttributes
     public const MESSAGING_EVENTHUBS_MESSAGE_ENQUEUED_TIME = 'messaging.eventhubs.message.enqueued_time';
 
     /**
+     * The ack deadline in seconds set for the modify ack deadline request.
+     *
+     * @example 10
+     */
+    public const MESSAGING_GCP_PUBSUB_MESSAGE_ACK_DEADLINE = 'messaging.gcp_pubsub.message.ack_deadline';
+
+    /**
+     * The ack id for a given message.
+     *
+     * @example ack_id
+     */
+    public const MESSAGING_GCP_PUBSUB_MESSAGE_ACK_ID = 'messaging.gcp_pubsub.message.ack_id';
+
+    /**
+     * The delivery attempt for a given message.
+     *
+     * @example 2
+     */
+    public const MESSAGING_GCP_PUBSUB_MESSAGE_DELIVERY_ATTEMPT = 'messaging.gcp_pubsub.message.delivery_attempt';
+
+    /**
      * The ordering key for a given message. If the attribute is not present, the message does not have an ordering key.
      *
      * @example ordering_key
@@ -1950,7 +2340,7 @@ interface TraceAttributes
     public const MESSAGING_KAFKA_CONSUMER_GROUP = 'messaging.kafka.consumer.group';
 
     /**
-     * &quot;Deprecated, use `messaging.destination.partition.id` instead.&quot;.
+     * Deprecated, use `messaging.destination.partition.id` instead.
      *
      * @deprecated Replaced by `messaging.destination.partition.id`.
      *
@@ -2014,11 +2404,31 @@ interface TraceAttributes
     public const MESSAGING_MESSAGE_ID = 'messaging.message.id';
 
     /**
-     * A string identifying the kind of messaging operation.
+     * Deprecated, use `messaging.operation.type` instead.
+     *
+     * @deprecated Replaced by `messaging.operation.type`.
+     *
+     * @example publish
+     * @example create
+     * @example process
+     */
+    public const MESSAGING_OPERATION = 'messaging.operation';
+
+    /**
+     * The system-specific name of the messaging operation.
+     *
+     * @example ack
+     * @example nack
+     * @example send
+     */
+    public const MESSAGING_OPERATION_NAME = 'messaging.operation.name';
+
+    /**
+     * A string identifying the type of the messaging operation.
      *
      * If a custom value is used, it MUST be of low cardinality.
      */
-    public const MESSAGING_OPERATION = 'messaging.operation';
+    public const MESSAGING_OPERATION_TYPE = 'messaging.operation.type';
 
     /**
      * RabbitMQ message routing key.
@@ -2121,9 +2531,20 @@ interface TraceAttributes
     public const MESSAGING_SERVICEBUS_MESSAGE_ENQUEUED_TIME = 'messaging.servicebus.message.enqueued_time';
 
     /**
-     * An identifier for the messaging system being used. See below for a list of well-known identifiers.
+     * The messaging system as identified by the client instrumentation.
+     *
+     * The actual messaging system may differ from the one known by the client. For example, when using Kafka client libraries to communicate with Azure Event Hubs, the `messaging.system` is set to `kafka` based on the instrumentation's best knowledge.
      */
     public const MESSAGING_SYSTEM = 'messaging.system';
+
+    /**
+     * Deprecated, use `network.local.address`.
+     *
+     * @deprecated Replaced by `network.local.address`.
+     *
+     * @example 192.168.0.1
+     */
+    public const NET_HOST_IP = 'net.host.ip';
 
     /**
      * Deprecated, use `server.address`.
@@ -2142,6 +2563,15 @@ interface TraceAttributes
      * @example 8080
      */
     public const NET_HOST_PORT = 'net.host.port';
+
+    /**
+     * Deprecated, use `network.peer.address`.
+     *
+     * @deprecated Replaced by `network.peer.address`.
+     *
+     * @example 127.0.0.1
+     */
+    public const NET_PEER_IP = 'net.peer.ip';
 
     /**
      * Deprecated, use `server.address` on client spans and `client.address` on server spans.
@@ -2420,6 +2850,38 @@ interface TraceAttributes
     public const OS_VERSION = 'os.version';
 
     /**
+     * None.
+     *
+     * @deprecated use the `otel.scope.name` attribute.
+     *
+     * @example io.opentelemetry.contrib.mongodb
+     */
+    public const OTEL_LIBRARY_NAME = 'otel.library.name';
+
+    /**
+     * None.
+     *
+     * @deprecated use the `otel.scope.version` attribute.
+     *
+     * @example 1.0.0
+     */
+    public const OTEL_LIBRARY_VERSION = 'otel.library.version';
+
+    /**
+     * The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
+     *
+     * @example io.opentelemetry.contrib.mongodb
+     */
+    public const OTEL_SCOPE_NAME = 'otel.scope.name';
+
+    /**
+     * The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP).
+     *
+     * @example 1.0.0
+     */
+    public const OTEL_SCOPE_VERSION = 'otel.scope.version';
+
+    /**
      * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status code is UNSET.
      */
     public const OTEL_STATUS_CODE = 'otel.status_code';
@@ -2439,7 +2901,9 @@ interface TraceAttributes
     public const PEER_SERVICE = 'peer.service';
 
     /**
-     * The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation should use a combination of `server.address` and `server.port` attributes formatted as `server.address:server.port`.
+     * Deprecated, use `db.client.connections.pool.name` instead.
+     *
+     * @deprecated Replaced by `db.client.connections.pool.name`.
      *
      * @example myDataSource
      */
@@ -2468,9 +2932,21 @@ interface TraceAttributes
     public const PROCESS_COMMAND_LINE = 'process.command_line';
 
     /**
-     * The CPU state for this data point. A process SHOULD be characterized <em>either</em> by data points with no `state` labels, <em>or only</em> data points with `state` labels.
+     * Specifies whether the context switches for this data point were voluntary or involuntary.
+     */
+    public const PROCESS_CONTEXT_SWITCH_TYPE = 'process.context_switch_type';
+
+    /**
+     * The CPU state of the process.
      */
     public const PROCESS_CPU_STATE = 'process.cpu.state';
+
+    /**
+     * The date and time the process was created, in ISO 8601 format.
+     *
+     * @example 2023-11-21T09:25:34.853Z
+     */
+    public const PROCESS_CREATION_TIME = 'process.creation.time';
 
     /**
      * The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
@@ -2487,11 +2963,42 @@ interface TraceAttributes
     public const PROCESS_EXECUTABLE_PATH = 'process.executable.path';
 
     /**
+     * The exit code of the process.
+     *
+     * @example 127
+     */
+    public const PROCESS_EXIT_CODE = 'process.exit.code';
+
+    /**
+     * The date and time the process exited, in ISO 8601 format.
+     *
+     * @example 2023-11-21T09:26:12.315Z
+     */
+    public const PROCESS_EXIT_TIME = 'process.exit.time';
+
+    /**
+     * The PID of the process's group leader. This is also the process group ID (PGID) of the process.
+     *
+     * @example 23
+     */
+    public const PROCESS_GROUP_LEADER_PID = 'process.group_leader.pid';
+
+    /**
+     * Whether the process is connected to an interactive shell.
+     */
+    public const PROCESS_INTERACTIVE = 'process.interactive';
+
+    /**
      * The username of the user that owns the process.
      *
      * @example root
      */
     public const PROCESS_OWNER = 'process.owner';
+
+    /**
+     * The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor` is for minor/soft page faults.
+     */
+    public const PROCESS_PAGING_FAULT_TYPE = 'process.paging.fault_type';
 
     /**
      * Parent Process identifier (PPID).
@@ -2506,6 +3013,20 @@ interface TraceAttributes
      * @example 1234
      */
     public const PROCESS_PID = 'process.pid';
+
+    /**
+     * The real user ID (RUID) of the process.
+     *
+     * @example 1000
+     */
+    public const PROCESS_REAL_USER_ID = 'process.real_user.id';
+
+    /**
+     * The username of the real user of the process.
+     *
+     * @example operator
+     */
+    public const PROCESS_REAL_USER_NAME = 'process.real_user.name';
 
     /**
      * An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
@@ -2527,6 +3048,50 @@ interface TraceAttributes
      * @example 14.0.2
      */
     public const PROCESS_RUNTIME_VERSION = 'process.runtime.version';
+
+    /**
+     * The saved user ID (SUID) of the process.
+     *
+     * @example 1002
+     */
+    public const PROCESS_SAVED_USER_ID = 'process.saved_user.id';
+
+    /**
+     * The username of the saved user.
+     *
+     * @example operator
+     */
+    public const PROCESS_SAVED_USER_NAME = 'process.saved_user.name';
+
+    /**
+     * The PID of the process's session leader. This is also the session ID (SID) of the process.
+     *
+     * @example 14
+     */
+    public const PROCESS_SESSION_LEADER_PID = 'process.session_leader.pid';
+
+    /**
+     * The effective user ID (EUID) of the process.
+     *
+     * @example 1001
+     */
+    public const PROCESS_USER_ID = 'process.user.id';
+
+    /**
+     * The username of the effective user of the process.
+     *
+     * @example root
+     */
+    public const PROCESS_USER_NAME = 'process.user.name';
+
+    /**
+     * Virtual process identifier.
+     *
+     * The process ID within a PID namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.
+     *
+     * @example 12
+     */
+    public const PROCESS_VPID = 'process.vpid';
 
     /**
      * The error codes of the Connect request. Error codes are always string values.
@@ -2571,6 +3136,28 @@ interface TraceAttributes
     public const RPC_JSONRPC_VERSION = 'rpc.jsonrpc.version';
 
     /**
+     * Compressed size of the message in bytes.
+     */
+    public const RPC_MESSAGE_COMPRESSED_SIZE = 'rpc.message.compressed_size';
+
+    /**
+     * MUST be calculated as two different counters starting from `1` one for sent messages and one for received message.
+     *
+     * This way we guarantee that the values will be consistent between different implementations.
+     */
+    public const RPC_MESSAGE_ID = 'rpc.message.id';
+
+    /**
+     * Whether this is a received or sent message.
+     */
+    public const RPC_MESSAGE_TYPE = 'rpc.message.type';
+
+    /**
+     * Uncompressed size of the message in bytes.
+     */
+    public const RPC_MESSAGE_UNCOMPRESSED_SIZE = 'rpc.message.uncompressed_size';
+
+    /**
      * The name of the (logical) method being called, must be equal to the $method part in the span name.
      *
      * This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
@@ -2594,7 +3181,7 @@ interface TraceAttributes
     public const RPC_SYSTEM = 'rpc.system';
 
     /**
-     * Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+     * Name of the database host.
      *
      * When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
      *
@@ -2717,7 +3304,9 @@ interface TraceAttributes
     public const SOURCE_PORT = 'source.port';
 
     /**
-     * The state of a connection in the pool.
+     * Deprecated, use `db.client.connections.state` instead.
+     *
+     * @deprecated Replaced by `db.client.connections.state`.
      *
      * @example idle
      */
@@ -2731,7 +3320,7 @@ interface TraceAttributes
     public const SYSTEM_CPU_LOGICAL_NUMBER = 'system.cpu.logical_number';
 
     /**
-     * The CPU state for this data point. A system's CPU SHOULD be characterized <em>either</em> by data points with no `state` labels, <em>or only</em> data points with `state` labels.
+     * The state of the CPU.
      *
      * @example idle
      * @example interrupt
@@ -3195,6 +3784,17 @@ interface TraceAttributes
     public const URL_SUBDOMAIN = 'url.subdomain';
 
     /**
+     * The low-cardinality template of an absolute path reference.
+     *
+     * The `url.template` MUST have low cardinality. It is not usually available on HTTP clients, but may be known by the application or specialized HTTP instrumentation.
+     *
+     * @example /users/{id}
+     * @example /users/:id
+     * @example /users?id={id}
+     */
+    public const URL_TEMPLATE = 'url.template';
+
+    /**
      * The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is `com`.
      *
      * This value can be determined precisely with the public suffix list.
@@ -3234,6 +3834,27 @@ interface TraceAttributes
     public const USER_AGENT_VERSION = 'user_agent.version';
 
     /**
+     * Additional description of the web engine (e.g. detailed version and edition information).
+     *
+     * @example WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final
+     */
+    public const WEBENGINE_DESCRIPTION = 'webengine.description';
+
+    /**
+     * The name of the web engine.
+     *
+     * @example WildFly
+     */
+    public const WEBENGINE_NAME = 'webengine.name';
+
+    /**
+     * The version of the web engine.
+     *
+     * @example 21.0.0
+     */
+    public const WEBENGINE_VERSION = 'webengine.version';
+
+    /**
      * @deprecated
      */
     public const FAAS_EXECUTION = 'faas.execution';
@@ -3241,27 +3862,7 @@ interface TraceAttributes
     /**
      * @deprecated
      */
-    public const HTTP_HOST = 'http.host';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = 'http.request_content_length_uncompressed';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = 'http.response_content_length_uncompressed';
-
-    /**
-     * @deprecated
-     */
     public const HTTP_RETRY_COUNT = 'http.retry_count';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_SERVER_NAME = 'http.server_name';
 
     /**
      * @deprecated
@@ -3307,21 +3908,6 @@ interface TraceAttributes
      * @deprecated
      */
     public const MESSAGING_URL = 'messaging.url';
-
-    /**
-     * @deprecated
-     */
-    public const NET_HOST_IP = 'net.host.ip';
-
-    /**
-     * @deprecated
-     */
-    public const NET_PEER_IP = 'net.peer.ip';
-
-    /**
-     * @deprecated
-     */
-    public const HTTP_CLIENT_IP = 'http.client_ip';
 
     /**
      * @deprecated

--- a/src/SemConv/Version.php
+++ b/src/SemConv/Version.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\SemConv;
 
 enum Version: string
 {
+    case VERSION_1_26_0 = '1.26.0';
     case VERSION_1_25_0 = '1.25.0';
     case VERSION_1_24_0 = '1.24.0';
     case VERSION_1_23_1 = '1.23.1';

--- a/tests/Integration/Config/configurations/kitchen-sink.yaml
+++ b/tests/Integration/Config/configurations/kitchen-sink.yaml
@@ -349,4 +349,4 @@ resource:
         # Environment variable: OTEL_SERVICE_NAME
         service.name: !!str "unknown_service"
     # Configure the resource schema URL.
-    schema_url: https://opentelemetry.io/schemas/1.25.0
+    schema_url: https://opentelemetry.io/schemas/1.26.0


### PR DESCRIPTION
note that messaging.client_id was renamed to messaging.client.id, which causes a conflict in const name. It hasn't been resolved upstream yet, but manually removing the duplicate seems like the best way to go for us.