### PR TITLE
Fix HookManagerInterface annotation 

### DIFF
--- a/src/API/Instrumentation/AutoInstrumentation/HookManagerInterface.php
+++ b/src/API/Instrumentation/AutoInstrumentation/HookManagerInterface.php
@@ -9,10 +9,9 @@ use Throwable;
 
 interface HookManagerInterface
 {
-
     /**
-     * @param Closure(object|string|null,array,string,string,string|null,int|null):void|null $preHook
-     * @param Closure(object|string|null,array,mixed,Throwable|null,string,string,string|null,int|null):void|null $postHook
+     * @param ?Closure(object|string|null, array, ?string, string, ?string, ?int): (array|null|void) $preHook
+     * @param ?Closure(object|string|null, array, mixed, ?Throwable): mixed $postHook
      */
     public function hook(?string $class, string $function, ?Closure $preHook = null, ?Closure $postHook = null): void;
 }

--- a/src/API/Instrumentation/AutoInstrumentation/HookManagerInterface.php
+++ b/src/API/Instrumentation/AutoInstrumentation/HookManagerInterface.php
@@ -11,7 +11,7 @@ interface HookManagerInterface
 {
     /**
      * @param ?Closure(object|string|null, array, ?string, string, ?string, ?int): (array|null|void) $preHook
-     * @param ?Closure(object|string|null, array, mixed, ?Throwable): mixed $postHook
+     * @param ?Closure(object|string|null, array, mixed, ?Throwable): (mixed|void) $postHook
      */
     public function hook(?string $class, string $function, ?Closure $preHook = null, ?Closure $postHook = null): void;
 }


### PR DESCRIPTION
Align OpenTelemetry\API\Instrumentation\AutoInstrumentation\HookManagerInterface::hook postHook Closure signature with OpenTelemetry\Instrumentation\hook.


Phan complains in open-telemetry/opentelemetry-php-contrib#269. Upon checking, I think the annotated signature of the post-hook is possibly incorrect?

This is an example of what I am seeing:.

In pre-hook:
```
src/Hooks/Illuminate/Contracts/Http/Kernel.php:48 PhanTypeMismatchArgumentSuperType Argument 3 ($preHook) is (function) of type Closure(\Illuminate\Contracts\Http\Kernel,array,string,string,?string,?int):array{0:?\Illuminate\Http\Request} but \OpenTelemetry\API\Instrumentation\AutoInstrumentation\HookManagerInterface::hook() takes Closure(null|object|string,array,string,string,null|string,int|null):void|null defined at vendor/open-telemetry/api/Instrumentation/AutoInstrumentation/HookManagerInterface.php:17 (expected type to be the same or a subtype, but saw a supertype instead)
```

In post-hook:
```
\OpenTelemetry\API\Instrumentation\AutoInstrumentation\HookManagerInterface::hook() takes Closure(null|object|string,array,mixed,\Throwable|null):void|null defined at vendor/open-telemetry/api/Instrumentation/AutoInstrumentation/HookManagerInterface.php:17 (expected type to be the same or a subtype, but saw a supertype instead
```

Edit: it was late and I pasted an example of pre-hook instead of post-hook. Both were throwing phan errors.