### PR TITLE
yaml config env var spec conformance

### DIFF
--- a/src/Config/SDK/Configuration/Internal/EnvSubstitutionNormalization.php
+++ b/src/Config/SDK/Configuration/Internal/EnvSubstitutionNormalization.php
@@ -65,7 +65,7 @@ final class EnvSubstitutionNormalization implements Normalization
     private function replaceEnvVariables(string $value, int $filter = FILTER_DEFAULT): mixed
     {
         $replaced = preg_replace_callback(
-            '/\$\{(?<ENV_NAME>[a-zA-Z_]\w*)(?::-(?<DEFAULT_VALUE>[^\n]*))?}/',
+            '/\$\{(?:env:)?(?<ENV_NAME>[a-zA-Z_]\w*)(?::-(?<DEFAULT_VALUE>[^\n]*))?}/',
             fn (array $matches): string => $this->envReader->read($matches['ENV_NAME']) ?? $matches['DEFAULT_VALUE'] ?? '',
             $value,
             -1,

--- a/src/Config/SDK/Configuration/Internal/EnvSubstitutionNormalization.php
+++ b/src/Config/SDK/Configuration/Internal/EnvSubstitutionNormalization.php
@@ -50,8 +50,7 @@ final class EnvSubstitutionNormalization implements Normalization
                 default => FILTER_DEFAULT,
             };
             $node->beforeNormalization()->ifString()->then(fn (string $v) => $this->replaceEnvVariables($v, $filter))->end();
-        }
-        if ($node instanceof VariableNodeDefinition) {
+        } elseif ($node instanceof VariableNodeDefinition) {
             $node->beforeNormalization()->always($this->replaceEnvVariablesRecursive(...))->end();
         }
 


### PR DESCRIPTION
Updating env var substitution to conform to https://github.com/open-telemetry/opentelemetry-specification/blob/v1.41.0/specification/configuration/data-model.md#environment-variable-substitution

- `env:` prefix allowed in environment variable
- do not recursively apply env var substitution (ie don't allow env vars in env vars)