### PR TITLE
Allow immediate gc of `ContextStorageNode`s after `::detach()`

### DIFF
--- a/src/Context/ContextStorageNode.php
+++ b/src/Context/ContextStorageNode.php
@@ -52,15 +52,18 @@ final class ContextStorageNode implements ScopeInterface, ContextStorageScopeInt
             $flags |= ScopeInterface::INACTIVE;
         }
 
+        static $detached;
+        $detached ??= (new \ReflectionClass(self::class))->newInstanceWithoutConstructor();
+
         if ($this === $this->head->node) {
-            assert($this->previous !== $this);
+            assert($this->previous !== $detached);
             $this->head->node = $this->previous;
-            $this->previous = $this;
+            $this->previous = $detached;
 
             return $flags;
         }
 
-        if ($this->previous === $this) {
+        if ($this->previous === $detached) {
             return $flags | ScopeInterface::DETACHED;
         }
 
@@ -71,7 +74,7 @@ final class ContextStorageNode implements ScopeInterface, ContextStorageScopeInt
             assert($n->previous !== null);
         }
         $n->previous = $this->previous;
-        $this->previous = $this;
+        $this->previous = $detached;
 
         return $flags | ScopeInterface::MISMATCH | $depth;
     }

--- a/tests/Unit/Context/ScopeTest.php
+++ b/tests/Unit/Context/ScopeTest.php
@@ -127,4 +127,16 @@ class ScopeTest extends TestCase
         $this->assertNotNull($scope);
         $this->assertArrayNotHasKey('key', $scope);
     }
+
+    public function test_scope_is_gced_after_detach(): void
+    {
+        $storage = new ContextStorage();
+        $scope = $storage->attach($storage->current());
+
+        $ref = \WeakReference::create($scope);
+        $scope->detach();
+        unset($scope);
+
+        $this->assertNull($ref->get());
+    }
 }


### PR DESCRIPTION
Use dummy object instead of self references as detached-marker to avoid relying on gc cycle collection.

Resolves #1584.