### PR TITLE
adding config provider

### DIFF
--- a/examples/src/ExampleInstrumentation.php
+++ b/examples/src/ExampleInstrumentation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Example;
 
 use Exception;
-use OpenTelemetry\API\Instrumentation\AutoInstrumentation\ConfigurationRegistry;
+use OpenTelemetry\API\Configuration\ConfigProperties;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\Context as InstrumentationContext;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\HookManagerInterface;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\Instrumentation;
@@ -15,7 +15,7 @@ use OpenTelemetry\Context\Context;
 final class ExampleInstrumentation implements Instrumentation
 {
 
-    public function register(HookManagerInterface $hookManager, ConfigurationRegistry $configuration, InstrumentationContext $context): void
+    public function register(HookManagerInterface $hookManager, ConfigProperties $configuration, InstrumentationContext $context): void
     {
         $config = $configuration->get(ExampleConfig::class) ?? throw new Exception('example instrumentation must be configured');
         if (!$config->enabled) {

--- a/src/API/Configuration/ConfigProperties.php
+++ b/src/API/Configuration/ConfigProperties.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Configuration;
+
+interface ConfigProperties
+{
+    public function get(string $id): mixed;
+}

--- a/src/API/Configuration/ConfigProviderInterface.php
+++ b/src/API/Configuration/ConfigProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Configuration;
+
+interface ConfigProviderInterface
+{
+    public function getInstrumentationConfig(): ConfigProperties;
+}

--- a/src/API/Configuration/Noop/NoopConfigProperties.php
+++ b/src/API/Configuration/Noop/NoopConfigProperties.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Configuration\Noop;
+
+use OpenTelemetry\API\Configuration\ConfigProperties;
+
+class NoopConfigProperties implements ConfigProperties
+{
+
+    public function get(string $id): mixed
+    {
+        return null;
+    }
+}

--- a/src/API/Configuration/Noop/NoopConfigProperties.php
+++ b/src/API/Configuration/Noop/NoopConfigProperties.php
@@ -8,7 +8,6 @@ use OpenTelemetry\API\Configuration\ConfigProperties;
 
 class NoopConfigProperties implements ConfigProperties
 {
-
     public function get(string $id): mixed
     {
         return null;

--- a/src/API/Configuration/Noop/NoopConfigProvider.php
+++ b/src/API/Configuration/Noop/NoopConfigProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Configuration\Noop;
+
+use OpenTelemetry\API\Configuration\ConfigProperties;
+use OpenTelemetry\API\Configuration\ConfigProviderInterface;
+
+class NoopConfigProvider implements ConfigProviderInterface
+{
+    public function getInstrumentationConfig(): ConfigProperties
+    {
+        return new NoopConfigProperties();
+    }
+}

--- a/src/API/Instrumentation/AutoInstrumentation/ConfigurationRegistry.php
+++ b/src/API/Instrumentation/AutoInstrumentation/ConfigurationRegistry.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Instrumentation\AutoInstrumentation;
 
-final class ConfigurationRegistry
+use OpenTelemetry\API\Configuration\ConfigProperties;
+
+final class ConfigurationRegistry implements ConfigProperties
 {
 
     private array $configurations = [];
@@ -18,6 +20,7 @@ final class ConfigurationRegistry
 
     /**
      * @template C of InstrumentationConfiguration
+     * @psalm-suppress MoreSpecificImplementedParamType
      * @param class-string<C> $id
      * @return C|null
      */

--- a/src/API/Instrumentation/AutoInstrumentation/Instrumentation.php
+++ b/src/API/Instrumentation/AutoInstrumentation/Instrumentation.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Instrumentation\AutoInstrumentation;
 
+use OpenTelemetry\API\Configuration\ConfigProperties;
+
 interface Instrumentation
 {
-    public function register(HookManagerInterface $hookManager, ConfigurationRegistry $configuration, Context $context): void;
+    public function register(HookManagerInterface $hookManager, ConfigProperties $configuration, Context $context): void;
 }

--- a/src/SDK/SdkAutoloader.php
+++ b/src/SDK/SdkAutoloader.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\SDK;
 
 use Nevay\SPI\ServiceLoader;
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
+use OpenTelemetry\API\Configuration\Noop\NoopConfigProperties;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\Context as InstrumentationContext;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\HookManager;
@@ -34,6 +35,7 @@ use OpenTelemetry\SDK\Trace\ExporterFactory;
 use OpenTelemetry\SDK\Trace\SamplerFactory;
 use OpenTelemetry\SDK\Trace\SpanProcessorFactory;
 use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -49,6 +51,9 @@ class SdkAutoloader
             return false;
         }
         if (Configuration::has(Variables::OTEL_EXPERIMENTAL_CONFIG_FILE)) {
+            if (!class_exists(SdkConfiguration::class)) {
+                throw new RuntimeException('File-based configuration requires open-telemetry/sdk-configuration');
+            }
             Globals::registerInitializer(fn ($configurator) => self::fileBasedInitializer($configurator));
         } else {
             Globals::registerInitializer(fn ($configurator) => self::environmentBasedInitializer($configurator));
@@ -131,7 +136,11 @@ class SdkAutoloader
         $files = Configuration::has(Variables::OTEL_EXPERIMENTAL_CONFIG_FILE)
             ? Configuration::getList(Variables::OTEL_EXPERIMENTAL_CONFIG_FILE)
             : [];
-        $configuration = SdkInstrumentation::parseFile($files)->create();
+        if (class_exists(SdkInstrumentation::class)) {
+            $configuration = SdkInstrumentation::parseFile($files)->create();
+        } else {
+            $configuration = new NoopConfigProperties();
+        }
         $hookManager = self::getHookManager();
         $tracerProvider = self::createLateBindingTracerProvider();
         $meterProvider = self::createLateBindingMeterProvider();
@@ -145,7 +154,6 @@ class SdkAutoloader
             } catch (Throwable $t) {
                 self::logError(sprintf('Unable to load instrumentation: %s', $instrumentation::class), ['exception' => $t]);
             }
-
         }
     }
 

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -49,7 +49,8 @@
     },
     "suggest": {
         "ext-gmp": "To support unlimited number of synchronous metric readers",
-        "ext-mbstring": "To increase performance of string operations"
+        "ext-mbstring": "To increase performance of string operations",
+        "open-telemetry/sdk-configuration": "File-based OpenTelemetry SDK configuration"
     },
     "extra": {
         "branch-alias": {

--- a/tests/Unit/API/Configuration/Noop/NoopConfigPropertiesTest.php
+++ b/tests/Unit/API/Configuration/Noop/NoopConfigPropertiesTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\API\Configuration\Noop;
+
+use OpenTelemetry\API\Configuration\Noop\NoopConfigProperties;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NoopConfigProperties::class)]
+class NoopConfigPropertiesTest extends TestCase
+{
+    public function test_get(): void
+    {
+        $properties = new NoopConfigProperties();
+        $this->assertNull($properties->get('foo'));
+    }
+}

--- a/tests/Unit/API/Configuration/Noop/NoopConfigProviderTest.php
+++ b/tests/Unit/API/Configuration/Noop/NoopConfigProviderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\API\Configuration\Noop;
+
+use OpenTelemetry\API\Configuration\Noop\NoopConfigProperties;
+use OpenTelemetry\API\Configuration\Noop\NoopConfigProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NoopConfigProvider::class)]
+class NoopConfigProviderTest extends TestCase
+{
+    public function test_get_instrumentation_config(): void
+    {
+        $provider = new NoopConfigProvider();
+        $this->assertInstanceOf(NoopConfigProperties::class, $provider->getInstrumentationConfig());
+    }
+}

--- a/tests/Unit/API/Instrumentation/AutoInstrumentation/ExtensionHookManagerTest.php
+++ b/tests/Unit/API/Instrumentation/AutoInstrumentation/ExtensionHookManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\API\Instrumentation\AutoInstrumentation;
 
+use OpenTelemetry\API\Configuration\ConfigProperties;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\ConfigurationRegistry;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\Context as InstrumentationContext;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\ExtensionHookManager;
@@ -132,7 +133,7 @@ class ExtensionHookManagerTest extends TestCase
                 $this->post = $post;
             }
 
-            public function register(HookManagerInterface $hookManager, ConfigurationRegistry $configuration, InstrumentationContext $context): void
+            public function register(HookManagerInterface $hookManager, ConfigProperties $configuration, InstrumentationContext $context): void
             {
                 $hookManager->hook($this->class, $this->method, $this->pre, $this->post);
             }

--- a/tests/Unit/API/Instrumentation/AutoInstrumentation/LateBindingProviderTest.php
+++ b/tests/Unit/API/Instrumentation/AutoInstrumentation/LateBindingProviderTest.php
@@ -6,8 +6,8 @@ namespace OpenTelemetry\Tests\Unit\API\Instrumentation\AutoInstrumentation;
 
 use Nevay\SPI\ServiceLoader;
 use OpenTelemetry\API\Behavior\Internal\Logging;
+use OpenTelemetry\API\Configuration\ConfigProperties;
 use OpenTelemetry\API\Globals;
-use OpenTelemetry\API\Instrumentation\AutoInstrumentation\ConfigurationRegistry;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\Context;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\HookManagerInterface;
 use OpenTelemetry\API\Instrumentation\AutoInstrumentation\Instrumentation;
@@ -55,7 +55,7 @@ class LateBindingProviderTest extends TestCase
     {
         $instrumentation = new class() implements Instrumentation {
             private static ?Context $context;
-            public function register(HookManagerInterface $hookManager, ConfigurationRegistry $configuration, Context $context): void
+            public function register(HookManagerInterface $hookManager, ConfigProperties $configuration, Context $context): void
             {
                 self::$context = $context;
             }


### PR DESCRIPTION
implement recent additions to the otel spec re: config provider. Config provider should return a ConfigProperties, but we were already returning a ConfigurationRegistry. Added a ConfigProperties interface for ConfigurationRegistry to implement, which gets us pretty close to spec. We don't make ConfigProvider globally available, instead passing the ConfigurationRegistry in to each instrumentation as we register it. The spec allows for this.