### PR TITLE
Use timeout to set max_duration on symfony http client

### DIFF
--- a/src/SDK/Common/Http/Psr/Client/Discovery/Symfony.php
+++ b/src/SDK/Common/Http/Psr/Client/Discovery/Symfony.php
@@ -23,6 +23,10 @@ class Symfony implements DiscoveryInterface
      */
     public function create(mixed $options): ClientInterface
     {
+        if (is_array($options) && array_key_exists('timeout', $options)) {
+            $options['max_duration'] = $options['timeout'];
+        }
+
         return new Psr18Client(HttpClient::create($options));
     }
 }


### PR DESCRIPTION
Closes: https://github.com/open-telemetry/opentelemetry-php/issues/1574