### PR TITLE
Remove `MeterInterface::isEnabled()` and recreate metric streams on config re-enabling

### DIFF
--- a/src/API/Metrics/LateBindingMeter.php
+++ b/src/API/Metrics/LateBindingMeter.php
@@ -58,9 +58,4 @@ class LateBindingMeter implements MeterInterface
     {
         return ($this->meter ??= ($this->factory)())->createObservableUpDownCounter($name, $unit, $description, $advisory, $callbacks);
     }
-
-    public function isEnabled(): bool
-    {
-        return true;
-    }
 }

--- a/src/API/Metrics/MeterInterface.php
+++ b/src/API/Metrics/MeterInterface.php
@@ -178,6 +178,4 @@ interface MeterInterface
         array|callable $advisory = [],
         callable ...$callbacks,
     ): ObservableUpDownCounterInterface;
-
-    public function isEnabled(): bool;
 }

--- a/src/API/Metrics/Noop/NoopMeter.php
+++ b/src/API/Metrics/Noop/NoopMeter.php
@@ -56,9 +56,4 @@ final class NoopMeter implements MeterInterface
     {
         return new NoopObservableUpDownCounter();
     }
-
-    public function isEnabled(): bool
-    {
-        return false;
-    }
 }

--- a/src/SDK/Metrics/Instrument.php
+++ b/src/SDK/Metrics/Instrument.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Metrics;
 
-use OpenTelemetry\API\Metrics\MeterInterface;
-
 final class Instrument
 {
     public function __construct(
@@ -14,12 +12,6 @@ final class Instrument
         public readonly ?string $unit,
         public readonly ?string $description,
         public readonly array $advisory = [],
-        public readonly ?MeterInterface $meter = null,
     ) {
-    }
-
-    public function isEnabled(): bool
-    {
-        return $this->meter?->isEnabled() ?? true;
     }
 }

--- a/src/SDK/Metrics/MeterInstruments.php
+++ b/src/SDK/Metrics/MeterInstruments.php
@@ -11,11 +11,11 @@ final class MeterInstruments
 {
     public ?int $startTimestamp = null;
     /**
-     * @var array<string, array<string, array{Instrument, ReferenceCounterInterface}>>
+     * @var array<string, array<string, array{Instrument, StalenessHandlerInterface&ReferenceCounterInterface, RegisteredInstrument}>>
      */
     public array $observers = [];
     /**
-     * @var array<string, array<string, array{Instrument, ReferenceCounterInterface}>>
+     * @var array<string, array<string, array{Instrument, StalenessHandlerInterface&ReferenceCounterInterface, RegisteredInstrument}>>
      */
     public array $writers = [];
 }

--- a/src/SDK/Metrics/MeterProvider.php
+++ b/src/SDK/Metrics/MeterProvider.php
@@ -128,7 +128,7 @@ final class MeterProvider implements MeterProviderInterface
     /**
      * Update the {@link Configurator} for a {@link MeterProvider}, which will reconfigure
      *  all meters created from the provider.
-     * @todo enabling a previous-disabled meter does not drop/recreate the underlying metric streams, so previously collected synchronous metrics will still be exported.
+     *
      * @experimental
      */
     public function updateConfigurator(Configurator $configurator): void

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSource.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSource.php
@@ -39,9 +39,4 @@ final class StreamMetricSource implements MetricSourceInterface
     {
         $this->provider->stream->unregister($this->reader);
     }
-
-    public function isEnabled(): bool
-    {
-        return $this->provider->instrument->isEnabled();
-    }
 }

--- a/src/SDK/Metrics/MetricRegistry/MetricRegistryInterface.php
+++ b/src/SDK/Metrics/MetricRegistry/MetricRegistryInterface.php
@@ -18,5 +18,5 @@ interface MetricRegistryInterface extends MetricCollectorInterface
 
     public function registerAsynchronousStream(Instrument $instrument, MetricStreamInterface $stream, MetricAggregatorFactoryInterface $aggregatorFactory): int;
 
-    public function unregisterStream(int $streamId): void;
+    public function unregisterStreams(Instrument $instrument): array;
 }

--- a/src/SDK/Metrics/MetricSourceInterface.php
+++ b/src/SDK/Metrics/MetricSourceInterface.php
@@ -21,5 +21,4 @@ interface MetricSourceInterface
      * @return Metric collected metric
      */
     public function collect(): Metric;
-    public function isEnabled(): bool;
 }

--- a/src/SDK/Metrics/MetricSourceRegistryUnregisterInterface.php
+++ b/src/SDK/Metrics/MetricSourceRegistryUnregisterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Metrics;
+
+use OpenTelemetry\SDK\Metrics\MetricRegistry\MetricCollectorInterface;
+
+/**
+ * To be replaced by MetricProducer abstraction.
+ *
+ * @internal
+ */
+interface MetricSourceRegistryUnregisterInterface
+{
+
+    public function unregisterStream(MetricCollectorInterface $collector, int $streamId): void;
+}

--- a/src/SDK/Metrics/ObservableInstrumentTrait.php
+++ b/src/SDK/Metrics/ObservableInstrumentTrait.php
@@ -6,7 +6,6 @@ namespace OpenTelemetry\SDK\Metrics;
 
 use ArrayAccess;
 use function assert;
-use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Metrics\ObservableCallbackInterface;
 use OpenTelemetry\API\Metrics\ObserverInterface;
 use OpenTelemetry\SDK\Metrics\MetricRegistry\MetricWriterInterface;
@@ -21,7 +20,6 @@ trait ObservableInstrumentTrait
         private readonly Instrument $instrument,
         private readonly ReferenceCounterInterface $referenceCounter,
         private readonly ArrayAccess $destructors,
-        private readonly MeterInterface $meter,
     ) {
         assert($this instanceof InstrumentHandle);
 
@@ -54,10 +52,6 @@ trait ObservableInstrumentTrait
 
     public function isEnabled(): bool
     {
-        if (!$this->meter->isEnabled()) {
-            return false;
-        }
-
         return $this->writer->enabled($this->instrument);
     }
 }

--- a/src/SDK/Metrics/RegisteredInstrument.php
+++ b/src/SDK/Metrics/RegisteredInstrument.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Metrics;
+
+/**
+ * @internal
+ */
+final class RegisteredInstrument
+{
+    public function __construct(
+        public bool $dormant,
+        public readonly object $configKeepAlive,
+    ) {
+    }
+}

--- a/src/SDK/Metrics/SynchronousInstrumentTrait.php
+++ b/src/SDK/Metrics/SynchronousInstrumentTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Metrics;
 
 use function assert;
-use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\SDK\Metrics\MetricRegistry\MetricWriterInterface;
 
 /**
@@ -16,16 +15,14 @@ trait SynchronousInstrumentTrait
     private MetricWriterInterface $writer;
     private Instrument $instrument;
     private ReferenceCounterInterface $referenceCounter;
-    private MeterInterface $meter;
 
-    public function __construct(MetricWriterInterface $writer, Instrument $instrument, ReferenceCounterInterface $referenceCounter, MeterInterface $meter)
+    public function __construct(MetricWriterInterface $writer, Instrument $instrument, ReferenceCounterInterface $referenceCounter)
     {
         assert($this instanceof InstrumentHandle);
 
         $this->writer = $writer;
         $this->instrument = $instrument;
         $this->referenceCounter = $referenceCounter;
-        $this->meter = $meter;
 
         $this->referenceCounter->acquire();
     }
@@ -49,10 +46,6 @@ trait SynchronousInstrumentTrait
 
     public function isEnabled(): bool
     {
-        if (!$this->meter->isEnabled()) {
-            return false;
-        }
-
         return $this->writer->enabled($this->instrument);
     }
 }

--- a/tests/Unit/SDK/Metrics/MeterProviderTest.php
+++ b/tests/Unit/SDK/Metrics/MeterProviderTest.php
@@ -114,11 +114,11 @@ final class MeterProviderTest extends TestCase
         $meterProvider = MeterProvider::builder()->addReader(new ExportingReader(new InMemoryExporter()))->build();
         $this->assertInstanceOf(MeterProvider::class, $meterProvider);
         $meter = $meterProvider->getMeter('one');
-        $this->assertTrue($meter->isEnabled());
+        $this->assertTrue($meter->createCounter('test')->isEnabled());
         $counter = $meter->createCounter('A');
         $this->assertTrue($counter->isEnabled());
         $meterProvider->updateConfigurator(Configurator::meter()->with(static fn (MeterConfig $config) => $config->setDisabled(true), name: 'one'));
-        $this->assertFalse($meter->isEnabled());
+        $this->assertFalse($meter->createCounter('test')->isEnabled());
         $this->assertFalse($counter->isEnabled());
     }
 }

--- a/tests/Unit/SDK/Metrics/MeterTest.php
+++ b/tests/Unit/SDK/Metrics/MeterTest.php
@@ -9,13 +9,11 @@ use OpenTelemetry\API\Common\Time\Clock;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScope;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
-use OpenTelemetry\SDK\Common\InstrumentationScope\Configurator;
 use OpenTelemetry\SDK\Metrics\AggregationInterface;
 use OpenTelemetry\SDK\Metrics\DefaultAggregationProviderInterface;
 use OpenTelemetry\SDK\Metrics\Instrument;
 use OpenTelemetry\SDK\Metrics\InstrumentType;
 use OpenTelemetry\SDK\Metrics\Meter;
-use OpenTelemetry\SDK\Metrics\MeterConfig;
 use OpenTelemetry\SDK\Metrics\MeterProvider;
 use OpenTelemetry\SDK\Metrics\MetricFactoryInterface;
 use OpenTelemetry\SDK\Metrics\MetricReaderInterface;
@@ -41,7 +39,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::COUNTER, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::COUNTER, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
                 $this->anything(),
@@ -61,7 +59,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::HISTOGRAM, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::HISTOGRAM, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
                 $this->anything(),
@@ -87,7 +85,6 @@ final class MeterTest extends TestCase
                     's',
                     'Measures the duration of inbound HTTP requests.',
                     ['ExplicitBucketBoundaries' => [0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]],
-                    $meter,
                 ),
                 $this->anything(),
                 $this->anything(),
@@ -113,7 +110,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::GAUGE, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::GAUGE, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
                 $this->anything(),
@@ -133,7 +130,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::UP_DOWN_COUNTER, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::UP_DOWN_COUNTER, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
                 $this->anything(),
@@ -153,7 +150,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::ASYNCHRONOUS_COUNTER, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::ASYNCHRONOUS_COUNTER, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
             )
@@ -172,7 +169,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::ASYNCHRONOUS_GAUGE, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::ASYNCHRONOUS_GAUGE, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
             )
@@ -191,7 +188,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::ASYNCHRONOUS_UP_DOWN_COUNTER, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::ASYNCHRONOUS_UP_DOWN_COUNTER, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
             )
@@ -211,7 +208,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::COUNTER, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::COUNTER, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
                 $this->anything(),
@@ -232,7 +229,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::COUNTER, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::COUNTER, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
                 $this->anything(),
@@ -254,7 +251,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::ASYNCHRONOUS_COUNTER, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::ASYNCHRONOUS_COUNTER, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
             )
@@ -274,7 +271,7 @@ final class MeterTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 new InstrumentationScope('test', null, null, Attributes::create([])),
-                new Instrument(InstrumentType::ASYNCHRONOUS_COUNTER, 'name', 'unit', 'description', meter: $meter),
+                new Instrument(InstrumentType::ASYNCHRONOUS_COUNTER, 'name', 'unit', 'description'),
                 $this->anything(),
                 $this->anything(),
             )
@@ -374,18 +371,6 @@ final class MeterTest extends TestCase
         $meterProvider = $this->createMeterProviderForMetricFactory($metricFactory, $viewRegistry, [$metricReader]);
         $meter = $meterProvider->getMeter('test');
         $meter->createCounter('name');
-    }
-
-    public function test_update_configurator(): void
-    {
-        $metricFactory = $this->createMock(MetricFactoryInterface::class);
-        $metricFactory->method('createSynchronousWriter')->willReturn([]);
-
-        $meterProvider = $this->createMeterProviderForMetricFactory($metricFactory);
-        $meter = $meterProvider->getMeter('test');
-        $this->assertTrue($meter->isEnabled());
-        $meterProvider->updateConfigurator(Configurator::meter()->with(static fn (MeterConfig $config) => $config->setDisabled(true), name: 'test'));
-        $this->assertFalse($meter->isEnabled());
     }
 
     /**

--- a/tests/Unit/SDK/Metrics/MetricReader/ExportingReaderTest.php
+++ b/tests/Unit/SDK/Metrics/MetricReader/ExportingReaderTest.php
@@ -148,7 +148,6 @@ final class ExportingReaderTest extends TestCase
 
         $source = $this->createMock(MetricSourceInterface::class);
         $source->expects($this->once())->method('collect')->willReturn($metric);
-        $source->method('isEnabled')->willReturn(true);
         $provider = $this->createMock(MetricSourceProviderInterface::class);
         $provider->expects($this->once())->method('create')->willReturn($source);
         $metricMetadata = $this->createMock(MetricMetadataInterface::class);
@@ -184,7 +183,6 @@ final class ExportingReaderTest extends TestCase
         $provider = $this->createMock(MetricSourceProviderInterface::class);
         $source = $this->createMock(MetricSourceInterface::class);
         $source->method('collect')->willReturn($this->createMock(Metric::class));
-        $source->method('isEnabled')->willReturn(true);
         $provider->method('create')->willReturn($source);
         $exporter->method('temporality')->willReturn('foo');
         $exporter->expects($this->once())->method('export')->willReturn(true);

--- a/tests/Unit/SDK/Metrics/View/SelectionCriteriaTest.php
+++ b/tests/Unit/SDK/Metrics/View/SelectionCriteriaTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Metrics\View;
 
-use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScope;
 use OpenTelemetry\SDK\Metrics\Instrument;
@@ -31,22 +30,14 @@ final class SelectionCriteriaTest extends TestCase
 {
     use ProphecyTrait;
 
-    private MeterInterface $meter;
-
-    public function setUp(): void
-    {
-        $this->meter = $this->createMock(MeterInterface::class);
-        $this->meter->method('isEnabled')->willReturn(true);
-    }
-
     public function test_instrument_scope_name_criteria(): void
     {
         $this->assertTrue((new InstrumentationScopeNameCriteria('scopeName'))->accepts(
-            new Instrument(InstrumentType::COUNTER, 'name', null, null, meter: $this->meter),
+            new Instrument(InstrumentType::COUNTER, 'name', null, null),
             new InstrumentationScope('scopeName', null, null, Attributes::create([])),
         ));
         $this->assertFalse((new InstrumentationScopeNameCriteria('scopeName'))->accepts(
-            new Instrument(InstrumentType::COUNTER, 'name', null, null, meter: $this->meter),
+            new Instrument(InstrumentType::COUNTER, 'name', null, null),
             new InstrumentationScope('scope-name', null, null, Attributes::create([])),
         ));
     }


### PR DESCRIPTION
Removes `MeterInterface::isEnabled()` as it is not part of the spec, metrics API uses `Instrument::isEnabled()` instead.

Also resolves https://github.com/open-telemetry/opentelemetry-php/pull/1353#discussion_r1688754362 by dropping/recreating metric streams on configuration change.