### PR TITLE
adding otlp/file exporter

### DIFF
--- a/examples/traces/exporters/otlp_file_autoload.php
+++ b/examples/traces/exporters/otlp_file_autoload.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Example;
+
+use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+
+putenv('OTEL_PHP_AUTOLOAD_ENABLED=true');
+putenv('OTEL_TRACES_EXPORTER=otlp/stdout');
+putenv('OTEL_LOGS_EXPORTER=otlp/stdout');
+putenv('OTEL_METRICS_EXPORTER=otlp/stdout');
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+$instrumentation = new CachedInstrumentation('demo');
+
+$instrumentation->tracer()->spanBuilder('root')->startSpan()->end();
+$instrumentation->meter()->createCounter('cnt')->add(1);
+$instrumentation->eventLogger()->emit('foo', 'hello, otel');
+
+echo PHP_EOL . 'OTLP/stdout autoload example complete!';
+echo PHP_EOL;

--- a/examples/traces/exporters/otlp_file_from_factory.php
+++ b/examples/traces/exporters/otlp_file_from_factory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Example;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+use OpenTelemetry\SDK\Trace\TracerProviderFactory;
+
+putenv('OTEL_TRACES_EXPORTER=otlp/stdout');
+$factory = new TracerProviderFactory();
+$tracerProvider = $factory->create();
+
+$tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
+
+$root = $span = $tracer->spanBuilder('root')->startSpan();
+$scope = $span->activate();
+
+for ($i = 0; $i < 3; $i++) {
+    // start a span, register some events
+    $span = $tracer->spanBuilder('loop-' . $i)->startSpan();
+
+    $span->setAttribute('remote_ip', '1.2.3.4')
+        ->setAttribute('country', 'USA');
+
+    $span->addEvent('found_login' . $i, [
+        'id' => $i,
+        'username' => 'otuser' . $i,
+    ]);
+    $span->addEvent('generated_session', [
+        'id' => md5((string) microtime(true)),
+    ]);
+
+    $span->end();
+}
+$root->end();
+$scope->detach();
+echo PHP_EOL . 'OTLP/stdout example complete!';
+
+echo PHP_EOL;
+$tracerProvider->shutdown();

--- a/src/Contrib/Otlp/StdoutLogsExporterFactory.php
+++ b/src/Contrib/Otlp/StdoutLogsExporterFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Otlp;
+
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory;
+use OpenTelemetry\SDK\Logs\LogRecordExporterFactoryInterface;
+use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
+
+class StdoutLogsExporterFactory implements LogRecordExporterFactoryInterface
+{
+
+    public function create(): LogRecordExporterInterface
+    {
+        $transport = (new StreamTransportFactory())->create('php://stdout', ContentTypes::NDJSON);
+
+        return new LogsExporter($transport);
+    }
+}

--- a/src/Contrib/Otlp/StdoutMetricExporterFactory.php
+++ b/src/Contrib/Otlp/StdoutMetricExporterFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Otlp;
+
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory;
+use OpenTelemetry\SDK\Metrics\MetricExporterFactoryInterface;
+use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
+
+class StdoutMetricExporterFactory implements MetricExporterFactoryInterface
+{
+
+    public function create(): MetricExporterInterface
+    {
+        $transport = (new StreamTransportFactory())->create('php://stdout', ContentTypes::NDJSON);
+
+        return new MetricExporter($transport);
+    }
+}

--- a/src/Contrib/Otlp/StdoutSpanExporterFactory.php
+++ b/src/Contrib/Otlp/StdoutSpanExporterFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Otlp;
+
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory;
+use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+
+class StdoutSpanExporterFactory implements SpanExporterFactoryInterface
+{
+    public function create(): SpanExporterInterface
+    {
+        $transport = (new StreamTransportFactory())->create('php://stdout', ContentTypes::NDJSON);
+
+        return new SpanExporter($transport);
+    }
+}

--- a/src/Contrib/Otlp/_register.php
+++ b/src/Contrib/Otlp/_register.php
@@ -2,8 +2,12 @@
 
 declare(strict_types=1);
 \OpenTelemetry\SDK\Registry::registerSpanExporterFactory('otlp', \OpenTelemetry\Contrib\Otlp\SpanExporterFactory::class);
+\OpenTelemetry\SDK\Registry::registerSpanExporterFactory('otlp/stdout', \OpenTelemetry\Contrib\Otlp\StdoutSpanExporterFactory::class);
+
 \OpenTelemetry\SDK\Registry::registerMetricExporterFactory('otlp', \OpenTelemetry\Contrib\Otlp\MetricExporterFactory::class);
+\OpenTelemetry\SDK\Registry::registerMetricExporterFactory('otlp/stdout', \OpenTelemetry\Contrib\Otlp\StdoutMetricExporterFactory::class);
 
 \OpenTelemetry\SDK\Registry::registerTransportFactory('http', \OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory::class);
 
 \OpenTelemetry\SDK\Registry::registerLogRecordExporterFactory('otlp', \OpenTelemetry\Contrib\Otlp\LogsExporterFactory::class);
+\OpenTelemetry\SDK\Registry::registerLogRecordExporterFactory('otlp/stdout', \OpenTelemetry\Contrib\Otlp\StdoutLogsExporterFactory::class);

--- a/src/SDK/Common/Configuration/KnownValues.php
+++ b/src/SDK/Common/Configuration/KnownValues.php
@@ -43,6 +43,7 @@ interface KnownValues
     public const VALUE_HTTP_JSON = 'http/json';
     public const VALUE_HTTP_NDJSON = 'http/ndjson';
     public const VALUE_OTLP = 'otlp';
+    public const VALUE_OTLP_STDOUT = 'otlp/stdout';
     public const VALUE_ZIPKIN = 'zipkin';
     public const VALUE_PROMETHEUS = 'prometheus';
     public const VALUE_WITH_SAMPLED_TRACE = 'with_sampled_trace';
@@ -148,16 +149,19 @@ interface KnownValues
      */
     public const OTEL_TRACES_EXPORTER = [
         self::VALUE_OTLP,
+        self::VALUE_OTLP_STDOUT,
         self::VALUE_ZIPKIN,
         self::VALUE_NONE,
     ];
     public const OTEL_METRICS_EXPORTER = [
         self::VALUE_OTLP,
+        self::VALUE_OTLP_STDOUT,
         self::VALUE_PROMETHEUS,
         self::VALUE_NONE,
     ];
     public const OTEL_LOGS_EXPORTER = [
         self::VALUE_OTLP,
+        self::VALUE_OTLP_STDOUT,
         self::VALUE_NONE,
     ];
     /**


### PR DESCRIPTION
the spec has added in-development otlp file/stdout exporter. We already supported this programmatically, so add some factories and sdk config to allow configuration from environment (only for stdout, per spec)

See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/file-exporter.md

Closes: #1457 