### PR TITLE
add sdk-config 0.3 support for key/value headers and attributes

### DIFF
--- a/examples/load_config.yaml
+++ b/examples/load_config.yaml
@@ -2,7 +2,9 @@ file_format: '0.3'
 
 resource:
   attributes:
-    service.name: opentelemetry-demo
+    - name: service.name
+      value: opentelemetry-demo
+  attributes_list: service.name=unused,example.foo=foo_value,example.bar=bar_value
 
 propagators:
   composite: [ tracecontext, baggage ]

--- a/examples/load_config_env.yaml
+++ b/examples/load_config_env.yaml
@@ -4,7 +4,8 @@ disabled: ${OTEL_SDK_DISABLED}
 
 resource:
   attributes:
-    service.name: ${OTEL_SERVICE_NAME}
+    - name: service.name
+      value: ${OTEL_SERVICE_NAME}
 
 propagators:
   composite: [ tracecontext, baggage ]

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlp.php
@@ -32,7 +32,7 @@ final class LogRecordExporterOtlp implements ComponentProvider
      *     certificate: ?string,
      *     client_key: ?string,
      *     client_certificate: ?string,
-     *     headers: list<array{name: string, value: string, type: ?string}>,
+     *     headers: list<array{name: string, value: string}>,
      *     headers_list: ?string,
      *     compression: 'gzip'|null,
      *     timeout: int<0, max>,

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlp.php
@@ -32,7 +32,7 @@ final class LogRecordExporterOtlp implements ComponentProvider
      *     certificate: ?string,
      *     client_key: ?string,
      *     client_certificate: ?string,
-     *     headers: list<array{name: string, value: string}>,
+     *     headers: list<array{name: string, value: string, type: ?string}>,
      *     headers_list: ?string,
      *     compression: 'gzip'|null,
      *     timeout: int<0, max>,

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlp.php
@@ -13,6 +13,7 @@ use OpenTelemetry\Config\SDK\Configuration\Validation;
 use OpenTelemetry\Contrib\Otlp\LogsExporter;
 use OpenTelemetry\Contrib\Otlp\OtlpUtil;
 use OpenTelemetry\Contrib\Otlp\Protocols;
+use OpenTelemetry\SDK\Common\Configuration\Parser\MapParser;
 use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
 use OpenTelemetry\SDK\Registry;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -41,8 +42,7 @@ final class LogRecordExporterOtlp implements ComponentProvider
     {
         $protocol = $properties['protocol'];
 
-        $headers_list = array_column(array_map(fn ($item) => explode('=', $item), explode(',', $properties['headers_list'] ?? '')), 1, 0);
-        $headers = array_column($properties['headers'], 'value', 'name') + $headers_list;
+        $headers = array_column($properties['headers'], 'value', 'name') + MapParser::parse($properties['headers_list']);
 
         return new LogsExporter(Registry::transportFactory($protocol)->create(
             endpoint: $properties['endpoint'] . OtlpUtil::path(Signals::LOGS, $protocol),

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlp.php
@@ -32,7 +32,7 @@ final class LogRecordExporterOtlp implements ComponentProvider
      *     certificate: ?string,
      *     client_key: ?string,
      *     client_certificate: ?string,
-     *     headers: array,
+     *     headers: list<array{name: string, value: string}>,
      *     headers_list: ?string,
      *     compression: 'gzip'|null,
      *     timeout: int<0, max>,

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlp.php
@@ -33,7 +33,7 @@ final class MetricExporterOtlp implements ComponentProvider
      *     certificate: ?string,
      *     client_key: ?string,
      *     client_certificate: ?string,
-     *     headers: list<array{name: string, value: string, type: ?string}>,
+     *     headers: list<array{name: string, value: string}>,
      *     headers_list: ?string,
      *     compression: 'gzip'|null,
      *     timeout: int<0, max>,

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlp.php
@@ -13,6 +13,7 @@ use OpenTelemetry\Config\SDK\Configuration\Validation;
 use OpenTelemetry\Contrib\Otlp\MetricExporter;
 use OpenTelemetry\Contrib\Otlp\OtlpUtil;
 use OpenTelemetry\Contrib\Otlp\Protocols;
+use OpenTelemetry\SDK\Common\Configuration\Parser\MapParser;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Registry;
@@ -44,8 +45,7 @@ final class MetricExporterOtlp implements ComponentProvider
     {
         $protocol = $properties['protocol'];
 
-        $headers_list = array_column(array_map(fn ($item) => explode('=', $item), explode(',', $properties['headers_list'] ?? '')), 1, 0);
-        $headers = array_column($properties['headers'], 'value', 'name') + $headers_list;
+        $headers = array_column($properties['headers'], 'value', 'name') + MapParser::parse($properties['headers_list']);
 
         $temporality = match ($properties['temporality_preference']) {
             'cumulative' => Temporality::CUMULATIVE,

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlp.php
@@ -33,7 +33,7 @@ final class MetricExporterOtlp implements ComponentProvider
      *     certificate: ?string,
      *     client_key: ?string,
      *     client_certificate: ?string,
-     *     headers: array,
+     *     headers: list<array{name: string, value: string, type: ?string}>,
      *     headers_list: ?string,
      *     compression: 'gzip'|null,
      *     timeout: int<0, max>,

--- a/src/Config/SDK/ComponentProvider/OpenTelemetrySdk.php
+++ b/src/Config/SDK/ComponentProvider/OpenTelemetrySdk.php
@@ -13,6 +13,7 @@ use OpenTelemetry\Config\SDK\Configuration\Validation;
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Configuration\Parser\MapParser;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
 use OpenTelemetry\SDK\Logs\EventLoggerProvider;
 use OpenTelemetry\SDK\Logs\LoggerProvider;
@@ -114,9 +115,7 @@ final class OpenTelemetrySdk implements ComponentProvider
         if ($properties['disabled']) {
             return $sdkBuilder;
         }
-        $attributes_list = array_column(array_map(fn ($item) => explode('=', $item), explode(',', $properties['resource']['attributes_list'] ?? '')), 1, 0);
-        $attributes = array_column($properties['resource']['attributes'], 'value', 'name') + $attributes_list;
-        //todo merge with attributes_list
+        $attributes = array_column($properties['resource']['attributes'], 'value', 'name') + MapParser::parse($properties['resource']['attributes_list']);
         $resource = ResourceInfoFactory::defaultResource()
             ->merge(ResourceInfo::create(
                 attributes: Attributes::create($attributes),

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlp.php
@@ -32,7 +32,7 @@ final class SpanExporterOtlp implements ComponentProvider
      *     certificate: ?string,
      *     client_key: ?string,
      *     client_certificate: ?string,
-     *     headers: list<array{name: string, value: string, type: ?string}>,
+     *     headers: list<array{name: string, value: string}>,
      *     headers_list: ?string,
      *     compression: 'gzip'|null,
      *     timeout: int<0, max>,

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlp.php
@@ -13,6 +13,7 @@ use OpenTelemetry\Config\SDK\Configuration\Validation;
 use OpenTelemetry\Contrib\Otlp\OtlpUtil;
 use OpenTelemetry\Contrib\Otlp\Protocols;
 use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\SDK\Common\Configuration\Parser\MapParser;
 use OpenTelemetry\SDK\Registry;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -41,8 +42,7 @@ final class SpanExporterOtlp implements ComponentProvider
     {
         $protocol = $properties['protocol'];
 
-        $headers_list = array_column(array_map(fn ($item) => explode('=', $item), explode(',', $properties['headers_list'] ?? '')), 1, 0);
-        $headers = array_column($properties['headers'], 'value', 'name') + $headers_list;
+        $headers = array_column($properties['headers'], 'value', 'name') + MapParser::parse($properties['headers_list']);
 
         return new SpanExporter(Registry::transportFactory($protocol)->create(
             endpoint: $properties['endpoint'] . OtlpUtil::path(Signals::TRACE, $protocol),

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlp.php
@@ -32,7 +32,7 @@ final class SpanExporterOtlp implements ComponentProvider
      *     certificate: ?string,
      *     client_key: ?string,
      *     client_certificate: ?string,
-     *     headers: array,
+     *     headers: list<array{name: string, value: string, type: ?string}>,
      *     headers_list: ?string,
      *     compression: 'gzip'|null,
      *     timeout: int<0, max>,

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlp.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlp.php
@@ -31,7 +31,8 @@ final class SpanExporterOtlp implements ComponentProvider
      *     certificate: ?string,
      *     client_key: ?string,
      *     client_certificate: ?string,
-     *     headers: array<string, string>,
+     *     headers: array,
+     *     headers_list: ?string,
      *     compression: 'gzip'|null,
      *     timeout: int<0, max>,
      * } $properties
@@ -40,10 +41,13 @@ final class SpanExporterOtlp implements ComponentProvider
     {
         $protocol = $properties['protocol'];
 
+        $headers_list = array_column(array_map(fn ($item) => explode('=', $item), explode(',', $properties['headers_list'] ?? '')), 1, 0);
+        $headers = array_column($properties['headers'], 'value', 'name') + $headers_list;
+
         return new SpanExporter(Registry::transportFactory($protocol)->create(
             endpoint: $properties['endpoint'] . OtlpUtil::path(Signals::TRACE, $protocol),
             contentType: Protocols::contentType($protocol),
-            headers: $properties['headers'],
+            headers: $headers,
             compression: $properties['compression'],
             timeout: $properties['timeout'],
             cacert: $properties['certificate'],
@@ -63,8 +67,14 @@ final class SpanExporterOtlp implements ComponentProvider
                 ->scalarNode('client_key')->defaultNull()->validate()->always(Validation::ensureString())->end()->end()
                 ->scalarNode('client_certificate')->defaultNull()->validate()->always(Validation::ensureString())->end()->end()
                 ->arrayNode('headers')
-                    ->scalarPrototype()->end()
+                    ->arrayPrototype()
+                            ->children()
+                            ->scalarNode('name')->isRequired()->cannotBeEmpty()->end()
+                            ->scalarNode('value')->defaultNull()->validate()->always(Validation::ensureString())->end()->end()
+                        ->end()
+                    ->end()
                 ->end()
+                ->scalarNode('headers_list')->defaultNull()->validate()->always(Validation::ensureString())->end()->end()
                 ->enumNode('compression')->values(['gzip'])->defaultNull()->end()
                 ->integerNode('timeout')->min(0)->defaultValue(10)->end()
             ->end()

--- a/src/SDK/Metrics/Stream/DeltaStorage.php
+++ b/src/SDK/Metrics/Stream/DeltaStorage.php
@@ -14,7 +14,7 @@ use OpenTelemetry\SDK\Metrics\AggregationInterface;
  */
 final class DeltaStorage
 {
-    private Delta $head;
+    private readonly Delta $head;
 
     public function __construct(private readonly AggregationInterface $aggregation)
     {

--- a/src/SDK/Metrics/Stream/DeltaStorage.php
+++ b/src/SDK/Metrics/Stream/DeltaStorage.php
@@ -14,7 +14,7 @@ use OpenTelemetry\SDK\Metrics\AggregationInterface;
  */
 final class DeltaStorage
 {
-    private readonly Delta $head;
+    private Delta $head;
 
     public function __construct(private readonly AggregationInterface $aggregation)
     {

--- a/tests/Integration/Config/configurations/anchors.yaml
+++ b/tests/Integration/Config/configurations/anchors.yaml
@@ -9,7 +9,8 @@ exporters:
         client_key: /app/cert.pem
         client_certificate: /app/cert.pem
         headers:
-            api-key: !!str 1234
+            - name: api-key
+              value: "str 1234"
         compression: gzip
         timeout: 10000
 

--- a/tests/Integration/Config/configurations/kitchen-sink.yaml
+++ b/tests/Integration/Config/configurations/kitchen-sink.yaml
@@ -74,11 +74,13 @@ logger_provider:
                       #
                       # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE
                       client_certificate: /app/cert.pem
-                      # Configure headers.
-                      #
-                      # Environment variable: OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_LOGS_HEADERS
+                      # Configure headers. Entries have higher priority than entries from .headers_list.
                       headers:
-                          api-key: "1234"
+                          - name: api-key
+                            value: "1234"
+                      # Configure headers. Entries have lower priority than entries from .headers.
+                      # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+                      headers_list: "api-key=1234"
                       # Configure compression.
                       #
                       # Environment variable: OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION
@@ -138,11 +140,13 @@ meter_provider:
                       #
                       # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE
                       client_certificate: /app/cert.pem
-                      # Configure headers.
-                      #
-                      # Environment variable: OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_METRICS_HEADERS
+                      # Configure headers. Entries have higher priority than entries from .headers_list.
                       headers:
-                          api-key: !!str 1234
+                          - name: api-key
+                            value: "1234"
+                      # Configure headers. Entries have lower priority than entries from .headers.
+                      # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+                      headers_list: "api-key=1234"
                       # Configure compression.
                       #
                       # Environment variable: OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION
@@ -244,11 +248,13 @@ tracer_provider:
                       #
                       # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE
                       client_certificate: /app/cert.pem
-                      # Configure headers.
-                      #
-                      # Environment variable: OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_TRACES_HEADERS
+                      # Configure headers. Entries have higher priority than entries from .headers_list.
                       headers:
-                          api-key: !!str 1234
+                          - name: api-key
+                            value: "1234"
+                      # Configure headers. Entries have lower priority than entries from .headers.
+                      # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+                      headers_list: "api-key=1234"
                       # Configure compression.
                       #
                       # Environment variable: OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION
@@ -340,14 +346,38 @@ tracer_provider:
 
 # Configure resource for all signals.
 resource:
-    # Configure resource attributes.
-    #
-    # Environment variable: OTEL_RESOURCE_ATTRIBUTES
+    # Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.
+    # Entries must contain .name nand .value, and may optionally include .type, which defaults ot "string" if not set. The value must match the type. Values for .type include: string, bool, int, double, string_array, bool_array, int_array, double_array.
     attributes:
-        # Configure `service.name` resource attribute
-        #
-        # Environment variable: OTEL_SERVICE_NAME
-        service.name: !!str "unknown_service"
+      - name: service.name
+        value: unknown_service
+      - name: string_key
+        value: value
+        type: string
+      - name: bool_key
+        value: true
+        type: bool
+      - name: int_key
+        value: 1
+        type: int
+      - name: double_key
+        value: 1.1
+        type: double
+      - name: string_array_key
+        value: [ "value1", "value2" ]
+        type: string_array
+      - name: bool_array_key
+        value: [ true, false ]
+        type: bool_array
+      - name: int_array_key
+        value: [ 1, 2 ]
+        type: int_array
+      - name: double_array_key
+        value: [ 1.1, 2.2 ]
+        type: double_array
+    # Configure resource attributes. Entries have lower priority than entries from .resource.attributes.
+    # The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
+    attributes_list: "service.namespace=my-namespace,service.version=1.0.0"
     # Configure the resource schema URL.
     schema_url: https://opentelemetry.io/schemas/1.27.0
 


### PR DESCRIPTION
- headers and attributes are now arrays with `key` and `value` elements
- headers can optionally contain a `headers_list` element which supports a lower-priority CSV of key/value entries
- attributes can optionally contain an `attributes_list` element which supports a lower-priority CSV of key/value entries

Related: #1423