### PR TITLE
deprecate event logger

### DIFF
--- a/src/API/Globals.php
+++ b/src/API/Globals.php
@@ -58,6 +58,10 @@ final class Globals
         return Context::getCurrent()->get(ContextKeys::loggerProvider()) ?? self::globals()->loggerProvider;
     }
 
+    /**
+     * @deprecated
+     * @phan-suppress PhanDeprecatedFunction
+     */
     public static function eventLoggerProvider(): EventLoggerProviderInterface
     {
         return Context::getCurrent()->get(ContextKeys::eventLoggerProvider()) ?? self::globals()->eventLoggerProvider;
@@ -76,7 +80,7 @@ final class Globals
     }
 
     /**
-     * @phan-suppress PhanTypeMismatchReturnNullable
+     * @phan-suppress PhanTypeMismatchReturnNullable,PhanDeprecatedFunction
      */
     private static function globals(): self
     {

--- a/src/API/Instrumentation/CachedInstrumentation.php
+++ b/src/API/Instrumentation/CachedInstrumentation.php
@@ -68,6 +68,11 @@ final class CachedInstrumentation
 
         return $this->loggers[$loggerProvider] ??= $loggerProvider->getLogger($this->name, $this->version, $this->schemaUrl, $this->attributes);
     }
+
+    /**
+     * @deprecated
+     * @phan-suppress PhanDeprecatedFunction
+     */
     public function eventLogger(): EventLoggerInterface
     {
         $eventLoggerProvider = Globals::eventLoggerProvider();

--- a/src/API/Instrumentation/Configurator.php
+++ b/src/API/Instrumentation/Configurator.php
@@ -46,6 +46,7 @@ final class Configurator implements ImplicitContextKeyedInterface
 
     /**
      * Creates a configurator that uses noop instances for not configured values.
+     * @phan-suppress PhanDeprecatedFunction
      */
     public static function createNoop(): Configurator
     {
@@ -63,6 +64,9 @@ final class Configurator implements ImplicitContextKeyedInterface
         return $this->storeInContext()->activate();
     }
 
+    /**
+     * @phan-suppress PhanDeprecatedFunction
+     */
     public function storeInContext(?ContextInterface $context = null): ContextInterface
     {
         $context ??= Context::getCurrent();
@@ -118,6 +122,9 @@ final class Configurator implements ImplicitContextKeyedInterface
         return $self;
     }
 
+    /**
+     * @deprecated
+     */
     public function withEventLoggerProvider(?EventLoggerProviderInterface $eventLoggerProvider): Configurator
     {
         $self = clone $this;

--- a/src/API/Instrumentation/ContextKeys.php
+++ b/src/API/Instrumentation/ContextKeys.php
@@ -58,6 +58,7 @@ final class ContextKeys
     }
 
     /**
+     * @deprecated
      * @return ContextKeyInterface<EventLoggerProviderInterface>
      */
     public static function eventLoggerProvider(): ContextKeyInterface

--- a/src/API/Logs/EventLoggerInterface.php
+++ b/src/API/Logs/EventLoggerInterface.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\API\Logs;
 use OpenTelemetry\Context\ContextInterface;
 
 /**
+ * @deprecated
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/event-api.md#events-api-interface
  */
 interface EventLoggerInterface

--- a/src/API/Logs/EventLoggerProviderInterface.php
+++ b/src/API/Logs/EventLoggerProviderInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\API\Logs;
 
 /**
+ * @deprecated
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.32.0/specification/logs/event-api.md#get-an-eventlogger
  */
 interface EventLoggerProviderInterface

--- a/src/API/Logs/NoopEventLogger.php
+++ b/src/API/Logs/NoopEventLogger.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\API\Logs;
 
 use OpenTelemetry\Context\ContextInterface;
 
+/**
+ * @phan-suppress PhanDeprecatedInterface
+ */
 class NoopEventLogger implements EventLoggerInterface
 {
     public static function instance(): self

--- a/src/API/Logs/NoopEventLoggerProvider.php
+++ b/src/API/Logs/NoopEventLoggerProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Logs;
 
+/**
+ * @phan-suppress PhanDeprecatedInterface
+ */
 class NoopEventLoggerProvider implements EventLoggerProviderInterface
 {
     public static function getInstance(): self

--- a/src/SDK/Logs/EventLogger.php
+++ b/src/SDK/Logs/EventLogger.php
@@ -12,6 +12,9 @@ use OpenTelemetry\API\Logs\Severity;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextInterface;
 
+/**
+ * @phan-suppress PhanDeprecatedInterface
+ */
 class EventLogger implements EventLoggerInterface
 {
     /**

--- a/src/SDK/Logs/EventLogger.php
+++ b/src/SDK/Logs/EventLogger.php
@@ -13,6 +13,7 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextInterface;
 
 /**
+ * @deprecated
  * @phan-suppress PhanDeprecatedInterface
  */
 class EventLogger implements EventLoggerInterface

--- a/src/SDK/Logs/EventLoggerProvider.php
+++ b/src/SDK/Logs/EventLoggerProvider.php
@@ -7,6 +7,9 @@ namespace OpenTelemetry\SDK\Logs;
 use OpenTelemetry\API\Common\Time\Clock;
 use OpenTelemetry\API\Logs\EventLoggerInterface;
 
+/**
+ * @phan-suppress PhanDeprecatedInterface
+ */
 class EventLoggerProvider implements EventLoggerProviderInterface
 {
     public function __construct(private readonly LoggerProviderInterface $loggerProvider)

--- a/src/SDK/Logs/EventLoggerProvider.php
+++ b/src/SDK/Logs/EventLoggerProvider.php
@@ -16,6 +16,9 @@ class EventLoggerProvider implements EventLoggerProviderInterface
     {
     }
 
+    /**
+     * @phan-suppress PhanDeprecatedClass
+     */
     public function getEventLogger(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): EventLoggerInterface
     {
         return new EventLogger(

--- a/src/SDK/Logs/EventLoggerProviderFactory.php
+++ b/src/SDK/Logs/EventLoggerProviderFactory.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\SDK\Logs;
 
 use OpenTelemetry\SDK\Sdk;
 
+/**
+ * @deprecated
+ */
 class EventLoggerProviderFactory
 {
     public function create(LoggerProviderInterface $loggerProvider): EventLoggerProviderInterface

--- a/src/SDK/Logs/EventLoggerProviderInterface.php
+++ b/src/SDK/Logs/EventLoggerProviderInterface.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\SDK\Logs;
 
 use OpenTelemetry\API\Logs as API;
 
+/**
+ * @phan-suppress PhanDeprecatedInterface
+ */
 interface EventLoggerProviderInterface extends API\EventLoggerProviderInterface
 {
     public function forceFlush(): bool;

--- a/src/SDK/Logs/NoopEventLoggerProvider.php
+++ b/src/SDK/Logs/NoopEventLoggerProvider.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\SDK\Logs;
 
 use OpenTelemetry\API\Logs as API;
 
+/**
+ * @phan-suppress PhanDeprecatedInterface
+ */
 class NoopEventLoggerProvider extends API\NoopEventLoggerProvider implements EventLoggerProviderInterface
 {
     public static function getInstance(): self

--- a/src/SDK/Sdk.php
+++ b/src/SDK/Sdk.php
@@ -60,6 +60,9 @@ class Sdk
         return $this->loggerProvider;
     }
 
+    /**
+     * @deprecated
+     */
     public function getEventLoggerProvider(): EventLoggerProviderInterface
     {
         return $this->eventLoggerProvider;

--- a/src/SDK/SdkAutoloader.php
+++ b/src/SDK/SdkAutoloader.php
@@ -74,6 +74,9 @@ class SdkAutoloader
         return true;
     }
 
+    /**
+     * @phan-suppress PhanDeprecatedClass,PhanDeprecatedFunction
+     */
     private static function environmentBasedInitializer(Configurator $configurator): Configurator
     {
         $propagator = (new PropagatorFactory())->create();
@@ -110,7 +113,7 @@ class SdkAutoloader
     }
 
     /**
-     * @phan-suppress PhanPossiblyUndeclaredVariable
+     * @phan-suppress PhanPossiblyUndeclaredVariable,PhanDeprecatedFunction
      */
     private static function fileBasedInitializer(Configurator $configurator): Configurator
     {

--- a/src/SDK/SdkBuilder.php
+++ b/src/SDK/SdkBuilder.php
@@ -59,6 +59,9 @@ class SdkBuilder
         return $this;
     }
 
+    /**
+     * @deprecated
+     */
     public function setEventLoggerProvider(EventLoggerProviderInterface $eventLoggerProvider): self
     {
         $this->eventLoggerProvider = $eventLoggerProvider;
@@ -95,6 +98,9 @@ class SdkBuilder
         );
     }
 
+    /**
+     * @phan-suppress PhanDeprecatedFunction
+     */
     public function buildAndRegisterGlobal(): ScopeInterface
     {
         $sdk = $this->build();


### PR DESCRIPTION
The event logger was a Development-status component of the logging signal. It has been removed in favour of adding emitEvent to the logger interface, see https://github.com/open-telemetry/opentelemetry-specification/pull/4319

Related: #1459 