### PR TITLE
Add linux/arm64 to base images support M3 devices

### DIFF
--- a/.github/workflows/publish-otel-php-base-docker-image.yml
+++ b/.github/workflows/publish-otel-php-base-docker-image.yml
@@ -34,5 +34,5 @@ jobs:
           push: true
           file: docker/Dockerfile
           build-args: PHP_VERSION=${{ matrix.php-version }}
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm/v8,linux/arm64
           tags: ghcr.io/open-telemetry/opentelemetry-php/opentelemetry-php-base:${{ matrix.php-version }}


### PR DESCRIPTION
This change adds a base-image for M3 devices using the linux/arm64 arch.