### PR TITLE
Move hook manager registration to API package

### DIFF
--- a/src/API/composer.json
+++ b/src/API/composer.json
@@ -36,6 +36,11 @@
     "extra": {
         "branch-alias": {
             "dev-main": "1.1.x-dev"
+        },
+        "spi": {
+            "OpenTelemetry\\API\\Instrumentation\\AutoInstrumentation\\HookManagerInterface": [
+                "OpenTelemetry\\API\\Instrumentation\\AutoInstrumentation\\ExtensionHookManager"
+            ]
         }
     }
 }


### PR DESCRIPTION
Makes extension hook manager available via SPI even if SDK is not installed.

Not removing registration in SDK to not break API 1.1.0 w/ SDK >1.1.0.