### PR TITLE
Fix `YamlSymfonyFileLoader` if locator uses directory besides `getcwd()`

### DIFF
--- a/src/Config/SDK/Configuration/Loader/YamlSymfonyFileLoader.php
+++ b/src/Config/SDK/Configuration/Loader/YamlSymfonyFileLoader.php
@@ -32,7 +32,7 @@ final class YamlSymfonyFileLoader extends FileLoader
         $this->configuration->addResource(new FileResource($path));
 
         try {
-            $content = Yaml::parseFile($resource, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+            $content = Yaml::parseFile($path, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
         } catch (ParseException $e) {
             throw new InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML: %s', $path, $e->getMessage()), 0, $e);
         }


### PR DESCRIPTION
Fixes a minor bug that did not affect our use-case.
We were passing the relative path `$resource` instead of the absolute path `$path` that was returned by the locator (in our case always resolved relative to `getcwd()` -> no impact) to `Yaml::parseFile()`.