### PR TITLE
fix gRPC timeout (#1498)

### DIFF
--- a/src/API/Common/Time/ClockInterface.php
+++ b/src/API/Common/Time/ClockInterface.php
@@ -9,6 +9,7 @@ interface ClockInterface
     public const NANOS_PER_SECOND = 1_000_000_000;
     public const NANOS_PER_MILLISECOND = 1_000_000;
     public const NANOS_PER_MICROSECOND = 1_000;
+    public const MICROS_PER_MILLISECOND = 1_000;
     public const MILLIS_PER_SECOND = 1_000;
 
     /**

--- a/src/Contrib/Grpc/GrpcTransport.php
+++ b/src/Contrib/Grpc/GrpcTransport.php
@@ -38,15 +38,18 @@ final class GrpcTransport implements TransportInterface
     private readonly array $metadata;
     private readonly Channel $channel;
     private bool $closed = false;
+    private Timeval $exportTimeout;
 
     public function __construct(
         string $endpoint,
         array $opts,
         private readonly string $method,
         array $headers = [],
+        int $timeoutMillis = 500,
     ) {
         $this->channel = new Channel($endpoint, $opts);
         $this->metadata = $this->formatMetadata(array_change_key_case($headers));
+        $this->exportTimeout = new Timeval($timeoutMillis * 1000);
     }
 
     public function contentType(): string
@@ -60,7 +63,7 @@ final class GrpcTransport implements TransportInterface
             return new ErrorFuture(new BadMethodCallException('Transport closed'));
         }
 
-        $call = new Call($this->channel, $this->method, Timeval::infFuture());
+        $call = new Call($this->channel, $this->method, $this->exportTimeout);
 
         $cancellation ??= new NullCancellation();
         $cancellationId = $cancellation->subscribe(static fn (Throwable $e) => $call->cancel());

--- a/src/Contrib/Grpc/GrpcTransport.php
+++ b/src/Contrib/Grpc/GrpcTransport.php
@@ -18,6 +18,7 @@ use const Grpc\OP_SEND_INITIAL_METADATA;
 use const Grpc\OP_SEND_MESSAGE;
 use const Grpc\STATUS_OK;
 use Grpc\Timeval;
+use OpenTelemetry\API\Common\Time\ClockInterface;
 use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
@@ -49,7 +50,7 @@ final class GrpcTransport implements TransportInterface
     ) {
         $this->channel = new Channel($endpoint, $opts);
         $this->metadata = $this->formatMetadata(array_change_key_case($headers));
-        $this->exportTimeout = new Timeval($timeoutMillis * 1000);
+        $this->exportTimeout = new Timeval($timeoutMillis * ClockInterface::MICROS_PER_MILLISECOND);
     }
 
     public function contentType(): string

--- a/src/Contrib/Grpc/GrpcTransportFactory.php
+++ b/src/Contrib/Grpc/GrpcTransportFactory.php
@@ -81,6 +81,7 @@ final class GrpcTransportFactory implements TransportFactoryInterface
             $opts,
             $method,
             $headers,
+            (int)($timeout * 1000),
         );
     }
 
@@ -116,7 +117,6 @@ final class GrpcTransportFactory implements TransportFactoryInterface
                             'method' => null,
                         ],
                     ],
-                    'timeout' => sprintf('%0.6fs', $timeout),
                     'retryPolicy' => [
                         'maxAttempts' => $maxRetries,
                         'initialBackoff' => sprintf('%0.3fs', $retryDelay / 1000),

--- a/src/Contrib/Grpc/GrpcTransportFactory.php
+++ b/src/Contrib/Grpc/GrpcTransportFactory.php
@@ -81,7 +81,7 @@ final class GrpcTransportFactory implements TransportFactoryInterface
             $opts,
             $method,
             $headers,
-            (int)($timeout * 1000),
+            (int) ($timeout * 1000),
         );
     }
 

--- a/tests/Unit/Contrib/Grpc/GrpcTransportTest.php
+++ b/tests/Unit/Contrib/Grpc/GrpcTransportTest.php
@@ -18,7 +18,7 @@ final class GrpcTransportTest extends TestCase
 
     public function setUp(): void
     {
-        $this->transport = new GrpcTransport('http://localhost:4317', [], '/method', []);
+        $this->transport = new GrpcTransport('http://localhost:4317', [], '/method', [], 123);
     }
 
     public function test_grpc_transport_supports_only_protobuf(): void


### PR DESCRIPTION
Fixes #1498 (grpc timeouts not being respected)

The timeout seems to work correctly for long and short variants of the bug with this code but  I wasn't able to create meaningful tests.  Whilst it was possible to get the calculated timeval from the transport instance using reflection,  actually calling functions on `\Grpc\Timeval` (such as [similar()](https://grpc.github.io/grpc/php/class_grpc_1_1_timeval.html#a6bc3609d25c19f9297749781efd1071e) just crashes the test runner

No additional unit tests fail compared to `main` (35 vs 35)
Happy to make any adjustments according to feedback

