### PR TITLE
add suppressInstrumentation context key

### DIFF
--- a/src/Context/ContextKeys.php
+++ b/src/Context/ContextKeys.php
@@ -22,4 +22,11 @@ final class ContextKeys
 
         return $instance ??= Context::createKey('opentelemetry-trace-baggage-key');
     }
+
+    public static function suppressInstrumentation(): ContextKeyInterface
+    {
+        static $instance;
+
+        return $instance ??= Context::createKey('opentelemetry-trace-suppress-instrumentation-key');
+    }
 }

--- a/tests/Unit/Context/ContextKeysTest.php
+++ b/tests/Unit/Context/ContextKeysTest.php
@@ -20,4 +20,9 @@ final class ContextKeysTest extends TestCase
     {
         $this->assertSame(ContextKeys::baggage(), ContextKeys::baggage());
     }
+
+    public function test_suppress_instrumentation_context_key(): void
+    {
+        $this->assertSame(ContextKeys::suppressInstrumentation(), ContextKeys::suppressInstrumentation());
+    }
 }


### PR DESCRIPTION
following Java's lead, we can use this key in instrumentation libraries to suppress later spans, for example if we have multiple CLIENT spans, then the highest-level one can stop lower CLIENT spans from being created