### PR TITLE
Semconv 1.30

### DIFF
--- a/script/semantic-conventions/semconv.sh
+++ b/script/semantic-conventions/semconv.sh
@@ -17,7 +17,7 @@ SPEC_DIR="${ROOT_DIR}/var/semantic-conventions"
 CODE_DIR="${ROOT_DIR}/src/SemConv"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.28.0
+SEMCONV_VERSION=1.30.0
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 OTEL_WEAVER_IMG_VERSION=v0.12.0

--- a/src/SemConv/ResourceAttributeValues.php
+++ b/src/SemConv/ResourceAttributeValues.php
@@ -11,7 +11,7 @@ interface ResourceAttributeValues
     /**
      * The URL of the OpenTelemetry schema for these values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.28.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.30.0';
 
     /**
      * ec2

--- a/src/SemConv/ResourceAttributes.php
+++ b/src/SemConv/ResourceAttributes.php
@@ -11,7 +11,7 @@ interface ResourceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.28.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.30.0';
 
     /**
      * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found [here](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels).
@@ -639,6 +639,16 @@ interface ResourceAttributes
     public const K8S_DEPLOYMENT_UID = 'k8s.deployment.uid';
 
     /**
+     * The name of the horizontal pod autoscaler.
+     */
+    public const K8S_HPA_NAME = 'k8s.hpa.name';
+
+    /**
+     * The UID of the horizontal pod autoscaler.
+     */
+    public const K8S_HPA_UID = 'k8s.hpa.uid';
+
+    /**
      * The name of the Job.
      */
     public const K8S_JOB_NAME = 'k8s.job.name';
@@ -692,6 +702,26 @@ interface ResourceAttributes
      * The UID of the ReplicaSet.
      */
     public const K8S_REPLICASET_UID = 'k8s.replicaset.uid';
+
+    /**
+     * The name of the replication controller.
+     */
+    public const K8S_REPLICATIONCONTROLLER_NAME = 'k8s.replicationcontroller.name';
+
+    /**
+     * The UID of the replication controller.
+     */
+    public const K8S_REPLICATIONCONTROLLER_UID = 'k8s.replicationcontroller.uid';
+
+    /**
+     * The name of the resource quota.
+     */
+    public const K8S_RESOURCEQUOTA_NAME = 'k8s.resourcequota.name';
+
+    /**
+     * The UID of the resource quota.
+     */
+    public const K8S_RESOURCEQUOTA_UID = 'k8s.resourcequota.uid';
 
     /**
      * The name of the StatefulSet.

--- a/src/SemConv/TraceAttributeValues.php
+++ b/src/SemConv/TraceAttributeValues.php
@@ -11,7 +11,7 @@ interface TraceAttributeValues
     /**
      * The URL of the OpenTelemetry schema for these values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.28.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.30.0';
     /**
      * Any time before Activity.onResume() or, if the app has no Activity, Context.startService() has been called in the app for the first time.
      *

--- a/src/SemConv/TraceAttributes.php
+++ b/src/SemConv/TraceAttributes.php
@@ -11,7 +11,7 @@ interface TraceAttributes
     /**
      * The URL of the OpenTelemetry schema for these keys and values.
      */
-    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.28.0';
+    public const SCHEMA_URL = 'https://opentelemetry.io/schemas/1.30.0';
 
     /**
      * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found [here](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels).
@@ -1044,14 +1044,14 @@ interface TraceAttributes
      * Low cardinality representation of a database query text.
      *
      * `db.query.summary` provides static summary of the query text. It describes a class of database queries and is useful as a grouping key, especially when analyzing telemetry for database calls involving complex queries.
-     * Summary may be available to the instrumentation through instrumentation hooks or other means. If it is not available, instrumentations that support query parsing SHOULD generate a summary following [Generating query summary](../../docs/database/database-spans.md#generating-a-summary-of-the-query-text) section.
+     * Summary may be available to the instrumentation through instrumentation hooks or other means. If it is not available, instrumentations that support query parsing SHOULD generate a summary following [Generating query summary](../database/database-spans.md#generating-a-summary-of-the-query-text) section.
      */
     public const DB_QUERY_SUMMARY = 'db.query.summary';
 
     /**
      * The database query being executed.
      *
-     * For sanitization see [Sanitization of `db.query.text`](../../docs/database/database-spans.md#sanitization-of-dbquerytext).
+     * For sanitization see [Sanitization of `db.query.text`](../database/database-spans.md#sanitization-of-dbquerytext).
      * For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
      * Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
      */
@@ -2189,6 +2189,16 @@ interface TraceAttributes
     public const K8S_DEPLOYMENT_UID = 'k8s.deployment.uid';
 
     /**
+     * The name of the horizontal pod autoscaler.
+     */
+    public const K8S_HPA_NAME = 'k8s.hpa.name';
+
+    /**
+     * The UID of the horizontal pod autoscaler.
+     */
+    public const K8S_HPA_UID = 'k8s.hpa.uid';
+
+    /**
      * The name of the Job.
      */
     public const K8S_JOB_NAME = 'k8s.job.name';
@@ -2257,6 +2267,26 @@ interface TraceAttributes
      * The UID of the ReplicaSet.
      */
     public const K8S_REPLICASET_UID = 'k8s.replicaset.uid';
+
+    /**
+     * The name of the replication controller.
+     */
+    public const K8S_REPLICATIONCONTROLLER_NAME = 'k8s.replicationcontroller.name';
+
+    /**
+     * The UID of the replication controller.
+     */
+    public const K8S_REPLICATIONCONTROLLER_UID = 'k8s.replicationcontroller.uid';
+
+    /**
+     * The name of the resource quota.
+     */
+    public const K8S_RESOURCEQUOTA_NAME = 'k8s.resourcequota.name';
+
+    /**
+     * The UID of the resource quota.
+     */
+    public const K8S_RESOURCEQUOTA_UID = 'k8s.resourcequota.uid';
 
     /**
      * The name of the StatefulSet.

--- a/src/SemConv/Version.php
+++ b/src/SemConv/Version.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\SemConv;
 
 enum Version: string
 {
+    case VERSION_1_30_0 = '1.30.0';
     case VERSION_1_28_0 = '1.28.0';
     case VERSION_1_27_0 = '1.27.0';
     case VERSION_1_26_0 = '1.26.0';

--- a/src/SemConv/composer.json
+++ b/src/SemConv/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
generate semantic conventions 1.30 (NB that 1.29 contained a bug, and the recommendation is to skip it).
support php 8.0, since it still works against this version and we have a bunch of auto-instrumentation packages that support 8.0