### PR TITLE
handle empty meter observers

### DIFF
--- a/src/SDK/Metrics/Meter.php
+++ b/src/SDK/Metrics/Meter.php
@@ -81,7 +81,7 @@ final class Meter implements MeterInterface, Configurable
         $this->config = $configurator->resolve($this->instrumentationScope);
 
         $startTimestamp = $this->clock->now();
-        foreach ($this->instruments->observers[self::instrumentationScopeId($this->instrumentationScope)] as [$instrument, $stalenessHandler, $r]) {
+        foreach ($this->instruments->observers[self::instrumentationScopeId($this->instrumentationScope)] ?? [] as [$instrument, $stalenessHandler, $r]) {
             if ($this->config->isEnabled() && $r->dormant) {
                 $this->metricFactory->createAsynchronousObserver(
                     $this->registry,

--- a/src/SDK/Metrics/Meter.php
+++ b/src/SDK/Metrics/Meter.php
@@ -98,7 +98,7 @@ final class Meter implements MeterInterface, Configurable
                 $r->dormant = true;
             }
         }
-        foreach ($this->instruments->writers[self::instrumentationScopeId($this->instrumentationScope)] as [$instrument, $stalenessHandler, $r]) {
+        foreach ($this->instruments->writers[self::instrumentationScopeId($this->instrumentationScope)] ?? [] as [$instrument, $stalenessHandler, $r]) {
             if ($this->config->isEnabled() && $r->dormant) {
                 $this->metricFactory->createSynchronousWriter(
                     $this->registry,


### PR DESCRIPTION
if no observers are registered for a meter's instruments, some tests were emitting php warnings:
- foreach() argument must be of type array|object, null given
- Undefined array key XXX

null coalesce to an empty array to make the test happy.