### PR TITLE
chore: update docker container versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,8 @@ ARG PHP_VERSION=8.0
 FROM php:8.0.30-cli-alpine AS php-8.0-cli-alpine
 FROM php:8.1.32-cli-alpine AS php-8.1-cli-alpine
 FROM php:8.2.28-cli-alpine AS php-8.2-cli-alpine
-FROM php:8.3.19-cli-alpine AS php-8.3-cli-alpine
-FROM php:8.4.5-cli-alpine AS php-8.4-cli-alpine
+FROM php:8.3.20-cli-alpine AS php-8.3-cli-alpine
+FROM php:8.4.7-cli-alpine AS php-8.4-cli-alpine
 
 FROM php-${PHP_VERSION}-cli-alpine
 


### PR DESCRIPTION
Dependabot opened a PR here: https://github.com/open-telemetry/opentelemetry-php/pull/1588 that inadvertently updated all of the versions of PHP in our docker file to `php:8.4.7-cli-alpine`.

That was incorrect, but was the inspiration for this PR -  which ensures each version of php is the latest for its particular release.