### PR TITLE
Workflow to publish phpdoc to github pages

### DIFF
--- a/.github/workflows/phpdoc-to-github-pages
+++ b/.github/workflows/phpdoc-to-github-pages
@@ -1,0 +1,35 @@
+name: "Generate API Documentation"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  documentation:
+    name: "Documentation"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+      - name: "Build"
+        uses: "phpDocumentor/phpDocumentor@v3.5.3"
+        with:
+          target: "docs/build"
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/build'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Follow-up to #1378 and #1385:

I did some investigation how to best publish the API documentation for PHP. Initially I was hoping that we can serve these pages through netlify (the service we use to publish opentelemetry.io), unfrotunately I ran into some limitations in my experiment, that I could not resolve, see: https://github.com/open-telemetry/opentelemetry.io/pull/5413

Therefore I suggest to publish the pages to github via the workflow in this PR. This will create a page similar to

https://svrnm.github.io/opentelemetry-php/

(it will then be named https://open-telemetry.github.io/opentelemetry-php/)

We can then link this page from the website here: https://opentelemetry.io/docs/languages/#api-references and from within the navigation tree of the PHP language specific documentation.

Workflow run example:

https://github.com/svrnm/opentelemetry-php/actions/runs/11512969202/job/32048846572

cc @open-telemetry/docs-approvers 