### PR TITLE
Update SPI dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/polyfill-mbstring": "^1.23",
         "symfony/polyfill-php82": "^1.26",
-        "tbachert/spi": ">= 0.2.1"
+        "tbachert/spi": "^1.0.1"
     },
     "config": {
         "sort-packages": true,

--- a/src/Config/SDK/composer.json
+++ b/src/Config/SDK/composer.json
@@ -21,7 +21,7 @@
         "open-telemetry/context": "^1.0",
         "open-telemetry/sdk": "^1.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
-        "tbachert/spi": ">= 0.2.1"
+        "tbachert/spi": "^1.0.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -32,7 +32,7 @@
         "ramsey/uuid": "^3.0 || ^4.0",
         "symfony/polyfill-mbstring": "^1.23",
         "symfony/polyfill-php82": "^1.26",
-        "tbachert/spi": ">= 0.2.1"
+        "tbachert/spi": "^1.0.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Move to v1 of SPI package, which includes some nice-to-have changes for pre-registering instrumentation outside of runtime.