### PR TITLE
Fix missing metrics attributes in console exporter

### DIFF
--- a/src/SDK/Common/Attribute/Attributes.php
+++ b/src/SDK/Common/Attribute/Attributes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Common\Attribute;
 
+use JsonSerializable;
 use function array_key_exists;
 use IteratorAggregate;
 use Traversable;
@@ -11,7 +12,7 @@ use Traversable;
 /**
  * @psalm-suppress MissingTemplateParam
  */
-final class Attributes implements AttributesInterface, IteratorAggregate
+final class Attributes implements AttributesInterface, IteratorAggregate, JsonSerializable
 {
     /**
      * @internal
@@ -46,6 +47,11 @@ final class Attributes implements AttributesInterface, IteratorAggregate
     public function count(): int
     {
         return \count($this->attributes);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->attributes;
     }
 
     public function getIterator(): Traversable


### PR DESCRIPTION
This PR fixes a case that when using console exporter for metrics, attributes are not included in the export

Without fix:
```json
{
                "name": "http.client.request.body.size",
                "description": null,
                "unit": "By",
                "data": {
                    "dataPoints": [
                        {
                            "count": 1,
                            "sum": 14,
                            "min": 14,
                            "max": 14,
                            "bucketCounts": [
                                0,
                                0,
                                0,
                                1,
                                0,
                                0,
                                0,
                                0,
                                0,
                                0,
                                0
                            ],
                            "explicitBounds": [
                                0,
                                5,
                                10,
                                25,
                                50,
                                75,
                                100,
                                250,
                                500,
                                1000
                            ],
                            "attributes": {},
                            "startTimestamp": 1744027586704128264,
                            "timestamp": 1744027586707302423,
                            "exemplars": [
                                {
                                    "value": 14,
                                    "timestamp": 1744027586707167890,
                                    "attributes": {},
                                    "traceId": "036ad4d4fb29b907001b2927da026772",
                                    "spanId": "bfb17e41639c4a12"
                                }
                            ]
                        }
                    ],
                    "temporality": "Delta"
                }
            }
```
with fix:
```json
{
                "name": "http.client.request.body.size",
                "description": null,
                "unit": "By",
                "data": {
                    "dataPoints": [
                        {
                            "count": 1,
                            "sum": 14,
                            "min": 14,
                            "max": 14,
                            "bucketCounts": [
                                0,
                                0,
                                0,
                                1,
                                0,
                                0,
                                0,
                                0,
                                0,
                                0,
                                0
                            ],
                            "explicitBounds": [
                                0,
                                5,
                                10,
                                25,
                                50,
                                75,
                                100,
                                250,
                                500,
                                1000
                            ],
                            "attributes": {
                                "http.request.method": "POST",
                                "server.address": "localhost",
                                "server.port": 8080,
                                "url.scheme": "http",
                                "url.path": "\/test",
                                "url.query": "",
                                "url.full": "http:\/\/localhost:8080\/test",
                                "http.response.status_code": 200
                            },
                            "startTimestamp": 1744027551835022869,
                            "timestamp": 1744027551837611698,
                            "exemplars": [
                                {
                                    "value": 14,
                                    "timestamp": 1744027551837484198,
                                    "attributes": [],
                                    "traceId": "241dbf53bd65ab601f93378768683444",
                                    "spanId": "b282920d21f7859e"
                                }
                            ]
                        }
                    ],
                    "temporality": "Delta"
                }
            }
```
