### PR TITLE
skip segfaulting test on more xdebug versions

### DIFF
--- a/tests/Unit/Context/ScopeTest.php
+++ b/tests/Unit/Context/ScopeTest.php
@@ -80,11 +80,14 @@ class ScopeTest extends TestCase
         $this->assertSame(0, $scope1->detach());
     }
 
+    /**
+     * @todo Don't skip when https://bugs.xdebug.org/view.php?id=2332 is fixed
+     */
     public function test_inactive_scope_detach(): void
     {
-        if (phpversion('xdebug') === '3.4.2') {
+        if (version_compare(phpversion('xdebug'), '3.4.2', '>=')) {
             //@see https://bugs.xdebug.org/view.php?id=2332
-            $this->markTestSkipped('skipping: segfault in xdebug 3.4.2');
+            $this->markTestSkipped('skipping: segfault in xdebug');
         }
         $scope1 = Context::getCurrent()->activate();
 


### PR DESCRIPTION
verified that the bug we experience still exists in xdebug 3.4.4 so lets assume it will be live for some more releases, and un-skip the test in the future