### PR TITLE
use a local const for grpc time conversions

### DIFF
--- a/src/Contrib/Grpc/GrpcTransport.php
+++ b/src/Contrib/Grpc/GrpcTransport.php
@@ -18,7 +18,6 @@ use const Grpc\OP_SEND_INITIAL_METADATA;
 use const Grpc\OP_SEND_MESSAGE;
 use const Grpc\STATUS_OK;
 use Grpc\Timeval;
-use OpenTelemetry\API\Common\Time\ClockInterface;
 use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
@@ -36,10 +35,11 @@ use Throwable;
  */
 final class GrpcTransport implements TransportInterface
 {
+    private const MICROS_PER_MILLISECOND = 1_000;
     private readonly array $metadata;
     private readonly Channel $channel;
     private bool $closed = false;
-    private Timeval $exportTimeout;
+    private readonly Timeval $exportTimeout;
 
     public function __construct(
         string $endpoint,
@@ -50,7 +50,7 @@ final class GrpcTransport implements TransportInterface
     ) {
         $this->channel = new Channel($endpoint, $opts);
         $this->metadata = $this->formatMetadata(array_change_key_case($headers));
-        $this->exportTimeout = new Timeval($timeoutMillis * ClockInterface::MICROS_PER_MILLISECOND);
+        $this->exportTimeout = new Timeval($timeoutMillis * self::MICROS_PER_MILLISECOND);
     }
 
     public function contentType(): string

--- a/src/Contrib/Grpc/GrpcTransportFactory.php
+++ b/src/Contrib/Grpc/GrpcTransportFactory.php
@@ -12,7 +12,6 @@ use function in_array;
 use InvalidArgumentException;
 use function json_encode;
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
-use OpenTelemetry\API\Common\Time\ClockInterface;
 use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
@@ -24,6 +23,8 @@ use function substr_count;
 final class GrpcTransportFactory implements TransportFactoryInterface
 {
     use LogsMessagesTrait;
+
+    public const MILLIS_PER_SECOND = 1_000;
 
     /**
      * @psalm-param "application/x-protobuf" $contentType
@@ -82,7 +83,7 @@ final class GrpcTransportFactory implements TransportFactoryInterface
             $opts,
             $method,
             $headers,
-            (int) ($timeout * ClockInterface::MILLIS_PER_SECOND),
+            (int) ($timeout * self::MILLIS_PER_SECOND),
         );
     }
 
@@ -119,8 +120,8 @@ final class GrpcTransportFactory implements TransportFactoryInterface
                     ],
                     'retryPolicy' => [
                         'maxAttempts' => $maxRetries,
-                        'initialBackoff' => sprintf('%0.3fs', $retryDelay / ClockInterface::MILLIS_PER_SECOND),
-                        'maxBackoff' => sprintf('%0.3fs', ($retryDelay << $maxRetries - 1) / ClockInterface::MILLIS_PER_SECOND),
+                        'initialBackoff' => sprintf('%0.3fs', $retryDelay / self::MILLIS_PER_SECOND),
+                        'maxBackoff' => sprintf('%0.3fs', ($retryDelay << $maxRetries - 1) / self::MILLIS_PER_SECOND),
                         'backoffMultiplier' => 2,
                         'retryableStatusCodes' => [
                             // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlpgrpc-response

--- a/src/Contrib/Grpc/GrpcTransportFactory.php
+++ b/src/Contrib/Grpc/GrpcTransportFactory.php
@@ -24,7 +24,7 @@ final class GrpcTransportFactory implements TransportFactoryInterface
 {
     use LogsMessagesTrait;
 
-    public const MILLIS_PER_SECOND = 1_000;
+    private const MILLIS_PER_SECOND = 1_000;
 
     /**
      * @psalm-param "application/x-protobuf" $contentType


### PR DESCRIPTION
using a newly-added const in ClockInterface breaks things for some older PHP versions, so lets use a local const for now