### PR TITLE
add Logger.Enabled event name parameter

### DIFF
--- a/src/API/Logs/LateBindingLogger.php
+++ b/src/API/Logs/LateBindingLogger.php
@@ -22,7 +22,7 @@ class LateBindingLogger implements LoggerInterface
         ($this->logger ??= ($this->factory)())->emit($logRecord);
     }
 
-    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null): bool
+    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null, ?string $eventName = null): bool
     {
         return true;
     }

--- a/src/API/Logs/LoggerInterface.php
+++ b/src/API/Logs/LoggerInterface.php
@@ -14,5 +14,5 @@ interface LoggerInterface
      * Determine if the logger is enabled. Instrumentation authors SHOULD call this method each time they
      * emit a LogRecord, to ensure they have the most up-to-date response.
      */
-    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null): bool;
+    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null, ?string $eventName = null): bool;
 }

--- a/src/API/Logs/NoopLogger.php
+++ b/src/API/Logs/NoopLogger.php
@@ -32,7 +32,7 @@ class NoopLogger implements LoggerInterface
     {
     }
 
-    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null): bool
+    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null, ?string $eventName = null): bool
     {
         return false;
     }

--- a/src/SDK/Logs/LogRecordProcessorInterface.php
+++ b/src/SDK/Logs/LogRecordProcessorInterface.php
@@ -7,6 +7,9 @@ namespace OpenTelemetry\SDK\Logs;
 use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 
+/**
+ * @todo implement (optional) isEnabled: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.45.0/specification/logs/sdk.md#enabled-1
+ */
 interface LogRecordProcessorInterface
 {
     public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void;

--- a/src/SDK/Logs/Logger.php
+++ b/src/SDK/Logs/Logger.php
@@ -53,7 +53,7 @@ class Logger implements LoggerInterface
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.44.0/specification/logs/api.md#enabled
      */
-    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null): bool
+    public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null, ?string $eventName = null): bool
     {
         return $this->config->isEnabled();
     }


### PR DESCRIPTION
extra parameter, "event name", added in spec 1.45.0 which is optional and development stability

see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.45.0/specification/logs/api.md#enabled

I've left LogRecordProcessor.enabled as a todo, as we're not using it and it would require another interface to avoid BC break (plus, we're not using it and it's not marked stable)