### PR TITLE
Add return types for ArrayAccess in docblocks in AttributesBuilder

### DIFF
--- a/src/SDK/Common/Attribute/AttributesBuilder.php
+++ b/src/SDK/Common/Attribute/AttributesBuilder.php
@@ -49,6 +49,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
 
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
@@ -58,6 +59,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
 
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
@@ -90,6 +92,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
 
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)


### PR DESCRIPTION
Using the open-telemetry SDK package in a Symfony project gives us a lot of deprecation messages based on the ArrayAccess methods going to change in the future. This PR tries to solve it in the softest way possible.

I saw that in other places the actual return types were added, but as this code has also `#[\ReturnTypeWillChange]`, I think this code can not be upgraded in the same way yet, right?