### PR TITLE
Refactor InMemory exporters to use shared storage manager

### DIFF
--- a/src/SDK/Common/Export/InMemoryStorageManager.php
+++ b/src/SDK/Common/Export/InMemoryStorageManager.php
@@ -12,19 +12,19 @@ class InMemoryStorageManager
     private static ArrayObject $metrics;
     private static ArrayObject $logs;
 
-    public static function getStorageForMetrics(): ArrayObject
+    public static function metrics(): ArrayObject
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
         return self::$metrics ??= new ArrayObject();
     }
 
-    public static function getStorageForLogs(): ArrayObject
+    public static function logs(): ArrayObject
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
         return self::$logs ??= new ArrayObject();
     }
 
-    public static function getStorageForSpans(): ArrayObject
+    public static function spans(): ArrayObject
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
         return self::$spans ??= new ArrayObject();

--- a/src/SDK/Common/Export/InMemoryStorageManager.php
+++ b/src/SDK/Common/Export/InMemoryStorageManager.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\SDK\Common\Export;
+
+use ArrayObject;
+
+class InMemoryStorageManager
+{
+    private static ArrayObject $spans;
+    private static ArrayObject $metrics;
+    private static ArrayObject $logs;
+
+    public static function getStorageForMetrics(): ArrayObject
+    {
+        /** @psalm-suppress RedundantPropertyInitializationCheck */
+        return self::$metrics ??= new ArrayObject();
+    }
+
+    public static function getStorageForLogs(): ArrayObject
+    {
+        /** @psalm-suppress RedundantPropertyInitializationCheck */
+        return self::$logs ??= new ArrayObject();
+    }
+
+    public static function getStorageForSpans(): ArrayObject
+    {
+        /** @psalm-suppress RedundantPropertyInitializationCheck */
+        return self::$spans ??= new ArrayObject();
+    }
+}

--- a/src/SDK/Logs/Exporter/InMemoryExporterFactory.php
+++ b/src/SDK/Logs/Exporter/InMemoryExporterFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Logs\Exporter;
 
+use OpenTelemetry\SDK\Common\Export\InMemoryStorageManager;
 use OpenTelemetry\SDK\Logs\LogRecordExporterFactoryInterface;
 use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
 
@@ -11,6 +12,6 @@ class InMemoryExporterFactory implements LogRecordExporterFactoryInterface
 {
     public function create(): LogRecordExporterInterface
     {
-        return new InMemoryExporter();
+        return new InMemoryExporter(InMemoryStorageManager::getStorageForLogs());
     }
 }

--- a/src/SDK/Logs/Exporter/InMemoryExporterFactory.php
+++ b/src/SDK/Logs/Exporter/InMemoryExporterFactory.php
@@ -12,6 +12,6 @@ class InMemoryExporterFactory implements LogRecordExporterFactoryInterface
 {
     public function create(): LogRecordExporterInterface
     {
-        return new InMemoryExporter(InMemoryStorageManager::getStorageForLogs());
+        return new InMemoryExporter(InMemoryStorageManager::logs());
     }
 }

--- a/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
+++ b/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
@@ -10,11 +10,12 @@ use OpenTelemetry\SDK\Metrics\Data\Metric;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Metrics\MetricMetadataInterface;
+use OpenTelemetry\SDK\Metrics\PushMetricExporterInterface;
 
 /**
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/in-memory.md
  */
-final class InMemoryExporter implements MetricExporterInterface, AggregationTemporalitySelectorInterface
+final class InMemoryExporter implements MetricExporterInterface, AggregationTemporalitySelectorInterface, PushMetricExporterInterface
 {
     private bool $closed = false;
 
@@ -68,6 +69,11 @@ final class InMemoryExporter implements MetricExporterInterface, AggregationTemp
 
         $this->closed = true;
 
+        return true;
+    }
+
+    public function forceFlush(): bool
+    {
         return true;
     }
 }

--- a/src/SDK/Metrics/MetricExporter/InMemoryExporterFactory.php
+++ b/src/SDK/Metrics/MetricExporter/InMemoryExporterFactory.php
@@ -12,6 +12,6 @@ class InMemoryExporterFactory implements MetricExporterFactoryInterface
 {
     public function create(): MetricExporterInterface
     {
-        return new InMemoryExporter(InMemoryStorageManager::getStorageForMetrics());
+        return new InMemoryExporter(InMemoryStorageManager::metrics());
     }
 }

--- a/src/SDK/Metrics/MetricExporter/InMemoryExporterFactory.php
+++ b/src/SDK/Metrics/MetricExporter/InMemoryExporterFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Metrics\MetricExporter;
 
+use OpenTelemetry\SDK\Common\Export\InMemoryStorageManager;
 use OpenTelemetry\SDK\Metrics\MetricExporterFactoryInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 
@@ -11,6 +12,6 @@ class InMemoryExporterFactory implements MetricExporterFactoryInterface
 {
     public function create(): MetricExporterInterface
     {
-        return new InMemoryExporter();
+        return new InMemoryExporter(InMemoryStorageManager::getStorageForMetrics());
     }
 }

--- a/src/SDK/Trace/SpanExporter/InMemorySpanExporterFactory.php
+++ b/src/SDK/Trace/SpanExporter/InMemorySpanExporterFactory.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace\SpanExporter;
 
+use OpenTelemetry\SDK\Common\Export\InMemoryStorageManager;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
 class InMemorySpanExporterFactory implements SpanExporterFactoryInterface
 {
     public function create(): SpanExporterInterface
     {
-        return new InMemoryExporter();
+        return new InMemoryExporter(InMemoryStorageManager::getStorageForSpans());
     }
 }

--- a/src/SDK/Trace/SpanExporter/InMemorySpanExporterFactory.php
+++ b/src/SDK/Trace/SpanExporter/InMemorySpanExporterFactory.php
@@ -11,6 +11,6 @@ class InMemorySpanExporterFactory implements SpanExporterFactoryInterface
 {
     public function create(): SpanExporterInterface
     {
-        return new InMemoryExporter(InMemoryStorageManager::getStorageForSpans());
+        return new InMemoryExporter(InMemoryStorageManager::spans());
     }
 }

--- a/tests/Integration/SDK/Common/InMemoryStorageManagerWithSKDAutoload.php
+++ b/tests/Integration/SDK/Common/InMemoryStorageManagerWithSKDAutoload.php
@@ -28,7 +28,6 @@ class InMemoryStorageManagerWithSKDAutoload extends TestCase
     {
         $this->logger = $this->createMock(LoggerInterface::class);
         LoggerHolder::set($this->logger);
-        Globals::reset();
     }
 
     public function test_in_memory_storage_manager_for_metrics_with_sdk_autoload_enabled(): void
@@ -50,7 +49,7 @@ class InMemoryStorageManagerWithSKDAutoload extends TestCase
             $meterProvider->forceFlush();
         }
 
-        $storage = InMemoryStorageManager::getStorageForMetrics();
+        $storage = InMemoryStorageManager::metrics();
         $this->assertEquals(1, $storage->count());
         $this->assertEquals('test_value', $storage[0]->name);
         $this->assertEquals(6, $storage[0]->data->dataPoints[0]->value);
@@ -69,7 +68,7 @@ class InMemoryStorageManagerWithSKDAutoload extends TestCase
             $loggerProvider->forceFlush();
         }
 
-        $storage = InMemoryStorageManager::getStorageForLogs();
+        $storage = InMemoryStorageManager::logs();
         $this->assertEquals(1, $storage->count());
         $this->assertEquals('some body', $storage[0]->getBody());
     }
@@ -88,7 +87,7 @@ class InMemoryStorageManagerWithSKDAutoload extends TestCase
             $tracerProvider->forceFlush();
         }
 
-        $storage = InMemoryStorageManager::getStorageForSpans();
+        $storage = InMemoryStorageManager::spans();
         $this->assertEquals(2, $storage->count());
         $this->assertEquals('test_span_1', $storage[0]->getName());
         $this->assertEquals('test_span_2', $storage[1]->getName());

--- a/tests/Integration/SDK/Common/InMemoryStorageManagerWithSKDAutoload.php
+++ b/tests/Integration/SDK/Common/InMemoryStorageManagerWithSKDAutoload.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Integration\SDK\Common;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\LoggerHolder;
+use OpenTelemetry\SDK\Common\Configuration\Variables;
+use OpenTelemetry\SDK\Common\Export\InMemoryStorageManager;
+use OpenTelemetry\SDK\Metrics\MeterProvider;
+use OpenTelemetry\SDK\SdkAutoloader;
+use OpenTelemetry\Tests\TestState;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class InMemoryStorageManagerWithSKDAutoload extends TestCase
+{
+    use TestState;
+
+    protected LoggerInterface&MockObject $logger;
+
+    public function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        LoggerHolder::set($this->logger);
+        Globals::reset();
+    }
+
+    public function test_in_memory_storage_manager_with_sdk_autoload_enabled(): void
+    {
+        $this->setEnvironmentVariable('OTEL_METRICS_EXPORTER', 'memory');
+        $this->setEnvironmentVariable('OTEL_METRICS_EXEMPLAR_FILTER', 'all');
+        $this->setEnvironmentVariable('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE', 'cumulative');
+        $this->setEnvironmentVariable(Variables::OTEL_PHP_AUTOLOAD_ENABLED, 'true');
+        SdkAutoloader::autoload();
+
+        $meterProvider = Globals::meterProvider();
+
+        $m = $meterProvider->getMeter('some_meter');
+        $counter = $m->createCounter('test_value');
+        $counter->add(1);
+        $counter->add(5);
+
+        if ($meterProvider instanceof MeterProvider) {
+            $meterProvider->forceFlush();
+        }
+
+        $storage = InMemoryStorageManager::getStorageForMetrics();
+        $this->assertEquals(1, $storage->count());
+        $this->assertEquals('test_value', $storage[0]->name);
+        $this->assertEquals(6, $storage[0]->data->dataPoints[0]->value);
+    }
+}

--- a/tests/Integration/SDK/Common/InMemoryStorageManagerWithSKDAutoload.php
+++ b/tests/Integration/SDK/Common/InMemoryStorageManagerWithSKDAutoload.php
@@ -6,10 +6,13 @@ namespace Integration\SDK\Common;
 
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\LoggerHolder;
+use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use OpenTelemetry\SDK\Common\Export\InMemoryStorageManager;
+use OpenTelemetry\SDK\Logs\LoggerProvider;
 use OpenTelemetry\SDK\Metrics\MeterProvider;
 use OpenTelemetry\SDK\SdkAutoloader;
+use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\Tests\TestState;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +31,7 @@ class InMemoryStorageManagerWithSKDAutoload extends TestCase
         Globals::reset();
     }
 
-    public function test_in_memory_storage_manager_with_sdk_autoload_enabled(): void
+    public function test_in_memory_storage_manager_for_metrics_with_sdk_autoload_enabled(): void
     {
         $this->setEnvironmentVariable('OTEL_METRICS_EXPORTER', 'memory');
         $this->setEnvironmentVariable('OTEL_METRICS_EXEMPLAR_FILTER', 'all');
@@ -51,5 +54,43 @@ class InMemoryStorageManagerWithSKDAutoload extends TestCase
         $this->assertEquals(1, $storage->count());
         $this->assertEquals('test_value', $storage[0]->name);
         $this->assertEquals(6, $storage[0]->data->dataPoints[0]->value);
+    }
+
+    public function test_in_memory_storage_manager_for_logs_with_sdk_autoload_enabled(): void
+    {
+        $this->setEnvironmentVariable('OTEL_LOGS_EXPORTER', 'memory');
+        $this->setEnvironmentVariable(Variables::OTEL_PHP_AUTOLOAD_ENABLED, 'true');
+        SdkAutoloader::autoload();
+
+        $loggerProvider = Globals::loggerProvider();
+        $log = new LogRecord('some body');
+        $loggerProvider->getLogger('test_logger')->emit($log);
+        if ($loggerProvider instanceof LoggerProvider) {
+            $loggerProvider->forceFlush();
+        }
+
+        $storage = InMemoryStorageManager::getStorageForLogs();
+        $this->assertEquals(1, $storage->count());
+        $this->assertEquals('some body', $storage[0]->getBody());
+    }
+
+    public function test_in_memory_storage_manager_for_traces_with_sdk_autoload_enabled(): void
+    {
+        $this->setEnvironmentVariable('OTEL_TRACES_EXPORTER', 'memory');
+        $this->setEnvironmentVariable(Variables::OTEL_PHP_AUTOLOAD_ENABLED, 'true');
+        SdkAutoloader::autoload();
+
+        $tracerProvider = Globals::tracerProvider();
+        $tracer = $tracerProvider->getTracer('test_tracer');
+        $tracer->spanBuilder('test_span_1')->startSpan()->end();
+        $tracer->spanBuilder('test_span_2')->startSpan()->end();
+        if ($tracerProvider instanceof TracerProvider) {
+            $tracerProvider->forceFlush();
+        }
+
+        $storage = InMemoryStorageManager::getStorageForSpans();
+        $this->assertEquals(2, $storage->count());
+        $this->assertEquals('test_span_1', $storage[0]->getName());
+        $this->assertEquals('test_span_2', $storage[1]->getName());
     }
 }

--- a/tests/Integration/SDK/Metrics/MeterConfigTest.php
+++ b/tests/Integration/SDK/Metrics/MeterConfigTest.php
@@ -105,7 +105,7 @@ class MeterConfigTest extends TestCase
         $clock = new TestClock(self::T0);
         $disabledConfigurator = Configurator::meter()
             ->with(static fn (MeterConfig $config) => $config->setDisabled(true), name: '*');
-        $exporter = new InMemoryExporter(Temporality::CUMULATIVE);
+        $exporter = new InMemoryExporter(temporality: Temporality::CUMULATIVE);
         $reader = new ExportingReader($exporter);
         $meterProvider = MeterProvider::builder()
             ->addReader($reader)

--- a/tests/Unit/SDK/Common/Export/InMemoryStorageManagerTest.php
+++ b/tests/Unit/SDK/Common/Export/InMemoryStorageManagerTest.php
@@ -29,8 +29,8 @@ class InMemoryStorageManagerTest extends TestCase
 
     public function test_get_storage_for_metrics_returns_same_instance(): void
     {
-        $storageFirstCall = InMemoryStorageManager::getStorageForMetrics();
-        $storageSecondCall = InMemoryStorageManager::getStorageForMetrics();
+        $storageFirstCall = InMemoryStorageManager::metrics();
+        $storageSecondCall = InMemoryStorageManager::metrics();
         $this->assertSame($storageFirstCall, $storageSecondCall);
     }
 

--- a/tests/Unit/SDK/Common/Export/InMemoryStorageManagerTest.php
+++ b/tests/Unit/SDK/Common/Export/InMemoryStorageManagerTest.php
@@ -21,9 +21,9 @@ class InMemoryStorageManagerTest extends TestCase
     public static function getStorageName(): array
     {
         return [
-            ['getStorageForMetrics'],
-            ['getStorageForLogs'],
-            ['getStorageForSpans'],
+            ['metrics'],
+            ['logs'],
+            ['spans'],
         ];
     }
 

--- a/tests/Unit/SDK/Common/Export/InMemoryStorageManagerTest.php
+++ b/tests/Unit/SDK/Common/Export/InMemoryStorageManagerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Unit\SDK\Common\Export;
+
+use ArrayObject;
+use OpenTelemetry\SDK\Common\Export\InMemoryStorageManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for InMemoryStorageManager.
+ *
+ * This class focuses on testing the `getStorageForMetrics` method.
+ */
+#[CoversClass(\OpenTelemetry\SDK\Common\Export\InMemoryStorageManager::class)]
+class InMemoryStorageManagerTest extends TestCase
+{
+    public static function getStorageName(): array
+    {
+        return [
+            ['getStorageForMetrics'],
+            ['getStorageForLogs'],
+            ['getStorageForSpans'],
+        ];
+    }
+
+    public function test_get_storage_for_metrics_returns_same_instance(): void
+    {
+        $storageFirstCall = InMemoryStorageManager::getStorageForMetrics();
+        $storageSecondCall = InMemoryStorageManager::getStorageForMetrics();
+        $this->assertSame($storageFirstCall, $storageSecondCall);
+    }
+
+    #[DataProvider('getStorageName')]
+    public function test_get_storage_for_metrics_operates_properly($method): void
+    {
+        /** @var ArrayObject $storage */
+        $storage = call_user_func(InMemoryStorageManager::class . '::' . $method);
+        $storage->append('test_metric');
+
+        $this->assertCount(1, $storage);
+        $this->assertEquals('test_metric', $storage[0]);
+
+        // test the similar when getting storage again
+        /** @var ArrayObject $storage */
+        $storage = call_user_func(InMemoryStorageManager::class . '::' . $method);
+        $this->assertCount(1, $storage);
+        $this->assertEquals('test_metric', $storage[0]);
+    }
+}

--- a/tests/Unit/SDK/Metrics/MetricReader/ExportingReaderTest.php
+++ b/tests/Unit/SDK/Metrics/MetricReader/ExportingReaderTest.php
@@ -75,7 +75,7 @@ final class ExportingReaderTest extends TestCase
 
     public function test_add_creates_metric_source_with_exporter_temporality(): void
     {
-        $exporter = new InMemoryExporter(Temporality::CUMULATIVE);
+        $exporter = new InMemoryExporter(temporality: Temporality::CUMULATIVE);
         $reader = new ExportingReader($exporter);
 
         $provider = $this->createMock(MetricSourceProviderInterface::class);
@@ -103,7 +103,7 @@ final class ExportingReaderTest extends TestCase
 
     public function test_add_does_not_create_metric_source_if_reader_closed(): void
     {
-        $exporter = new InMemoryExporter(Temporality::CUMULATIVE);
+        $exporter = new InMemoryExporter(temporality: Temporality::CUMULATIVE);
         $reader = new ExportingReader($exporter);
 
         $provider = $this->createMock(MetricSourceProviderInterface::class);
@@ -118,7 +118,7 @@ final class ExportingReaderTest extends TestCase
 
     public function test_staleness_handler_clears_source(): void
     {
-        $exporter = new InMemoryExporter(Temporality::CUMULATIVE);
+        $exporter = new InMemoryExporter(temporality: Temporality::CUMULATIVE);
         $reader = new ExportingReader($exporter);
 
         $provider = $this->createMock(MetricSourceProviderInterface::class);
@@ -134,7 +134,7 @@ final class ExportingReaderTest extends TestCase
 
     public function test_collect_collects_sources_with_current_timestamp(): void
     {
-        $exporter = new InMemoryExporter(Temporality::CUMULATIVE);
+        $exporter = new InMemoryExporter(temporality: Temporality::CUMULATIVE);
         $reader = new ExportingReader($exporter);
 
         $metric = new Metric(


### PR DESCRIPTION
Introduced `InMemoryStorageManager` to centralize storage management for spans, metrics, and logs. Updated InMemory exporters and their factory classes to utilize this shared storage.