### PR TITLE
span suppression strategy

### DIFF
--- a/examples/traces/features/span-suppression.php
+++ b/examples/traces/features/span-suppression.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+require_once DIRNAME(__DIR__, 3) . '/vendor/autoload.php';
+
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\SpanSuppression;
+
+/**
+ * Span suppression is a feature used by Instrumentation Libraries to eliminate redundant child spans. For example,
+ * multiple HTTP client implementations (a 3rd-party SDK client, which uses Guzzle, which uses cURL) may create a
+ * span for each of the HTTP calls. This can lead to multiple nested CLIENT spans being created.
+ */
+
+$scopes = [];
+
+function check(): void
+{
+    echo 'Should suppress SERVER span: ' . (SpanSuppression::shouldSuppress(SpanKind::KIND_SERVER) ? 'Yes' : 'No') . PHP_EOL;
+    echo 'Should suppress CLIENT span: ' . (SpanSuppression::shouldSuppress(SpanKind::KIND_CLIENT) ? 'Yes' : 'No') . PHP_EOL;
+    echo 'Should suppress CONSUMER span: ' . (SpanSuppression::shouldSuppress(SpanKind::KIND_CONSUMER) ? 'Yes' : 'No') . PHP_EOL;
+    echo 'Should suppress PRODUCER span: ' . (SpanSuppression::shouldSuppress(SpanKind::KIND_PRODUCER) ? 'Yes' : 'No') . PHP_EOL;
+    echo 'Should suppress INTERNAL span: ' . (SpanSuppression::shouldSuppress(SpanKind::KIND_INTERNAL) ? 'Yes' : 'No') . PHP_EOL;
+}
+
+// initially, no suppression
+echo "\nInitial state:\n";
+check();
+
+$scopes[] = SpanSuppression::suppressSpanKind([SpanKind::KIND_SERVER])->activate();
+
+// add suppression of SERVER spans
+echo "\nWith SERVER suppression:\n";
+
+check();
+
+$scopes[] = SpanSuppression::suppressSpanKind([
+    SpanKind::KIND_CLIENT,
+    SpanKind::KIND_CONSUMER,
+])->activate();
+
+// add suppression of CLIENT and CONSUMER spans, which should be additive
+echo "\nWith CLIENT+CONSUMER suppression added:\n";
+
+check();
+
+//detach active suppression, leaving SERVER
+array_pop($scopes)->detach();
+
+echo "\nWith CLIENT+CONSUMER suppression detached:\n";
+
+check();
+
+// detach active, leaving default (none) suppression
+array_pop($scopes)->detach();
+
+echo "\nWith SERVER suppression detached:\n";
+
+check();

--- a/src/API/Trace/SpanSuppression.php
+++ b/src/API/Trace/SpanSuppression.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Trace;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Context\ContextKeyInterface;
+use OpenTelemetry\Context\ImplicitContextKeyedInterface;
+use OpenTelemetry\Context\ScopeInterface;
+
+class SpanSuppression implements ImplicitContextKeyedInterface
+{
+    private const SUPPRESS_NONE = 0;
+    private const SUPPRESS_SPAN_KIND = 1;
+
+    private function __construct(
+        private readonly int $suppressionType,
+        private readonly array $suppressedSpanKinds = [],
+    ) {
+    }
+
+    public static function suppressSpanKind(array $spanKinds): self
+    {
+        $new = new self(self::SUPPRESS_SPAN_KIND, $spanKinds);
+
+        // Automatically merge with any existing strategy in the current context
+        $current = self::current();
+        if ($current->suppressionType !== self::SUPPRESS_NONE) {
+            return $current->mergeWith($new);
+        }
+
+        return $new;
+    }
+
+    public static function shouldSuppress(?int $spanKind): bool
+    {
+        return self::current()->shouldSuppressSpanKind($spanKind);
+    }
+
+    public function activate(): ScopeInterface
+    {
+        return Context::storage()->attach($this->storeInContext(Context::getCurrent()));
+    }
+
+    public function storeInContext(ContextInterface $context): ContextInterface
+    {
+        return $context->with(self::contextKey(), $this);
+    }
+
+    private static function suppressNone(): self
+    {
+        static $instance;
+        $instance ??= new self(self::SUPPRESS_NONE);
+
+        return $instance;
+    }
+
+    private function shouldSuppressSpanKind(?int $spanKind): bool
+    {
+        if ($this->suppressionType === self::SUPPRESS_NONE) {
+            return false;
+        }
+
+        if ($this->suppressionType === self::SUPPRESS_SPAN_KIND && $spanKind !== null) {
+            return in_array($spanKind, $this->suppressedSpanKinds, true);
+        }
+
+        return false;
+    }
+
+    private static function current(): self
+    {
+        $current = Context::getCurrent()->get(self::contextKey());
+        if ($current === null) {
+            return self::suppressNone();
+        }
+
+        return $current;
+    }
+
+    private static function contextKey(): ContextKeyInterface
+    {
+        static $key;
+        $key ??= Context::createKey(self::class);
+
+        return $key;
+    }
+
+    private function mergeWith(self $other): self
+    {
+        if ($this->suppressionType === self::SUPPRESS_NONE) {
+            return $other;
+        }
+
+        if ($other->suppressionType === self::SUPPRESS_NONE) {
+            return $this;
+        }
+
+        if ($this->suppressionType === self::SUPPRESS_SPAN_KIND &&
+            $other->suppressionType === self::SUPPRESS_SPAN_KIND) {
+            return new self(
+                self::SUPPRESS_SPAN_KIND,
+                array_unique(array_merge($this->suppressedSpanKinds, $other->suppressedSpanKinds))
+            );
+        }
+
+        // Default case
+        return $this;
+    }
+}

--- a/tests/Unit/API/Trace/SpanSuppressionTest.php
+++ b/tests/Unit/API/Trace/SpanSuppressionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\API\Trace;
+
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\SpanSuppression;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SpanSuppression::class)]
+class SpanSuppressionTest extends TestCase
+{
+    #[DataProvider('spanKindProvider')]
+    public function test_should_not_suppress_by_default(int $kind): void
+    {
+        $this->assertFalse(SpanSuppression::shouldSuppress($kind));
+    }
+
+    public static function spanKindProvider(): array
+    {
+        return [
+            [SpanKind::KIND_SERVER],
+            [SpanKind::KIND_CLIENT],
+            [SpanKind::KIND_CONSUMER],
+            [SpanKind::KIND_PRODUCER],
+            [SpanKind::KIND_INTERNAL],
+        ];
+    }
+
+    public function test_suppress_client_spans(): void
+    {
+        $this->assertFalse(SpanSuppression::shouldSuppress(SpanKind::KIND_CLIENT));
+        $scope = SpanSuppression::suppressSpanKind([SpanKind::KIND_CLIENT])->activate();
+
+        try {
+            $this->assertTrue(SpanSuppression::shouldSuppress(SpanKind::KIND_CLIENT));
+            $this->assertFalse(SpanSuppression::shouldSuppress(SpanKind::KIND_SERVER));
+        } finally {
+            $scope->detach();
+        }
+        //suppression removed after detach
+        $this->assertFalse(SpanSuppression::shouldSuppress(SpanKind::KIND_CLIENT));
+    }
+}


### PR DESCRIPTION
implement a span suppression strategy, modelled on Java's implementation. An instrumentation can suppress some later spans (stop them from being created), via `SpanSuppression::suppressSpanKind()`. The strategies are stored in Context, and can be activated and detached like other context values. Instrumentations should check span suppression before creating a new span.

Closes: #1579 