### PR TITLE
chore: build images dynamically

### DIFF
--- a/.github/workflows/publish-otel-php-base-docker-image.yml
+++ b/.github/workflows/publish-otel-php-base-docker-image.yml
@@ -6,6 +6,9 @@ on:
   push:
     paths:
       - docker/Dockerfile
+  pull_request:
+    paths:
+      - docker/Dockerfile
 jobs:
   push_to_registry:
     name: OpenTelemetry PHP base docker image creation

--- a/.github/workflows/publish-otel-php-base-docker-image.yml
+++ b/.github/workflows/publish-otel-php-base-docker-image.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:
+  push:
+    paths:
+      - docker/Dockerfile
 jobs:
   push_to_registry:
     name: OpenTelemetry PHP base docker image creation

--- a/.github/workflows/publish-otel-php-base-docker-image.yml
+++ b/.github/workflows/publish-otel-php-base-docker-image.yml
@@ -33,6 +33,17 @@ jobs:
 
       - name: Build and push ${{ matrix.php-version }} to ghcr.io
         uses: docker/build-push-action@v5
+        if: github.ref != 'refs/heads/main'
+        with:
+          push: false
+          file: docker/Dockerfile
+          build-args: PHP_VERSION=${{ matrix.php-version }}
+          platforms: linux/amd64,linux/arm/v8,linux/arm64
+          tags: ghcr.io/open-telemetry/opentelemetry-php/opentelemetry-php-base:${{ matrix.php-version }}
+
+      - name: Build and push ${{ matrix.php-version }} to ghcr.io
+        uses: docker/build-push-action@v5
+        if: github.ref == 'refs/heads/main'
         with:
           push: true
           file: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
+ARG PHP_VERSION=8.0
+
 FROM php:8.0.30-cli-alpine AS php-8.0-cli-alpine
 FROM php:8.1.32-cli-alpine AS php-8.1-cli-alpine
 FROM php:8.2.28-cli-alpine AS php-8.2-cli-alpine
 FROM php:8.3.19-cli-alpine AS php-8.3-cli-alpine
 FROM php:8.4.5-cli-alpine AS php-8.4-cli-alpine
 
-ARG PHP_VERSION=8.0
 FROM php-${PHP_VERSION}-cli-alpine
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,10 @@
+FROM php:8.1.32-cli-alpine as php-8.1-cli-alpine
+FROM php:8.2.28-cli-alpine as php-8.2-cli-alpine
+FROM php:8.3.19-cli-alpine as php-8.3-cli-alpine
+FROM php:8.4.5-cli-alpine as php-8.4-cli-alpine
+
 ARG PHP_VERSION=8.0
-FROM php:${PHP_VERSION}-cli-alpine
+FROM php-${PHP_VERSION}-cli-alpine
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+FROM php:8.0.30-cli-alpine AS php-8.0-cli-alpine
 FROM php:8.1.32-cli-alpine AS php-8.1-cli-alpine
 FROM php:8.2.28-cli-alpine AS php-8.2-cli-alpine
 FROM php:8.3.19-cli-alpine AS php-8.3-cli-alpine

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM php:8.1.32-cli-alpine as php-8.1-cli-alpine
-FROM php:8.2.28-cli-alpine as php-8.2-cli-alpine
-FROM php:8.3.19-cli-alpine as php-8.3-cli-alpine
-FROM php:8.4.5-cli-alpine as php-8.4-cli-alpine
+FROM php:8.1.32-cli-alpine AS php-8.1-cli-alpine
+FROM php:8.2.28-cli-alpine AS php-8.2-cli-alpine
+FROM php:8.3.19-cli-alpine AS php-8.3-cli-alpine
+FROM php:8.4.5-cli-alpine AS php-8.4-cli-alpine
 
 ARG PHP_VERSION=8.0
 FROM php-${PHP_VERSION}-cli-alpine


### PR DESCRIPTION
This changes how images are built. In order to be a little more deterministic, we use set versions in `Dockerfile`.

This, in conjunction with #1544 , will make for a more ordered dependency updates.