### PR TITLE
add return type hints to Attributes* classes

### DIFF
--- a/src/SDK/Common/Attribute/AttributesBuilder.php
+++ b/src/SDK/Common/Attribute/AttributesBuilder.php
@@ -49,20 +49,16 @@ final class AttributesBuilder implements AttributesBuilderInterface
 
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
-     * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->attributes[$offset] ?? null;
     }
 
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
-     * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
             return;
@@ -92,10 +88,8 @@ final class AttributesBuilder implements AttributesBuilderInterface
 
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
-     * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->attributes[$offset]);
     }

--- a/src/SDK/Common/Attribute/FilteredAttributesBuilder.php
+++ b/src/SDK/Common/Attribute/FilteredAttributesBuilder.php
@@ -48,8 +48,7 @@ final class FilteredAttributesBuilder implements AttributesBuilderInterface
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->builder->offsetGet($offset);
     }
@@ -57,8 +56,7 @@ final class FilteredAttributesBuilder implements AttributesBuilderInterface
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($value !== null && in_array($offset, $this->rejectedKeys, true)) {
             $this->rejected++;
@@ -72,8 +70,7 @@ final class FilteredAttributesBuilder implements AttributesBuilderInterface
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->builder->offsetUnset($offset);
     }


### PR DESCRIPTION
now that 7.4 and 8.0 support is dropped, we can add correct return type-hints to these functions, and remove the ReturnTypeWillChange attribute.

Fixes: #1348 