### PR TITLE
PoC: Implement span suppression strategies

### DIFF
--- a/examples/spansuppression/SemanticConventionResolver.php
+++ b/examples/spansuppression/SemanticConventionResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConvention;
+use OpenTelemetry\API\Trace\SpanKind;
+
+final class SemanticConventionResolver implements \OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionResolver {
+
+    public function resolveSemanticConventions(string $name, ?string $version, ?string $schemaUrl): array {
+        if ($schemaUrl === null || !\str_starts_with($schemaUrl, 'https://opentelemetry.io/schemas/')) {
+            return [];
+        }
+
+        return [
+            new SemanticConvention("span.azure.cosmosdb.client", SpanKind::KIND_CLIENT, ["db.operation.name"], ["azure.client.id", "azure.cosmosdb.request.body.size", "error.type", "azure.cosmosdb.consistency.level", "azure.cosmosdb.response.sub_status_code", "az.namespace", "azure.cosmosdb.connection.mode", "azure.cosmosdb.operation.contacted_regions", "azure.cosmosdb.operation.request_charge", "user_agent.original", "db.query.text", "db.operation.batch.size", "db.stored_procedure.name", "server.address", "db.query.parameter", "db.namespace", "db.collection.name", "db.response.returned_rows", "db.response.status_code", "server.port"]),
+            new SemanticConvention("span.cicd.pipeline.task.internal", SpanKind::KIND_INTERNAL, ["cicd.pipeline.task.name", "cicd.pipeline.task.run.id", "cicd.pipeline.task.run.url.full"], ["error.type"]),
+            new SemanticConvention("span.db.client", SpanKind::KIND_CLIENT, ["db.system.name"], ["error.type", "network.peer.address", "network.peer.port", "db.operation.batch.size", "db.response.status_code", "db.stored_procedure.name", "db.operation.name", "server.address", "server.port", "db.query.parameter", "db.query.summary", "db.query.text", "db.collection.name", "db.namespace", "db.response.returned_rows"]),
+            new SemanticConvention("span.db.elasticsearch.client", SpanKind::KIND_CLIENT, ["http.request.method", "url.full", "db.operation.name"], ["error.type", "elasticsearch.node.name", "db.operation.batch.size", "server.address", "server.port", "db.collection.name", "db.namespace", "db.operation.parameter", "db.query.text", "db.response.status_code"]),
+            new SemanticConvention("span.db.hbase.client", SpanKind::KIND_CLIENT, ["db.operation.name"], ["error.type", "db.operation.batch.size", "server.address", "server.port", "db.collection.name", "db.namespace", "db.response.status_code"]),
+            new SemanticConvention("span.db.mongodb.client", SpanKind::KIND_CLIENT, ["db.collection.name", "db.operation.name"], ["error.type", "db.operation.batch.size", "server.address", "server.port", "db.namespace", "db.response.status_code"]),
+            new SemanticConvention("span.db.redis.client", SpanKind::KIND_CLIENT, ["db.operation.name"], ["error.type", "network.peer.port", "network.peer.address", "db.operation.batch.size", "server.address", "server.port", "db.namespace", "db.query.text", "db.response.status_code", "db.stored_procedure.name"]),
+            new SemanticConvention("span.http.client", SpanKind::KIND_CLIENT, ["http.request.method", "server.address", "server.port", "url.full"], ["network.peer.address", "network.peer.port", "error.type", "http.request.body.size", "http.request.header", "http.request.method_original", "http.request.resend_count", "http.request.size", "http.response.body.size", "http.response.header", "http.response.size", "http.response.status_code", "network.protocol.name", "network.protocol.version", "network.transport", "user_agent.original", "user_agent.synthetic.type", "url.scheme", "url.template"]),
+            new SemanticConvention("span.http.server", SpanKind::KIND_SERVER, ["http.request.method", "url.path", "url.scheme"], ["network.peer.address", "network.peer.port", "error.type", "http.request.body.size", "http.request.method_original", "http.request.size", "http.response.body.size", "http.response.header", "http.response.size", "http.response.status_code", "network.protocol.name", "network.protocol.version", "network.transport", "user_agent.synthetic.type", "client.address", "client.port", "http.request.header", "http.route", "network.local.address", "network.local.port", "user_agent.original", "server.address", "server.port", "url.query"]),
+        ];
+    }
+}

--- a/examples/spansuppression/semanticconventionssuppression-1.php
+++ b/examples/spansuppression/semanticconventionssuppression-1.php
@@ -1,0 +1,63 @@
+<?php
+
+use OpenTelemetry\API\Common\Time\SystemClock;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionSuppressionStrategy\SemanticConventionSuppressionStrategy;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransport;
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/SemanticConventionResolver.php';
+
+// Two nested http client instrumentations
+
+$tp = (new TracerProviderBuilder())
+    ->setResource(ResourceInfoFactory::emptyResource())
+    ->addSpanProcessor(new BatchSpanProcessor(new SpanExporter(new StreamTransport(fopen('php://stdout', 'ab'), 'application/x-ndjson')), SystemClock::create()))
+    ->setSpanSuppressionStrategy(new SemanticConventionSuppressionStrategy([
+        new SemanticConventionResolver(),
+    ]))
+    ->build()
+;
+
+$t = $tp->getTracer('test');
+$c1 = $tp
+    ->getTracer('instrumentation-1', schemaUrl: 'https://opentelemetry.io/schemas/1.33.0')
+    ->spanBuilder('GET')
+    ->setSpanKind(SpanKind::KIND_CLIENT)
+    ->setAttributes([
+        'http.request.method' => 'GET',
+        'server.address' => 'http://example.com',
+        'server.port' => '80',
+        'url.full' => 'http://example.com',
+    ])
+    ->startSpan();
+$s1 = $c1->activate();
+try {
+    $c2 = $tp
+        ->getTracer('instrumentation-2', schemaUrl: 'https://opentelemetry.io/schemas/1.31.0')
+        ->spanBuilder('GET')
+        ->setSpanKind(SpanKind::KIND_CLIENT)
+        ->setAttributes([
+            'http.request.method' => 'GET',
+            'server.address' => 'http://example.com',
+            'server.port' => '80',
+            'url.full' => 'http://example.com',
+        ])
+        ->startSpan();
+    $s2 = $c2->activate();
+    try {
+        // ...
+    } finally {
+        $s2->detach();
+        $c2->end();
+    }
+} finally {
+    $s1->detach();
+    $c1->end();
+}
+
+$tp->shutdown();

--- a/examples/spansuppression/semanticconventionssuppression-2.php
+++ b/examples/spansuppression/semanticconventionssuppression-2.php
@@ -1,0 +1,65 @@
+<?php
+
+use OpenTelemetry\API\Common\Time\SystemClock;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionSuppressionStrategy\SemanticConventionSuppressionStrategy;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransport;
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/SemanticConventionResolver.php';
+
+// Elasticsearch client instrumentation that uses an instrumented http client
+
+$tp = (new TracerProviderBuilder())
+    ->setResource(ResourceInfoFactory::emptyResource())
+    ->addSpanProcessor(new BatchSpanProcessor(new SpanExporter(new StreamTransport(fopen('php://stdout', 'ab'), 'application/x-ndjson')), SystemClock::create()))
+    ->setSpanSuppressionStrategy(new SemanticConventionSuppressionStrategy([
+        new SemanticConventionResolver(),
+    ]))
+    ->build()
+;
+
+$t = $tp->getTracer('test');
+
+$c1 = $tp
+    ->getTracer('elasticsearch-instrumentation', schemaUrl: 'https://opentelemetry.io/schemas/1.33.0')
+    ->spanBuilder('SELECT')
+    ->setSpanKind(SpanKind::KIND_CLIENT)
+    ->setAttributes([
+        'http.request.method' => 'GET',
+        'server.address' => 'http://example.com',
+        'server.port' => '80',
+        'url.full' => 'http://example.com',
+        'db.operation.name' => 'SELECT',
+    ])
+    ->startSpan();
+$s1 = $c1->activate();
+try {
+    $c2 = $tp
+        ->getTracer('httpclient-instrumentation', schemaUrl: 'https://opentelemetry.io/schemas/1.33.0')
+        ->spanBuilder('GET')
+        ->setSpanKind(SpanKind::KIND_CLIENT)
+        ->setAttributes([
+            'http.request.method' => 'GET',
+            'server.address' => 'http://example.com',
+            'server.port' => '80',
+            'url.full' => 'http://example.com',
+        ])
+        ->startSpan();
+    $s2 = $c2->activate();
+    try {
+        // ...
+    } finally {
+        $s2->detach();
+        $c2->end();
+    }
+} finally {
+    $s1->detach();
+    $c1->end();
+}
+
+$tp->shutdown();

--- a/examples/spansuppression/semanticconventionssuppression-3.php
+++ b/examples/spansuppression/semanticconventionssuppression-3.php
@@ -1,0 +1,57 @@
+<?php
+
+use OpenTelemetry\API\Common\Time\SystemClock;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConvention;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionSuppressionStrategy\SemanticConventionSuppressionStrategy;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransport;
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Nested Twig template rendering
+
+$tp = (new TracerProviderBuilder())
+    ->setResource(ResourceInfoFactory::emptyResource())
+    ->addSpanProcessor(new BatchSpanProcessor(new SpanExporter(new StreamTransport(fopen('php://stdout', 'ab'), 'application/x-ndjson')), SystemClock::create()))
+    ->setSpanSuppressionStrategy(new SemanticConventionSuppressionStrategy([
+        new class implements \OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionResolver {
+
+            public function resolveSemanticConventions(string $name, ?string $version, ?string $schemaUrl): array {
+                if ($name !== 'io.open-telemetry.php.twig') {
+                    return [];
+                }
+
+                return [
+                    new SemanticConvention('io.open-telemetry.php.twig.template.render', SpanKind::KIND_INTERNAL, ['twig.template.name'], []),
+                ];
+            }
+        },
+    ]))
+    ->build()
+;
+
+$t = $tp->getTracer('io.open-telemetry.php.twig');
+$c1 = $t->spanBuilder('render index.html.twig')->setAttribute('twig.template.name', 'index.html.twig')->startSpan();
+$s1 = $c1->activate();
+try {
+    $c2 = $t->spanBuilder('render header.html.twig')->setAttribute('twig.template.name', 'header.html.twig')->startSpan();
+    $s2 = $c2->activate();
+    try {
+        for ($i = 0; $i < 5; $i++) {
+            $t->spanBuilder('render meta.html.twig')->setAttribute('twig.template.name', 'meta.html.twig')->startSpan()->end();
+        }
+        // ...
+    } finally {
+        $s2->detach();
+        $c2->end();
+    }
+} finally {
+    $s1->detach();
+    $c1->end();
+}
+
+$tp->shutdown();

--- a/examples/spansuppression/spankindsuppression.php
+++ b/examples/spansuppression/spankindsuppression.php
@@ -1,0 +1,38 @@
+<?php
+
+use OpenTelemetry\API\Common\Time\SystemClock;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanKindSuppressionStrategy\SpanKindSuppressionStrategy;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransport;
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$tp = (new TracerProviderBuilder())
+    ->setResource(ResourceInfoFactory::emptyResource())
+    ->addSpanProcessor(new BatchSpanProcessor(new SpanExporter(new StreamTransport(fopen('php://stdout', 'ab'), 'application/x-ndjson')), SystemClock::create()))
+    ->setSpanSuppressionStrategy(new SpanKindSuppressionStrategy())
+    ->build()
+;
+
+$t = $tp->getTracer('test');
+$c1 = $t->spanBuilder('client-1')->setSpanKind(SpanKind::KIND_CLIENT)->startSpan();
+$s1 = $c1->activate();
+try {
+    $c2 = $t->spanBuilder('client-2')->setSpanKind(SpanKind::KIND_CLIENT)->startSpan();
+    $s2 = $c2->activate();
+    try {
+        // ...
+    } finally {
+        $s2->detach();
+        $c2->end();
+    }
+} finally {
+    $s1->detach();
+    $c1->end();
+}
+
+$tp->shutdown();

--- a/src/API/Instrumentation/SpanSuppression/NoopSuppressionStrategy/NoopSuppression.php
+++ b/src/API/Instrumentation/SpanSuppression/NoopSuppressionStrategy/NoopSuppression.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppression;
+use OpenTelemetry\Context\ContextInterface;
+
+final class NoopSuppression implements SpanSuppression {
+
+    public function isSuppressed(ContextInterface $context): bool {
+        return false;
+    }
+
+    public function suppress(ContextInterface $context): ContextInterface {
+        return $context;
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/NoopSuppressionStrategy/NoopSuppressionStrategy.php
+++ b/src/API/Instrumentation/SpanSuppression/NoopSuppressionStrategy/NoopSuppressionStrategy.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressionStrategy;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressor;
+
+final class NoopSuppressionStrategy implements SpanSuppressionStrategy {
+
+    public function getSuppressor(string $name, ?string $version, ?string $schemaUrl): SpanSuppressor {
+        return new NoopSuppressor();
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/NoopSuppressionStrategy/NoopSuppressor.php
+++ b/src/API/Instrumentation/SpanSuppression/NoopSuppressionStrategy/NoopSuppressor.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppression;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressor;
+
+final class NoopSuppressor implements SpanSuppressor {
+
+    public function resolveSuppression(int $spanKind, array $attributes): SpanSuppression {
+        return new NoopSuppression();
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/SemanticConvention.php
+++ b/src/API/Instrumentation/SpanSuppression/SemanticConvention.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression;
+
+final class SemanticConvention {
+
+    /**
+     * @param list<string> $samplingAttributes
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly int $spanKind,
+        public readonly array $samplingAttributes,
+        public readonly array $attributes,
+    ) {}
+}

--- a/src/API/Instrumentation/SpanSuppression/SemanticConventionResolver.php
+++ b/src/API/Instrumentation/SpanSuppression/SemanticConventionResolver.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression;
+
+interface SemanticConventionResolver {
+
+    /**
+     * @return list<SemanticConvention>
+     */
+    public function resolveSemanticConventions(string $name, ?string $version, ?string $schemaUrl): array;
+}

--- a/src/API/Instrumentation/SpanSuppression/SemanticConventionSuppressionStrategy/SemanticConventionSuppression.php
+++ b/src/API/Instrumentation/SpanSuppression/SemanticConventionSuppressionStrategy/SemanticConventionSuppression.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppression;
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Context\ContextKeyInterface;
+
+final class SemanticConventionSuppression implements SpanSuppression {
+
+    public function __construct(
+        private readonly ContextKeyInterface $contextKey,
+        private readonly array $semanticConventions,
+    ) {
+    }
+
+    public function isSuppressed(ContextInterface $context): bool {
+        $suppressedConventions = $context->get($this->contextKey);
+        if ($suppressedConventions === null) {
+            return false;
+        }
+
+        foreach ($this->semanticConventions as $semanticConvention) {
+            if (!isset($suppressedConventions[$semanticConvention])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function suppress(ContextInterface $context): ContextInterface {
+        $suppressedConventions = $context->get($this->contextKey) ?? [];
+        foreach ($this->semanticConventions as $semanticConvention) {
+            $suppressedConventions[$semanticConvention] ??= true;
+        }
+
+        return $context->with($this->contextKey, $suppressedConventions);
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/SemanticConventionSuppressionStrategy/SemanticConventionSuppressionContextKey.php
+++ b/src/API/Instrumentation/SpanSuppression/SemanticConventionSuppressionStrategy/SemanticConventionSuppressionContextKey.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionSuppressionStrategy;
+
+use OpenTelemetry\Context\ContextKeyInterface;
+
+/**
+ * @implements ContextKeyInterface<array<string, true>>
+ */
+enum SemanticConventionSuppressionContextKey implements ContextKeyInterface {
+
+    case Internal;
+    case Client;
+    case Server;
+    case Producer;
+    case Consumer;
+}

--- a/src/API/Instrumentation/SpanSuppression/SemanticConventionSuppressionStrategy/SemanticConventionSuppressionStrategy.php
+++ b/src/API/Instrumentation/SpanSuppression/SemanticConventionSuppressionStrategy/SemanticConventionSuppressionStrategy.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressionStrategy;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressor;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionResolver;
+use function array_merge;
+
+final class SemanticConventionSuppressionStrategy implements SpanSuppressionStrategy {
+
+    /**
+     * @param iterable<SemanticConventionResolver> $resolvers
+     */
+    public function __construct(
+        private readonly iterable $resolvers,
+    ) {}
+
+    public function getSuppressor(string $name, ?string $version, ?string $schemaUrl): SpanSuppressor {
+        $semanticConventions = [];
+        foreach ($this->resolvers as $resolver) {
+            if ($conventions = $resolver->resolveSemanticConventions($name, $version, $schemaUrl)) {
+                $semanticConventions[] = $conventions;
+            }
+        }
+
+        return new SemanticConventionSuppressor(array_merge(...$semanticConventions));
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/SemanticConventionSuppressionStrategy/SemanticConventionSuppressor.php
+++ b/src/API/Instrumentation/SpanSuppression/SemanticConventionSuppressionStrategy/SemanticConventionSuppressor.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConventionSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy\NoopSuppression;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppression;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressor;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SemanticConvention;
+use OpenTelemetry\API\Trace\SpanKind;
+use function array_key_exists;
+use function count;
+
+final class SemanticConventionSuppressor implements SpanSuppressor {
+
+    /**
+     * @param iterable<SemanticConvention> $semanticConventions
+     */
+    public function __construct(
+        private readonly iterable $semanticConventions,
+    ) {}
+
+    public function resolveSuppression(int $spanKind, array $attributes): SpanSuppression {
+        $semanticConventions = [];
+        foreach ($this->semanticConventions as $entry) {
+            if ($entry->spanKind !== $spanKind) {
+                continue;
+            }
+            foreach ($entry->samplingAttributes as $attribute) {
+                if (!array_key_exists($attribute, $attributes)) {
+                    continue 2;
+                }
+            }
+            $matchingAttributes = 0;
+            foreach ($entry->attributes as $attribute) {
+                if (array_key_exists($attribute, $attributes)) {
+                    $matchingAttributes++;
+                }
+            }
+            if ($matchingAttributes !== count($attributes) - count($entry->samplingAttributes)) {
+                continue;
+            }
+
+            $semanticConventions[] = $entry->name;
+        }
+
+        if (!$semanticConventions && $spanKind === SpanKind::KIND_INTERNAL) {
+            return new NoopSuppression();
+        }
+
+        return new SemanticConventionSuppression(
+            contextKey: match ($spanKind) {
+                SpanKind::KIND_INTERNAL => SemanticConventionSuppressionContextKey::Internal,
+                SpanKind::KIND_CLIENT => SemanticConventionSuppressionContextKey::Client,
+                SpanKind::KIND_SERVER => SemanticConventionSuppressionContextKey::Server,
+                SpanKind::KIND_PRODUCER => SemanticConventionSuppressionContextKey::Producer,
+                SpanKind::KIND_CONSUMER => SemanticConventionSuppressionContextKey::Consumer,
+            },
+            semanticConventions: $semanticConventions,
+        );
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/SpanKindSuppressionStrategy/SpanKindSuppression.php
+++ b/src/API/Instrumentation/SpanSuppression/SpanKindSuppressionStrategy/SpanKindSuppression.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\SpanKindSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppression;
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Context\ContextKeyInterface;
+
+final class SpanKindSuppression implements SpanSuppression {
+
+    public function __construct(
+        private readonly ContextKeyInterface $contextKey,
+    ) {}
+
+    public function isSuppressed(ContextInterface $context): bool {
+        return $context->get($this->contextKey) === true;
+    }
+
+    public function suppress(ContextInterface $context): ContextInterface {
+        return $context->with($this->contextKey, true);
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/SpanKindSuppressionStrategy/SpanKindSuppressionContextKey.php
+++ b/src/API/Instrumentation/SpanSuppression/SpanKindSuppressionStrategy/SpanKindSuppressionContextKey.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\SpanKindSuppressionStrategy;
+
+use OpenTelemetry\Context\ContextKeyInterface;
+
+/**
+ * @implements ContextKeyInterface<true>
+ */
+enum SpanKindSuppressionContextKey implements ContextKeyInterface {
+
+    case Client;
+    case Server;
+    case Producer;
+    case Consumer;
+}

--- a/src/API/Instrumentation/SpanSuppression/SpanKindSuppressionStrategy/SpanKindSuppressionStrategy.php
+++ b/src/API/Instrumentation/SpanSuppression/SpanKindSuppressionStrategy/SpanKindSuppressionStrategy.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\SpanKindSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressionStrategy;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressor;
+
+final class SpanKindSuppressionStrategy implements SpanSuppressionStrategy {
+
+    public function getSuppressor(string $name, ?string $version, ?string $schemaUrl): SpanSuppressor {
+        return new SpanKindSuppressor();
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/SpanKindSuppressionStrategy/SpanKindSuppressor.php
+++ b/src/API/Instrumentation/SpanSuppression/SpanKindSuppressionStrategy/SpanKindSuppressor.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression\SpanKindSuppressionStrategy;
+
+use OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy\NoopSuppression;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppression;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressor;
+use OpenTelemetry\API\Trace\SpanKind;
+
+final class SpanKindSuppressor implements SpanSuppressor {
+
+    public function resolveSuppression(int $spanKind, array $attributes): SpanSuppression {
+        return match ($spanKind) {
+            SpanKind::KIND_INTERNAL => new NoopSuppression(),
+            SpanKind::KIND_CLIENT => new SpanKindSuppression(SpanKindSuppressionContextKey::Client),
+            SpanKind::KIND_SERVER => new SpanKindSuppression(SpanKindSuppressionContextKey::Server),
+            SpanKind::KIND_PRODUCER => new SpanKindSuppression(SpanKindSuppressionContextKey::Producer),
+            SpanKind::KIND_CONSUMER => new SpanKindSuppression(SpanKindSuppressionContextKey::Consumer),
+        };
+    }
+}

--- a/src/API/Instrumentation/SpanSuppression/SpanSuppression.php
+++ b/src/API/Instrumentation/SpanSuppression/SpanSuppression.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression;
+
+use OpenTelemetry\Context\ContextInterface;
+
+interface SpanSuppression {
+
+    public function isSuppressed(ContextInterface $context): bool;
+
+    public function suppress(ContextInterface $context): ContextInterface;
+}

--- a/src/API/Instrumentation/SpanSuppression/SpanSuppressionStrategy.php
+++ b/src/API/Instrumentation/SpanSuppression/SpanSuppressionStrategy.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression;
+
+interface SpanSuppressionStrategy {
+
+    public function getSuppressor(string $name, ?string $version, ?string $schemaUrl): SpanSuppressor;
+}

--- a/src/API/Instrumentation/SpanSuppression/SpanSuppressor.php
+++ b/src/API/Instrumentation/SpanSuppression/SpanSuppressor.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+namespace OpenTelemetry\API\Instrumentation\SpanSuppression;
+
+interface SpanSuppressor {
+
+    public function resolveSuppression(int $spanKind, array $attributes): SpanSuppression;
+}

--- a/src/API/Trace/Span.php
+++ b/src/API/Trace/Span.php
@@ -52,7 +52,7 @@ abstract class Span implements SpanInterface
     }
 
     /** @inheritDoc */
-    final public function storeInContext(ContextInterface $context): ContextInterface
+    public function storeInContext(ContextInterface $context): ContextInterface
     {
         if (LocalRootSpan::isLocalRoot($context)) {
             $context = LocalRootSpan::store($context, $this);

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
+use OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy\NoopSuppressor;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressor;
 use function in_array;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\Context\Context;
@@ -32,6 +34,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
         private readonly string $spanName,
         private readonly InstrumentationScopeInterface $instrumentationScope,
         private readonly TracerSharedState $tracerSharedState,
+        private readonly SpanSuppressor $spanSuppressor = new NoopSuppressor(),
     ) {
         $this->attributesBuilder = $this->tracerSharedState->getSpanLimits()->getAttributesFactory()->builder();
     }
@@ -118,6 +121,11 @@ final class SpanBuilder implements API\SpanBuilderInterface
         $parentSpan = Span::fromContext($parentContext);
         $parentSpanContext = $parentSpan->getContext();
 
+        $spanSuppression = $this->spanSuppressor->resolveSuppression($this->spanKind, $this->attributesBuilder->build()->toArray());
+        if ($spanSuppression->isSuppressed($parentContext)) {
+            return Span::wrap($parentSpanContext);
+        }
+
         $spanId = $this->tracerSharedState->getIdGenerator()->generateSpanId();
 
         if (!$parentSpanContext->isValid()) {
@@ -148,6 +156,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
         );
 
         if (!in_array($samplingDecision, [SamplingResult::RECORD_AND_SAMPLE, SamplingResult::RECORD_ONLY], true)) {
+            // TODO must suppress no-op spans too
             return Span::wrap($spanContext);
         }
 
@@ -169,7 +178,8 @@ final class SpanBuilder implements API\SpanBuilderInterface
             $attributesBuilder,
             $this->links,
             $this->totalNumberOfLinksAdded,
-            $this->startEpochNanos
+            $this->startEpochNanos,
+            $spanSuppression,
         );
     }
 }

--- a/src/SDK/Trace/Tracer.php
+++ b/src/SDK/Trace/Tracer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
+use OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy\NoopSuppressor;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressor;
 use function ctype_space;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\Context\Context;
@@ -20,6 +22,7 @@ class Tracer implements API\TracerInterface
         private readonly TracerSharedState $tracerSharedState,
         private readonly InstrumentationScopeInterface $instrumentationScope,
         ?Configurator $configurator = null,
+        private readonly SpanSuppressor $spanSuppressor = new NoopSuppressor(),
     ) {
         $this->config = $configurator ? $configurator->resolve($this->instrumentationScope) : TracerConfig::default();
     }
@@ -39,6 +42,7 @@ class Tracer implements API\TracerInterface
             $spanName,
             $this->instrumentationScope,
             $this->tracerSharedState,
+            $this->spanSuppressor,
         );
     }
 

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
+use OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy\NoopSuppressionStrategy;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressionStrategy;
 use function is_array;
 use OpenTelemetry\API\Trace as API;
 use OpenTelemetry\API\Trace\NoopTracer;
@@ -33,6 +35,7 @@ final class TracerProvider implements TracerProviderInterface
         ?IdGeneratorInterface $idGenerator = null,
         ?InstrumentationScopeFactoryInterface $instrumentationScopeFactory = null,
         private ?Configurator $configurator = null,
+        private SpanSuppressionStrategy $spanSuppressionStrategy = new NoopSuppressionStrategy(),
     ) {
         $spanProcessors ??= [];
         $spanProcessors = is_array($spanProcessors) ? $spanProcessors : [$spanProcessors];
@@ -75,6 +78,7 @@ final class TracerProvider implements TracerProviderInterface
             $this->tracerSharedState,
             $scope,
             $this->configurator,
+            $this->spanSuppressionStrategy->getSuppressor($name, $version, $schemaUrl),
         );
         $this->tracers->offsetSet($tracer, null);
 

--- a/src/SDK/Trace/TracerProviderBuilder.php
+++ b/src/SDK/Trace/TracerProviderBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Trace;
 
+use OpenTelemetry\API\Instrumentation\SpanSuppression\NoopSuppressionStrategy\NoopSuppressionStrategy;
+use OpenTelemetry\API\Instrumentation\SpanSuppression\SpanSuppressionStrategy;
 use OpenTelemetry\SDK\Common\InstrumentationScope\Configurator;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 
@@ -14,6 +16,7 @@ class TracerProviderBuilder
     private ?ResourceInfo $resource = null;
     private ?SamplerInterface $sampler = null;
     private ?Configurator $configurator = null;
+    private ?SpanSuppressionStrategy $spanSuppressionStrategy = null;
 
     public function addSpanProcessor(SpanProcessorInterface $spanProcessor): self
     {
@@ -43,6 +46,12 @@ class TracerProviderBuilder
         return $this;
     }
 
+    public function setSpanSuppressionStrategy(SpanSuppressionStrategy $spanSuppressionStrategy): self {
+        $this->spanSuppressionStrategy = $spanSuppressionStrategy;
+
+        return $this;
+    }
+
     public function build(): TracerProviderInterface
     {
         return new TracerProvider(
@@ -50,6 +59,7 @@ class TracerProviderBuilder
             $this->sampler,
             $this->resource,
             configurator: $this->configurator ?? Configurator::tracer(),
+            spanSuppressionStrategy: $this->spanSuppressionStrategy ?? new NoopSuppressionStrategy(),
         );
     }
 }


### PR DESCRIPTION
Alternative to #1583

Span suppression is implemented in the SDK -> instrumentation does not need to handle suppression.
(Everything besides `SemanticConvention` and `SemanticConventionResolver` could be moved to the SDK.)

Provides three span suppression strategies:
Noop: does not suppress anything
SpanKind: suppresses nested spans with the same span kind (except for internal)
SemConv: attempts to resolve the semantic convention based on span attributes, otherwise falls back to span kind suppression