### PR TITLE
skip segfault-inducing test

### DIFF
--- a/tests/Unit/Context/ScopeTest.php
+++ b/tests/Unit/Context/ScopeTest.php
@@ -82,6 +82,8 @@ class ScopeTest extends TestCase
 
     public function test_inactive_scope_detach(): void
     {
+        //@see https://bugs.xdebug.org/view.php?id=2332
+        $this->markTestSkipped('skipping: segfault in xdebug 3.4.2');
         $scope1 = Context::getCurrent()->activate();
 
         $fiber = new Fiber(static fn () => @$scope1->detach());

--- a/tests/Unit/Context/ScopeTest.php
+++ b/tests/Unit/Context/ScopeTest.php
@@ -82,8 +82,10 @@ class ScopeTest extends TestCase
 
     public function test_inactive_scope_detach(): void
     {
-        //@see https://bugs.xdebug.org/view.php?id=2332
-        $this->markTestSkipped('skipping: segfault in xdebug 3.4.2');
+        if (phpversion('xdebug') === '3.4.2') {
+            //@see https://bugs.xdebug.org/view.php?id=2332
+            $this->markTestSkipped('skipping: segfault in xdebug 3.4.2');
+        }
         $scope1 = Context::getCurrent()->activate();
 
         $fiber = new Fiber(static fn () => @$scope1->detach());


### PR DESCRIPTION
this test triggers a bug that surfaced in xdebug 3.4.2, see https://bugs.xdebug.org/view.php?id=2332

Related issue: #1554 