### PR TITLE
reduce default set of resource detectors

### DIFF
--- a/src/SDK/Common/Configuration/Defaults.php
+++ b/src/SDK/Common/Configuration/Defaults.php
@@ -113,7 +113,7 @@ interface Defaults
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#language-specific-environment-variables
      */
     public const OTEL_PHP_TRACES_PROCESSOR = 'batch';
-    public const OTEL_PHP_DETECTORS = 'all';
+    public const OTEL_PHP_DETECTORS = 'default';
     public const OTEL_PHP_AUTOLOAD_ENABLED = 'false';
     public const OTEL_PHP_INTERNAL_METRICS_ENABLED = 'false';
     public const OTEL_PHP_DISABLED_INSTRUMENTATIONS = [];

--- a/src/SDK/Common/Configuration/KnownValues.php
+++ b/src/SDK/Common/Configuration/KnownValues.php
@@ -185,6 +185,7 @@ interface KnownValues
     public const VALUE_STDOUT = 'stdout';
     public const VALUE_PSR3 = 'psr3';
     public const VALUE_EMPTY = '';
+    public const VALUE_DETECTORS_DEFAULT = 'default';
     public const VALUE_DETECTORS_ENVIRONMENT = 'env';
     public const VALUE_DETECTORS_HOST = 'host';
     public const VALUE_DETECTORS_OS = 'os';
@@ -195,6 +196,7 @@ interface KnownValues
     public const VALUE_DETECTORS_SERVICE = 'service';
     public const VALUE_DETECTORS_COMPOSER = 'composer';
     public const OTEL_PHP_DETECTORS = [
+        self::VALUE_DETECTORS_DEFAULT,
         self::VALUE_ALL,
         self::VALUE_DETECTORS_ENVIRONMENT,
         self::VALUE_DETECTORS_HOST,

--- a/src/SDK/Resource/ResourceInfoFactory.php
+++ b/src/SDK/Resource/ResourceInfoFactory.php
@@ -42,6 +42,12 @@ class ResourceInfoFactory
 
         foreach ($detectors as $detector) {
             switch ($detector) {
+                case Values::VALUE_DETECTORS_DEFAULT:
+                    $resourceDetectors[] = new Detectors\Sdk();
+                    $resourceDetectors[] = new Detectors\SdkProvided();
+                    $resourceDetectors[] = new Detectors\Environment();
+
+                    break;
                 case Values::VALUE_DETECTORS_SERVICE:
                     $resourceDetectors[] = new Detectors\Service();
 

--- a/tests/Integration/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Integration/SDK/Resource/ResourceInfoFactoryTest.php
@@ -18,6 +18,7 @@ class ResourceInfoFactoryTest extends TestCase
 
     public function test_all_default_resources(): void
     {
+        $this->setEnvironmentVariable('OTEL_PHP_DETECTORS', 'all');
         $resource = ResourceInfoFactory::defaultResource();
 
         $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());


### PR DESCRIPTION
Limit the default detectors from everything to:
- sdk
- sdk_provided
- env

This is controlled by a new detector key, OTEL_PHP_DETECTORS=default (which is the default if no value is provided). The previous behaviour can be restored by explicitly setting OTEL_PHP_DETECTORS=all.

Closes: #1320