### PR TITLE
handle host detector with custom error handler and open_basedir

### DIFF
--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -55,17 +55,12 @@ final class Host implements ResourceDetectorInterface
         set_error_handler(static fn () => true);
 
         try {
-            if (is_file($file) && is_readable($file)) {
-                $contents = file_get_contents($file);
-                if ($contents !== false) {
-                    return $contents;
-                }
-            }
+            $contents = file_get_contents($file);
+
+            return $contents !== false ? trim($contents) : false;
         } finally {
             restore_error_handler();
         }
-
-        return false;
     }
 
     private function getLinuxId(): ?string

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -9,6 +9,7 @@ use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SemConv\ResourceAttributes;
 use function php_uname;
+use Throwable;
 
 /**
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/resource/semantic_conventions/host.md#host
@@ -53,10 +54,15 @@ final class Host implements ResourceDetectorInterface
 
         foreach ($paths as $path) {
             $file = $this->dir . $path;
-            if (is_file($file) && is_readable($file)) {
-                $contents = file_get_contents($file);
 
-                return $contents !== false ? trim($contents) : null;
+            try {
+                if (is_file($file) && is_readable($file)) {
+                    $contents = file_get_contents($file);
+
+                    return $contents !== false ? trim($contents) : null;
+                }
+            } catch (Throwable $t) {
+                //do nothing
             }
         }
 
@@ -66,10 +72,15 @@ final class Host implements ResourceDetectorInterface
     private function getBsdId(): ?string
     {
         $file = $this->dir . self::PATH_ETC_HOSTID;
-        if (is_file($file) && is_readable($file)) {
-            $contents = file_get_contents($file);
 
-            return $contents !== false ? trim($contents) : null;
+        try {
+            if (is_file($file) && is_readable($file)) {
+                $contents = file_get_contents($file);
+
+                return $contents !== false ? trim($contents) : null;
+            }
+        } catch (Throwable $t) {
+            //do nothing
         }
 
         $out = exec('which kenv && kenv -q smbios.system.uuid');

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -59,7 +59,11 @@ final class Host implements ResourceDetectorInterface
                 if (is_file($file) && is_readable($file)) {
                     $contents = file_get_contents($file);
 
-                    return $contents !== false ? trim($contents) : null;
+                    if ($contents === false) {
+                        continue;
+                    }
+
+                    return trim($contents);
                 }
             } catch (Throwable $t) {
                 //do nothing
@@ -77,7 +81,9 @@ final class Host implements ResourceDetectorInterface
             if (is_file($file) && is_readable($file)) {
                 $contents = file_get_contents($file);
 
-                return $contents !== false ? trim($contents) : null;
+                if ($contents !== false) {
+                    return trim($contents);
+                }
             }
         } catch (Throwable $t) {
             //do nothing

--- a/tests/Integration/SDK/Resource/Detectors/test_host_detector_with_open_basedir.phpt
+++ b/tests/Integration/SDK/Resource/Detectors/test_host_detector_with_open_basedir.phpt
@@ -5,8 +5,6 @@ An error handler is installed which converts PHP warnings to exceptions, and ope
 is configured such that /etc/machine-id and friends cannot be read
 --SKIPIF--
 <?php if (!in_array(PHP_OS_FAMILY, ['Linux', 'BSD'])) die('skip requires Linux or BSD'); ?>
---ENV--
-OTEL_PHP_FIBERS_ENABLED=0
 --INI--
 open_basedir=${PWD}
 --FILE--

--- a/tests/Integration/SDK/Resource/Detectors/test_host_detector_with_open_basedir.phpt
+++ b/tests/Integration/SDK/Resource/Detectors/test_host_detector_with_open_basedir.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Host detector with custom error handler and open_basedir
+--DESCRIPTION--
+An error handler is installed which converts PHP warnings to exceptions, and open_basedir
+is configured such that /etc/machine-id and friends cannot be read
+--SKIPIF--
+<?php if (!in_array(PHP_OS_FAMILY, ['Linux', 'BSD'])) die('skip requires Linux or BSD'); ?>
+--ENV--
+OTEL_PHP_FIBERS_ENABLED=0
+--INI--
+open_basedir=${PWD}
+--FILE--
+<?php
+use OpenTelemetry\SDK\Resource\Detectors\Host;
+
+require_once 'vendor/autoload.php';
+
+function warningToException($errno, $errstr, $errfile, $errline)
+{
+    throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+}
+set_error_handler('warningToException');
+
+$detector = new Host();
+$resource = $detector->getResource();
+var_dump($resource->getAttributes()->toArray());
+?>
+--EXPECTF--
+array(2) {
+  ["host.name"]=>
+  string(%d) "%s"
+  ["host.arch"]=>
+  string(%d) "%s"
+}


### PR DESCRIPTION
if `open_basedir` is configured such that files that the host detector tries to open are denied with a php warning, and a custom error handler is installed which converts warnings to exceptions, an unhandled exception occurs.
add a test for this, and some try/catch/ignore blocks around the code that can trigger this.

Closes: #1450
Replace: #1451