### PR TITLE
check for readable host id files before read

### DIFF
--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -52,8 +52,9 @@ final class Host implements ResourceDetectorInterface
         $paths = [self::PATH_ETC_MACHINEID, self::PATH_VAR_LIB_DBUS_MACHINEID];
 
         foreach ($paths as $path) {
-            if (file_exists($this->dir . $path)) {
-                return trim(file_get_contents($this->dir . $path));
+            $file = $this->dir . $path;
+            if (file_exists($file) && is_readable($file)) {
+                return trim(file_get_contents($file));
             }
         }
 
@@ -62,13 +63,14 @@ final class Host implements ResourceDetectorInterface
 
     private function getBsdId(): ?string
     {
-        if (file_exists($this->dir . self::PATH_ETC_HOSTID)) {
-            return trim(file_get_contents($this->dir . self::PATH_ETC_HOSTID));
+        $file = $this->dir . self::PATH_ETC_HOSTID;
+        if (file_exists($file) && is_readable($file)) {
+            return trim(file_get_contents($file));
         }
 
-        $out = exec('kenv -q smbios.system.uuid');
+        $out = exec('which kenv && kenv -q smbios.system.uuid');
 
-        if ($out !== false) {
+        if ($out) {
             return $out;
         }
 

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -53,7 +53,7 @@ final class Host implements ResourceDetectorInterface
 
         foreach ($paths as $path) {
             $file = $this->dir . $path;
-            if (file_exists($file) && is_readable($file)) {
+            if (is_file($file) && is_readable($file)) {
                 return trim(file_get_contents($file));
             }
         }
@@ -64,7 +64,7 @@ final class Host implements ResourceDetectorInterface
     private function getBsdId(): ?string
     {
         $file = $this->dir . self::PATH_ETC_HOSTID;
-        if (file_exists($file) && is_readable($file)) {
+        if (is_file($file) && is_readable($file)) {
             return trim(file_get_contents($file));
         }
 

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -15,6 +15,12 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Host::class)]
 class HostTest extends TestCase
 {
+    public function setUp(): void
+    {
+        //reset vfs between tests
+        vfsStream::setup('/');
+    }
+
     public function test_host_get_resource(): void
     {
         $resourceDetector = new Host();
@@ -74,9 +80,7 @@ class HostTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider nonReadableFileProvider
-     */
+    #[DataProvider('nonReadableFileProvider')]
     public function test_file_not_readable(string $os, vfsStreamDirectory $root): void
     {
         $resourceDetector = new Host($root->url(), $os);

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -93,7 +93,7 @@ class HostTest extends TestCase
         vfsStream::newFile('machine-id')
             ->at($etc)
             ->setContent('you-cant-see-me')
-            ->chmod(0);
+            ->chmod(0222);
         vfsStream::newFile('hostid')
             ->at($etc)
             ->setContent('you-cant-see-me')


### PR DESCRIPTION
Check if files are readable before trying to read them. Also check whether `kenv` exists before executing it, since it complains when I run it locally on a non-BSD system.

Closes: #1397