### PR TITLE
Allow for 'google/protobuf' '^4.0' to be used as well.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^8.1",
-        "google/protobuf": "^3.22",
+        "google/protobuf": "^3.22 || ^4.0",
         "php-http/discovery": "^1.14",
         "psr/http-client": "^1.0",
         "psr/http-client-implementation": "^1.0",


### PR DESCRIPTION
Resolves #1359.