### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/examples/traces/demo/collector/config.yaml
+++ b/examples/traces/demo/collector/config.yaml
@@ -4,8 +4,8 @@ receivers:
       grpc:
 
 exporters:
-  logging:
-    logLevel: debug
+  debug:
+    verbosity: detailed
   zipkin:
     endpoint: "http://zipkin:9411/api/v2/spans"
   jaeger:
@@ -19,6 +19,6 @@ service:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - zipkin
         - jaeger

--- a/files/collector/otel-collector-config.yml
+++ b/files/collector/otel-collector-config.yml
@@ -8,7 +8,7 @@ receivers:
 exporters:
   zipkin:
     endpoint: "http://zipkin:9411/api/v2/spans"
-  logging:
+  debug:
     verbosity: detailed
 
 processors:
@@ -27,12 +27,12 @@ service:
   pipelines:
     traces:
       receivers: [otlp, zipkin]
-      exporters: [logging]
+      exporters: [debug]
       processors: [batch]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [ otlp ]
       processors: [ batch ]
-      exporters: [ logging ]
+      exporters: [ debug ]


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon. Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037