### PR TITLE
Added \Attribute::TARGET_PARAMETER to \OpenTelemetry\API\Instrumentation\SpanAttribute

### DIFF
--- a/src/API/Instrumentation/SpanAttribute.php
+++ b/src/API/Instrumentation/SpanAttribute.php
@@ -11,7 +11,7 @@ use Attribute;
  * attribute, adding this attribute to an argument will
  * add the argument as a span attribute.
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 final class SpanAttribute
 {
     /**

--- a/tests/Unit/API/Instrumentation/SpanAttributeTest.php
+++ b/tests/Unit/API/Instrumentation/SpanAttributeTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\API\Instrumentation;
 
 use OpenTelemetry\API\Instrumentation\SpanAttribute;
+use OpenTelemetry\API\Instrumentation\WithSpan;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(SpanAttribute::class)]
@@ -15,5 +17,18 @@ class SpanAttributeTest extends TestCase
     {
         $attr = new SpanAttribute('foo');
         $this->assertSame('foo', $attr->name);
+    }
+
+    #[DoesNotPerformAssertions]
+    public function test_attribute_targets_parameter(): void
+    {
+        new class() {
+            #[WithSpan]
+            public function foo(
+                #[SpanAttribute] string $a,
+                #[SpanAttribute('a_better_attribute_name')] string $b,
+            ): void {
+            }
+        };
     }
 }


### PR DESCRIPTION
Fixes #1429

Although the added "test" might not be appropriate. Is there a better way to test this?

It just proves that phpstan is happy rather than asserting anything more concrete.