### PR TITLE
revert pass-by-reference to LogRecordProcessor::onEmit

### DIFF
--- a/src/SDK/Logs/LogRecordProcessorInterface.php
+++ b/src/SDK/Logs/LogRecordProcessorInterface.php
@@ -9,7 +9,7 @@ use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 
 interface LogRecordProcessorInterface
 {
-    public function onEmit(ReadWriteLogRecord &$record, ?ContextInterface $context = null): void;
+    public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void;
     public function shutdown(?CancellationInterface $cancellation = null): bool;
     public function forceFlush(?CancellationInterface $cancellation = null): bool;
 }

--- a/src/SDK/Logs/Processor/BatchLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/BatchLogRecordProcessor.php
@@ -134,7 +134,7 @@ class BatchLogRecordProcessor implements LogRecordProcessorInterface
             });
     }
 
-    public function onEmit(ReadWriteLogRecord &$record, ?ContextInterface $context = null): void
+    public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
     {
         if ($this->closed) {
             return;

--- a/src/SDK/Logs/Processor/MultiLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/MultiLogRecordProcessor.php
@@ -22,7 +22,7 @@ class MultiLogRecordProcessor implements LogRecordProcessorInterface
         }
     }
 
-    public function onEmit(ReadWriteLogRecord &$record, ?ContextInterface $context = null): void
+    public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
     {
         foreach ($this->processors as $processor) {
             $processor->onEmit($record, $context);

--- a/src/SDK/Logs/Processor/NoopLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/NoopLogRecordProcessor.php
@@ -21,7 +21,7 @@ class NoopLogRecordProcessor implements LogRecordProcessorInterface
     /**
      * @codeCoverageIgnore
      */
-    public function onEmit(ReadWriteLogRecord &$record, ?ContextInterface $context = null): void
+    public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
     {
     }
 

--- a/src/SDK/Logs/Processor/SimpleLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/SimpleLogRecordProcessor.php
@@ -19,7 +19,7 @@ class SimpleLogRecordProcessor implements LogRecordProcessorInterface
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#onemit
      */
-    public function onEmit(ReadWriteLogRecord &$record, ?ContextInterface $context = null): void
+    public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
     {
         $this->exporter->export([$record]);
     }

--- a/tests/Integration/SDK/Logs/LoggerTest.php
+++ b/tests/Integration/SDK/Logs/LoggerTest.php
@@ -35,7 +35,7 @@ class LoggerTest extends TestCase
             {
             }
 
-            public function onEmit(ReadWriteLogRecord &$record, ?ContextInterface $context = null): void
+            public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
             {
                 $record->setAttributes(['baz' => 'bat']);
                 $this->exporter->export([$record]);

--- a/tests/Integration/SDK/Logs/test_mutate_log_record_in_onemit.phpt
+++ b/tests/Integration/SDK/Logs/test_mutate_log_record_in_onemit.phpt
@@ -1,0 +1,80 @@
+--TEST--
+Test mutating a LogRecord during SpanProcessor::onEmit
+--FILE--
+<?php
+require_once 'vendor/autoload.php';
+
+use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
+use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
+use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
+use OpenTelemetry\SDK\Common\Future\CancellationInterface;
+use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
+use OpenTelemetry\Context\ContextInterface;
+
+$exporter = (new \OpenTelemetry\SDK\Logs\Exporter\ConsoleExporterFactory())->create();
+
+$one = new class implements \OpenTelemetry\SDK\Logs\LogRecordProcessorInterface {
+    public function onEmit(\OpenTelemetry\SDK\Logs\ReadWriteLogRecord $record, ?ContextInterface $context = null): void
+    {
+        $record->setBody('updated');
+        $record->setAttribute('new-key', 'new-value');
+    }
+
+    public function shutdown(?CancellationInterface $cancellation = null): bool
+    {
+        return true;
+    }
+
+    public function forceFlush(?CancellationInterface $cancellation = null): bool
+    {
+        return true;
+    }
+};
+$two = new \OpenTelemetry\SDK\Logs\Processor\SimpleLogRecordProcessor($exporter);
+
+$loggerProvider = (new \OpenTelemetry\SDK\Logs\LoggerProviderBuilder())
+    ->addLogRecordProcessor(new \OpenTelemetry\SDK\Logs\Processor\MultiLogRecordProcessor([$one, $two]))
+    ->build();
+
+$logger = $loggerProvider->getLogger('test');
+$logger->emit(new \OpenTelemetry\API\Logs\LogRecord('body'));
+?>
+--EXPECTF--
+{
+    "resource": {
+        "attributes": {
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.language": "php",
+            "telemetry.sdk.version": "%s",
+            "telemetry.distro.name": "%s",
+            "telemetry.distro.version": "%s",
+            "service.name": "%s"
+        },
+        "dropped_attributes_count": 0
+    },
+    "scopes": [
+        {
+            "name": "test",
+            "version": null,
+            "attributes": [],
+            "dropped_attributes_count": 0,
+            "schema_url": null,
+            "logs": [
+                {
+                    "timestamp": null,
+                    "observed_timestamp": %d,
+                    "severity_number": 0,
+                    "severity_text": null,
+                    "body": "updated",
+                    "trace_id": "%s",
+                    "span_id": "%s",
+                    "trace_flags": 0,
+                    "attributes": {
+                        "new-key": "new-value"
+                    },
+                    "dropped_attributes_count": 0
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
add a test to demonstrate that mutations are still seen by later processors without by-reference