### PR TITLE
Fix `IncompatibleReturnValueException` in `MessageFactoryTest`

### DIFF
--- a/tests/Unit/SDK/Common/Http/Psr/Message/UsesRequestFactoryTrait.php
+++ b/tests/Unit/SDK/Common/Http/Psr/Message/UsesRequestFactoryTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Common\Http\Psr\Message;
 
+use Nyholm\Psr7\Uri;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 
@@ -19,7 +20,7 @@ trait UsesRequestFactoryTrait
         $request->method('getMethod')
             ->willReturn((string) $requestMethod);
         $request->method('getUri')
-            ->willReturn((string) $requestUri);
+            ->willReturn(new Uri((string) $requestUri));
         $factory = $this->createMock(RequestFactoryInterface::class);
         $factory->method('createRequest')
             ->willReturn($request);

--- a/tests/Unit/SDK/Common/Http/Psr/Message/UsesServerRequestFactoryTrait.php
+++ b/tests/Unit/SDK/Common/Http/Psr/Message/UsesServerRequestFactoryTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Unit\SDK\Common\Http\Psr\Message;
 
+use Nyholm\Psr7\Uri;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -19,7 +20,7 @@ trait UsesServerRequestFactoryTrait
         $request->method('getMethod')
             ->willReturn((string) $requestMethod);
         $request->method('getUri')
-            ->willReturn((string) $requestUri);
+            ->willReturn(new Uri((string) $requestUri));
         $factory = $this->createMock(ServerRequestFactoryInterface::class);
         $factory->method('createServerRequest')
             ->willReturn($request);


### PR DESCRIPTION
PSR7 `RequestInterface::getUri()` must return `UriInterface`, not `string`; explicit typehint was added in `2.0`.

See https://github.com/open-telemetry/opentelemetry-php/actions/runs/11087368795/job/30806007374?pr=1391#step:17:50.