### PR TITLE
re-adding removed trace attribute values

### DIFF
--- a/script/semantic-conventions/README.md
+++ b/script/semantic-conventions/README.md
@@ -35,6 +35,8 @@ Use this output as a basis for updating the relevant deprecations file and gener
 Note that some previously-removed semconv entries have been added back in recent versions, so may need to be removed from the
 deprecations partials.
 
+NB should also check `TraceAttributeValues` and `ResourceAttributeValues`, since those can also change.
+
 ## Add to SemConv/Version
 
 Add an entry to `src/SemConv/Version.php` for the new version.

--- a/script/semantic-conventions/templates/AttributeValues.php.j2
+++ b/script/semantic-conventions/templates/AttributeValues.php.j2
@@ -36,5 +36,7 @@ interface {{ class }}AttributeValues
 {%- endif -%}
 {% if not loop.last %}{# blank line #}{% endif %}
 {%- endfor -%}
+{# add our own deprecations for moved/removed values, so we don't break things #}
+{% include class|lower + "_values_deprecations.php.partial" ignore missing without context %}
 }
 {# blank line #}

--- a/script/semantic-conventions/templates/trace_values_deprecations.php.partial
+++ b/script/semantic-conventions/templates/trace_values_deprecations.php.partial
@@ -1,0 +1,24 @@
+    /**
+     * @deprecated Use `messaging.operation.type.publish`
+     */
+    public const MESSAGING_OPERATION_PUBLISH = 'publish';
+
+    /**
+     * @deprecated Use `messaging.operation.type.create`
+     */
+    public const MESSAGING_OPERATION_CREATE = 'create';
+
+    /**
+     * @deprecated Use `messaging.operation.type.receive`
+     */
+    public const MESSAGING_OPERATION_RECEIVE = 'receive';
+
+    /**
+     * @deprecated Use `messaging.operation.type.deliver`
+     */
+    public const MESSAGING_OPERATION_DELIVER = 'process';
+
+    /**
+     * @deprecated Use `messaging.operation.type.settle`
+     */
+    public const MESSAGING_OPERATION_SETTLE = 'settle';

--- a/src/SemConv/ResourceAttributeValues.php
+++ b/src/SemConv/ResourceAttributeValues.php
@@ -488,5 +488,4 @@ interface ResourceAttributeValues
      */
     public const TELEMETRY_SDK_LANGUAGE_WEBJS = 'webjs';
 
-
 }

--- a/src/SemConv/ResourceAttributeValues.php
+++ b/src/SemConv/ResourceAttributeValues.php
@@ -487,4 +487,6 @@ interface ResourceAttributeValues
      * @see ResourceAttributes::TELEMETRY_SDK_LANGUAGE
      */
     public const TELEMETRY_SDK_LANGUAGE_WEBJS = 'webjs';
+
+
 }

--- a/src/SemConv/TraceAttributeValues.php
+++ b/src/SemConv/TraceAttributeValues.php
@@ -3144,4 +3144,29 @@ interface TraceAttributeValues
      * @see TraceAttributes::VCS_REPOSITORY_REF_TYPE
      */
     public const VCS_REPOSITORY_REF_TYPE_TAG = 'tag';
+
+    /**
+     * @deprecated Use `messaging.operation.type.publish`
+     */
+    public const MESSAGING_OPERATION_PUBLISH = 'publish';
+
+    /**
+     * @deprecated Use `messaging.operation.type.create`
+     */
+    public const MESSAGING_OPERATION_CREATE = 'create';
+
+    /**
+     * @deprecated Use `messaging.operation.type.receive`
+     */
+    public const MESSAGING_OPERATION_RECEIVE = 'receive';
+
+    /**
+     * @deprecated Use `messaging.operation.type.deliver`
+     */
+    public const MESSAGING_OPERATION_DELIVER = 'process';
+
+    /**
+     * @deprecated Use `messaging.operation.type.settle`
+     */
+    public const MESSAGING_OPERATION_SETTLE = 'settle';
 }


### PR DESCRIPTION
the MESSAGING_OPERATION_* attribute values were removed in semconv 1.26.0, so update our generation to put them back, marking as deprecated