### PR TITLE
guard against possible false value from file_get_contents in Host.php

### DIFF
--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -54,7 +54,8 @@ final class Host implements ResourceDetectorInterface
         foreach ($paths as $path) {
             $file = $this->dir . $path;
             if (is_file($file) && is_readable($file)) {
-                return trim(file_get_contents($file));
+                $contents = file_get_contents($file);
+                return $contents !== false ? trim($contents) : null;
             }
         }
 
@@ -65,7 +66,8 @@ final class Host implements ResourceDetectorInterface
     {
         $file = $this->dir . self::PATH_ETC_HOSTID;
         if (is_file($file) && is_readable($file)) {
-            return trim(file_get_contents($file));
+            $contents = file_get_contents($file);
+            return $contents !== false ? trim($contents) : null;
         }
 
         $out = exec('which kenv && kenv -q smbios.system.uuid');

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -55,6 +55,7 @@ final class Host implements ResourceDetectorInterface
             $file = $this->dir . $path;
             if (is_file($file) && is_readable($file)) {
                 $contents = file_get_contents($file);
+
                 return $contents !== false ? trim($contents) : null;
             }
         }
@@ -67,6 +68,7 @@ final class Host implements ResourceDetectorInterface
         $file = $this->dir . self::PATH_ETC_HOSTID;
         if (is_file($file) && is_readable($file)) {
             $contents = file_get_contents($file);
+
             return $contents !== false ? trim($contents) : null;
         }
 


### PR DESCRIPTION
There's other circumstances besides is_file && is_readable when file_get_contents may return false. This is a defensive change to prevent TypeErrors when calling trim()