### PR TITLE
Add purge method to TraceProvider

### DIFF
--- a/src/SDK/Trace/NoopTracerProvider.php
+++ b/src/SDK/Trace/NoopTracerProvider.php
@@ -23,4 +23,8 @@ class NoopTracerProvider extends API\Trace\NoopTracerProvider implements TracerP
     public function updateConfigurator(Configurator $configurator): void
     {
     }
+
+    public function purge(): void
+    {
+    }
 }

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -190,6 +190,12 @@ class BatchSpanProcessor implements SpanProcessorInterface
         return $this->flush(__FUNCTION__, $cancellation);
     }
 
+    public function purge(): void
+    {
+        $this->queue = new SplQueue();
+        $this->flush = new SplQueue();
+    }
+
     public static function builder(SpanExporterInterface $exporter): BatchSpanProcessorBuilder
     {
         return new BatchSpanProcessorBuilder($exporter);

--- a/src/SDK/Trace/SpanProcessor/MultiSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/MultiSpanProcessor.php
@@ -76,4 +76,12 @@ final class MultiSpanProcessor implements SpanProcessorInterface
 
         return $result;
     }
+
+    /** @inheritDoc */
+    public function purge(): void
+    {
+        foreach ($this->processors as $processor) {
+            $processor->purge();
+        }
+    }
 }

--- a/src/SDK/Trace/SpanProcessor/NoopSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/NoopSpanProcessor.php
@@ -44,4 +44,9 @@ class NoopSpanProcessor implements SpanProcessorInterface
     {
         return $this->forceFlush();
     }
+
+    /** @inheritDoc */
+    public function purge(): void
+    {
+    } //@codeCoverageIgnore
 }

--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -71,6 +71,11 @@ class SimpleSpanProcessor implements SpanProcessorInterface
         return $this->flush(fn (): bool => $this->exporter->shutdown($cancellation), __FUNCTION__, true, Context::getCurrent());
     }
 
+    public function purge(): void
+    {
+        $this->queue = new SplQueue();
+    }
+
     private function flush(Closure $task, string $taskName, bool $propagateResult, ContextInterface $context): bool
     {
         $this->queue->enqueue([$task, $taskName, $propagateResult && !$this->running, $context]);

--- a/src/SDK/Trace/SpanProcessorInterface.php
+++ b/src/SDK/Trace/SpanProcessorInterface.php
@@ -35,4 +35,9 @@ interface SpanProcessorInterface
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/trace/sdk.md#shutdown-1
      */
     public function shutdown(?CancellationInterface $cancellation = null): bool;
+
+    /**
+     * Remove all spans from the queue
+     */
+    public function purge(): void;
 }

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -57,6 +57,11 @@ final class TracerProvider implements TracerProviderInterface
         return $this->tracerSharedState->getSpanProcessor()->forceFlush($cancellation);
     }
 
+    public function purge(): void
+    {
+        return $this->tracerSharedState->getSpanProcessor()->purge();
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/SDK/Trace/TracerProviderInterface.php
+++ b/src/SDK/Trace/TracerProviderInterface.php
@@ -13,4 +13,6 @@ interface TracerProviderInterface extends API\TracerProviderInterface, Configura
     public function forceFlush(?CancellationInterface $cancellation = null): bool;
 
     public function shutdown(?CancellationInterface $cancellation = null): bool;
+
+    public function purge(): void;
 }


### PR DESCRIPTION
Hi, 
this PR to add the "purge" method to the traceProvider.

# Use case
When the traces are activated on a project, all traces, without exceptions, are collected and sent to the span storage.

The storage is not free. I want to store only usefull data. When you process a lot of requests per second, It is quickly costly for nothing.

I am only interested with traces related to an incoming httpRequest related to a log with at least a level of warning.

In symfony, I did a POC that works:
- use hook on LoggerInterface warning/error/... => set a static variable to true
- use hook on HttpKernel, on "post", if variable true => forceFlush, and then purge, reset variable

With this, only >=warning related spans are sent.

The same system can be applied to messenger, etc.

The purge method allows this kind of behaviour without interfering with the original one.