### PR TITLE
Fix type error when using `LateBindingMeter::createObservable{Instrument}()`

### DIFF
--- a/src/API/Metrics/LateBindingMeter.php
+++ b/src/API/Metrics/LateBindingMeter.php
@@ -31,7 +31,7 @@ class LateBindingMeter implements MeterInterface
 
     public function createObservableCounter(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableCounterInterface
     {
-        return ($this->meter ??= ($this->factory)())->createObservableCounter($name, $unit, $description, $advisory, $callbacks);
+        return ($this->meter ??= ($this->factory)())->createObservableCounter($name, $unit, $description, $advisory, ...$callbacks);
     }
 
     public function createHistogram(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): HistogramInterface
@@ -46,7 +46,7 @@ class LateBindingMeter implements MeterInterface
 
     public function createObservableGauge(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableGaugeInterface
     {
-        return ($this->meter ??= ($this->factory)())->createObservableGauge($name, $unit, $description, $advisory, $callbacks);
+        return ($this->meter ??= ($this->factory)())->createObservableGauge($name, $unit, $description, $advisory, ...$callbacks);
     }
 
     public function createUpDownCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): UpDownCounterInterface
@@ -56,6 +56,6 @@ class LateBindingMeter implements MeterInterface
 
     public function createObservableUpDownCounter(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableUpDownCounterInterface
     {
-        return ($this->meter ??= ($this->factory)())->createObservableUpDownCounter($name, $unit, $description, $advisory, $callbacks);
+        return ($this->meter ??= ($this->factory)())->createObservableUpDownCounter($name, $unit, $description, $advisory, ...$callbacks);
     }
 }

--- a/tests/Unit/API/Instrumentation/AutoInstrumentation/LateBindingProviderTest.php
+++ b/tests/Unit/API/Instrumentation/AutoInstrumentation/LateBindingProviderTest.php
@@ -28,6 +28,7 @@ use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
+use OpenTelemetry\SDK\Metrics\NoopMeterProvider;
 use OpenTelemetry\SDK\SdkAutoloader;
 use OpenTelemetry\Tests\TestState;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -148,5 +149,15 @@ class LateBindingProviderTest extends TestCase
         $instrumentation->getPropagator()->fields();
         /** @phpstan-ignore-next-line */
         $propagator->fields()->shouldHaveBeenCalledOnce();
+    }
+
+    public function test_late_binding_meter_observable_instruments(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $meterProvider = new LateBindingMeterProvider(static fn () => new NoopMeterProvider());
+        $meterProvider->getMeter('test')->createObservableCounter('test');
+        $meterProvider->getMeter('test')->createObservableGauge('test');
+        $meterProvider->getMeter('test')->createObservableUpDownCounter('test');
     }
 }


### PR DESCRIPTION
```
NoopMeter::createObservableUpDownCounter(): Argument #5 must be of type callable, array given
#0 NoopMeter->createObservableUpDownCounter('php.memory.usag...', 'By', 'The amount of p...', Array, Array)
#1 LateBindingMeter->createObservableUpDownCounter('php.memory.usag...', 'By', 'The amount of p...', _: Object(Closure))
```