### PR TITLE
disallow empty string for baggage name

### DIFF
--- a/src/API/Baggage/BaggageBuilder.php
+++ b/src/API/Baggage/BaggageBuilder.php
@@ -22,6 +22,9 @@ final class BaggageBuilder implements BaggageBuilderInterface
     /** @inheritDoc */
     public function set(string $key, $value, ?MetadataInterface $metadata = null): BaggageBuilderInterface
     {
+        if ($key === '') {
+            return $this;
+        }
         $metadata ??= Metadata::getEmpty();
 
         $this->entries[$key] = new Entry($value, $metadata);

--- a/tests/Unit/API/Baggage/BaggageTest.php
+++ b/tests/Unit/API/Baggage/BaggageTest.php
@@ -125,5 +125,11 @@ class BaggageTest extends TestCase
         );
     }
 
+    public function test_empty_name_disallowed(): void
+    {
+        $baggage = Baggage::getBuilder()->set('', 'bar')->build();
+        $this->assertTrue($baggage->isEmpty());
+    }
+
     // endregion
 }


### PR DESCRIPTION
spec 1.36.0 clarifies that empty string is not a valid baggage name

see https://github.com/open-telemetry/opentelemetry-specification/pull/4144