### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/proto/otel/Opentelemetry/Proto/Metrics/V1/ExponentialHistogramDataPoint.php
+++ b/proto/otel/Opentelemetry/Proto/Metrics/V1/ExponentialHistogramDataPoint.php
@@ -59,7 +59,7 @@ class ExponentialHistogramDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
      *
      * Generated from protobuf field <code>optional double sum = 5;</code>
      */
@@ -173,7 +173,7 @@ class ExponentialHistogramDataPoint extends \Google\Protobuf\Internal\Message
      *           events, and is assumed to be monotonic over the values of these events.
      *           Negative events *can* be recorded, but sum should not be filled out when
      *           doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     *           see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+     *           see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
      *     @type int $scale
      *           scale describes the resolution of the histogram.  Boundaries are
      *           located at powers of the base, where:
@@ -353,7 +353,7 @@ class ExponentialHistogramDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
      *
      * Generated from protobuf field <code>optional double sum = 5;</code>
      * @return float
@@ -380,7 +380,7 @@ class ExponentialHistogramDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
      *
      * Generated from protobuf field <code>optional double sum = 5;</code>
      * @param float $var

--- a/proto/otel/Opentelemetry/Proto/Metrics/V1/HistogramDataPoint.php
+++ b/proto/otel/Opentelemetry/Proto/Metrics/V1/HistogramDataPoint.php
@@ -64,7 +64,7 @@ class HistogramDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
      *
      * Generated from protobuf field <code>optional double sum = 5;</code>
      */
@@ -151,7 +151,7 @@ class HistogramDataPoint extends \Google\Protobuf\Internal\Message
      *           events, and is assumed to be monotonic over the values of these events.
      *           Negative events *can* be recorded, but sum should not be filled out when
      *           doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     *           see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+     *           see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
      *     @type int[]|string[]|\Google\Protobuf\Internal\RepeatedField $bucket_counts
      *           bucket_counts is an optional field contains the count values of histogram
      *           for each bucket.
@@ -316,7 +316,7 @@ class HistogramDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
      *
      * Generated from protobuf field <code>optional double sum = 5;</code>
      * @return float
@@ -343,7 +343,7 @@ class HistogramDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
      *
      * Generated from protobuf field <code>optional double sum = 5;</code>
      * @param float $var

--- a/proto/otel/Opentelemetry/Proto/Metrics/V1/SummaryDataPoint.php
+++ b/proto/otel/Opentelemetry/Proto/Metrics/V1/SummaryDataPoint.php
@@ -55,7 +55,7 @@ class SummaryDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
      *
      * Generated from protobuf field <code>double sum = 5;</code>
      */
@@ -104,7 +104,7 @@ class SummaryDataPoint extends \Google\Protobuf\Internal\Message
      *           events, and is assumed to be monotonic over the values of these events.
      *           Negative events *can* be recorded, but sum should not be filled out when
      *           doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     *           see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+     *           see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
      *     @type \Opentelemetry\Proto\Metrics\V1\SummaryDataPoint\ValueAtQuantile[]|\Google\Protobuf\Internal\RepeatedField $quantile_values
      *           (Optional) list of values at different quantiles of the distribution calculated
      *           from the current snapshot. The quantiles must be strictly increasing.
@@ -245,7 +245,7 @@ class SummaryDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
      *
      * Generated from protobuf field <code>double sum = 5;</code>
      * @return float
@@ -262,7 +262,7 @@ class SummaryDataPoint extends \Google\Protobuf\Internal\Message
      * events, and is assumed to be monotonic over the values of these events.
      * Negative events *can* be recorded, but sum should not be filled out when
      * doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-     * see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+     * see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
      *
      * Generated from protobuf field <code>double sum = 5;</code>
      * @param float $var


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.