### PR TITLE
Support google protobuf v4

### DIFF
--- a/proto/otel/composer.json
+++ b/proto/otel/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "google/protobuf": "^3.3.0"
+        "google/protobuf": "^3.22 || ^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
If google protobuf v4 is not allowed, the package version 1.0.0beta5 will be installed, which breaks the application.

The same value is in the root composer.json:
https://github.com/open-telemetry/opentelemetry-php/blob/1aae9dd61930ac02d2936e1eda795c39c4f7a959/composer.json#L11