### PR TITLE
Fix logs exporter factory exception message

### DIFF
--- a/src/SDK/Logs/ExporterFactory.php
+++ b/src/SDK/Logs/ExporterFactory.php
@@ -16,7 +16,7 @@ class ExporterFactory
     {
         $exporters = Configuration::getList(Variables::OTEL_LOGS_EXPORTER);
         if (1 !== count($exporters)) {
-            throw new InvalidArgumentException(sprintf('Configuration %s requires exactly 1 exporter', Variables::OTEL_TRACES_EXPORTER));
+            throw new InvalidArgumentException(sprintf('Configuration %s requires exactly 1 exporter', Variables::OTEL_LOGS_EXPORTER));
         }
         $exporter = $exporters[0];
         if ($exporter === 'none') {


### PR DESCRIPTION
### Fixed

- Use `OTEL_LOGS_EXPORTER` variable in logs exporter factory exception message