### PR TITLE
Ignore `TypeError` in `::serializeToJsonString()` if `google/protobuf` `^4.31` and `ext-protobuf` `<4.31` are installed

### DIFF
--- a/src/Contrib/Otlp/ProtobufSerializer.php
+++ b/src/Contrib/Otlp/ProtobufSerializer.php
@@ -102,8 +102,12 @@ final class ProtobufSerializer
     {
         // @phan-suppress-next-line PhanUndeclaredClassReference
         if (\class_exists(\Google\Protobuf\PrintOptions::class)) {
-            /** @psalm-suppress TooManyArguments @phan-suppress-next-line PhanParamTooManyInternal,PhanUndeclaredClassConstant @phpstan-ignore arguments.count */
-            return $message->serializeToJsonString(\Google\Protobuf\PrintOptions::ALWAYS_PRINT_ENUMS_AS_INTS);
+            try {
+                /** @psalm-suppress TooManyArguments @phan-suppress-next-line PhanParamTooManyInternal,PhanUndeclaredClassConstant @phpstan-ignore arguments.count */
+                return $message->serializeToJsonString(\Google\Protobuf\PrintOptions::ALWAYS_PRINT_ENUMS_AS_INTS);
+            } catch (\TypeError) {
+                // google/protobuf ^4.31 w/ ext-protobuf <4.31 installed
+            }
         }
 
         $payload = $message->serializeToJsonString();


### PR DESCRIPTION
Resolves #1597 by ignoring the `TypeError`; could alternatively check for installed extension version but this fix seems simpler.