### PR TITLE
handle empty encoded responses

### DIFF
--- a/src/SDK/Common/Export/Http/PsrUtils.php
+++ b/src/SDK/Common/Export/Http/PsrUtils.php
@@ -91,6 +91,10 @@ final class PsrUtils
      */
     public static function decode(string $value, array $encodings): string
     {
+        if ($value === '') {
+            return $value;
+        }
+
         for ($i = count($encodings); --$i >= 0;) {
             if (strcasecmp($encodings[$i], 'identity') === 0) {
                 continue;

--- a/tests/Unit/SDK/Common/Export/Http/PsrTransportTest.php
+++ b/tests/Unit/SDK/Common/Export/Http/PsrTransportTest.php
@@ -97,7 +97,7 @@ final class PsrTransportTest extends TestCase
 
     public function test_send_decode_unknown_encoding_returns_error(): void
     {
-        $this->client->expects($this->once())->method('sendRequest')->willReturn(new Response(200, ['Content-Encoding' => 'invalid'], ''));
+        $this->client->expects($this->once())->method('sendRequest')->willReturn(new Response(200, ['Content-Encoding' => 'invalid'], 'foo'));
         $transport = $this->factory->create('http://localhost', 'text/plain');
 
         $response = $transport->send('');

--- a/tests/Unit/SDK/Common/Export/Http/PsrUtilsTest.php
+++ b/tests/Unit/SDK/Common/Export/Http/PsrUtilsTest.php
@@ -89,7 +89,12 @@ final class PsrUtilsTest extends TestCase
     {
         $this->expectException(UnexpectedValueException::class);
 
-        PsrUtils::decode('', ['invalid']);
+        PsrUtils::decode('foo', ['invalid']);
+    }
+
+    public function test_decode_empty_value(): void
+    {
+        $this->assertSame('', PsrUtils::decode('', ['gzip']));
     }
 
     #[DataProvider('compressionProvider')]


### PR DESCRIPTION
at least one otel backend product sends an empty response with a gzip encoding, which we fail to decode (because an empty string is not valid). Work around this by not trying to decode an empty value.

Fixes: #1264 