### PR TITLE
stabilize logger.enabled

### DIFF
--- a/src/API/Logs/LateBindingLogger.php
+++ b/src/API/Logs/LateBindingLogger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\API\Logs;
 
 use Closure;
+use OpenTelemetry\Context\ContextInterface;
 
 class LateBindingLogger implements LoggerInterface
 {
@@ -21,7 +22,7 @@ class LateBindingLogger implements LoggerInterface
         ($this->logger ??= ($this->factory)())->emit($logRecord);
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null): bool
     {
         return true;
     }

--- a/src/API/Logs/LogRecord.php
+++ b/src/API/Logs/LogRecord.php
@@ -16,6 +16,7 @@ class LogRecord
     protected int $severityNumber = 0;
     protected ?string $severityText = null;
     protected array $attributes = [];
+    protected ?string $eventName = null;
 
     public function __construct(protected mixed $body = null)
     {
@@ -86,6 +87,13 @@ class LogRecord
     public function setBody(mixed $body = null): self
     {
         $this->body = $body;
+
+        return $this;
+    }
+
+    public function setEventName(string $eventName): self
+    {
+        $this->eventName = $eventName;
 
         return $this;
     }

--- a/src/API/Logs/LoggerInterface.php
+++ b/src/API/Logs/LoggerInterface.php
@@ -4,18 +4,15 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Logs;
 
+use OpenTelemetry\Context\ContextInterface;
+
 interface LoggerInterface
 {
-    /**
-     * This method should only be used when implementing a `log appender`
-     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.32.0/specification/logs/bridge-api.md#artifact-naming
-     */
     public function emit(LogRecord $logRecord): void;
 
     /**
-     * Determine if the logger is enabled. Logs bridge API authors SHOULD call this method each time they
-     * are about to generate a LogRecord, to avoid performing computationally expensive work.
-     * @experimental
+     * Determine if the logger is enabled. Instrumentation authors SHOULD call this method each time they
+     * emit a LogRecord, to ensure they have the most up-to-date response.
      */
-    public function isEnabled(): bool;
+    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null): bool;
 }

--- a/src/API/Logs/NoopLogger.php
+++ b/src/API/Logs/NoopLogger.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\API\Logs;
 
+use OpenTelemetry\Context\ContextInterface;
 use Psr\Log\LoggerTrait;
 
 class NoopLogger implements LoggerInterface
@@ -31,7 +32,7 @@ class NoopLogger implements LoggerInterface
     {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null): bool
     {
         return false;
     }

--- a/src/Contrib/Otlp/LogsConverter.php
+++ b/src/Contrib/Otlp/LogsConverter.php
@@ -95,6 +95,10 @@ class LogsConverter
         if ($severityText !== null) {
             $pLogRecord->setSeverityText($severityText);
         }
+        $eventName = $record->getEventName();
+        if ($eventName !== null) {
+            $pLogRecord->setEventName($eventName);
+        }
         $this->setAttributes($pLogRecord, $record->getAttributes());
         $pLogRecord->setDroppedAttributesCount($record->getAttributes()->getDroppedAttributesCount());
 

--- a/src/SDK/Logs/Logger.php
+++ b/src/SDK/Logs/Logger.php
@@ -7,15 +7,10 @@ namespace OpenTelemetry\SDK\Logs;
 use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\API\Logs\LoggerInterface;
 use OpenTelemetry\API\Logs\LogRecord;
+use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 use OpenTelemetry\SDK\Common\InstrumentationScope\Configurator;
 
-/**
- * Note that this logger class is deliberately NOT psr-3 compatible, per spec: "Note: this document defines a log
- * backend API. The API is not intended to be called by application developers directly."
- *
- * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md
- */
 class Logger implements LoggerInterface
 {
     use LogsMessagesTrait;
@@ -33,6 +28,9 @@ class Logger implements LoggerInterface
         $this->config = $configurator ? $configurator->resolve($scope) : LoggerConfig::default();
     }
 
+    /**
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.44.0/specification/logs/api.md#emit-a-logrecord
+     */
     public function emit(LogRecord $logRecord): void
     {
         //If a Logger is disabled, it MUST behave equivalently to No-op Logger.
@@ -52,12 +50,16 @@ class Logger implements LoggerInterface
         }
     }
 
-    public function isEnabled(): bool
+    /**
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.44.0/specification/logs/api.md#enabled
+     */
+    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null): bool
     {
         return $this->config->isEnabled();
     }
 
     /**
+     * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.44.0/specification/logs/sdk.md#loggerconfigurator
      * @param Configurator<LoggerConfig> $configurator
      */
     public function updateConfig(Configurator $configurator): void

--- a/src/SDK/Logs/ReadableLogRecord.php
+++ b/src/SDK/Logs/ReadableLogRecord.php
@@ -37,6 +37,7 @@ class ReadableLogRecord extends LogRecord
         $this->spanContext = Span::fromContext($context)->getContext();
         $this->severityNumber = $logRecord->severityNumber;
         $this->severityText = $logRecord->severityText;
+        $this->eventName = $logRecord->eventName;
 
         //convert attributes now so that excess data is not sent to processors
         $this->convertedAttributes = $this->loggerSharedState
@@ -92,6 +93,11 @@ class ReadableLogRecord extends LogRecord
     public function getBody()
     {
         return $this->body;
+    }
+
+    public function getEventName(): ?string
+    {
+        return $this->eventName;
     }
 
     public function getAttributes(): AttributesInterface


### PR DESCRIPTION
- update Logger.isEnabled signature to include context and severity number, per spec
- remove experimental tag from isEnabled
- accept event_name on a LogRecord
- add event name to otlp logs payload
- update or remove some comments that were based on the old logs-bridge specification

Closes: #1563 