### PR TITLE
A string with a number could be passed as a boolean value

### DIFF
--- a/src/SDK/Common/Configuration/Parser/BooleanParser.php
+++ b/src/SDK/Common/Configuration/Parser/BooleanParser.php
@@ -28,11 +28,11 @@ class BooleanParser
             return false;
         }
 
-        if ((int)($value) === 1) {
+        if ((int) ($value) === 1) {
             return true;
         }
 
-        if ((int)($value) === 0) {
+        if ((int) ($value) === 0) {
             return false;
         }
 

--- a/src/SDK/Common/Configuration/Parser/BooleanParser.php
+++ b/src/SDK/Common/Configuration/Parser/BooleanParser.php
@@ -19,11 +19,20 @@ class BooleanParser
         if (is_bool($value)) {
             return $value;
         }
+
         if (strtolower($value) === self::TRUE_VALUE) {
             return true;
         }
 
         if (strtolower($value) === self::FALSE_VALUE) {
+            return false;
+        }
+
+        if ((int)($value) === 1) {
+            return true;
+        }
+
+        if ((int)($value) === 0) {
             return false;
         }
 


### PR DESCRIPTION
get_cfg_var() evaluates "true" in php.ini to "1" which is not correctly parsed by the boolean parser.

Fixes issue raised on [https://github.com/open-telemetry/opentelemetry-php/issues/1431](https://github.com/open-telemetry/opentelemetry-php/issues/1431).

