### PR TITLE
drop string options for Temporality, InstrumentType

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -25,3 +25,7 @@ Various component factory interfaces (eg `TextMapPropagatorFactoryInterface`, `T
 updated to include `priority()` and `type()` methods. These are used in conjunction with SPI ServiceLoader to associate
 a type (eg `otlp`) with a factory, and to allow SDK-provided factories to be replaced by user-provided factories (by
 providing a higher priority for the same type).
+
+#### Metrics: InstrumentType, Temporality, advisory
+Methods which previously accepted `Temporality|string`, or `InstrumentType|string` no longer accept strings.
+`$advisory` is now a required parameter for `OpenTelemetry\SDK\Metrics\DefaultAggregationProviderInterface`.

--- a/src/Contrib/Otlp/MetricExporter.php
+++ b/src/Contrib/Otlp/MetricExporter.php
@@ -29,7 +29,7 @@ final class MetricExporter implements PushMetricExporterInterface, AggregationTe
      */
     public function __construct(
         private readonly TransportInterface $transport,
-        private readonly string|Temporality|null $temporality = null,
+        private readonly ?Temporality $temporality = null,
     ) {
         if (!class_exists('\Google\Protobuf\Api')) {
             throw new RuntimeException('No protobuf implementation found (ext-protobuf or google/protobuf)');
@@ -37,7 +37,7 @@ final class MetricExporter implements PushMetricExporterInterface, AggregationTe
         $this->serializer = ProtobufSerializer::forTransport($this->transport);
     }
 
-    public function temporality(MetricMetadataInterface $metric): Temporality|string|null
+    public function temporality(MetricMetadataInterface $metric): ?Temporality
     {
         return $this->temporality ?? $metric->temporality();
     }

--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -72,10 +72,7 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
         );
     }
 
-    /**
-     * @phpstan-ignore-next-line
-     */
-    private function getTemporality(): string|Temporality|null
+    private function getTemporality(): ?Temporality
     {
         $value = Configuration::getEnum(Variables::OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE);
 

--- a/src/SDK/Metrics/AggregationInterface.php
+++ b/src/SDK/Metrics/AggregationInterface.php
@@ -44,7 +44,7 @@ interface AggregationInterface
      * @param array<AttributesInterface> $attributes
      * @psalm-param array<T> $summaries
      * @param array<list<Exemplar>> $exemplars
-     * @param string|Temporality $temporality
+     * @param Temporality $temporality
      */
     public function toData(
         array $attributes,
@@ -52,6 +52,6 @@ interface AggregationInterface
         array $exemplars,
         int $startTimestamp,
         int $timestamp,
-        $temporality,
+        Temporality $temporality,
     ): DataInterface;
 }

--- a/src/SDK/Metrics/AggregationTemporalitySelectorInterface.php
+++ b/src/SDK/Metrics/AggregationTemporalitySelectorInterface.php
@@ -14,8 +14,8 @@ interface AggregationTemporalitySelectorInterface
      * It is recommended to return {@see MetricMetadataInterface::temporality()}
      * if the exporter does not require a specific temporality.
      *
-     * @return string|Temporality|null temporality to use, or null to signal
+     * @return ?Temporality temporality to use, or null to signal
      *         that the given metric should not be exported by this exporter
      */
-    public function temporality(MetricMetadataInterface $metric);
+    public function temporality(MetricMetadataInterface $metric): ?Temporality;
 }

--- a/src/SDK/Metrics/Data/Histogram.php
+++ b/src/SDK/Metrics/Data/Histogram.php
@@ -11,7 +11,7 @@ final class Histogram implements DataInterface
      */
     public function __construct(
         public readonly iterable $dataPoints,
-        public readonly string|Temporality $temporality,
+        public readonly Temporality $temporality,
     ) {
     }
 }

--- a/src/SDK/Metrics/Data/Sum.php
+++ b/src/SDK/Metrics/Data/Sum.php
@@ -11,7 +11,7 @@ final class Sum implements DataInterface
      */
     public function __construct(
         public readonly iterable $dataPoints,
-        public readonly string|Temporality $temporality,
+        public readonly Temporality $temporality,
         public readonly bool $monotonic,
     ) {
     }

--- a/src/SDK/Metrics/Data/Temporality.php
+++ b/src/SDK/Metrics/Data/Temporality.php
@@ -6,16 +6,9 @@ namespace OpenTelemetry\SDK\Metrics\Data;
 
 /**
  * Metric aggregation temporality.
- *
- * Has to be type-hinted as `string|Temporality` to be forward compatible.
- * @todo convert to enum (php >= 8.1)
  */
-final class Temporality
+enum Temporality
 {
-    public const DELTA = 'Delta';
-    public const CUMULATIVE = 'Cumulative';
-
-    private function __construct()
-    {
-    }
+    case DELTA;
+    case CUMULATIVE;
 }

--- a/src/SDK/Metrics/DefaultAggregationProviderInterface.php
+++ b/src/SDK/Metrics/DefaultAggregationProviderInterface.php
@@ -9,9 +9,6 @@ interface DefaultAggregationProviderInterface
     /**
      * @param InstrumentType $instrumentType
      * @param array $advisory optional set of recommendations
-     *
-     * @noinspection PhpDocSignatureInspection not added for BC
-     * @phan-suppress PhanCommentParamWithoutRealParam @phpstan-ignore-next-line
      */
-    public function defaultAggregation(InstrumentType $instrumentType /*, array $advisory = [] */): ?AggregationInterface;
+    public function defaultAggregation(InstrumentType $instrumentType, array $advisory = []): ?AggregationInterface;
 }

--- a/src/SDK/Metrics/DefaultAggregationProviderInterface.php
+++ b/src/SDK/Metrics/DefaultAggregationProviderInterface.php
@@ -7,11 +7,11 @@ namespace OpenTelemetry\SDK\Metrics;
 interface DefaultAggregationProviderInterface
 {
     /**
-     * @param string|InstrumentType $instrumentType
+     * @param InstrumentType $instrumentType
      * @param array $advisory optional set of recommendations
      *
      * @noinspection PhpDocSignatureInspection not added for BC
      * @phan-suppress PhanCommentParamWithoutRealParam @phpstan-ignore-next-line
      */
-    public function defaultAggregation($instrumentType /*, array $advisory = [] */): ?AggregationInterface;
+    public function defaultAggregation(InstrumentType $instrumentType /*, array $advisory = [] */): ?AggregationInterface;
 }

--- a/src/SDK/Metrics/DefaultAggregationProviderTrait.php
+++ b/src/SDK/Metrics/DefaultAggregationProviderTrait.php
@@ -6,14 +6,13 @@ namespace OpenTelemetry\SDK\Metrics;
 
 trait DefaultAggregationProviderTrait
 {
-    public function defaultAggregation($instrumentType, array $advisory = []): ?AggregationInterface
+    public function defaultAggregation(InstrumentType $instrumentType, array $advisory = []): ?AggregationInterface
     {
         return match ($instrumentType) {
             InstrumentType::COUNTER, InstrumentType::ASYNCHRONOUS_COUNTER => new Aggregation\SumAggregation(true),
             InstrumentType::UP_DOWN_COUNTER, InstrumentType::ASYNCHRONOUS_UP_DOWN_COUNTER => new Aggregation\SumAggregation(),
             InstrumentType::HISTOGRAM => new Aggregation\ExplicitBucketHistogramAggregation($advisory['ExplicitBucketBoundaries'] ?? [0, 5, 10, 25, 50, 75, 100, 250, 500, 1000]),
             InstrumentType::GAUGE, InstrumentType::ASYNCHRONOUS_GAUGE => new Aggregation\LastValueAggregation(),
-            default => null,
         };
     }
 }

--- a/src/SDK/Metrics/Instrument.php
+++ b/src/SDK/Metrics/Instrument.php
@@ -7,7 +7,7 @@ namespace OpenTelemetry\SDK\Metrics;
 final class Instrument
 {
     public function __construct(
-        public readonly string|InstrumentType $type,
+        public readonly InstrumentType $type,
         public readonly string $name,
         public readonly ?string $unit,
         public readonly ?string $description,

--- a/src/SDK/Metrics/InstrumentType.php
+++ b/src/SDK/Metrics/InstrumentType.php
@@ -6,22 +6,16 @@ namespace OpenTelemetry\SDK\Metrics;
 
 /**
  * Instrument type.
- *
- * Has to be type-hinted as `string|InstrumentType` to be forward compatible.
  */
-final class InstrumentType
+enum InstrumentType
 {
-    public const COUNTER = 'Counter';
-    public const UP_DOWN_COUNTER = 'UpDownCounter';
-    public const HISTOGRAM = 'Histogram';
+    case COUNTER;
+    case UP_DOWN_COUNTER;
+    case HISTOGRAM;
     /** @experimental */
-    public const GAUGE = 'Gauge';
+    case GAUGE;
 
-    public const ASYNCHRONOUS_COUNTER = 'AsynchronousCounter';
-    public const ASYNCHRONOUS_UP_DOWN_COUNTER = 'AsynchronousUpDownCounter';
-    public const ASYNCHRONOUS_GAUGE = 'AsynchronousGauge';
-
-    private function __construct()
-    {
-    }
+    case ASYNCHRONOUS_COUNTER;
+    case ASYNCHRONOUS_UP_DOWN_COUNTER;
+    case ASYNCHRONOUS_GAUGE;
 }

--- a/src/SDK/Metrics/Meter.php
+++ b/src/SDK/Metrics/Meter.php
@@ -420,7 +420,6 @@ final class Meter implements MeterInterface, Configurable
                             $view->unit,
                             $view->description,
                             $view->attributeKeys,
-                            /** @phan-suppress-next-line PhanParamTooMany @phpstan-ignore-next-line */
                             $metricRegistry->defaultAggregation($instrument->type, $instrument->advisory),
                         ),
                         new RegistryRegistration($metricRegistry, $stalenessHandler),

--- a/src/SDK/Metrics/Meter.php
+++ b/src/SDK/Metrics/Meter.php
@@ -294,7 +294,7 @@ final class Meter implements MeterInterface, Configurable
     /**
      * @return array{Instrument, ReferenceCounterInterface, RegisteredInstrument}
      */
-    private function createSynchronousWriter(string|InstrumentType $instrumentType, string $name, ?string $unit, ?string $description, array $advisory = []): array
+    private function createSynchronousWriter(InstrumentType $instrumentType, string $name, ?string $unit, ?string $description, array $advisory = []): array
     {
         $instrument = new Instrument($instrumentType, $name, $unit, $description, $advisory);
 
@@ -340,7 +340,7 @@ final class Meter implements MeterInterface, Configurable
     /**
      * @return array{Instrument, ReferenceCounterInterface, RegisteredInstrument}
      */
-    private function createAsynchronousObserver(string|InstrumentType $instrumentType, string $name, ?string $unit, ?string $description, array $advisory): array
+    private function createAsynchronousObserver(InstrumentType $instrumentType, string $name, ?string $unit, ?string $description, array $advisory): array
     {
         $instrument = new Instrument($instrumentType, $name, $unit, $description, $advisory);
 

--- a/src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php
+++ b/src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php
@@ -18,13 +18,13 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
  */
 class ConsoleMetricExporter implements PushMetricExporterInterface, AggregationTemporalitySelectorInterface
 {
-    public function __construct(private readonly Temporality|string|null $temporality = null)
+    public function __construct(private readonly ?Temporality $temporality = null)
     {
     }
     /**
      * @inheritDoc
      */
-    public function temporality(MetricMetadataInterface $metric): Temporality|string|null
+    public function temporality(MetricMetadataInterface $metric): ?Temporality
     {
         return $this->temporality ?? $metric->temporality();
     }

--- a/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
+++ b/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
@@ -23,11 +23,11 @@ final class InMemoryExporter implements MetricExporterInterface, AggregationTemp
 
     private bool $closed = false;
 
-    public function __construct(private readonly string|Temporality|null $temporality = null)
+    public function __construct(private readonly ?Temporality $temporality = null)
     {
     }
 
-    public function temporality(MetricMetadataInterface $metric): string|Temporality|null
+    public function temporality(MetricMetadataInterface $metric): ?Temporality
     {
         return $this->temporality ?? $metric->temporality();
     }

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\SDK\Metrics\MetricFactory;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\Instrument;
+use OpenTelemetry\SDK\Metrics\InstrumentType;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
 use OpenTelemetry\SDK\Metrics\MetricRegistry\MetricCollectorInterface;
 use OpenTelemetry\SDK\Metrics\MetricSourceInterface;
@@ -36,7 +37,7 @@ final class StreamMetricSourceProvider implements MetricSourceProviderInterface,
         return new StreamMetricSource($this, $this->stream->register($temporality));
     }
 
-    public function instrumentType()
+    public function instrumentType(): InstrumentType
     {
         return $this->instrument->type;
     }

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\SDK\Metrics\MetricFactory;
 
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
+use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\Instrument;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
 use OpenTelemetry\SDK\Metrics\MetricRegistry\MetricCollectorInterface;
@@ -55,7 +56,7 @@ final class StreamMetricSourceProvider implements MetricSourceProviderInterface,
         return $this->view->description;
     }
 
-    public function temporality()
+    public function temporality(): Temporality
     {
         return $this->stream->temporality();
     }

--- a/src/SDK/Metrics/MetricMetadataInterface.php
+++ b/src/SDK/Metrics/MetricMetadataInterface.php
@@ -22,7 +22,7 @@ interface MetricMetadataInterface
     /**
      * Returns the underlying temporality of this metric.
      *
-     * @return ?Temporality internal temporality
+     * @return Temporality internal temporality
      */
-    public function temporality(): ?Temporality;
+    public function temporality(): Temporality;
 }

--- a/src/SDK/Metrics/MetricMetadataInterface.php
+++ b/src/SDK/Metrics/MetricMetadataInterface.php
@@ -9,9 +9,9 @@ use OpenTelemetry\SDK\Metrics\Data\Temporality;
 interface MetricMetadataInterface
 {
     /**
-     * @return string|InstrumentType
+     * @return InstrumentType
      */
-    public function instrumentType();
+    public function instrumentType(): InstrumentType;
 
     public function name(): string;
 

--- a/src/SDK/Metrics/MetricMetadataInterface.php
+++ b/src/SDK/Metrics/MetricMetadataInterface.php
@@ -22,7 +22,7 @@ interface MetricMetadataInterface
     /**
      * Returns the underlying temporality of this metric.
      *
-     * @return string|Temporality internal temporality
+     * @return ?Temporality internal temporality
      */
-    public function temporality();
+    public function temporality(): ?Temporality;
 }

--- a/src/SDK/Metrics/MetricReader/ExportingReader.php
+++ b/src/SDK/Metrics/MetricReader/ExportingReader.php
@@ -9,6 +9,7 @@ use OpenTelemetry\SDK\Metrics\AggregationInterface;
 use OpenTelemetry\SDK\Metrics\AggregationTemporalitySelectorInterface;
 use OpenTelemetry\SDK\Metrics\DefaultAggregationProviderInterface;
 use OpenTelemetry\SDK\Metrics\DefaultAggregationProviderTrait;
+use OpenTelemetry\SDK\Metrics\InstrumentType;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Metrics\MetricFactory\StreamMetricSourceProvider;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
@@ -39,7 +40,7 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
     {
     }
 
-    public function defaultAggregation($instrumentType, array $advisory = []): ?AggregationInterface
+    public function defaultAggregation(InstrumentType $instrumentType, array $advisory = []): ?AggregationInterface
     {
         if ($this->exporter instanceof DefaultAggregationProviderInterface) {
             /** @phan-suppress-next-line PhanParamTooMany @phpstan-ignore-next-line */

--- a/src/SDK/Metrics/MetricReader/ExportingReader.php
+++ b/src/SDK/Metrics/MetricReader/ExportingReader.php
@@ -43,7 +43,6 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
     public function defaultAggregation(InstrumentType $instrumentType, array $advisory = []): ?AggregationInterface
     {
         if ($this->exporter instanceof DefaultAggregationProviderInterface) {
-            /** @phan-suppress-next-line PhanParamTooMany @phpstan-ignore-next-line */
             return $this->exporter->defaultAggregation($instrumentType, $advisory);
         }
 

--- a/src/SDK/Metrics/MetricSourceProviderInterface.php
+++ b/src/SDK/Metrics/MetricSourceProviderInterface.php
@@ -8,8 +8,5 @@ use OpenTelemetry\SDK\Metrics\Data\Temporality;
 
 interface MetricSourceProviderInterface
 {
-    /**
-     * @param string|Temporality $temporality
-     */
-    public function create($temporality): MetricSourceInterface;
+    public function create(Temporality $temporality): MetricSourceInterface;
 }

--- a/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
@@ -28,7 +28,7 @@ final class AsynchronousMetricStream implements MetricStreamInterface
         $this->metric = new Metric([], [], $startTimestamp);
     }
 
-    public function temporality(): Temporality|string
+    public function temporality(): Temporality
     {
         return Temporality::CUMULATIVE;
     }

--- a/src/SDK/Metrics/Stream/MetricStreamInterface.php
+++ b/src/SDK/Metrics/Stream/MetricStreamInterface.php
@@ -15,9 +15,9 @@ interface MetricStreamInterface
     /**
      * Returns the internal temporality of this stream.
      *
-     * @return string|Temporality internal temporality
+     * @return Temporality internal temporality
      */
-    public function temporality();
+    public function temporality(): Temporality;
 
     /**
      * Returns the last metric timestamp.
@@ -36,10 +36,10 @@ interface MetricStreamInterface
     /**
      * Registers a new reader with the given temporality.
      *
-     * @param string|Temporality $temporality temporality to use
+     * @param Temporality $temporality temporality to use
      * @return int reader id
      */
-    public function register($temporality): int;
+    public function register(Temporality $temporality): int;
 
     /**
      * Unregisters the given reader.

--- a/src/SDK/Metrics/Stream/SynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/SynchronousMetricStream.php
@@ -39,7 +39,7 @@ final class SynchronousMetricStream implements MetricStreamInterface
         $this->delta = new DeltaStorage($this->aggregation);
     }
 
-    public function temporality(): Temporality|string
+    public function temporality(): Temporality
     {
         return Temporality::DELTA;
     }

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentTypeCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentTypeCriteria.php
@@ -15,11 +15,11 @@ final class InstrumentTypeCriteria implements SelectionCriteriaInterface
     private readonly array $instrumentTypes;
 
     /**
-     * @param string|InstrumentType|string[]|InstrumentType[] $instrumentType
+     * @param InstrumentType|InstrumentType[] $instrumentType
      */
-    public function __construct($instrumentType)
+    public function __construct(array|InstrumentType $instrumentType)
     {
-        $this->instrumentTypes = (array) $instrumentType;
+        $this->instrumentTypes = is_array($instrumentType) ? $instrumentType : [$instrumentType];
     }
 
     public function accepts(Instrument $instrument, InstrumentationScopeInterface $instrumentationScope): bool

--- a/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
@@ -58,7 +58,7 @@ class MetricExporterFactoryTest extends TestCase
 
         $this->assertInstanceOf(AggregationTemporalitySelectorInterface::class, $exporter);
         $metric = $this->createMock(MetricMetadataInterface::class);
-        $metric->method('temporality')->willReturn(null);
+        $metric->method('temporality')->willReturn(Temporality::DELTA);
         $this->assertSame($expected, $exporter->temporality($metric));
     }
 
@@ -85,11 +85,11 @@ class MetricExporterFactoryTest extends TestCase
                 [
                     'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'lowmemory',
                 ],
-                null,
+                Temporality::DELTA,
             ],
             'CuMuLaTiVe (mixed case)' => [
                 [
-                    'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative',
+                    'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'CuMuLaTiVe',
                 ],
                 Temporality::CUMULATIVE,
             ],

--- a/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
@@ -43,7 +43,7 @@ class MetricExporterFactoryTest extends TestCase
     }
 
     #[DataProvider('temporalityProvider')]
-    public function test_create_with_temporality(array $env, ?string $expected): void
+    public function test_create_with_temporality(array $env, ?Temporality $expected): void
     {
         // @phpstan-ignore-next-line
         $this->transportFactory->method('create')->willReturn($this->transport);
@@ -57,7 +57,9 @@ class MetricExporterFactoryTest extends TestCase
         $exporter = $factory->create();
 
         $this->assertInstanceOf(AggregationTemporalitySelectorInterface::class, $exporter);
-        $this->assertSame($expected, $exporter->temporality($this->createMock(MetricMetadataInterface::class)));
+        $metric = $this->createMock(MetricMetadataInterface::class);
+        $metric->method('temporality')->willReturn(null);
+        $this->assertSame($expected, $exporter->temporality($metric));
     }
 
     public static function temporalityProvider(): array

--- a/tests/Unit/SDK/Metrics/MetricReader/ExportingReaderTest.php
+++ b/tests/Unit/SDK/Metrics/MetricReader/ExportingReaderTest.php
@@ -184,7 +184,7 @@ final class ExportingReaderTest extends TestCase
         $source = $this->createMock(MetricSourceInterface::class);
         $source->method('collect')->willReturn($this->createMock(Metric::class));
         $provider->method('create')->willReturn($source);
-        $exporter->method('temporality')->willReturn('foo');
+        $exporter->method('temporality')->willReturn(Temporality::CUMULATIVE);
         $exporter->expects($this->once())->method('export')->willReturn(true);
         $exporter->expects($this->once())->method('shutdown')->willReturn(true);
 

--- a/tests/Unit/SDK/Metrics/View/SelectionCriteriaTest.php
+++ b/tests/Unit/SDK/Metrics/View/SelectionCriteriaTest.php
@@ -94,6 +94,10 @@ final class SelectionCriteriaTest extends TestCase
 
     public function test_instrument_type_criteria_wildcard(): void
     {
+        $this->assertTrue((new InstrumentTypeCriteria([InstrumentType::COUNTER, InstrumentType::HISTOGRAM]))->accepts(
+            new Instrument(InstrumentType::COUNTER, 'name', null, null),
+            new InstrumentationScope('scopeName', null, null, Attributes::create([])),
+        ));
         $this->assertTrue((new InstrumentTypeCriteria(InstrumentType::COUNTER))->accepts(
             new Instrument(InstrumentType::COUNTER, 'name', null, null),
             new InstrumentationScope('scopeName', null, null, Attributes::create([])),


### PR DESCRIPTION
Remove forwards-compatible Metrics features for 2.x:
- No longer accept strings for Temporality and InstrumentType
- `$advisory` added to `DefaultAggregationProviderInterface`