### PR TITLE
upgrade psalm and fix complaints

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -286,6 +286,7 @@ return [
         'PhanAccessPropertyInternal',
         'PhanTypeMismatchPropertyReal',
         'PhanTemplateTypeNotUsedInFunctionReturn',
+        'PhanUndeclaredClassAttribute',
     ],
 
     // A regular expression to match files to be excluded

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,8 @@
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/polyfill-mbstring": "^1.23",
         "symfony/polyfill-php82": "^1.26",
+        "symfony/polyfill-php83": "^1.32",
+        "symfony/polyfill-php84": "^1.32",
         "tbachert/spi": "^1.0.1"
     },
     "config": {
@@ -98,7 +100,7 @@
         "open-telemetry/dev-tools": "dev-main",
         "php-http/mock-client": "^1.5",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "phpspec/prophecy": "^1.17.0",
+        "phpspec/prophecy": "^1.22",
         "phpspec/prophecy-phpunit": "^2",
         "phpstan/phpstan": "^1.10.13",
         "phpstan/phpstan-mockery": "^1.1",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2 AS composer
+FROM composer:2.8 AS composer
 FROM debian:bullseye
 WORKDIR /usr/src/myapp
 
@@ -38,7 +38,7 @@ RUN apt-get install -y \
 
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
-RUN echo ";grpc.enable_fork_support = 1" > $(php-config --ini-dir)/40-otel-dev.ini \
+RUN echo "grpc.enable_fork_support = 1" > $(php-config --ini-dir)/40-otel-dev.ini \
   && echo "grpc.poll_strategy = epoll1" >> $(php-config --ini-dir)/40-otel-dev.ini \
   && echo "zend.assertions = 1" >> $(php-config --ini-dir)/40-otel-dev.ini
 

--- a/examples/autoload_sdk_with_custom_transport.php
+++ b/examples/autoload_sdk_with_custom_transport.php
@@ -24,21 +24,26 @@ require dirname(__DIR__) . '/vendor/autoload.php';
  * @psalm-suppress MissingTemplateParam
  */
 $factory = new class() implements \OpenTelemetry\SDK\Common\Export\TransportFactoryInterface {
+    #[\Override]
     public function create(string $endpoint, string $contentType, array $headers = [], $compression = null, float $timeout = 10., int $retryDelay = 100, int $maxRetries = 3, ?string $cacert = null, ?string $cert = null, ?string $key = null): \OpenTelemetry\SDK\Common\Export\TransportInterface
     {
         return new class() implements \OpenTelemetry\SDK\Common\Export\TransportInterface {
+            #[\Override]
             public function contentType(): string
             {
                 return 'application/x-protobuf';
             }
+            #[\Override]
             public function send(string $payload, ?\OpenTelemetry\SDK\Common\Future\CancellationInterface $cancellation = null): \OpenTelemetry\SDK\Common\Future\FutureInterface
             {
                 return new \OpenTelemetry\SDK\Common\Future\CompletedFuture(null);
             }
+            #[\Override]
             public function shutdown(?\OpenTelemetry\SDK\Common\Future\CancellationInterface $cancellation = null): bool
             {
                 return true;
             }
+            #[\Override]
             public function forceFlush(?\OpenTelemetry\SDK\Common\Future\CancellationInterface $cancellation = null): bool
             {
                 return true;

--- a/examples/logs/features/monolog-otel-integration.php
+++ b/examples/logs/features/monolog-otel-integration.php
@@ -60,7 +60,7 @@ $otelHandler = new class(LogLevel::INFO) extends AbstractProcessingHandler {
     {
         return (new LogRecord($record['message']))
             ->setSeverityText($record->level->toPsrLogLevel())
-            ->setTimestamp((int) (microtime(true) * LogRecord::NANOS_PER_SECOND))
+            ->setTimestamp((int) (microtime(true) * (float) LogRecord::NANOS_PER_SECOND))
             ->setObservedTimestamp((int) $record->datetime->format('U') * LogRecord::NANOS_PER_SECOND)
             ->setSeverityNumber(Severity::fromPsr3($record->level->toPsrLogLevel()))
             ->setAttributes($record->context + $record->extra);

--- a/examples/logs/features/monolog-otel-integration.php
+++ b/examples/logs/features/monolog-otel-integration.php
@@ -50,6 +50,7 @@ $otelHandler = new class(LogLevel::INFO) extends AbstractProcessingHandler {
         $this->logger = $provider->getLogger('monolog-demo', null, null, ['logging.library' => 'monolog']);
     }
 
+    #[\Override]
     protected function write(MonologLogRecord $record): void
     {
         $this->logger->emit($this->convert($record));

--- a/examples/src/ExampleConfigLoader.php
+++ b/examples/src/ExampleConfigLoader.php
@@ -15,6 +15,7 @@ use OpenTelemetry\API\Instrumentation\AutoInstrumentation\InstrumentationConfigu
  */
 final class ExampleConfigLoader implements EnvComponentLoader
 {
+    #[\Override]
     public function load(EnvResolver $env, EnvComponentLoaderRegistry $registry, Context $context): InstrumentationConfiguration
     {
         return new ExampleConfig(
@@ -22,6 +23,7 @@ final class ExampleConfigLoader implements EnvComponentLoader
         );
     }
 
+    #[\Override]
     public function name(): string
     {
         return ExampleConfig::class;

--- a/examples/src/ExampleConfigProvider.php
+++ b/examples/src/ExampleConfigProvider.php
@@ -24,6 +24,7 @@ final class ExampleConfigProvider implements ComponentProvider
      *     enabled: bool,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): InstrumentationConfiguration
     {
         return new ExampleConfig(
@@ -35,6 +36,7 @@ final class ExampleConfigProvider implements ComponentProvider
     /**
      * @psalm-suppress UndefinedInterfaceMethod,PossiblyNullReference
      */
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('example_instrumentation');

--- a/examples/src/ExampleInstrumentation.php
+++ b/examples/src/ExampleInstrumentation.php
@@ -13,6 +13,7 @@ use OpenTelemetry\Context\Context;
 
 final class ExampleInstrumentation implements Instrumentation
 {
+    #[\Override]
     public function register(HookManagerInterface $hookManager, ConfigProperties $configuration, InstrumentationContext $context): void
     {
         $config = $configuration->get(ExampleConfig::class) ?? new ExampleConfig();

--- a/examples/traces/exporters/otlp_file.php
+++ b/examples/traces/exporters/otlp_file.php
@@ -15,6 +15,9 @@ use OpenTelemetry\SDK\Trace\TracerProvider;
 
 $filename = sys_get_temp_dir() . '/traces.jsonl';
 $file = fopen($filename, 'a');
+if ($file === false) {
+    throw new \RuntimeException('Failed to open file for writing: ' . $filename);
+}
 $transport = (new StreamTransportFactory())->create($file, ContentTypes::NDJSON);
 $exporter = new SpanExporter($transport);
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -39,6 +39,11 @@
                 <directory name="./examples"/>
             </errorLevel>
         </ArgumentTypeCoercion>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <directory name="src/Config/SDK/Configuration/Internal"/>
+            </errorLevel>
+        </InvalidArgument>
         <UndefinedInterfaceMethod>
             <errorLevel type="suppress">
                 <directory name="src/Config/SDK/ComponentProvider"/>
@@ -51,6 +56,12 @@
                 <directory name="tests/Integration/Config"/>
             </errorLevel>
         </PossiblyInvalidArgument>
+        <PossiblyNullReference>
+            <errorLevel type="suppress">
+                <directory name="src/Config/SDK/ComponentProvider"/>
+                <directory name="tests/Integration/Config/ComponentProvider"/>
+            </errorLevel>
+        </PossiblyNullReference>
         <MoreSpecificImplementedParamType>
             <errorLevel type="suppress">
                 <directory name="src/Config/SDK/ComponentProvider"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -15,6 +15,7 @@
             <directory name="./examples/traces/demo/"/>
             <directory name="tests/Unit/Config/SDK/Configuration/ExampleSdk"/>
             <directory name="tests/TraceContext/W3CTestService"/>
+            <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
     <plugins>
@@ -27,11 +28,6 @@
                 <referencedClass name="GMP"/>
             </errorLevel>
         </UndefinedClass>
-        <UndefinedFunction>
-            <errorLevel type="suppress">
-                <referencedFunction name="OpenTelemetry\Instrumentation\hook"/>
-            </errorLevel>
-        </UndefinedFunction>
         <UndefinedMethod>
             <errorLevel type="suppress">
                 <referencedMethod name="Google\Protobuf\Internal\RepeatedField::offsetGet"/>
@@ -43,11 +39,6 @@
                 <directory name="./examples"/>
             </errorLevel>
         </ArgumentTypeCoercion>
-        <InvalidArgument>
-            <errorLevel type="suppress">
-                <directory name="src/Config/SDK/Configuration/Internal"/>
-            </errorLevel>
-        </InvalidArgument>
         <UndefinedInterfaceMethod>
             <errorLevel type="suppress">
                 <directory name="src/Config/SDK/ComponentProvider"/>
@@ -57,34 +48,56 @@
         <PossiblyInvalidArgument>
             <errorLevel type="suppress">
                 <directory name="src/Config/SDK/Configuration"/>
+                <directory name="tests/Integration/Config"/>
             </errorLevel>
         </PossiblyInvalidArgument>
-        <PossiblyNullReference>
-            <errorLevel type="suppress">
-                <directory name="src/Config/SDK/ComponentProvider"/>
-                <directory name="tests/Integration/Config/ComponentProvider"/>
-            </errorLevel>
-        </PossiblyNullReference>
         <MoreSpecificImplementedParamType>
             <errorLevel type="suppress">
                 <directory name="src/Config/SDK/ComponentProvider"/>
-                <directory name="tests/Integration/Config/ComponentProvider"/>
+                <directory name="tests"/>
             </errorLevel>
         </MoreSpecificImplementedParamType>
-        <InvalidDocblock>
+        <UndefinedMagicMethod>
             <errorLevel type="suppress">
-                <directory name="src/Config/SDK/ComponentProvider"/>
+                <referencedMethod name="Prophecy\Prophecy\ObjectProphecy::accepts"/>
+                <referencedMethod name="Prophecy\Prophecy\ObjectProphecy::fields"/>
             </errorLevel>
-        </InvalidDocblock>
-        <NonInvariantDocblockPropertyType>
+        </UndefinedMagicMethod>
+        <PossiblyFalseArgument>
             <errorLevel type="suppress">
-                <directory name="src/Config/SDK/Configuration/Internal"/>
+                <directory name="tests"/>
             </errorLevel>
-        </NonInvariantDocblockPropertyType>
-        <NonInvariantPropertyType>
+        </PossiblyFalseArgument>
+        <PossiblyFalseOperand>
             <errorLevel type="suppress">
-                <directory name="src/Config/SDK/Configuration/Internal"/>
+                <directory name="examples/baggage"/>
+                <file name="src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php"/>
             </errorLevel>
-        </NonInvariantPropertyType>
+        </PossiblyFalseOperand>
+        <InvalidOperand>
+            <errorLevel type="suppress">
+                <directory name="tests"/>
+            </errorLevel>
+        </InvalidOperand>
+        <FalsableReturnStatement>
+            <errorLevel type="suppress">
+                <directory name="src/API/Trace"/>
+            </errorLevel>
+        </FalsableReturnStatement>
+        <PossiblyNullArgument>
+            <errorLevel type="suppress">
+                <file name="src/API/Instrumentation/CachedInstrumentation.php"/>
+            </errorLevel>
+        </PossiblyNullArgument>
+        <InvalidNullableReturnType>
+            <errorLevel type="suppress">
+                <file name="src/API/Instrumentation/CachedInstrumentation.php"/>
+            </errorLevel>
+        </InvalidNullableReturnType>
+        <NullableReturnStatement>
+            <errorLevel type="suppress">
+                <file name="src/API/Instrumentation/CachedInstrumentation.php"/>
+            </errorLevel>
+        </NullableReturnStatement>
     </issueHandlers>
 </psalm>

--- a/rector.php
+++ b/rector.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Array_\CallableThisArrayToAnonymousFunctionRector;
 use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\ValueObject\PhpVersion;
 use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->phpVersion(PhpVersion::PHP_81);
+    $rectorConfig->phpVersion(PhpVersion::PHP_83);
 
     $rectorConfig->paths([
         __DIR__ . '/src',
@@ -27,6 +27,7 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::CODE_QUALITY,
         PHPUnitSetList::PHPUNIT_100,
     ]);
+    $rectorConfig->rule(AddOverrideAttributeToOverriddenMethodsRector::class);
     $rectorConfig->skip([
         FlipTypeControlToUseExclusiveTypeRector::class,
         NewInInitializerRector::class => [

--- a/src/API/Baggage/Baggage.php
+++ b/src/API/Baggage/Baggage.php
@@ -14,24 +14,28 @@ final class Baggage implements BaggageInterface
     private static ?self $emptyBaggage = null;
 
     /** @inheritDoc */
+    #[\Override]
     public static function fromContext(ContextInterface $context): BaggageInterface
     {
         return $context->get(ContextKeys::baggage()) ?? self::getEmpty();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public static function getBuilder(): BaggageBuilderInterface
     {
         return new BaggageBuilder();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public static function getCurrent(): BaggageInterface
     {
         return self::fromContext(Context::getCurrent());
     }
 
     /** @inheritDoc */
+    #[\Override]
     public static function getEmpty(): BaggageInterface
     {
         if (null === self::$emptyBaggage) {
@@ -47,18 +51,21 @@ final class Baggage implements BaggageInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function activate(): ScopeInterface
     {
         return Context::getCurrent()->withContextValue($this)->activate();
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getEntry(string $key): ?Entry
     {
         return $this->entries[$key] ?? null;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getValue(string $key)
     {
         if (($entry = $this->getEntry($key)) !== null) {
@@ -69,6 +76,7 @@ final class Baggage implements BaggageInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getAll(): iterable
     {
         foreach ($this->entries as $key => $entry) {
@@ -77,18 +85,21 @@ final class Baggage implements BaggageInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function isEmpty(): bool
     {
         return $this->entries === [];
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function toBuilder(): BaggageBuilderInterface
     {
         return new BaggageBuilder($this->entries);
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function storeInContext(ContextInterface $context): ContextInterface
     {
         return $context->with(ContextKeys::baggage(), $this);

--- a/src/API/Baggage/BaggageBuilder.php
+++ b/src/API/Baggage/BaggageBuilder.php
@@ -12,6 +12,7 @@ final class BaggageBuilder implements BaggageBuilderInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function remove(string $key): BaggageBuilderInterface
     {
         unset($this->entries[$key]);
@@ -20,6 +21,7 @@ final class BaggageBuilder implements BaggageBuilderInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function set(string $key, $value, ?MetadataInterface $metadata = null): BaggageBuilderInterface
     {
         if ($key === '') {
@@ -32,6 +34,7 @@ final class BaggageBuilder implements BaggageBuilderInterface
         return $this;
     }
 
+    #[\Override]
     public function build(): BaggageInterface
     {
         return new Baggage($this->entries);

--- a/src/API/Baggage/Metadata.php
+++ b/src/API/Baggage/Metadata.php
@@ -17,6 +17,7 @@ final class Metadata implements MetadataInterface
     {
     }
 
+    #[\Override]
     public function getValue(): string
     {
         return $this->metadata;

--- a/src/API/Baggage/Propagation/BaggagePropagator.php
+++ b/src/API/Baggage/Propagation/BaggagePropagator.php
@@ -34,11 +34,13 @@ final class BaggagePropagator implements TextMapPropagatorInterface
         return self::$instance;
     }
 
+    #[\Override]
     public function fields(): array
     {
         return [self::BAGGAGE];
     }
 
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
@@ -70,6 +72,7 @@ final class BaggagePropagator implements TextMapPropagatorInterface
         }
     }
 
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $getter ??= ArrayAccessGetterSetter::getInstance();

--- a/src/API/Behavior/Internal/LogWriter/ErrorLogWriter.php
+++ b/src/API/Behavior/Internal/LogWriter/ErrorLogWriter.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\API\Behavior\Internal\LogWriter;
 
 class ErrorLogWriter implements LogWriterInterface
 {
+    #[\Override]
     public function write($level, string $message, array $context): void
     {
         error_log(Formatter::format($level, $message, $context));

--- a/src/API/Behavior/Internal/LogWriter/NoopLogWriter.php
+++ b/src/API/Behavior/Internal/LogWriter/NoopLogWriter.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\API\Behavior\Internal\LogWriter;
 
 class NoopLogWriter implements LogWriterInterface
 {
+    #[\Override]
     public function write($level, string $message, array $context): void
     {
         //do nothing

--- a/src/API/Behavior/Internal/LogWriter/Psr3LogWriter.php
+++ b/src/API/Behavior/Internal/LogWriter/Psr3LogWriter.php
@@ -12,6 +12,7 @@ class Psr3LogWriter implements LogWriterInterface
     {
     }
 
+    #[\Override]
     public function write($level, string $message, array $context): void
     {
         $this->logger->log($level, $message, $context);

--- a/src/API/Behavior/Internal/LogWriter/StreamLogWriter.php
+++ b/src/API/Behavior/Internal/LogWriter/StreamLogWriter.php
@@ -18,6 +18,7 @@ class StreamLogWriter implements LogWriterInterface
         }
     }
 
+    #[\Override]
     public function write($level, string $message, array $context): void
     {
         fwrite($this->stream, Formatter::format($level, $message, $context));

--- a/src/API/Common/Time/SystemClock.php
+++ b/src/API/Common/Time/SystemClock.php
@@ -25,6 +25,7 @@ final class SystemClock implements ClockInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function now(): int
     {
         return self::$referenceTime + hrtime(true);

--- a/src/API/Common/Time/SystemClock.php
+++ b/src/API/Common/Time/SystemClock.php
@@ -48,6 +48,6 @@ final class SystemClock implements ClockInterface
      */
     private static function calculateReferenceTime(float $wallClockMicroTime, int $upTime): int
     {
-        return ((int) ($wallClockMicroTime * ClockInterface::NANOS_PER_SECOND)) - $upTime;
+        return ((int) ($wallClockMicroTime * (float) ClockInterface::NANOS_PER_SECOND)) - $upTime;
     }
 }

--- a/src/API/Common/Time/TestClock.php
+++ b/src/API/Common/Time/TestClock.php
@@ -33,6 +33,7 @@ final class TestClock implements ClockInterface
         $this->currentEpochNanos = $nanoSeconds;
     }
 
+    #[\Override]
     public function now(): int
     {
         return $this->currentEpochNanos;

--- a/src/API/Configuration/Noop/NoopConfigProperties.php
+++ b/src/API/Configuration/Noop/NoopConfigProperties.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Configuration\ConfigProperties;
 
 class NoopConfigProperties implements ConfigProperties
 {
+    #[\Override]
     public function get(string $id): mixed
     {
         return null;

--- a/src/API/Configuration/Noop/NoopConfigProvider.php
+++ b/src/API/Configuration/Noop/NoopConfigProvider.php
@@ -9,6 +9,7 @@ use OpenTelemetry\API\Configuration\ConfigProviderInterface;
 
 class NoopConfigProvider implements ConfigProviderInterface
 {
+    #[\Override]
     public function getInstrumentationConfig(): ConfigProperties
     {
         return new NoopConfigProperties();

--- a/src/API/Instrumentation/AutoInstrumentation/ConfigurationRegistry.php
+++ b/src/API/Instrumentation/AutoInstrumentation/ConfigurationRegistry.php
@@ -23,6 +23,7 @@ final class ConfigurationRegistry implements ConfigProperties
      * @param class-string<C> $id
      * @return C|null
      */
+    #[\Override]
     public function get(string $id): ?InstrumentationConfiguration
     {
         return $this->configurations[$id] ?? null;

--- a/src/API/Instrumentation/AutoInstrumentation/ExtensionHookManager.php
+++ b/src/API/Instrumentation/AutoInstrumentation/ExtensionHookManager.php
@@ -18,6 +18,7 @@ final class ExtensionHookManager implements HookManagerInterface
     /**
      * @phan-suppress PhanUndeclaredFunction
      */
+    #[\Override]
     public function hook(?string $class, string $function, ?Closure $preHook = null, ?Closure $postHook = null): void
     {
         assert(extension_loaded('opentelemetry'));

--- a/src/API/Instrumentation/AutoInstrumentation/NoopHookManager.php
+++ b/src/API/Instrumentation/AutoInstrumentation/NoopHookManager.php
@@ -8,6 +8,7 @@ use Closure;
 
 final class NoopHookManager implements HookManagerInterface
 {
+    #[\Override]
     public function hook(?string $class, string $function, ?Closure $preHook = null, ?Closure $postHook = null): void
     {
         // no-op

--- a/src/API/Instrumentation/CachedInstrumentation.php
+++ b/src/API/Instrumentation/CachedInstrumentation.php
@@ -62,6 +62,7 @@ final class CachedInstrumentation
 
         return $this->meters[$meterProvider] ??= $meterProvider->getMeter($this->name, $this->version, $this->schemaUrl, $this->attributes);
     }
+
     public function logger(): LoggerInterface
     {
         $loggerProvider = Globals::loggerProvider();

--- a/src/API/Instrumentation/Configuration/General/ConfigEnv/EnvComponentLoaderHttpConfig.php
+++ b/src/API/Instrumentation/Configuration/General/ConfigEnv/EnvComponentLoaderHttpConfig.php
@@ -16,6 +16,7 @@ use OpenTelemetry\API\Instrumentation\Configuration\General\HttpConfig;
  */
 final class EnvComponentLoaderHttpConfig implements EnvComponentLoader
 {
+    #[\Override]
     public function load(EnvResolver $env, EnvComponentLoaderRegistry $registry, Context $context): GeneralInstrumentationConfiguration
     {
         return new HttpConfig([
@@ -30,6 +31,7 @@ final class EnvComponentLoaderHttpConfig implements EnvComponentLoader
         ]);
     }
 
+    #[\Override]
     public function name(): string
     {
         return HttpConfig::class;

--- a/src/API/Instrumentation/Configuration/General/ConfigEnv/EnvComponentLoaderPeerConfig.php
+++ b/src/API/Instrumentation/Configuration/General/ConfigEnv/EnvComponentLoaderPeerConfig.php
@@ -16,11 +16,13 @@ use OpenTelemetry\API\Instrumentation\Configuration\General\PeerConfig;
  */
 final class EnvComponentLoaderPeerConfig implements EnvComponentLoader
 {
+    #[\Override]
     public function load(EnvResolver $env, EnvComponentLoaderRegistry $registry, Context $context): GeneralInstrumentationConfiguration
     {
         return new PeerConfig([]);
     }
 
+    #[\Override]
     public function name(): string
     {
         return PeerConfig::class;

--- a/src/API/Instrumentation/ConfigurationResolver.php
+++ b/src/API/Instrumentation/ConfigurationResolver.php
@@ -6,16 +6,19 @@ namespace OpenTelemetry\API\Instrumentation;
 
 class ConfigurationResolver implements ConfigurationResolverInterface
 {
+    #[\Override]
     public function has(string $name): bool
     {
         return $this->getVariable($name) !== null;
     }
 
+    #[\Override]
     public function getString(string $name): ?string
     {
         return $this->getVariable($name);
     }
 
+    #[\Override]
     public function getBoolean(string $name): ?bool
     {
         $value = $this->getVariable($name);
@@ -26,6 +29,7 @@ class ConfigurationResolver implements ConfigurationResolverInterface
         return ($value === 'true');
     }
 
+    #[\Override]
     public function getInt(string $name): ?int
     {
         $value = $this->getVariable($name);
@@ -40,6 +44,7 @@ class ConfigurationResolver implements ConfigurationResolverInterface
         return (int) $value;
     }
 
+    #[\Override]
     public function getList(string $name): array
     {
         $value = $this->getVariable($name);

--- a/src/API/Instrumentation/Configurator.php
+++ b/src/API/Instrumentation/Configurator.php
@@ -59,6 +59,7 @@ final class Configurator implements ImplicitContextKeyedInterface
         ;
     }
 
+    #[\Override]
     public function activate(): ScopeInterface
     {
         return $this->storeInContext()->activate();
@@ -67,6 +68,7 @@ final class Configurator implements ImplicitContextKeyedInterface
     /**
      * @phan-suppress PhanDeprecatedFunction
      */
+    #[\Override]
     public function storeInContext(?ContextInterface $context = null): ContextInterface
     {
         $context ??= Context::getCurrent();

--- a/src/API/Logs/LateBindingLogger.php
+++ b/src/API/Logs/LateBindingLogger.php
@@ -17,11 +17,13 @@ class LateBindingLogger implements LoggerInterface
     ) {
     }
 
+    #[\Override]
     public function emit(LogRecord $logRecord): void
     {
         ($this->logger ??= ($this->factory)())->emit($logRecord);
     }
 
+    #[\Override]
     public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null, ?string $eventName = null): bool
     {
         return true;

--- a/src/API/Logs/LateBindingLoggerProvider.php
+++ b/src/API/Logs/LateBindingLoggerProvider.php
@@ -16,6 +16,7 @@ class LateBindingLoggerProvider implements LoggerProviderInterface
     ) {
     }
 
+    #[\Override]
     public function getLogger(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): LoggerInterface
     {
         return $this->loggerProvider?->getLogger($name, $version, $schemaUrl, $attributes)

--- a/src/API/Logs/NoopEventLogger.php
+++ b/src/API/Logs/NoopEventLogger.php
@@ -19,6 +19,7 @@ class NoopEventLogger implements EventLoggerInterface
         return $instance;
     }
 
+    #[\Override]
     public function emit(string $name, mixed $body = null, ?int $timestamp = null, ?ContextInterface $context = null, Severity|int|null $severityNumber = null, iterable $attributes = []): void
     {
     }

--- a/src/API/Logs/NoopEventLoggerProvider.php
+++ b/src/API/Logs/NoopEventLoggerProvider.php
@@ -16,6 +16,7 @@ class NoopEventLoggerProvider implements EventLoggerProviderInterface
         return $instance ??= new self();
     }
 
+    #[\Override]
     public function getEventLogger(
         string $name,
         ?string $version = null,

--- a/src/API/Logs/NoopLogger.php
+++ b/src/API/Logs/NoopLogger.php
@@ -21,6 +21,7 @@ class NoopLogger implements LoggerInterface
     /**
      * @codeCoverageIgnore
      */
+    #[\Override]
     public function emit(LogRecord $logRecord): void
     {
     }
@@ -28,10 +29,12 @@ class NoopLogger implements LoggerInterface
     /**
      * @codeCoverageIgnore
      */
+    #[\Override]
     public function log($level, $message, array $context = []): void
     {
     }
 
+    #[\Override]
     public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null, ?string $eventName = null): bool
     {
         return false;

--- a/src/API/Logs/NoopLoggerProvider.php
+++ b/src/API/Logs/NoopLoggerProvider.php
@@ -13,6 +13,7 @@ class NoopLoggerProvider implements LoggerProviderInterface
         return $instance ??= new self();
     }
 
+    #[\Override]
     public function getLogger(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): LoggerInterface
     {
         return NoopLogger::getInstance();

--- a/src/API/Metrics/LateBindingMeter.php
+++ b/src/API/Metrics/LateBindingMeter.php
@@ -19,41 +19,49 @@ class LateBindingMeter implements MeterInterface
     ) {
     }
 
+    #[\Override]
     public function batchObserve(callable $callback, AsynchronousInstrument $instrument, AsynchronousInstrument ...$instruments): ObservableCallbackInterface
     {
         return ($this->meter ??= ($this->factory)())->batchObserve($callback, $instrument, ...$instruments);
     }
 
+    #[\Override]
     public function createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): CounterInterface
     {
         return ($this->meter ??= ($this->factory)())->createCounter($name, $unit, $description, $advisory);
     }
 
+    #[\Override]
     public function createObservableCounter(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableCounterInterface
     {
         return ($this->meter ??= ($this->factory)())->createObservableCounter($name, $unit, $description, $advisory, ...$callbacks);
     }
 
+    #[\Override]
     public function createHistogram(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): HistogramInterface
     {
         return ($this->meter ??= ($this->factory)())->createHistogram($name, $unit, $description, $advisory);
     }
 
+    #[\Override]
     public function createGauge(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): GaugeInterface
     {
         return ($this->meter ??= ($this->factory)())->createGauge($name, $unit, $description, $advisory);
     }
 
+    #[\Override]
     public function createObservableGauge(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableGaugeInterface
     {
         return ($this->meter ??= ($this->factory)())->createObservableGauge($name, $unit, $description, $advisory, ...$callbacks);
     }
 
+    #[\Override]
     public function createUpDownCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): UpDownCounterInterface
     {
         return ($this->meter ??= ($this->factory)())->createUpDownCounter($name, $unit, $description, $advisory);
     }
 
+    #[\Override]
     public function createObservableUpDownCounter(string $name, ?string $unit = null, ?string $description = null, callable|array $advisory = [], callable ...$callbacks): ObservableUpDownCounterInterface
     {
         return ($this->meter ??= ($this->factory)())->createObservableUpDownCounter($name, $unit, $description, $advisory, ...$callbacks);

--- a/src/API/Metrics/LateBindingMeterProvider.php
+++ b/src/API/Metrics/LateBindingMeterProvider.php
@@ -16,6 +16,7 @@ class LateBindingMeterProvider implements MeterProviderInterface
     ) {
     }
 
+    #[\Override]
     public function getMeter(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): MeterInterface
     {
         return $this->meterProvider?->getMeter($name, $version, $schemaUrl, $attributes)

--- a/src/API/Metrics/Noop/NoopCounter.php
+++ b/src/API/Metrics/Noop/NoopCounter.php
@@ -11,11 +11,13 @@ use OpenTelemetry\API\Metrics\CounterInterface;
  */
 final class NoopCounter implements CounterInterface
 {
+    #[\Override]
     public function add($amount, iterable $attributes = [], $context = null): void
     {
         // no-op
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return false;

--- a/src/API/Metrics/Noop/NoopGauge.php
+++ b/src/API/Metrics/Noop/NoopGauge.php
@@ -11,11 +11,13 @@ use OpenTelemetry\API\Metrics\GaugeInterface;
  */
 final class NoopGauge implements GaugeInterface
 {
+    #[\Override]
     public function record(float|int $amount, iterable $attributes = [], $context = null): void
     {
         // no-op
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return false;

--- a/src/API/Metrics/Noop/NoopHistogram.php
+++ b/src/API/Metrics/Noop/NoopHistogram.php
@@ -11,11 +11,13 @@ use OpenTelemetry\API\Metrics\HistogramInterface;
  */
 final class NoopHistogram implements HistogramInterface
 {
+    #[\Override]
     public function record($amount, iterable $attributes = [], $context = null): void
     {
         // no-op
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return false;

--- a/src/API/Metrics/Noop/NoopMeter.php
+++ b/src/API/Metrics/Noop/NoopMeter.php
@@ -17,41 +17,49 @@ use OpenTelemetry\API\Metrics\UpDownCounterInterface;
 
 final class NoopMeter implements MeterInterface
 {
+    #[\Override]
     public function batchObserve(callable $callback, AsynchronousInstrument $instrument, AsynchronousInstrument ...$instruments): ObservableCallbackInterface
     {
         return new NoopObservableCallback();
     }
 
+    #[\Override]
     public function createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): CounterInterface
     {
         return new NoopCounter();
     }
 
+    #[\Override]
     public function createObservableCounter(string $name, ?string $unit = null, ?string $description = null, $advisory = [], callable ...$callbacks): ObservableCounterInterface
     {
         return new NoopObservableCounter();
     }
 
+    #[\Override]
     public function createHistogram(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): HistogramInterface
     {
         return new NoopHistogram();
     }
 
+    #[\Override]
     public function createGauge(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): GaugeInterface
     {
         return new NoopGauge();
     }
 
+    #[\Override]
     public function createObservableGauge(string $name, ?string $unit = null, ?string $description = null, $advisory = [], callable ...$callbacks): ObservableGaugeInterface
     {
         return new NoopObservableGauge();
     }
 
+    #[\Override]
     public function createUpDownCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): UpDownCounterInterface
     {
         return new NoopUpDownCounter();
     }
 
+    #[\Override]
     public function createObservableUpDownCounter(string $name, ?string $unit = null, ?string $description = null, $advisory = [], callable ...$callbacks): ObservableUpDownCounterInterface
     {
         return new NoopObservableUpDownCounter();

--- a/src/API/Metrics/Noop/NoopMeterProvider.php
+++ b/src/API/Metrics/Noop/NoopMeterProvider.php
@@ -9,6 +9,7 @@ use OpenTelemetry\API\Metrics\MeterProviderInterface;
 
 final class NoopMeterProvider implements MeterProviderInterface
 {
+    #[\Override]
     public function getMeter(
         string $name,
         ?string $version = null,

--- a/src/API/Metrics/Noop/NoopObservableCallback.php
+++ b/src/API/Metrics/Noop/NoopObservableCallback.php
@@ -11,6 +11,7 @@ use OpenTelemetry\API\Metrics\ObservableCallbackInterface;
  */
 final class NoopObservableCallback implements ObservableCallbackInterface
 {
+    #[\Override]
     public function detach(): void
     {
         // no-op

--- a/src/API/Metrics/Noop/NoopObservableCounter.php
+++ b/src/API/Metrics/Noop/NoopObservableCounter.php
@@ -12,11 +12,13 @@ use OpenTelemetry\API\Metrics\ObservableCounterInterface;
  */
 final class NoopObservableCounter implements ObservableCounterInterface
 {
+    #[\Override]
     public function observe(callable $callback, bool $weaken = false): ObservableCallbackInterface
     {
         return new NoopObservableCallback();
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return false;

--- a/src/API/Metrics/Noop/NoopObservableGauge.php
+++ b/src/API/Metrics/Noop/NoopObservableGauge.php
@@ -12,11 +12,13 @@ use OpenTelemetry\API\Metrics\ObservableGaugeInterface;
  */
 final class NoopObservableGauge implements ObservableGaugeInterface
 {
+    #[\Override]
     public function observe(callable $callback, bool $weaken = false): ObservableCallbackInterface
     {
         return new NoopObservableCallback();
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return false;

--- a/src/API/Metrics/Noop/NoopObservableUpDownCounter.php
+++ b/src/API/Metrics/Noop/NoopObservableUpDownCounter.php
@@ -12,11 +12,13 @@ use OpenTelemetry\API\Metrics\ObservableUpDownCounterInterface;
  */
 final class NoopObservableUpDownCounter implements ObservableUpDownCounterInterface
 {
+    #[\Override]
     public function observe(callable $callback, bool $weaken = false): ObservableCallbackInterface
     {
         return new NoopObservableCallback();
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return false;

--- a/src/API/Metrics/Noop/NoopUpDownCounter.php
+++ b/src/API/Metrics/Noop/NoopUpDownCounter.php
@@ -11,11 +11,13 @@ use OpenTelemetry\API\Metrics\UpDownCounterInterface;
  */
 final class NoopUpDownCounter implements UpDownCounterInterface
 {
+    #[\Override]
     public function add($amount, iterable $attributes = [], $context = null): void
     {
         // no-op
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return false;

--- a/src/API/Trace/LateBindingTracer.php
+++ b/src/API/Trace/LateBindingTracer.php
@@ -16,11 +16,13 @@ class LateBindingTracer implements TracerInterface
     ) {
     }
 
+    #[\Override]
     public function spanBuilder(string $spanName): SpanBuilderInterface
     {
         return ($this->tracer ??= ($this->factory)())->spanBuilder($spanName);
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return true;

--- a/src/API/Trace/LateBindingTracerProvider.php
+++ b/src/API/Trace/LateBindingTracerProvider.php
@@ -22,6 +22,7 @@ class LateBindingTracerProvider implements TracerProviderInterface
     ) {
     }
 
+    #[\Override]
     public function getTracer(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): TracerInterface
     {
         return $this->tracerProvider?->getTracer($name, $version, $schemaUrl, $attributes)

--- a/src/API/Trace/NonRecordingSpan.php
+++ b/src/API/Trace/NonRecordingSpan.php
@@ -18,59 +18,69 @@ final class NonRecordingSpan extends Span
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getContext(): SpanContextInterface
     {
         return $this->context;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function isRecording(): bool
     {
         return false;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setAttribute(string $key, $value): SpanInterface
     {
         return $this;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setAttributes(iterable $attributes): SpanInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function addLink(SpanContextInterface $context, iterable $attributes = []): SpanInterface
     {
         return $this;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function addEvent(string $name, iterable $attributes = [], ?int $timestamp = null): SpanInterface
     {
         return $this;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function recordException(Throwable $exception, iterable $attributes = []): SpanInterface
     {
         return $this;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function updateName(string $name): SpanInterface
     {
         return $this;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setStatus(string $code, ?string $description = null): SpanInterface
     {
         return $this;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function end(?int $endEpochNanos = null): void
     {
     }

--- a/src/API/Trace/NoopSpanBuilder.php
+++ b/src/API/Trace/NoopSpanBuilder.php
@@ -16,6 +16,7 @@ final class NoopSpanBuilder implements SpanBuilderInterface
     {
     }
 
+    #[\Override]
     public function setParent(ContextInterface|false|null $context): SpanBuilderInterface
     {
         $this->parentContext = $context;
@@ -23,31 +24,37 @@ final class NoopSpanBuilder implements SpanBuilderInterface
         return $this;
     }
 
+    #[\Override]
     public function addLink(SpanContextInterface $context, iterable $attributes = []): SpanBuilderInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function setAttribute(string $key, mixed $value): SpanBuilderInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function setAttributes(iterable $attributes): SpanBuilderInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function setStartTimestamp(int $timestampNanos): SpanBuilderInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function setSpanKind(int $spanKind): SpanBuilderInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function startSpan(): SpanInterface
     {
         $parentContext = Context::resolve($this->parentContext, $this->contextStorage);

--- a/src/API/Trace/NoopTracer.php
+++ b/src/API/Trace/NoopTracer.php
@@ -19,11 +19,13 @@ final class NoopTracer implements TracerInterface
         return self::$instance;
     }
 
+    #[\Override]
     public function spanBuilder(string $spanName): SpanBuilderInterface
     {
         return new NoopSpanBuilder(Context::storage());
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return false;

--- a/src/API/Trace/NoopTracerProvider.php
+++ b/src/API/Trace/NoopTracerProvider.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\API\Trace;
 
 class NoopTracerProvider implements TracerProviderInterface
 {
+    #[\Override]
     public function getTracer(
         string $name,
         ?string $version = null,

--- a/src/API/Trace/Propagation/TraceContextPropagator.php
+++ b/src/API/Trace/Propagation/TraceContextPropagator.php
@@ -53,12 +53,14 @@ final class TraceContextPropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function fields(): array
     {
         return self::FIELDS;
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
@@ -81,6 +83,7 @@ final class TraceContextPropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $getter ??= ArrayAccessGetterSetter::getInstance();

--- a/src/API/Trace/Span.php
+++ b/src/API/Trace/Span.php
@@ -14,18 +14,21 @@ abstract class Span implements SpanInterface
     private static ?self $invalidSpan = null;
 
     /** @inheritDoc */
+    #[\Override]
     final public static function fromContext(ContextInterface $context): SpanInterface
     {
         return $context->get(ContextKeys::span()) ?? self::getInvalid();
     }
 
     /** @inheritDoc */
+    #[\Override]
     final public static function getCurrent(): SpanInterface
     {
         return self::fromContext(Context::getCurrent());
     }
 
     /** @inheritDoc */
+    #[\Override]
     final public static function getInvalid(): SpanInterface
     {
         if (null === self::$invalidSpan) {
@@ -36,6 +39,7 @@ abstract class Span implements SpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     final public static function wrap(SpanContextInterface $spanContext): SpanInterface
     {
         if (!$spanContext->isValid()) {
@@ -46,12 +50,14 @@ abstract class Span implements SpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     final public function activate(): ScopeInterface
     {
         return Context::getCurrent()->withContextValue($this)->activate();
     }
 
     /** @inheritDoc */
+    #[\Override]
     final public function storeInContext(ContextInterface $context): ContextInterface
     {
         if (LocalRootSpan::isLocalRoot($context)) {

--- a/src/API/Trace/SpanContext.php
+++ b/src/API/Trace/SpanContext.php
@@ -35,52 +35,62 @@ final class SpanContext implements SpanContextInterface
         $this->isSampled = ($traceFlags & TraceFlags::SAMPLED) === TraceFlags::SAMPLED;
     }
 
+    #[\Override]
     public function getTraceId(): string
     {
         return $this->traceId;
     }
 
+    #[\Override]
     public function getTraceIdBinary(): string
     {
         return hex2bin($this->traceId);
     }
 
+    #[\Override]
     public function getSpanId(): string
     {
         return $this->spanId;
     }
 
+    #[\Override]
     public function getSpanIdBinary(): string
     {
         return hex2bin($this->spanId);
     }
 
+    #[\Override]
     public function getTraceState(): ?TraceStateInterface
     {
         return $this->traceState;
     }
 
+    #[\Override]
     public function isSampled(): bool
     {
         return $this->isSampled;
     }
 
+    #[\Override]
     public function isValid(): bool
     {
         return $this->isValid;
     }
 
+    #[\Override]
     public function isRemote(): bool
     {
         return $this->isRemote;
     }
 
+    #[\Override]
     public function getTraceFlags(): int
     {
         return $this->traceFlags;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public static function createFromRemoteParent(string $traceId, string $spanId, int $traceFlags = TraceFlags::DEFAULT, ?TraceStateInterface $traceState = null): SpanContextInterface
     {
         return new self(
@@ -93,6 +103,7 @@ final class SpanContext implements SpanContextInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public static function create(string $traceId, string $spanId, int $traceFlags = TraceFlags::DEFAULT, ?TraceStateInterface $traceState = null): SpanContextInterface
     {
         return new self(
@@ -105,6 +116,7 @@ final class SpanContext implements SpanContextInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public static function getInvalid(): SpanContextInterface
     {
         if (null === self::$invalidContext) {

--- a/src/API/Trace/TraceState.php
+++ b/src/API/Trace/TraceState.php
@@ -94,6 +94,9 @@ class TraceState implements TraceStateInterface
                 foreach ([128, 0] as $threshold) {
                     // Then entries SHOULD be removed starting from the end of tracestate.
                     for ($value = end($traceState); $key = key($traceState);) {
+                        if ($value === false) {
+                            continue;
+                        }
                         $entry = strlen($key) + 1 + strlen($value);
                         $value = prev($traceState);
                         if ($entry <= $threshold) {

--- a/src/API/Trace/TraceState.php
+++ b/src/API/Trace/TraceState.php
@@ -38,6 +38,7 @@ class TraceState implements TraceStateInterface
         $this->traceState = self::parse($rawTracestate ?? '');
     }
 
+    #[\Override]
     public function with(string $key, string $value): TraceStateInterface
     {
         if (!self::validateMember($this->traceState, $key, $value)) {
@@ -52,6 +53,7 @@ class TraceState implements TraceStateInterface
         return $clone;
     }
 
+    #[\Override]
     public function without(string $key): TraceStateInterface
     {
         if (!isset($this->traceState[$key])) {
@@ -64,16 +66,19 @@ class TraceState implements TraceStateInterface
         return $clone;
     }
 
+    #[\Override]
     public function get(string $key): ?string
     {
         return $this->traceState[$key] ?? null;
     }
 
+    #[\Override]
     public function getListMemberCount(): int
     {
         return count($this->traceState);
     }
 
+    #[\Override]
     public function toString(?int $limit = null): string
     {
         $traceState = $this->traceState;
@@ -115,6 +120,7 @@ class TraceState implements TraceStateInterface
         return $s;
     }
 
+    #[\Override]
     public function __toString(): string
     {
         return $this->toString();

--- a/src/Config/SDK/ComponentProvider/Detector/Composer.php
+++ b/src/Config/SDK/ComponentProvider/Detector/Composer.php
@@ -20,11 +20,13 @@ final class Composer implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): ResourceDetectorInterface
     {
         return new ComposerDetector();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('composer');

--- a/src/Config/SDK/ComponentProvider/Detector/Host.php
+++ b/src/Config/SDK/ComponentProvider/Detector/Host.php
@@ -20,11 +20,13 @@ final class Host implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): ResourceDetectorInterface
     {
         return new HostDetector();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('host');

--- a/src/Config/SDK/ComponentProvider/Detector/Process.php
+++ b/src/Config/SDK/ComponentProvider/Detector/Process.php
@@ -20,11 +20,13 @@ final class Process implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): ResourceDetectorInterface
     {
         return new ProcessDetector();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('process');

--- a/src/Config/SDK/ComponentProvider/Instrumentation/General/HttpConfigProvider.php
+++ b/src/Config/SDK/ComponentProvider/Instrumentation/General/HttpConfigProvider.php
@@ -17,11 +17,13 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 class HttpConfigProvider implements ComponentProvider
 {
+    #[\Override]
     public function createPlugin(array $properties, Context $context): GeneralInstrumentationConfiguration
     {
         return new HttpConfig($properties);
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('http');

--- a/src/Config/SDK/ComponentProvider/Instrumentation/General/PeerConfigProvider.php
+++ b/src/Config/SDK/ComponentProvider/Instrumentation/General/PeerConfigProvider.php
@@ -17,11 +17,13 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 class PeerConfigProvider implements ComponentProvider
 {
+    #[\Override]
     public function createPlugin(array $properties, Context $context): GeneralInstrumentationConfiguration
     {
         return new PeerConfig($properties);
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('peer');

--- a/src/Config/SDK/ComponentProvider/InstrumentationConfigurationRegistry.php
+++ b/src/Config/SDK/ComponentProvider/InstrumentationConfigurationRegistry.php
@@ -29,6 +29,7 @@ class InstrumentationConfigurationRegistry implements ComponentProvider
      *     }
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): ConfigurationRegistry
     {
         $configurationRegistry = new ConfigurationRegistry();
@@ -44,6 +45,7 @@ class InstrumentationConfigurationRegistry implements ComponentProvider
         return $configurationRegistry;
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $root = $builder->arrayNode('open_telemetry');

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterConsole.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterConsole.php
@@ -21,6 +21,7 @@ final class LogRecordExporterConsole implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordExporterInterface
     {
         return new ConsoleExporter(Registry::transportFactory('stream')->create(
@@ -29,6 +30,7 @@ final class LogRecordExporterConsole implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('console');

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterMemory.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterMemory.php
@@ -20,11 +20,13 @@ final class LogRecordExporterMemory implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordExporterInterface
     {
         return new InMemoryExporter();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('memory/development');

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlpFile.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlpFile.php
@@ -28,6 +28,7 @@ final class LogRecordExporterOtlpFile implements ComponentProvider
      *     output_stream: string,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordExporterInterface
     {
         $endpoint = OutputStreamParser::parse($properties['output_stream']);
@@ -38,6 +39,7 @@ final class LogRecordExporterOtlpFile implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_file/development');

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlpGrpc.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlpGrpc.php
@@ -40,6 +40,7 @@ final class LogRecordExporterOtlpGrpc implements ComponentProvider
      *     insecure: ?bool,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordExporterInterface
     {
         $protocol = Protocols::GRPC;
@@ -57,6 +58,7 @@ final class LogRecordExporterOtlpGrpc implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_grpc');

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlpHttp.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordExporterOtlpHttp.php
@@ -37,6 +37,7 @@ final class LogRecordExporterOtlpHttp implements ComponentProvider
      *     encoding: 'protobuf'|'json',
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordExporterInterface
     {
         $headers = array_column($properties['headers'], 'value', 'name') + MapParser::parse($properties['headers_list']);
@@ -56,6 +57,7 @@ final class LogRecordExporterOtlpHttp implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_http');

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordProcessorBatch.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordProcessorBatch.php
@@ -29,6 +29,7 @@ final class LogRecordProcessorBatch implements ComponentProvider
      *     exporter: ComponentPlugin<LogRecordExporterInterface>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordProcessorInterface
     {
         return new BatchLogRecordProcessor(
@@ -42,6 +43,7 @@ final class LogRecordProcessorBatch implements ComponentProvider
         );
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('batch');

--- a/src/Config/SDK/ComponentProvider/Logs/LogRecordProcessorSimple.php
+++ b/src/Config/SDK/ComponentProvider/Logs/LogRecordProcessorSimple.php
@@ -24,6 +24,7 @@ final class LogRecordProcessorSimple implements ComponentProvider
      *     exporter: ComponentPlugin<LogRecordExporterInterface>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordProcessorInterface
     {
         return new SimpleLogRecordProcessor(
@@ -31,6 +32,7 @@ final class LogRecordProcessorSimple implements ComponentProvider
         );
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('simple');

--- a/src/Config/SDK/ComponentProvider/Metrics/AggregationResolverDefault.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/AggregationResolverDefault.php
@@ -20,6 +20,7 @@ final class AggregationResolverDefault implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): DefaultAggregationProviderInterface
     {
         // TODO Implement proper aggregation providers (default, drop, explicit_bucket_histogram, last_value, sum) to handle advisory
@@ -28,6 +29,7 @@ final class AggregationResolverDefault implements ComponentProvider
         };
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('default');

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricExporterConsole.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricExporterConsole.php
@@ -20,11 +20,13 @@ final class MetricExporterConsole implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporterInterface
     {
         return new ConsoleMetricExporter();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('console');

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricExporterMemory.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricExporterMemory.php
@@ -20,11 +20,13 @@ final class MetricExporterMemory implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporterInterface
     {
         return new InMemoryExporter();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('memory/development');

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlpFile.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlpFile.php
@@ -31,6 +31,7 @@ final class MetricExporterOtlpFile implements ComponentProvider
      *      default_histogram_aggregation: 'explicit_bucket_histogram|base2_exponential_bucket_histogram',
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporterInterface
     {
         $endpoint = OutputStreamParser::parse($properties['output_stream']);
@@ -47,6 +48,7 @@ final class MetricExporterOtlpFile implements ComponentProvider
         ), $temporality);
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_file/development');

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlpGrpc.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlpGrpc.php
@@ -43,6 +43,7 @@ final class MetricExporterOtlpGrpc implements ComponentProvider
      *     default_histogram_aggregation: 'explicit_bucket_histogram|base2_exponential_bucket_histogram',
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporterInterface
     {
         $protocol = Protocols::GRPC;
@@ -67,6 +68,7 @@ final class MetricExporterOtlpGrpc implements ComponentProvider
         ), $temporality);
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_grpc');

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlpHttp.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricExporterOtlpHttp.php
@@ -40,6 +40,7 @@ final class MetricExporterOtlpHttp implements ComponentProvider
      *     default_histogram_aggregation: 'explicit_bucket_histogram|base2_exponential_bucket_histogram',
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporterInterface
     {
         $headers = array_column($properties['headers'], 'value', 'name') + MapParser::parse($properties['headers_list']);
@@ -65,6 +66,7 @@ final class MetricExporterOtlpHttp implements ComponentProvider
         ), $temporality);
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_http');

--- a/src/Config/SDK/ComponentProvider/Metrics/MetricReaderPeriodic.php
+++ b/src/Config/SDK/ComponentProvider/Metrics/MetricReaderPeriodic.php
@@ -37,6 +37,7 @@ final class MetricReaderPeriodic implements ComponentProvider
      *     },
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricReaderInterface
     {
         return new ExportingReader(
@@ -44,6 +45,7 @@ final class MetricReaderPeriodic implements ComponentProvider
         );
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('periodic');

--- a/src/Config/SDK/ComponentProvider/OpenTelemetrySdk.php
+++ b/src/Config/SDK/ComponentProvider/OpenTelemetrySdk.php
@@ -165,6 +165,7 @@ final class OpenTelemetrySdk implements ComponentProvider
      *     },
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SdkBuilder
     {
         $sdkBuilder = new SdkBuilder();
@@ -381,6 +382,7 @@ final class OpenTelemetrySdk implements ComponentProvider
         return $sdkBuilder;
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('open_telemetry');

--- a/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorB3.php
+++ b/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorB3.php
@@ -22,11 +22,13 @@ final class TextMapPropagatorB3 implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         return B3Propagator::getB3SingleHeaderInstance();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('b3');

--- a/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorB3Multi.php
+++ b/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorB3Multi.php
@@ -22,11 +22,13 @@ final class TextMapPropagatorB3Multi implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         return B3Propagator::getB3MultiHeaderInstance();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('b3multi');

--- a/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorBaggage.php
+++ b/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorBaggage.php
@@ -20,11 +20,13 @@ final class TextMapPropagatorBaggage implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         return BaggagePropagator::getInstance();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('baggage');

--- a/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorComposite.php
+++ b/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorComposite.php
@@ -21,6 +21,7 @@ final class TextMapPropagatorComposite implements ComponentProvider
     /**
      * @param list<ComponentPlugin<TextMapPropagatorInterface>> $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         $propagators = [];
@@ -31,6 +32,7 @@ final class TextMapPropagatorComposite implements ComponentProvider
         return new MultiTextMapPropagator($propagators);
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $registry->componentNames('composite', TextMapPropagatorInterface::class);

--- a/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorJaeger.php
+++ b/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorJaeger.php
@@ -22,11 +22,13 @@ final class TextMapPropagatorJaeger implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         return JaegerPropagator::getInstance();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('jaeger');

--- a/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorTraceContext.php
+++ b/src/Config/SDK/ComponentProvider/Propagator/TextMapPropagatorTraceContext.php
@@ -20,11 +20,13 @@ final class TextMapPropagatorTraceContext implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         return TraceContextPropagator::getInstance();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('tracecontext');

--- a/src/Config/SDK/ComponentProvider/Trace/SamplerAlwaysOff.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SamplerAlwaysOff.php
@@ -20,11 +20,13 @@ final class SamplerAlwaysOff implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SamplerInterface
     {
         return new AlwaysOffSampler();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('always_off');

--- a/src/Config/SDK/ComponentProvider/Trace/SamplerAlwaysOn.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SamplerAlwaysOn.php
@@ -20,11 +20,13 @@ final class SamplerAlwaysOn implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SamplerInterface
     {
         return new AlwaysOnSampler();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('always_on');

--- a/src/Config/SDK/ComponentProvider/Trace/SamplerParentBased.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SamplerParentBased.php
@@ -29,6 +29,7 @@ final class SamplerParentBased implements ComponentProvider
      *     local_parent_not_sampled: ?ComponentPlugin<SamplerInterface>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SamplerInterface
     {
         return new ParentBased(
@@ -40,6 +41,7 @@ final class SamplerParentBased implements ComponentProvider
         );
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('parent_based');

--- a/src/Config/SDK/ComponentProvider/Trace/SamplerTraceIdRatioBased.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SamplerTraceIdRatioBased.php
@@ -22,6 +22,7 @@ final class SamplerTraceIdRatioBased implements ComponentProvider
      *     ratio: float,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SamplerInterface
     {
         return new TraceIdRatioBasedSampler(
@@ -29,6 +30,7 @@ final class SamplerTraceIdRatioBased implements ComponentProvider
         );
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('trace_id_ratio_based');

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterConsole.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterConsole.php
@@ -21,6 +21,7 @@ final class SpanExporterConsole implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporterInterface
     {
         return new ConsoleSpanExporter(Registry::transportFactory('stream')->create(
@@ -29,6 +30,7 @@ final class SpanExporterConsole implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('console');

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterMemory.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterMemory.php
@@ -20,11 +20,13 @@ final class SpanExporterMemory implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporterInterface
     {
         return new InMemoryExporter();
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('memory/development');

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlpFile.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlpFile.php
@@ -28,6 +28,7 @@ final class SpanExporterOtlpFile implements ComponentProvider
      *     output_stream: string,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporterInterface
     {
         $endpoint = OutputStreamParser::parse($properties['output_stream']);
@@ -38,6 +39,7 @@ final class SpanExporterOtlpFile implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_file/development');

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlpGrpc.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlpGrpc.php
@@ -40,6 +40,7 @@ final class SpanExporterOtlpGrpc implements ComponentProvider
      *     insecure: ?bool,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporterInterface
     {
         $protocol = Protocols::GRPC;
@@ -57,6 +58,7 @@ final class SpanExporterOtlpGrpc implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_grpc');

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlpHttp.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterOtlpHttp.php
@@ -37,6 +37,7 @@ final class SpanExporterOtlpHttp implements ComponentProvider
      *     encoding: 'protobuf'|'json',
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporterInterface
     {
         $headers = array_column($properties['headers'], 'value', 'name') + MapParser::parse($properties['headers_list']);
@@ -56,6 +57,7 @@ final class SpanExporterOtlpHttp implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp_http');

--- a/src/Config/SDK/ComponentProvider/Trace/SpanExporterZipkin.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanExporterZipkin.php
@@ -28,6 +28,7 @@ final class SpanExporterZipkin implements ComponentProvider
      *     timeout: int<0, max>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporterInterface
     {
         return new Zipkin\Exporter(Registry::transportFactory('http')->create(
@@ -37,6 +38,7 @@ final class SpanExporterZipkin implements ComponentProvider
         ));
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('zipkin');

--- a/src/Config/SDK/ComponentProvider/Trace/SpanProcessorBatch.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanProcessorBatch.php
@@ -29,6 +29,7 @@ final class SpanProcessorBatch implements ComponentProvider
      *     exporter: ComponentPlugin<SpanExporterInterface>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanProcessorInterface
     {
         return new BatchSpanProcessor(
@@ -42,6 +43,7 @@ final class SpanProcessorBatch implements ComponentProvider
         );
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('batch');

--- a/src/Config/SDK/ComponentProvider/Trace/SpanProcessorSimple.php
+++ b/src/Config/SDK/ComponentProvider/Trace/SpanProcessorSimple.php
@@ -24,6 +24,7 @@ final class SpanProcessorSimple implements ComponentProvider
      *     exporter: ComponentPlugin<SpanExporterInterface>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanProcessorInterface
     {
         return new SimpleSpanProcessor(
@@ -31,6 +32,7 @@ final class SpanProcessorSimple implements ComponentProvider
         );
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('simple');

--- a/src/Config/SDK/Configuration/ConfigurationFactory.php
+++ b/src/Config/SDK/Configuration/ConfigurationFactory.php
@@ -27,6 +27,7 @@ use OpenTelemetry\Config\SDK\Configuration\Internal\ResourceCollection;
 use OpenTelemetry\Config\SDK\Configuration\Internal\TrackingEnvReader;
 use OpenTelemetry\Config\SDK\Configuration\Loader\YamlExtensionFileLoader;
 use OpenTelemetry\Config\SDK\Configuration\Loader\YamlSymfonyFileLoader;
+use RuntimeException;
 use function serialize;
 use function sprintf;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
@@ -107,7 +108,11 @@ final class ConfigurationFactory
         }
 
         $loader = new ConfigurationLoader($resources);
-        $locator = new FileLocator(getcwd());
+        $cwd = getcwd();
+        if ($cwd === false) {
+            throw new RuntimeException('Current working directory could not be determined.');
+        }
+        $locator = new FileLocator($cwd);
         $fileLoader = new DelegatingLoader(new LoaderResolver([
             new YamlSymfonyFileLoader($loader, $locator),
             new YamlExtensionFileLoader($loader, $locator),

--- a/src/Config/SDK/Configuration/Environment/ArrayEnvSource.php
+++ b/src/Config/SDK/Configuration/Environment/ArrayEnvSource.php
@@ -11,6 +11,7 @@ final class ArrayEnvSource implements EnvSource
     ) {
     }
 
+    #[\Override]
     public function readRaw(string $name): mixed
     {
         return $this->env[$name] ?? null;

--- a/src/Config/SDK/Configuration/Environment/EnvResource.php
+++ b/src/Config/SDK/Configuration/Environment/EnvResource.php
@@ -14,6 +14,7 @@ class EnvResource implements ResourceInterface
     ) {
     }
 
+    #[\Override]
     public function __toString(): string
     {
         return 'env.' . $this->name;

--- a/src/Config/SDK/Configuration/Environment/EnvResourceChecker.php
+++ b/src/Config/SDK/Configuration/Environment/EnvResourceChecker.php
@@ -15,11 +15,13 @@ final class EnvResourceChecker implements ResourceCheckerInterface
     ) {
     }
 
+    #[\Override]
     public function supports(ResourceInterface $metadata): bool
     {
         return $metadata instanceof EnvResource;
     }
 
+    #[\Override]
     public function isFresh(ResourceInterface $resource, int $timestamp): bool
     {
         assert($resource instanceof EnvResource);

--- a/src/Config/SDK/Configuration/Environment/EnvSourceReader.php
+++ b/src/Config/SDK/Configuration/Environment/EnvSourceReader.php
@@ -17,6 +17,7 @@ final class EnvSourceReader implements EnvReader
     ) {
     }
 
+    #[\Override]
     public function read(string $name): ?string
     {
         foreach ($this->envSources as $envSource) {

--- a/src/Config/SDK/Configuration/Environment/PhpIniEnvSource.php
+++ b/src/Config/SDK/Configuration/Environment/PhpIniEnvSource.php
@@ -8,6 +8,7 @@ use function get_cfg_var;
 
 final class PhpIniEnvSource implements EnvSource
 {
+    #[\Override]
     public function readRaw(string $name): string|array|false
     {
         return get_cfg_var($name);

--- a/src/Config/SDK/Configuration/Environment/ServerEnvSource.php
+++ b/src/Config/SDK/Configuration/Environment/ServerEnvSource.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Config\SDK\Configuration\Environment;
 
 final class ServerEnvSource implements EnvSource
 {
+    #[\Override]
     public function readRaw(string $name): mixed
     {
         return $_SERVER[$name] ?? null;

--- a/src/Config/SDK/Configuration/Internal/ComponentPlugin.php
+++ b/src/Config/SDK/Configuration/Internal/ComponentPlugin.php
@@ -25,6 +25,7 @@ final class ComponentPlugin implements \OpenTelemetry\API\Configuration\Config\C
     ) {
     }
 
+    #[\Override]
     public function create(Context $context): mixed
     {
         return $this->provider->createPlugin($this->properties, $context);

--- a/src/Config/SDK/Configuration/Internal/ComponentProviderRegistry.php
+++ b/src/Config/SDK/Configuration/Internal/ComponentProviderRegistry.php
@@ -61,11 +61,13 @@ final class ComponentProviderRegistry implements \OpenTelemetry\API\Configuratio
         $this->providers[$type][$name] = new ComponentProviderRegistryEntry($provider, $config);
     }
 
+    #[\Override]
     public function trackResources(?ResourceCollection $resources): void
     {
         $this->resources = $resources;
     }
 
+    #[\Override]
     public function component(string $name, string $type): NodeDefinition
     {
         $node = $this->builder->arrayNode($name);
@@ -74,6 +76,7 @@ final class ComponentProviderRegistry implements \OpenTelemetry\API\Configuratio
         return $node;
     }
 
+    #[\Override]
     public function componentList(string $name, string $type): ArrayNodeDefinition
     {
         $node = $this->builder->arrayNode($name)->defaultValue([]);
@@ -82,6 +85,7 @@ final class ComponentProviderRegistry implements \OpenTelemetry\API\Configuratio
         return $node;
     }
 
+    #[\Override]
     public function componentMap(string $name, string $type): ArrayNodeDefinition
     {
         $node = $this->builder->arrayNode($name);
@@ -100,6 +104,7 @@ final class ComponentProviderRegistry implements \OpenTelemetry\API\Configuratio
         return $node;
     }
 
+    #[\Override]
     public function componentNames(string $name, string $type): ArrayNodeDefinition
     {
         $node = $this->builder->arrayNode($name);

--- a/src/Config/SDK/Configuration/Internal/ComposerPackageResource.php
+++ b/src/Config/SDK/Configuration/Internal/ComposerPackageResource.php
@@ -21,11 +21,13 @@ final class ComposerPackageResource implements SelfCheckingResourceInterface
         $this->version = self::getVersion($packageName);
     }
 
+    #[\Override]
     public function isFresh(int $timestamp): bool
     {
         return $this->version === self::getVersion($this->packageName);
     }
 
+    #[\Override]
     public function __toString(): string
     {
         return 'composer.' . $this->packageName;

--- a/src/Config/SDK/Configuration/Internal/ConfigurationLoader.php
+++ b/src/Config/SDK/Configuration/Internal/ConfigurationLoader.php
@@ -20,11 +20,13 @@ final class ConfigurationLoader implements \OpenTelemetry\Config\SDK\Configurati
         $this->resources = $resources;
     }
 
+    #[\Override]
     public function loadConfiguration(mixed $configuration): void
     {
         $this->configurations[] = $configuration;
     }
 
+    #[\Override]
     public function addResource(ResourceInterface $resource): void
     {
         $this->resources?->addResource($resource);

--- a/src/Config/SDK/Configuration/Internal/EnvSubstitutionNormalization.php
+++ b/src/Config/SDK/Configuration/Internal/EnvSubstitutionNormalization.php
@@ -33,6 +33,7 @@ final class EnvSubstitutionNormalization implements Normalization
     ) {
     }
 
+    #[\Override]
     public function apply(ArrayNodeDefinition $root): void
     {
         foreach ($root->getChildNodeDefinitions() as $childNode) {

--- a/src/Config/SDK/Configuration/Internal/Node/ArrayNode.php
+++ b/src/Config/SDK/Configuration/Internal/Node/ArrayNode.php
@@ -33,11 +33,13 @@ final class ArrayNode extends \Symfony\Component\Config\Definition\ArrayNode
         $this->defaultValueSet = true;
     }
 
+    #[\Override]
     public function hasDefaultValue(): bool
     {
         return $this->defaultValueSet || parent::hasDefaultValue();
     }
 
+    #[\Override]
     public function getDefaultValue(): mixed
     {
         return $this->defaultValueSet

--- a/src/Config/SDK/Configuration/Internal/Node/PrototypedArrayNode.php
+++ b/src/Config/SDK/Configuration/Internal/Node/PrototypedArrayNode.php
@@ -22,17 +22,20 @@ final class PrototypedArrayNode extends \Symfony\Component\Config\Definition\Pro
         return $_node;
     }
 
+    #[\Override]
     public function setDefaultValue(mixed $value): void
     {
         $this->defaultValue_ = $value;
         $this->defaultValueSet = true;
     }
 
+    #[\Override]
     public function hasDefaultValue(): bool
     {
         return $this->defaultValueSet || parent::hasDefaultValue();
     }
 
+    #[\Override]
     public function getDefaultValue(): mixed
     {
         return $this->defaultValueSet

--- a/src/Config/SDK/Configuration/Internal/Node/StringNode.php
+++ b/src/Config/SDK/Configuration/Internal/Node/StringNode.php
@@ -14,6 +14,7 @@ class StringNode extends \Symfony\Component\Config\Definition\ScalarNode
 {
     use NodeTrait;
 
+    #[\Override]
     protected function validateType(mixed $value): void
     {
         if (!is_string($value)) {

--- a/src/Config/SDK/Configuration/Internal/NodeDefinition/ArrayNodeDefinition.php
+++ b/src/Config/SDK/Configuration/Internal/NodeDefinition/ArrayNodeDefinition.php
@@ -22,6 +22,7 @@ class ArrayNodeDefinition extends \Symfony\Component\Config\Definition\Builder\A
         $this->nullEquivalent = null;
     }
 
+    #[\Override]
     protected function createNode(): NodeInterface
     {
         $node = parent::createNode();
@@ -40,6 +41,7 @@ class ArrayNodeDefinition extends \Symfony\Component\Config\Definition\Builder\A
         return $node;
     }
 
+    #[\Override]
     public function defaultValue(mixed $value): static
     {
         $this->defaultValueSet = true;

--- a/src/Config/SDK/Configuration/Internal/NodeDefinition/BooleanNodeDefinition.php
+++ b/src/Config/SDK/Configuration/Internal/NodeDefinition/BooleanNodeDefinition.php
@@ -13,6 +13,7 @@ final class BooleanNodeDefinition extends \Symfony\Component\Config\Definition\B
 {
     use NodeDefinitionTrait;
 
+    #[\Override]
     protected function instantiateNode(): BooleanNode
     {
         return new BooleanNode($this->name, $this->parent, $this->pathSeparator);

--- a/src/Config/SDK/Configuration/Internal/NodeDefinition/EnumNodeDefinition.php
+++ b/src/Config/SDK/Configuration/Internal/NodeDefinition/EnumNodeDefinition.php
@@ -13,6 +13,7 @@ final class EnumNodeDefinition extends \Symfony\Component\Config\Definition\Buil
 {
     use NodeDefinitionTrait;
 
+    #[\Override]
     protected function instantiateNode(): EnumNode
     {
         $node = parent::instantiateNode();

--- a/src/Config/SDK/Configuration/Internal/NodeDefinition/FloatNodeDefinition.php
+++ b/src/Config/SDK/Configuration/Internal/NodeDefinition/FloatNodeDefinition.php
@@ -13,6 +13,7 @@ final class FloatNodeDefinition extends \Symfony\Component\Config\Definition\Bui
 {
     use NodeDefinitionTrait;
 
+    #[\Override]
     protected function instantiateNode(): FloatNode
     {
         return new FloatNode($this->name, $this->parent, $this->min, $this->max, $this->pathSeparator);

--- a/src/Config/SDK/Configuration/Internal/NodeDefinition/IntegerNodeDefinition.php
+++ b/src/Config/SDK/Configuration/Internal/NodeDefinition/IntegerNodeDefinition.php
@@ -13,6 +13,7 @@ final class IntegerNodeDefinition extends \Symfony\Component\Config\Definition\B
 {
     use NodeDefinitionTrait;
 
+    #[\Override]
     protected function instantiateNode(): IntegerNode
     {
         return new IntegerNode($this->name, $this->parent, $this->min, $this->max, $this->pathSeparator);

--- a/src/Config/SDK/Configuration/Internal/NodeDefinition/ScalarNodeDefinition.php
+++ b/src/Config/SDK/Configuration/Internal/NodeDefinition/ScalarNodeDefinition.php
@@ -13,6 +13,7 @@ final class ScalarNodeDefinition extends \Symfony\Component\Config\Definition\Bu
 {
     use NodeDefinitionTrait;
 
+    #[\Override]
     protected function instantiateNode(): ScalarNode
     {
         return new ScalarNode($this->name, $this->parent, $this->pathSeparator);

--- a/src/Config/SDK/Configuration/Internal/NodeDefinition/StringNodeDefinition.php
+++ b/src/Config/SDK/Configuration/Internal/NodeDefinition/StringNodeDefinition.php
@@ -14,6 +14,7 @@ final class StringNodeDefinition extends \Symfony\Component\Config\Definition\Bu
 {
     use NodeDefinitionTrait;
 
+    #[\Override]
     protected function instantiateNode(): ScalarNode
     {
         return new StringNode($this->name, $this->parent, $this->pathSeparator);

--- a/src/Config/SDK/Configuration/Internal/NodeDefinition/VariableNodeDefinition.php
+++ b/src/Config/SDK/Configuration/Internal/NodeDefinition/VariableNodeDefinition.php
@@ -13,6 +13,7 @@ final class VariableNodeDefinition extends \Symfony\Component\Config\Definition\
 {
     use NodeDefinitionTrait;
 
+    #[\Override]
     protected function instantiateNode(): VariableNode
     {
         return new VariableNode($this->name, $this->parent, $this->pathSeparator);

--- a/src/Config/SDK/Configuration/Internal/ResourceCollection.php
+++ b/src/Config/SDK/Configuration/Internal/ResourceCollection.php
@@ -41,6 +41,7 @@ final class ResourceCollection implements \OpenTelemetry\Config\SDK\Configuratio
     /**
      * @psalm-suppress PossiblyInvalidArgument
      */
+    #[\Override]
     public function addClassResource(object|string $class): void
     {
         try {
@@ -56,6 +57,7 @@ final class ResourceCollection implements \OpenTelemetry\Config\SDK\Configuratio
         }
     }
 
+    #[\Override]
     public function addResource(ResourceInterface $resource): void
     {
         $path = match (true) {

--- a/src/Config/SDK/Configuration/Internal/TrackingEnvReader.php
+++ b/src/Config/SDK/Configuration/Internal/TrackingEnvReader.php
@@ -21,11 +21,13 @@ final class TrackingEnvReader implements EnvReader, ResourceTrackable
         $this->envReader = $envReader;
     }
 
+    #[\Override]
     public function trackResources(?ResourceCollection $resources): void
     {
         $this->resources = $resources;
     }
 
+    #[\Override]
     public function read(string $name): ?string
     {
         $value = $this->envReader->read($name);

--- a/src/Config/SDK/Configuration/Loader/YamlExtensionFileLoader.php
+++ b/src/Config/SDK/Configuration/Loader/YamlExtensionFileLoader.php
@@ -22,6 +22,7 @@ final class YamlExtensionFileLoader extends FileLoader
         parent::__construct($locator, $env);
     }
 
+    #[\Override]
     public function load(mixed $resource, ?string $type = null): mixed
     {
         assert(extension_loaded('yaml'));
@@ -38,6 +39,7 @@ final class YamlExtensionFileLoader extends FileLoader
         return null;
     }
 
+    #[\Override]
     public function supports(mixed $resource, ?string $type = null): bool
     {
         return extension_loaded('yaml')

--- a/src/Config/SDK/Configuration/Loader/YamlSymfonyFileLoader.php
+++ b/src/Config/SDK/Configuration/Loader/YamlSymfonyFileLoader.php
@@ -24,6 +24,7 @@ final class YamlSymfonyFileLoader extends FileLoader
         parent::__construct($locator, $env);
     }
 
+    #[\Override]
     public function load(mixed $resource, ?string $type = null): mixed
     {
         assert(class_exists(Yaml::class));
@@ -42,6 +43,7 @@ final class YamlSymfonyFileLoader extends FileLoader
         return null;
     }
 
+    #[\Override]
     public function supports(mixed $resource, ?string $type = null): bool
     {
         return class_exists(Yaml::class)

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -31,6 +31,7 @@ final class Context implements ContextInterface
         self::$spanContextKey = ContextKeys::span();
     }
 
+    #[\Override]
     public static function createKey(string $key): ContextKeyInterface
     {
         return new ContextKey($key);
@@ -67,11 +68,13 @@ final class Context implements ContextInterface
         return $empty ??= new self();
     }
 
+    #[\Override]
     public static function getCurrent(): ContextInterface
     {
         return self::storage()->current();
     }
 
+    #[\Override]
     public function activate(): ScopeInterface
     {
         $scope = self::storage()->attach($this);
@@ -89,11 +92,13 @@ final class Context implements ContextInterface
         );
     }
 
+    #[\Override]
     public function withContextValue(ImplicitContextKeyedInterface $value): ContextInterface
     {
         return $value->storeInContext($this);
     }
 
+    #[\Override]
     public function with(ContextKeyInterface $key, $value): self
     {
         if ($this->get($key) === $value) {
@@ -122,6 +127,7 @@ final class Context implements ContextInterface
         return $self;
     }
 
+    #[\Override]
     public function get(ContextKeyInterface $key)
     {
         if ($key === self::$spanContextKey) {

--- a/src/Context/ContextStorage.php
+++ b/src/Context/ContextStorage.php
@@ -19,26 +19,31 @@ final class ContextStorage implements ContextStorageInterface, ContextStorageHea
         $this->current = $this->main = new ContextStorageHead($this);
     }
 
+    #[\Override]
     public function fork(int|string $id): void
     {
         $this->forks[$id] = clone $this->current;
     }
 
+    #[\Override]
     public function switch(int|string $id): void
     {
         $this->current = $this->forks[$id] ?? $this->main;
     }
 
+    #[\Override]
     public function destroy(int|string $id): void
     {
         unset($this->forks[$id]);
     }
 
+    #[\Override]
     public function head(): ContextStorageHead
     {
         return $this->current;
     }
 
+    #[\Override]
     public function scope(): ?ContextStorageScopeInterface
     {
         return ($this->current->node->head ?? null) === $this->current
@@ -46,11 +51,13 @@ final class ContextStorage implements ContextStorageInterface, ContextStorageHea
             : null;
     }
 
+    #[\Override]
     public function current(): ContextInterface
     {
         return $this->current->node->context ?? Context::getRoot();
     }
 
+    #[\Override]
     public function attach(ContextInterface $context): ContextStorageScopeInterface
     {
         return $this->current->node = new ContextStorageNode($context, $this->current, $this->current->node);

--- a/src/Context/ContextStorageNode.php
+++ b/src/Context/ContextStorageNode.php
@@ -20,31 +20,37 @@ final class ContextStorageNode implements ScopeInterface, ContextStorageScopeInt
     ) {
     }
 
+    #[\Override]
     public function offsetExists(mixed $offset): bool
     {
         return isset($this->localStorage[$offset]);
     }
 
+    #[\Override]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->localStorage[$offset];
     }
 
+    #[\Override]
     public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->localStorage[$offset] = $value;
     }
 
+    #[\Override]
     public function offsetUnset(mixed $offset): void
     {
         unset($this->localStorage[$offset]);
     }
 
+    #[\Override]
     public function context(): ContextInterface
     {
         return $this->context;
     }
 
+    #[\Override]
     public function detach(): int
     {
         $flags = 0;

--- a/src/Context/ContextStorageScopeInterface.php
+++ b/src/Context/ContextStorageScopeInterface.php
@@ -21,5 +21,6 @@ interface ContextStorageScopeInterface extends ScopeInterface, ArrayAccess
     /**
      * @param string $offset
      */
+    #[\Override]
     public function offsetSet($offset, $value): void;
 }

--- a/src/Context/DebugScope.php
+++ b/src/Context/DebugScope.php
@@ -39,6 +39,7 @@ final class DebugScope implements ScopeInterface
         }
     }
 
+    #[\Override]
     public function detach(): int
     {
         $this->detachedAt ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);

--- a/src/Context/FiberBoundContextStorage.php
+++ b/src/Context/FiberBoundContextStorage.php
@@ -32,6 +32,9 @@ final class FiberBoundContextStorage implements ContextStorageInterface, Context
         return $this->heads[Fiber::getCurrent() ?? $this] ?? null;
     }
 
+    /**
+     * @psalm-suppress PossiblyNullPropertyFetch
+     */
     #[\Override]
     public function scope(): ?ContextStorageScopeInterface
     {
@@ -62,6 +65,9 @@ final class FiberBoundContextStorage implements ContextStorageInterface, Context
         return $head->node->context ?? Context::getRoot();
     }
 
+    /**
+     * @psalm-suppress PossiblyNullArgument,PossiblyNullPropertyFetch
+     */
     #[\Override]
     public function attach(ContextInterface $context): ContextStorageScopeInterface
     {

--- a/src/Context/FiberBoundContextStorage.php
+++ b/src/Context/FiberBoundContextStorage.php
@@ -26,11 +26,13 @@ final class FiberBoundContextStorage implements ContextStorageInterface, Context
         $this->heads[$this] = new ContextStorageHead($this);
     }
 
+    #[\Override]
     public function head(): ?ContextStorageHead
     {
         return $this->heads[Fiber::getCurrent() ?? $this] ?? null;
     }
 
+    #[\Override]
     public function scope(): ?ContextStorageScopeInterface
     {
         $head = $this->heads[Fiber::getCurrent() ?? $this] ?? null;
@@ -45,6 +47,7 @@ final class FiberBoundContextStorage implements ContextStorageInterface, Context
         return $head->node;
     }
 
+    #[\Override]
     public function current(): ContextInterface
     {
         $head = $this->heads[Fiber::getCurrent() ?? $this] ?? null;
@@ -59,6 +62,7 @@ final class FiberBoundContextStorage implements ContextStorageInterface, Context
         return $head->node->context ?? Context::getRoot();
     }
 
+    #[\Override]
     public function attach(ContextInterface $context): ContextStorageScopeInterface
     {
         $head = $this->heads[Fiber::getCurrent() ?? $this] ??= new ContextStorageHead($this);

--- a/src/Context/FiberBoundContextStorageExecutionAwareBC.php
+++ b/src/Context/FiberBoundContextStorageExecutionAwareBC.php
@@ -17,16 +17,19 @@ final class FiberBoundContextStorageExecutionAwareBC implements ContextStorageIn
         $this->storage = new FiberBoundContextStorage();
     }
 
+    #[\Override]
     public function fork(int|string $id): void
     {
         $this->bcStorage()->fork($id);
     }
 
+    #[\Override]
     public function switch(int|string $id): void
     {
         $this->bcStorage()->switch($id);
     }
 
+    #[\Override]
     public function destroy(int|string $id): void
     {
         $this->bcStorage()->destroy($id);
@@ -51,6 +54,7 @@ final class FiberBoundContextStorageExecutionAwareBC implements ContextStorageIn
         return $this->bc;
     }
 
+    #[\Override]
     public function scope(): ?ContextStorageScopeInterface
     {
         return $this->bc
@@ -58,6 +62,7 @@ final class FiberBoundContextStorageExecutionAwareBC implements ContextStorageIn
             : $this->storage->scope();
     }
 
+    #[\Override]
     public function current(): ContextInterface
     {
         return $this->bc
@@ -65,6 +70,7 @@ final class FiberBoundContextStorageExecutionAwareBC implements ContextStorageIn
             : $this->storage->current();
     }
 
+    #[\Override]
     public function attach(ContextInterface $context): ContextStorageScopeInterface
     {
         return $this->bc

--- a/src/Context/Propagation/ArrayAccessGetterSetter.php
+++ b/src/Context/Propagation/ArrayAccessGetterSetter.php
@@ -36,6 +36,7 @@ final class ArrayAccessGetterSetter implements ExtendedPropagationGetterInterfac
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function keys($carrier): array
     {
         if ($this->isSupportedCarrier($carrier)) {
@@ -56,6 +57,7 @@ final class ArrayAccessGetterSetter implements ExtendedPropagationGetterInterfac
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function get($carrier, string $key): ?string
     {
         if ($this->isSupportedCarrier($carrier)) {
@@ -79,6 +81,7 @@ final class ArrayAccessGetterSetter implements ExtendedPropagationGetterInterfac
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function getAll($carrier, string $key): array
     {
         if ($this->isSupportedCarrier($carrier)) {
@@ -102,6 +105,7 @@ final class ArrayAccessGetterSetter implements ExtendedPropagationGetterInterfac
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function set(&$carrier, string $key, string $value): void
     {
         if ($key === '') {

--- a/src/Context/Propagation/MultiTextMapPropagator.php
+++ b/src/Context/Propagation/MultiTextMapPropagator.php
@@ -27,11 +27,13 @@ final class MultiTextMapPropagator implements TextMapPropagatorInterface
         $this->fields = $this->extractFields($this->propagators);
     }
 
+    #[\Override]
     public function fields(): array
     {
         return $this->fields;
     }
 
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         foreach ($this->propagators as $propagator) {
@@ -39,6 +41,7 @@ final class MultiTextMapPropagator implements TextMapPropagatorInterface
         }
     }
 
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $context ??= Context::getCurrent();

--- a/src/Context/Propagation/NoopTextMapPropagator.php
+++ b/src/Context/Propagation/NoopTextMapPropagator.php
@@ -20,16 +20,19 @@ final class NoopTextMapPropagator implements TextMapPropagatorInterface
         return self::$instance;
     }
 
+    #[\Override]
     public function fields(): array
     {
         return [];
     }
 
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         return $context ?? Context::getCurrent();
     }
 
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
     }

--- a/src/Context/Propagation/SanitizeCombinedHeadersPropagationGetter.php
+++ b/src/Context/Propagation/SanitizeCombinedHeadersPropagationGetter.php
@@ -22,11 +22,13 @@ final class SanitizeCombinedHeadersPropagationGetter implements ExtendedPropagat
     {
     }
 
+    #[\Override]
     public function keys($carrier): array
     {
         return $this->getter->keys($carrier);
     }
 
+    #[\Override]
     public function get($carrier, string $key): ?string
     {
         $value = $this->getter->get($carrier, $key);
@@ -41,6 +43,7 @@ final class SanitizeCombinedHeadersPropagationGetter implements ExtendedPropagat
         );
     }
 
+    #[\Override]
     public function getAll($carrier, string $key): array
     {
         $value = $this->getter instanceof ExtendedPropagationGetterInterface

--- a/src/Context/Propagation/SanitizeCombinedHeadersPropagationGetter.php
+++ b/src/Context/Propagation/SanitizeCombinedHeadersPropagationGetter.php
@@ -43,6 +43,9 @@ final class SanitizeCombinedHeadersPropagationGetter implements ExtendedPropagat
         );
     }
 
+    /**
+     * @psalm-suppress PossiblyNullArgument
+     */
     #[\Override]
     public function getAll($carrier, string $key): array
     {

--- a/src/Context/ZendObserverFiber.php
+++ b/src/Context/ZendObserverFiber.php
@@ -33,6 +33,9 @@ final class ZendObserverFiber
             : (bool) $enabled;
     }
 
+    /**
+     * @psalm-suppress PossiblyNullReference,UndefinedMethod
+     */
     public static function init(): bool
     {
         static $fibers;

--- a/src/Contrib/Grpc/GrpcTransport.php
+++ b/src/Contrib/Grpc/GrpcTransport.php
@@ -53,11 +53,13 @@ final class GrpcTransport implements TransportInterface
         $this->exportTimeout = new Timeval($timeoutMillis * self::MICROS_PER_MILLISECOND);
     }
 
+    #[\Override]
     public function contentType(): string
     {
         return ContentTypes::PROTOBUF;
     }
 
+    #[\Override]
     public function send(string $payload, ?CancellationInterface $cancellation = null): FutureInterface
     {
         if ($this->closed) {
@@ -91,6 +93,7 @@ final class GrpcTransport implements TransportInterface
         return new ErrorFuture(new RuntimeException($event->status->details, $event->status->code));
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         if ($this->closed) {
@@ -103,6 +106,7 @@ final class GrpcTransport implements TransportInterface
         return true;
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return !$this->closed;

--- a/src/Contrib/Grpc/GrpcTransportFactory.php
+++ b/src/Contrib/Grpc/GrpcTransportFactory.php
@@ -33,6 +33,7 @@ final class GrpcTransportFactory implements TransportFactoryInterface
      * @psalm-suppress ImplementedReturnTypeMismatch
      * @psalm-suppress NoValue
      */
+    #[\Override]
     public function create(
         string $endpoint,
         string $contentType = ContentTypes::PROTOBUF,

--- a/src/Contrib/Grpc/GrpcTransportFactory.php
+++ b/src/Contrib/Grpc/GrpcTransportFactory.php
@@ -84,7 +84,7 @@ final class GrpcTransportFactory implements TransportFactoryInterface
             $opts,
             $method,
             $headers,
-            (int) ($timeout * self::MILLIS_PER_SECOND),
+            (int) ($timeout * (float) self::MILLIS_PER_SECOND),
         );
     }
 

--- a/src/Contrib/Otlp/HttpEndpointResolver.php
+++ b/src/Contrib/Otlp/HttpEndpointResolver.php
@@ -37,6 +37,7 @@ class HttpEndpointResolver implements HttpEndpointResolverInterface
         return new self($httpFactoryResolver);
     }
 
+    #[\Override]
     public function resolve(string $endpoint, string $signal): UriInterface
     {
         $components = self::parseEndpoint($endpoint);
@@ -50,6 +51,7 @@ class HttpEndpointResolver implements HttpEndpointResolverInterface
         );
     }
 
+    #[\Override]
     public function resolveToString(string $endpoint, string $signal): string
     {
         return (string) $this->resolve($endpoint, $signal);

--- a/src/Contrib/Otlp/LogsExporter.php
+++ b/src/Contrib/Otlp/LogsExporter.php
@@ -36,6 +36,7 @@ class LogsExporter implements LogRecordExporterInterface
     /**
      * @param iterable<ReadableLogRecord> $batch
      */
+    #[\Override]
     public function export(iterable $batch, ?CancellationInterface $cancellation = null): FutureInterface
     {
         return $this->transport
@@ -70,11 +71,13 @@ class LogsExporter implements LogRecordExporterInterface
             });
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return $this->transport->forceFlush($cancellation);
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return $this->transport->shutdown($cancellation);

--- a/src/Contrib/Otlp/LogsExporterFactory.php
+++ b/src/Contrib/Otlp/LogsExporterFactory.php
@@ -25,6 +25,7 @@ class LogsExporterFactory implements LogRecordExporterFactoryInterface
     /**
      * @psalm-suppress ArgumentTypeCoercion
      */
+    #[\Override]
     public function create(): LogRecordExporterInterface
     {
         $protocol = Configuration::has(Variables::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL)

--- a/src/Contrib/Otlp/MetricConverter.php
+++ b/src/Contrib/Otlp/MetricConverter.php
@@ -214,6 +214,9 @@ final class MetricConverter
         return $pHistogramDataPoint;
     }
 
+    /**
+     * @psalm-suppress PossiblyFalseArgument
+     */
     private function convertExemplar(SDK\Metrics\Data\Exemplar $exemplar): Exemplar
     {
         $pExemplar = new Exemplar();

--- a/src/Contrib/Otlp/MetricExporter.php
+++ b/src/Contrib/Otlp/MetricExporter.php
@@ -37,11 +37,13 @@ final class MetricExporter implements PushMetricExporterInterface, AggregationTe
         $this->serializer = ProtobufSerializer::forTransport($this->transport);
     }
 
+    #[\Override]
     public function temporality(MetricMetadataInterface $metric): Temporality|string|null
     {
         return $this->temporality ?? $metric->temporality();
     }
 
+    #[\Override]
     public function export(iterable $batch): bool
     {
         return $this->transport
@@ -77,11 +79,13 @@ final class MetricExporter implements PushMetricExporterInterface, AggregationTe
             ->await();
     }
 
+    #[\Override]
     public function shutdown(): bool
     {
         return $this->transport->shutdown();
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         return $this->transport->forceFlush();

--- a/src/Contrib/Otlp/MetricExporterFactory.php
+++ b/src/Contrib/Otlp/MetricExporterFactory.php
@@ -26,6 +26,7 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
     /**
      * @psalm-suppress ArgumentTypeCoercion
      */
+    #[\Override]
     public function create(): MetricExporterInterface
     {
         $protocol = Configuration::has(Variables::OTEL_EXPORTER_OTLP_METRICS_PROTOCOL)

--- a/src/Contrib/Otlp/OtlpHttpTransportFactory.php
+++ b/src/Contrib/Otlp/OtlpHttpTransportFactory.php
@@ -12,6 +12,7 @@ class OtlpHttpTransportFactory implements TransportFactoryInterface
 {
     private const DEFAULT_COMPRESSION = 'none';
 
+    #[\Override]
     public function create(
         string $endpoint,
         string $contentType,

--- a/src/Contrib/Otlp/ProtobufSerializer.php
+++ b/src/Contrib/Otlp/ProtobufSerializer.php
@@ -117,7 +117,7 @@ final class ProtobufSerializer
             return $payload;
         }
 
-        $data = json_decode($payload);
+        $data = json_decode((string) $payload);
         unset($payload);
         self::traverseDescriptor($data, $desc);
 

--- a/src/Contrib/Otlp/SpanExporter.php
+++ b/src/Contrib/Otlp/SpanExporter.php
@@ -32,6 +32,7 @@ final class SpanExporter implements SpanExporterInterface
         $this->serializer = ProtobufSerializer::forTransport($this->transport);
     }
 
+    #[\Override]
     public function export(iterable $batch, ?CancellationInterface $cancellation = null): FutureInterface
     {
         return $this->transport
@@ -66,11 +67,13 @@ final class SpanExporter implements SpanExporterInterface
             });
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return $this->transport->shutdown($cancellation);
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return $this->transport->forceFlush($cancellation);

--- a/src/Contrib/Otlp/SpanExporterFactory.php
+++ b/src/Contrib/Otlp/SpanExporterFactory.php
@@ -28,6 +28,7 @@ class SpanExporterFactory implements SpanExporterFactoryInterface
     /**
      * @psalm-suppress ArgumentTypeCoercion
      */
+    #[\Override]
     public function create(): SpanExporterInterface
     {
         $transport = $this->buildTransport();

--- a/src/Contrib/Otlp/StdoutLogsExporterFactory.php
+++ b/src/Contrib/Otlp/StdoutLogsExporterFactory.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
 
 class StdoutLogsExporterFactory implements LogRecordExporterFactoryInterface
 {
+    #[\Override]
     public function create(): LogRecordExporterInterface
     {
         $transport = (new StreamTransportFactory())->create('php://stdout', ContentTypes::NDJSON);

--- a/src/Contrib/Otlp/StdoutMetricExporterFactory.php
+++ b/src/Contrib/Otlp/StdoutMetricExporterFactory.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 
 class StdoutMetricExporterFactory implements MetricExporterFactoryInterface
 {
+    #[\Override]
     public function create(): MetricExporterInterface
     {
         $transport = (new StreamTransportFactory())->create('php://stdout', ContentTypes::NDJSON);

--- a/src/Contrib/Otlp/StdoutSpanExporterFactory.php
+++ b/src/Contrib/Otlp/StdoutSpanExporterFactory.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
 class StdoutSpanExporterFactory implements SpanExporterFactoryInterface
 {
+    #[\Override]
     public function create(): SpanExporterInterface
     {
         $transport = (new StreamTransportFactory())->create('php://stdout', ContentTypes::NDJSON);

--- a/src/Contrib/Zipkin/Exporter.php
+++ b/src/Contrib/Zipkin/Exporter.php
@@ -41,6 +41,7 @@ class Exporter implements SpanExporterInterface
         );
     }
 
+    #[\Override]
     public function export(iterable $batch, ?CancellationInterface $cancellation = null): FutureInterface
     {
         return $this->transport
@@ -53,11 +54,13 @@ class Exporter implements SpanExporterInterface
             });
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return $this->transport->shutdown($cancellation);
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return $this->transport->forceFlush($cancellation);

--- a/src/Contrib/Zipkin/SpanConverter.php
+++ b/src/Contrib/Zipkin/SpanConverter.php
@@ -74,6 +74,7 @@ class SpanConverter implements SpanConverterInterface
         return (string) $value;
     }
 
+    #[\Override]
     public function convert(iterable $spans): array
     {
         $aggregate = [];

--- a/src/Contrib/Zipkin/SpanExporterFactory.php
+++ b/src/Contrib/Zipkin/SpanExporterFactory.php
@@ -12,6 +12,7 @@ use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
 class SpanExporterFactory implements SpanExporterFactoryInterface
 {
+    #[\Override]
     public function create(): SpanExporterInterface
     {
         $endpoint = Configuration::getString(Variables::OTEL_EXPORTER_ZIPKIN_ENDPOINT);

--- a/src/Extension/Propagator/B3/B3MultiPropagator.php
+++ b/src/Extension/Propagator/B3/B3MultiPropagator.php
@@ -97,12 +97,14 @@ final class B3MultiPropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function fields(): array
     {
         return self::FIELDS;
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
@@ -125,6 +127,7 @@ final class B3MultiPropagator implements TextMapPropagatorInterface
         }
     }
 
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $getter ??= ArrayAccessGetterSetter::getInstance();

--- a/src/Extension/Propagator/B3/B3Propagator.php
+++ b/src/Extension/Propagator/B3/B3Propagator.php
@@ -36,18 +36,21 @@ final class B3Propagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function fields(): array
     {
         return $this->propagator->fields();
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         $this->propagator->inject($carrier, $setter, $context);
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $getter ??= ArrayAccessGetterSetter::getInstance();

--- a/src/Extension/Propagator/B3/B3SinglePropagator.php
+++ b/src/Extension/Propagator/B3/B3SinglePropagator.php
@@ -49,12 +49,14 @@ final class B3SinglePropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function fields(): array
     {
         return self::FIELDS;
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
@@ -78,6 +80,7 @@ final class B3SinglePropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $getter ??= ArrayAccessGetterSetter::getInstance();

--- a/src/Extension/Propagator/CloudTrace/CloudTracePropagator.php
+++ b/src/Extension/Propagator/CloudTrace/CloudTracePropagator.php
@@ -51,12 +51,14 @@ final class CloudTracePropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function fields(): array
     {
         return self::FIELDS;
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         if ($this->oneWay) {
@@ -76,6 +78,7 @@ final class CloudTracePropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $getter ??= ArrayAccessGetterSetter::getInstance();

--- a/src/Extension/Propagator/Jaeger/JaegerBaggagePropagator.php
+++ b/src/Extension/Propagator/Jaeger/JaegerBaggagePropagator.php
@@ -33,12 +33,14 @@ class JaegerBaggagePropagator implements TextMapPropagatorInterface
         return self::$instance;
     }
 
+    #[\Override]
     public function fields(): array
     {
         return [];
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
@@ -59,6 +61,7 @@ class JaegerBaggagePropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $getter ??= ArrayAccessGetterSetter::getInstance();

--- a/src/Extension/Propagator/Jaeger/JaegerPropagator.php
+++ b/src/Extension/Propagator/Jaeger/JaegerPropagator.php
@@ -45,12 +45,14 @@ class JaegerPropagator implements TextMapPropagatorInterface
         return self::$instance;
     }
 
+    #[\Override]
     public function fields(): array
     {
         return self::FIELDS;
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function inject(&$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         $setter ??= ArrayAccessGetterSetter::getInstance();
@@ -75,6 +77,7 @@ class JaegerPropagator implements TextMapPropagatorInterface
     }
 
     /** {@inheritdoc} */
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         $getter ??= ArrayAccessGetterSetter::getInstance();

--- a/src/SDK/Common/Adapter/HttpDiscovery/DependencyResolver.php
+++ b/src/SDK/Common/Adapter/HttpDiscovery/DependencyResolver.php
@@ -41,41 +41,49 @@ final class DependencyResolver implements DependencyResolverInterface
         return new self($messageFactoryResolver, $psrClientResolver, $httpPlugClientResolver);
     }
 
+    #[\Override]
     public function resolveRequestFactory(): RequestFactoryInterface
     {
         return $this->messageFactoryResolver->resolveRequestFactory();
     }
 
+    #[\Override]
     public function resolveResponseFactory(): ResponseFactoryInterface
     {
         return $this->messageFactoryResolver->resolveResponseFactory();
     }
 
+    #[\Override]
     public function resolveServerRequestFactory(): ServerRequestFactoryInterface
     {
         return $this->messageFactoryResolver->resolveServerRequestFactory();
     }
 
+    #[\Override]
     public function resolveStreamFactory(): StreamFactoryInterface
     {
         return $this->messageFactoryResolver->resolveStreamFactory();
     }
 
+    #[\Override]
     public function resolveUploadedFileFactory(): UploadedFileFactoryInterface
     {
         return $this->messageFactoryResolver->resolveUploadedFileFactory();
     }
 
+    #[\Override]
     public function resolveUriFactory(): UriFactoryInterface
     {
         return $this->messageFactoryResolver->resolveUriFactory();
     }
 
+    #[\Override]
     public function resolveHttpPlugAsyncClient(): HttpAsyncClient
     {
         return $this->httpPlugClientResolver->resolveHttpPlugAsyncClient();
     }
 
+    #[\Override]
     public function resolvePsrClient(): ClientInterface
     {
         return $this->psrClientResolver->resolvePsrClient();

--- a/src/SDK/Common/Adapter/HttpDiscovery/HttpPlugClientResolver.php
+++ b/src/SDK/Common/Adapter/HttpDiscovery/HttpPlugClientResolver.php
@@ -19,6 +19,7 @@ final class HttpPlugClientResolver implements ResolverInterface
         return new self($httpAsyncClient);
     }
 
+    #[\Override]
     public function resolveHttpPlugAsyncClient(): HttpAsyncClient
     {
         return $this->httpAsyncClient ??= HttpAsyncClientDiscovery::find();

--- a/src/SDK/Common/Adapter/HttpDiscovery/MessageFactoryResolver.php
+++ b/src/SDK/Common/Adapter/HttpDiscovery/MessageFactoryResolver.php
@@ -43,31 +43,37 @@ final class MessageFactoryResolver implements FactoryResolverInterface
         );
     }
 
+    #[\Override]
     public function resolveRequestFactory(): RequestFactoryInterface
     {
         return $this->requestFactory ??= Psr17FactoryDiscovery::findRequestFactory();
     }
 
+    #[\Override]
     public function resolveResponseFactory(): ResponseFactoryInterface
     {
         return $this->responseFactory ??= Psr17FactoryDiscovery::findResponseFactory();
     }
 
+    #[\Override]
     public function resolveServerRequestFactory(): ServerRequestFactoryInterface
     {
         return $this->serverRequestFactory ??= Psr17FactoryDiscovery::findServerRequestFactory();
     }
 
+    #[\Override]
     public function resolveStreamFactory(): StreamFactoryInterface
     {
         return $this->streamFactory ??= Psr17FactoryDiscovery::findStreamFactory();
     }
 
+    #[\Override]
     public function resolveUploadedFileFactory(): UploadedFileFactoryInterface
     {
         return $this->uploadedFileFactory ??= Psr17FactoryDiscovery::findUploadedFileFactory();
     }
 
+    #[\Override]
     public function resolveUriFactory(): UriFactoryInterface
     {
         return $this->uriFactory ??= Psr17FactoryDiscovery::findUriFactory();

--- a/src/SDK/Common/Adapter/HttpDiscovery/PsrClientResolver.php
+++ b/src/SDK/Common/Adapter/HttpDiscovery/PsrClientResolver.php
@@ -19,6 +19,7 @@ final class PsrClientResolver implements ResolverInterface
         return new self($client);
     }
 
+    #[\Override]
     public function resolvePsrClient(): ClientInterface
     {
         return $this->client ??= Psr18ClientDiscovery::find();

--- a/src/SDK/Common/Attribute/AttributeValidator.php
+++ b/src/SDK/Common/Attribute/AttributeValidator.php
@@ -21,6 +21,7 @@ class AttributeValidator implements AttributeValidatorInterface
      * Validate whether a value is a primitive, or a homogeneous array of primitives (treating int/double as equivalent).
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/common/README.md#attribute
      */
+    #[\Override]
     public function validate($value): bool
     {
         if (is_array($value)) {
@@ -51,6 +52,7 @@ class AttributeValidator implements AttributeValidatorInterface
         return true;
     }
 
+    #[\Override]
     public function getInvalidMessage(): string
     {
         return 'attribute with non-primitive or non-homogeneous array of primitives dropped';

--- a/src/SDK/Common/Attribute/Attributes.php
+++ b/src/SDK/Common/Attribute/Attributes.php
@@ -33,27 +33,32 @@ final class Attributes implements AttributesInterface, IteratorAggregate, JsonSe
         return new AttributesFactory($attributeCountLimit, $attributeValueLengthLimit);
     }
 
+    #[\Override]
     public function has(string $name): bool
     {
         return array_key_exists($name, $this->attributes);
     }
 
+    #[\Override]
     public function get(string $name)
     {
         return $this->attributes[$name] ?? null;
     }
 
     /** @psalm-mutation-free */
+    #[\Override]
     public function count(): int
     {
         return \count($this->attributes);
     }
 
+    #[\Override]
     public function jsonSerialize(): mixed
     {
         return $this->attributes;
     }
 
+    #[\Override]
     public function getIterator(): Traversable
     {
         foreach ($this->attributes as $key => $value) {
@@ -61,11 +66,13 @@ final class Attributes implements AttributesInterface, IteratorAggregate, JsonSe
         }
     }
 
+    #[\Override]
     public function toArray(): array
     {
         return $this->attributes;
     }
 
+    #[\Override]
     public function getDroppedAttributesCount(): int
     {
         return $this->droppedAttributesCount;

--- a/src/SDK/Common/Attribute/AttributesBuilder.php
+++ b/src/SDK/Common/Attribute/AttributesBuilder.php
@@ -22,11 +22,13 @@ final class AttributesBuilder implements AttributesBuilderInterface
     {
     }
 
+    #[\Override]
     public function build(): AttributesInterface
     {
         return new Attributes($this->attributes, $this->droppedAttributesCount);
     }
 
+    #[\Override]
     public function merge(AttributesInterface $old, AttributesInterface $updating): AttributesInterface
     {
         $new = $old->toArray();
@@ -42,6 +44,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
         return new Attributes($new, $dropped);
     }
 
+    #[\Override]
     public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->attributes);
@@ -50,6 +53,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
      */
+    #[\Override]
     public function offsetGet($offset): mixed
     {
         return $this->attributes[$offset] ?? null;
@@ -58,6 +62,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
      */
+    #[\Override]
     public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
@@ -86,6 +91,7 @@ final class AttributesBuilder implements AttributesBuilderInterface
     /**
      * @phan-suppress PhanUndeclaredClassAttribute
      */
+    #[\Override]
     public function offsetUnset($offset): void
     {
         unset($this->attributes[$offset]);

--- a/src/SDK/Common/Attribute/AttributesFactory.php
+++ b/src/SDK/Common/Attribute/AttributesFactory.php
@@ -15,6 +15,7 @@ final class AttributesFactory implements AttributesFactoryInterface
     ) {
     }
 
+    #[\Override]
     public function builder(iterable $attributes = [], ?AttributeValidatorInterface $attributeValidator = null): AttributesBuilderInterface
     {
         $builder = new AttributesBuilder(

--- a/src/SDK/Common/Attribute/LogRecordAttributeValidator.php
+++ b/src/SDK/Common/Attribute/LogRecordAttributeValidator.php
@@ -6,11 +6,13 @@ namespace OpenTelemetry\SDK\Common\Attribute;
 
 class LogRecordAttributeValidator implements AttributeValidatorInterface
 {
+    #[\Override]
     public function validate($value): bool
     {
         return true;
     }
 
+    #[\Override]
     public function getInvalidMessage(): string
     {
         //not required as this validator always returns true

--- a/src/SDK/Common/Configuration/EnvComponentLoaderRegistry.php
+++ b/src/SDK/Common/Configuration/EnvComponentLoaderRegistry.php
@@ -41,6 +41,7 @@ final class EnvComponentLoaderRegistry implements \OpenTelemetry\API\Configurati
         return $this;
     }
 
+    #[\Override]
     public function load(string $type, string $name, EnvResolver $env, Context $context): mixed
     {
         if (!$loader = $this->loaders[$type][$name] ?? null) {

--- a/src/SDK/Common/Configuration/EnvResolver.php
+++ b/src/SDK/Common/Configuration/EnvResolver.php
@@ -11,6 +11,7 @@ use function in_array;
  */
 final class EnvResolver implements \OpenTelemetry\API\Configuration\ConfigEnv\EnvResolver
 {
+    #[\Override]
     public function string(string $name): ?string
     {
         if (!Configuration::has($name)) {
@@ -20,6 +21,7 @@ final class EnvResolver implements \OpenTelemetry\API\Configuration\ConfigEnv\En
         return Configuration::getString($name);
     }
 
+    #[\Override]
     public function enum(string $name, array $values): ?string
     {
         if (!Configuration::has($name)) {
@@ -34,6 +36,7 @@ final class EnvResolver implements \OpenTelemetry\API\Configuration\ConfigEnv\En
         return $value;
     }
 
+    #[\Override]
     public function bool(string $name): ?bool
     {
         if (!Configuration::has($name)) {
@@ -43,6 +46,7 @@ final class EnvResolver implements \OpenTelemetry\API\Configuration\ConfigEnv\En
         return Configuration::getBoolean($name);
     }
 
+    #[\Override]
     public function int(string $name, ?int $min = 0, ?int $max = ~(-1 << 31)): int|null
     {
         if (!Configuration::has($name)) {
@@ -57,6 +61,7 @@ final class EnvResolver implements \OpenTelemetry\API\Configuration\ConfigEnv\En
         return $value;
     }
 
+    #[\Override]
     public function numeric(string $name, float|int|null $min = 0, float|int|null $max = ~(-1 << 31)): float|int|null
     {
         if (!Configuration::has($name)) {
@@ -71,6 +76,7 @@ final class EnvResolver implements \OpenTelemetry\API\Configuration\ConfigEnv\En
         return $value;
     }
 
+    #[\Override]
     public function list(string $name): ?array
     {
         if (!Configuration::has($name)) {
@@ -83,6 +89,7 @@ final class EnvResolver implements \OpenTelemetry\API\Configuration\ConfigEnv\En
         return $value;
     }
 
+    #[\Override]
     public function map(string $name): ?array
     {
         if (!Configuration::has($name)) {

--- a/src/SDK/Common/Configuration/Resolver/EnvironmentResolver.php
+++ b/src/SDK/Common/Configuration/Resolver/EnvironmentResolver.php
@@ -11,6 +11,7 @@ use OpenTelemetry\SDK\Common\Configuration\Configuration;
  */
 class EnvironmentResolver implements ResolverInterface
 {
+    #[\Override]
     public function hasVariable(string $variableName): bool
     {
         if (!Configuration::isEmpty($_SERVER[$variableName] ?? null)) {
@@ -28,6 +29,7 @@ class EnvironmentResolver implements ResolverInterface
      * @psalm-suppress InvalidReturnStatement
      * @psalm-suppress InvalidReturnType
      */
+    #[\Override]
     public function retrieveValue(string $variableName)
     {
         $value = getenv($variableName);

--- a/src/SDK/Common/Configuration/Resolver/PhpIniResolver.php
+++ b/src/SDK/Common/Configuration/Resolver/PhpIniResolver.php
@@ -16,6 +16,7 @@ class PhpIniResolver implements ResolverInterface
     {
     }
 
+    #[\Override]
     public function retrieveValue(string $variableName)
     {
         $value = $this->accessor->get($variableName) ?: '';
@@ -26,6 +27,7 @@ class PhpIniResolver implements ResolverInterface
         return $value;
     }
 
+    #[\Override]
     public function hasVariable(string $variableName): bool
     {
         $value = $this->accessor->get($variableName);

--- a/src/SDK/Common/Export/Http/PsrTransport.php
+++ b/src/SDK/Common/Export/Http/PsrTransport.php
@@ -101,7 +101,7 @@ final class PsrTransport implements TransportInterface
 
             $delay = PsrUtils::retryDelay($retries, $this->retryDelay, $response);
             $sec = (int) $delay;
-            $nsec = (int) (($delay - $sec) * 1e9);
+            $nsec = (int) (($delay - (float) $sec) * 1e9);
 
             /** @psalm-suppress ArgumentTypeCoercion */
             if (time_nanosleep($sec, $nsec) !== true) {

--- a/src/SDK/Common/Export/Http/PsrTransport.php
+++ b/src/SDK/Common/Export/Http/PsrTransport.php
@@ -48,6 +48,7 @@ final class PsrTransport implements TransportInterface
     ) {
     }
 
+    #[\Override]
     public function contentType(): string
     {
         return $this->contentType;
@@ -56,6 +57,7 @@ final class PsrTransport implements TransportInterface
     /**
      * @psalm-suppress ArgumentTypeCoercion
      */
+    #[\Override]
     public function send(string $payload, ?CancellationInterface $cancellation = null): FutureInterface
     {
         if ($this->closed) {
@@ -136,6 +138,7 @@ final class PsrTransport implements TransportInterface
         return $encodings;
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         if ($this->closed) {
@@ -147,6 +150,7 @@ final class PsrTransport implements TransportInterface
         return true;
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return !$this->closed;

--- a/src/SDK/Common/Export/Http/PsrTransportFactory.php
+++ b/src/SDK/Common/Export/Http/PsrTransportFactory.php
@@ -28,6 +28,7 @@ final class PsrTransportFactory implements TransportFactoryInterface
     /**
      * @phan-suppress PhanTypeMismatchArgumentNullable
      */
+    #[\Override]
     public function create(
         string $endpoint,
         string $contentType,

--- a/src/SDK/Common/Export/Stream/StreamTransport.php
+++ b/src/SDK/Common/Export/Stream/StreamTransport.php
@@ -38,11 +38,13 @@ final class StreamTransport implements TransportInterface
     ) {
     }
 
+    #[\Override]
     public function contentType(): string
     {
         return $this->contentType;
     }
 
+    #[\Override]
     public function send(string $payload, ?CancellationInterface $cancellation = null): FutureInterface
     {
         if (!$this->stream) {
@@ -68,6 +70,7 @@ final class StreamTransport implements TransportInterface
         return new CompletedFuture(null);
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         if (!$this->stream) {
@@ -80,6 +83,7 @@ final class StreamTransport implements TransportInterface
         return $flush;
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         if (!$this->stream) {

--- a/src/SDK/Common/Export/Stream/StreamTransport.php
+++ b/src/SDK/Common/Export/Stream/StreamTransport.php
@@ -64,7 +64,7 @@ final class StreamTransport implements TransportInterface
         }
 
         if ($bytesWritten !== strlen($payload)) {
-            return new ErrorFuture(new RuntimeException(sprintf('Write failure, wrote %d of %d bytes', $bytesWritten, strlen($payload))));
+            return new ErrorFuture(new RuntimeException(sprintf('Write failure, wrote %d of %d bytes', $bytesWritten ?: 0, strlen($payload))));
         }
 
         return new CompletedFuture(null);

--- a/src/SDK/Common/Export/Stream/StreamTransportFactory.php
+++ b/src/SDK/Common/Export/Stream/StreamTransportFactory.php
@@ -28,8 +28,8 @@ final class StreamTransportFactory implements TransportFactoryInterface
      *
      * @psalm-template CONTENT_TYPE of string
      * @psalm-param CONTENT_TYPE $contentType
-     * @psalm-return TransportInterface<CONTENT_TYPE>
      * @throws ErrorException
+     * @psalm-return TransportInterface<CONTENT_TYPE>
      */
     #[\Override]
     public function create(

--- a/src/SDK/Common/Export/Stream/StreamTransportFactory.php
+++ b/src/SDK/Common/Export/Stream/StreamTransportFactory.php
@@ -31,6 +31,7 @@ final class StreamTransportFactory implements TransportFactoryInterface
      * @psalm-return TransportInterface<CONTENT_TYPE>
      * @throws ErrorException
      */
+    #[\Override]
     public function create(
         $endpoint,
         string $contentType,

--- a/src/SDK/Common/Future/CompletedFuture.php
+++ b/src/SDK/Common/Future/CompletedFuture.php
@@ -20,11 +20,13 @@ final class CompletedFuture implements FutureInterface
     {
     }
 
+    #[\Override]
     public function await()
     {
         return $this->value;
     }
 
+    #[\Override]
     public function map(Closure $closure): FutureInterface
     {
         $c = $closure;
@@ -37,6 +39,7 @@ final class CompletedFuture implements FutureInterface
         }
     }
 
+    #[\Override]
     public function catch(Closure $closure): FutureInterface
     {
         return $this;

--- a/src/SDK/Common/Future/ErrorFuture.php
+++ b/src/SDK/Common/Future/ErrorFuture.php
@@ -16,16 +16,19 @@ final class ErrorFuture implements FutureInterface
     {
     }
 
+    #[\Override]
     public function await(): never
     {
         throw $this->throwable;
     }
 
+    #[\Override]
     public function map(Closure $closure): FutureInterface
     {
         return $this;
     }
 
+    #[\Override]
     public function catch(Closure $closure): FutureInterface
     {
         $c = $closure;

--- a/src/SDK/Common/Future/NullCancellation.php
+++ b/src/SDK/Common/Future/NullCancellation.php
@@ -8,11 +8,13 @@ use Closure;
 
 final class NullCancellation implements CancellationInterface
 {
+    #[\Override]
     public function subscribe(Closure $callback): string
     {
         return self::class;
     }
 
+    #[\Override]
     public function unsubscribe(string $id): void
     {
         // no-op

--- a/src/SDK/Common/Http/Psr/Client/Discovery/Buzz.php
+++ b/src/SDK/Common/Http/Psr/Client/Discovery/Buzz.php
@@ -13,6 +13,7 @@ class Buzz implements DiscoveryInterface
     /**
      * @phan-suppress PhanUndeclaredClassReference
      */
+    #[\Override]
     public function available(): bool
     {
         return class_exists(FileGetContents::class);
@@ -21,6 +22,7 @@ class Buzz implements DiscoveryInterface
     /**
      * @phan-suppress PhanUndeclaredClassReference,PhanTypeMismatchReturn,PhanUndeclaredClassMethod
      */
+    #[\Override]
     public function create(mixed $options): ClientInterface
     {
         return new FileGetContents(Psr17FactoryDiscovery::findResponseFactory(), $options);

--- a/src/SDK/Common/Http/Psr/Client/Discovery/CurlClient.php
+++ b/src/SDK/Common/Http/Psr/Client/Discovery/CurlClient.php
@@ -12,6 +12,7 @@ class CurlClient implements DiscoveryInterface
     /**
      * @phan-suppress PhanUndeclaredClassReference
      */
+    #[\Override]
     public function available(): bool
     {
         return extension_loaded('curl') && class_exists(Client::class);
@@ -21,6 +22,7 @@ class CurlClient implements DiscoveryInterface
      * @phan-suppress PhanUndeclaredClassReference,PhanTypeMismatchReturn,PhanUndeclaredClassMethod
      * @psalm-suppress UndefinedClass,InvalidReturnType,InvalidReturnStatement
      */
+    #[\Override]
     public function create(mixed $options): ClientInterface
     {
         $options = [

--- a/src/SDK/Common/Http/Psr/Client/Discovery/Guzzle.php
+++ b/src/SDK/Common/Http/Psr/Client/Discovery/Guzzle.php
@@ -9,11 +9,13 @@ use Psr\Http\Client\ClientInterface;
 
 class Guzzle implements DiscoveryInterface
 {
+    #[\Override]
     public function available(): bool
     {
         return class_exists(Client::class) && is_a(Client::class, ClientInterface::class, true);
     }
 
+    #[\Override]
     public function create(mixed $options): ClientInterface
     {
         return new Client($options);

--- a/src/SDK/Common/Http/Psr/Client/Discovery/Symfony.php
+++ b/src/SDK/Common/Http/Psr/Client/Discovery/Symfony.php
@@ -13,6 +13,7 @@ class Symfony implements DiscoveryInterface
     /**
      * @phan-suppress PhanUndeclaredClassReference
      */
+    #[\Override]
     public function available(): bool
     {
         return class_exists(HttpClient::class) && class_exists(Psr18Client::class);
@@ -21,6 +22,7 @@ class Symfony implements DiscoveryInterface
     /**
      * @phan-suppress PhanTypeMismatchReturn,PhanUndeclaredClassMethod
      */
+    #[\Override]
     public function create(mixed $options): ClientInterface
     {
         if (is_array($options) && array_key_exists('timeout', $options)) {

--- a/src/SDK/Common/Http/Psr/Message/MessageFactory.php
+++ b/src/SDK/Common/Http/Psr/Message/MessageFactory.php
@@ -28,16 +28,19 @@ final class MessageFactory implements MessageFactoryInterface
         return new self($requestFactory, $responseFactory, $serverRequestFactory);
     }
 
+    #[\Override]
     public function createRequest(string $method, $uri): RequestInterface
     {
         return $this->requestFactory->createRequest($method, $uri);
     }
 
+    #[\Override]
     public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
     {
         return $this->responseFactory->createResponse($code, $reasonPhrase);
     }
 
+    #[\Override]
     public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface
     {
         return $this->serverRequestFactory->createServerRequest($method, $uri, $serverParams);

--- a/src/SDK/Common/Instrumentation/InstrumentationScope.php
+++ b/src/SDK/Common/Instrumentation/InstrumentationScope.php
@@ -19,21 +19,25 @@ final class InstrumentationScope implements InstrumentationScopeInterface
     ) {
     }
 
+    #[\Override]
     public function getName(): string
     {
         return $this->name;
     }
 
+    #[\Override]
     public function getVersion(): ?string
     {
         return $this->version;
     }
 
+    #[\Override]
     public function getSchemaUrl(): ?string
     {
         return $this->schemaUrl;
     }
 
+    #[\Override]
     public function getAttributes(): AttributesInterface
     {
         return $this->attributes;

--- a/src/SDK/Common/Instrumentation/InstrumentationScopeFactory.php
+++ b/src/SDK/Common/Instrumentation/InstrumentationScopeFactory.php
@@ -12,6 +12,7 @@ final class InstrumentationScopeFactory implements InstrumentationScopeFactoryIn
     {
     }
 
+    #[\Override]
     public function create(
         string $name,
         ?string $version = null,

--- a/src/SDK/Common/InstrumentationScope/Configurator.php
+++ b/src/SDK/Common/InstrumentationScope/Configurator.php
@@ -51,6 +51,7 @@ final class Configurator
 
     /**
      * @return T
+     * @psalm-suppress PossiblyNullArgument
      */
     public function resolve(InstrumentationScopeInterface $instrumentationScope): Config
     {

--- a/src/SDK/Common/Util/ShutdownHandler.php
+++ b/src/SDK/Common/Util/ShutdownHandler.php
@@ -46,6 +46,7 @@ final class ShutdownHandler
      * @param callable $shutdownFunction function to register
      *
      * @see register_shutdown_function
+     * @psalm-suppress PossiblyNullArgument,PossiblyNullPropertyFetch
      */
     public static function register(callable $shutdownFunction): void
     {

--- a/src/SDK/Common/Util/functions.php
+++ b/src/SDK/Common/Util/functions.php
@@ -47,7 +47,7 @@ function weaken(Closure $closure, ?object &$target = null): Closure
     $ref = WeakReference::create($target);
 
     /**
-     * @psalm-suppress all
+     * @psalm-suppress PossiblyNullReference,PossiblyNullFunctionCall
      */
     return $scope && $target::class === $scope->name && !$scope->isInternal()
         ? static fn (...$args) => ($obj = $ref->get()) ? $closure->call($obj, ...$args) : null

--- a/src/SDK/Logs/EventLogger.php
+++ b/src/SDK/Logs/EventLogger.php
@@ -30,6 +30,7 @@ class EventLogger implements EventLoggerInterface
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.32.0/specification/logs/event-sdk.md#emit-event
      */
+    #[\Override]
     public function emit(
         string $name,
         mixed $body = null,

--- a/src/SDK/Logs/EventLoggerProvider.php
+++ b/src/SDK/Logs/EventLoggerProvider.php
@@ -19,6 +19,7 @@ class EventLoggerProvider implements EventLoggerProviderInterface
     /**
      * @phan-suppress PhanDeprecatedClass
      */
+    #[\Override]
     public function getEventLogger(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): EventLoggerInterface
     {
         return new EventLogger(
@@ -27,6 +28,7 @@ class EventLoggerProvider implements EventLoggerProviderInterface
         );
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         return $this->loggerProvider->forceFlush();

--- a/src/SDK/Logs/Exporter/ConsoleExporter.php
+++ b/src/SDK/Logs/Exporter/ConsoleExporter.php
@@ -26,6 +26,7 @@ class ConsoleExporter implements LogRecordExporterInterface
     /**
      * @param iterable<mixed, ReadableLogRecord> $batch
      */
+    #[\Override]
     public function export(iterable $batch, ?CancellationInterface $cancellation = null): FutureInterface
     {
         $resource = null;
@@ -49,11 +50,13 @@ class ConsoleExporter implements LogRecordExporterInterface
         return new CompletedFuture(true);
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return true;
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return true;

--- a/src/SDK/Logs/Exporter/ConsoleExporter.php
+++ b/src/SDK/Logs/Exporter/ConsoleExporter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Logs\Exporter;
 
-use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;
@@ -51,7 +50,7 @@ class ConsoleExporter implements LogRecordExporterInterface
         if ($payload === false) {
             return new ErrorFuture(
                 new \RuntimeException('Failed to encode log records to JSON: ' . json_last_error_msg())
-            ););
+            );
         }
         $this->transport->send($payload);
 

--- a/src/SDK/Logs/Exporter/ConsoleExporter.php
+++ b/src/SDK/Logs/Exporter/ConsoleExporter.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Logs\Exporter;
 
+use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;
+use OpenTelemetry\SDK\Common\Future\ErrorFuture;
 use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
@@ -45,7 +47,13 @@ class ConsoleExporter implements LogRecordExporterInterface
             'resource' => $resource,
             'scopes' => array_values($scopes),
         ];
-        $this->transport->send(json_encode($output, JSON_PRETTY_PRINT));
+        $payload = json_encode($output, JSON_PRETTY_PRINT);
+        if ($payload === false) {
+            return new ErrorFuture(
+                new \RuntimeException('Failed to encode log records to JSON: ' . json_last_error_msg())
+            ););
+        }
+        $this->transport->send($payload);
 
         return new CompletedFuture(true);
     }

--- a/src/SDK/Logs/Exporter/ConsoleExporterFactory.php
+++ b/src/SDK/Logs/Exporter/ConsoleExporterFactory.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Registry;
 
 class ConsoleExporterFactory implements LogRecordExporterFactoryInterface
 {
+    #[\Override]
     public function create(): LogRecordExporterInterface
     {
         $transport = Registry::transportFactory('stream')->create('php://stdout', 'application/json');

--- a/src/SDK/Logs/Exporter/InMemoryExporter.php
+++ b/src/SDK/Logs/Exporter/InMemoryExporter.php
@@ -19,6 +19,7 @@ class InMemoryExporter implements LogRecordExporterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function export(iterable $batch, ?CancellationInterface $cancellation = null): FutureInterface
     {
         foreach ($batch as $record) {
@@ -28,11 +29,13 @@ class InMemoryExporter implements LogRecordExporterInterface
         return new CompletedFuture(true);
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return true;
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return true;

--- a/src/SDK/Logs/Exporter/InMemoryExporterFactory.php
+++ b/src/SDK/Logs/Exporter/InMemoryExporterFactory.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
 
 class InMemoryExporterFactory implements LogRecordExporterFactoryInterface
 {
+    #[\Override]
     public function create(): LogRecordExporterInterface
     {
         return new InMemoryExporter(InMemoryStorageManager::logs());

--- a/src/SDK/Logs/Exporter/NoopExporter.php
+++ b/src/SDK/Logs/Exporter/NoopExporter.php
@@ -11,16 +11,19 @@ use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
 
 class NoopExporter implements LogRecordExporterInterface
 {
+    #[\Override]
     public function export(iterable $batch, ?CancellationInterface $cancellation = null): FutureInterface
     {
         return new CompletedFuture(true);
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return true;
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return true;

--- a/src/SDK/Logs/Logger.php
+++ b/src/SDK/Logs/Logger.php
@@ -31,6 +31,7 @@ class Logger implements LoggerInterface
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.44.0/specification/logs/api.md#emit-a-logrecord
      */
+    #[\Override]
     public function emit(LogRecord $logRecord): void
     {
         //If a Logger is disabled, it MUST behave equivalently to No-op Logger.
@@ -53,6 +54,7 @@ class Logger implements LoggerInterface
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.44.0/specification/logs/api.md#enabled
      */
+    #[\Override]
     public function isEnabled(?ContextInterface $context = null, ?int $severityNumber = null, ?string $eventName = null): bool
     {
         return $this->config->isEnabled();

--- a/src/SDK/Logs/LoggerProvider.php
+++ b/src/SDK/Logs/LoggerProvider.php
@@ -38,6 +38,7 @@ class LoggerProvider implements LoggerProviderInterface
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#logger-creation
      */
+    #[\Override]
     public function getLogger(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): LoggerInterface
     {
         if ($this->loggerSharedState->hasShutdown()) {
@@ -50,11 +51,13 @@ class LoggerProvider implements LoggerProviderInterface
         return $logger;
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return $this->loggerSharedState->shutdown($cancellation);
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return $this->loggerSharedState->forceFlush($cancellation);
@@ -70,6 +73,7 @@ class LoggerProvider implements LoggerProviderInterface
      * reconfigure all loggers created from the provider.
      * @experimental
      */
+    #[\Override]
     public function updateConfigurator(Configurator $configurator): void
     {
         $this->configurator = $configurator;

--- a/src/SDK/Logs/NoopEventLoggerProvider.php
+++ b/src/SDK/Logs/NoopEventLoggerProvider.php
@@ -11,6 +11,7 @@ use OpenTelemetry\API\Logs as API;
  */
 class NoopEventLoggerProvider extends API\NoopEventLoggerProvider implements EventLoggerProviderInterface
 {
+    #[\Override]
     public static function getInstance(): self
     {
         static $instance;
@@ -18,6 +19,7 @@ class NoopEventLoggerProvider extends API\NoopEventLoggerProvider implements Eve
         return $instance ??= new self();
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         return true;

--- a/src/SDK/Logs/NoopLoggerProvider.php
+++ b/src/SDK/Logs/NoopLoggerProvider.php
@@ -17,21 +17,25 @@ class NoopLoggerProvider implements LoggerProviderInterface
         return $instance ??= new self();
     }
 
+    #[\Override]
     public function getLogger(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): LoggerInterface
     {
         return NoopLogger::getInstance();
     }
 
+    #[\Override]
     public function shutdown(): bool
     {
         return true;
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         return true;
     }
 
+    #[\Override]
     public function updateConfigurator(Configurator $configurator): void
     {
         //no-op

--- a/src/SDK/Logs/Processor/BatchLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/BatchLogRecordProcessor.php
@@ -134,6 +134,7 @@ class BatchLogRecordProcessor implements LogRecordProcessorInterface
             });
     }
 
+    #[\Override]
     public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
     {
         if ($this->closed) {
@@ -158,6 +159,7 @@ class BatchLogRecordProcessor implements LogRecordProcessorInterface
         }
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         if ($this->closed) {
@@ -167,6 +169,7 @@ class BatchLogRecordProcessor implements LogRecordProcessorInterface
         return $this->flush(__FUNCTION__, $cancellation);
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         if ($this->closed) {

--- a/src/SDK/Logs/Processor/MultiLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/MultiLogRecordProcessor.php
@@ -22,6 +22,7 @@ class MultiLogRecordProcessor implements LogRecordProcessorInterface
         }
     }
 
+    #[\Override]
     public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
     {
         foreach ($this->processors as $processor) {
@@ -33,6 +34,7 @@ class MultiLogRecordProcessor implements LogRecordProcessorInterface
      * Returns `true` if all processors shut down successfully, else `false`
      * Subsequent calls to `shutdown` are a no-op.
      */
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         $result = true;
@@ -48,6 +50,7 @@ class MultiLogRecordProcessor implements LogRecordProcessorInterface
     /**
      * Returns `true` if all processors flush successfully, else `false`.
      */
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         $result = true;

--- a/src/SDK/Logs/Processor/NoopLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/NoopLogRecordProcessor.php
@@ -21,15 +21,18 @@ class NoopLogRecordProcessor implements LogRecordProcessorInterface
     /**
      * @codeCoverageIgnore
      */
+    #[\Override]
     public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
     {
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return true;
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return true;

--- a/src/SDK/Logs/Processor/SimpleLogRecordProcessor.php
+++ b/src/SDK/Logs/Processor/SimpleLogRecordProcessor.php
@@ -19,16 +19,19 @@ class SimpleLogRecordProcessor implements LogRecordProcessorInterface
     /**
      * @see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#onemit
      */
+    #[\Override]
     public function onEmit(ReadWriteLogRecord $record, ?ContextInterface $context = null): void
     {
         $this->exporter->export([$record]);
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return $this->exporter->shutdown($cancellation);
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return $this->exporter->forceFlush($cancellation);

--- a/src/SDK/Logs/ReadableLogRecord.php
+++ b/src/SDK/Logs/ReadableLogRecord.php
@@ -31,7 +31,7 @@ class ReadableLogRecord extends LogRecord
         parent::__construct($logRecord->body);
         $this->timestamp = $logRecord->timestamp;
         $this->observedTimestamp = $logRecord->observedTimestamp
-            ?? (int) (microtime(true) * LogRecord::NANOS_PER_SECOND);
+            ?? (int) (microtime(true) * (float) LogRecord::NANOS_PER_SECOND);
         $this->context = $logRecord->context;
         $context = $this->context ?? Context::getCurrent();
         $this->spanContext = Span::fromContext($context)->getContext();

--- a/src/SDK/Logs/SimplePsrFileLogger.php
+++ b/src/SDK/Logs/SimplePsrFileLogger.php
@@ -28,6 +28,7 @@ class SimplePsrFileLogger implements LoggerInterface
     /**
      * @psalm-suppress MoreSpecificImplementedParamType
      */
+    #[\Override]
     public function log($level, $message, array $context = []): void
     {
         $level = strtolower((string) $level);

--- a/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramAggregation.php
+++ b/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramAggregation.php
@@ -26,6 +26,7 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
     ) {
     }
 
+    #[\Override]
     public function initialize(): ExplicitBucketHistogramSummary
     {
         return new ExplicitBucketHistogramSummary(
@@ -40,6 +41,7 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
     /**
      * @param ExplicitBucketHistogramSummary $summary
      */
+    #[\Override]
     public function record($summary, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         $boundariesCount = count($this->boundaries);
@@ -56,6 +58,7 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
      * @param ExplicitBucketHistogramSummary $left
      * @param ExplicitBucketHistogramSummary $right
      */
+    #[\Override]
     public function merge($left, $right): ExplicitBucketHistogramSummary
     {
         $count = $left->count + $right->count;
@@ -80,6 +83,7 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
      * @param ExplicitBucketHistogramSummary $left
      * @param ExplicitBucketHistogramSummary $right
      */
+    #[\Override]
     public function diff($left, $right): ExplicitBucketHistogramSummary
     {
         $count = -$left->count + $right->count;
@@ -103,6 +107,7 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
     /**
      * @param array<ExplicitBucketHistogramSummary> $summaries
      */
+    #[\Override]
     public function toData(
         array $attributes,
         array $summaries,

--- a/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramAggregation.php
+++ b/src/SDK/Metrics/Aggregation/ExplicitBucketHistogramAggregation.php
@@ -62,7 +62,9 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
     public function merge($left, $right): ExplicitBucketHistogramSummary
     {
         $count = $left->count + $right->count;
-        $sum = $left->sum + $right->sum;
+        $sum = (is_int($left->sum) && is_int($right->sum))
+            ? ($left->sum + $right->sum)
+            : ((float) $left->sum + (float) $right->sum);
         $min = self::min($left->min, $right->min);
         $max = self::max($left->max, $right->max);
         $buckets = $right->buckets;
@@ -87,7 +89,9 @@ final class ExplicitBucketHistogramAggregation implements AggregationInterface
     public function diff($left, $right): ExplicitBucketHistogramSummary
     {
         $count = -$left->count + $right->count;
-        $sum = -$left->sum + $right->sum;
+        $sum = (is_int($left->sum) && is_int($right->sum))
+            ? (-$left->sum + $right->sum)
+            : (-(float) $left->sum + (float) $right->sum);
         $min = $left->min > $right->min ? $right->min : NAN;
         $max = $left->max < $right->max ? $right->max : NAN;
         $buckets = $right->buckets;

--- a/src/SDK/Metrics/Aggregation/LastValueAggregation.php
+++ b/src/SDK/Metrics/Aggregation/LastValueAggregation.php
@@ -14,6 +14,7 @@ use OpenTelemetry\SDK\Metrics\Data;
  */
 final class LastValueAggregation implements AggregationInterface
 {
+    #[\Override]
     public function initialize(): LastValueSummary
     {
         return new LastValueSummary(null, 0);
@@ -22,6 +23,7 @@ final class LastValueAggregation implements AggregationInterface
     /**
      * @param LastValueSummary $summary
      */
+    #[\Override]
     public function record($summary, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         if ($summary->value === null || $timestamp >= $summary->timestamp) {
@@ -34,6 +36,7 @@ final class LastValueAggregation implements AggregationInterface
      * @param LastValueSummary $left
      * @param LastValueSummary $right
      */
+    #[\Override]
     public function merge($left, $right): LastValueSummary
     {
         return $right->timestamp >= $left->timestamp ? $right : $left;
@@ -43,6 +46,7 @@ final class LastValueAggregation implements AggregationInterface
      * @param LastValueSummary $left
      * @param LastValueSummary $right
      */
+    #[\Override]
     public function diff($left, $right): LastValueSummary
     {
         return $right->timestamp >= $left->timestamp ? $right : $left;
@@ -51,6 +55,7 @@ final class LastValueAggregation implements AggregationInterface
     /**
      * @param array<LastValueSummary> $summaries
      */
+    #[\Override]
     public function toData(
         array $attributes,
         array $summaries,

--- a/src/SDK/Metrics/Aggregation/SumAggregation.php
+++ b/src/SDK/Metrics/Aggregation/SumAggregation.php
@@ -40,11 +40,11 @@ final class SumAggregation implements AggregationInterface
     #[\Override]
     public function merge($left, $right): SumSummary
     {
-        $sum = $left->value + $right->value;
+        $sum = (is_int($left->value) && is_int($right->value))
+            ? ($left->value + $right->value)
+            : ((float) $left->value + (float) $right->value);
 
-        return new SumSummary(
-            $sum,
-        );
+        return new SumSummary($sum);
     }
 
     /**
@@ -54,11 +54,11 @@ final class SumAggregation implements AggregationInterface
     #[\Override]
     public function diff($left, $right): SumSummary
     {
-        $sum = -$left->value + $right->value;
+        $diff = (is_int($left->value) && is_int($right->value))
+            ? (-$left->value + $right->value)
+            : (-(float) $left->value + (float) $right->value);
 
-        return new SumSummary(
-            $sum,
-        );
+        return new SumSummary($diff);
     }
 
     /**

--- a/src/SDK/Metrics/Aggregation/SumAggregation.php
+++ b/src/SDK/Metrics/Aggregation/SumAggregation.php
@@ -18,6 +18,7 @@ final class SumAggregation implements AggregationInterface
     {
     }
 
+    #[\Override]
     public function initialize(): SumSummary
     {
         return new SumSummary(0);
@@ -26,6 +27,7 @@ final class SumAggregation implements AggregationInterface
     /**
      * @param SumSummary $summary
      */
+    #[\Override]
     public function record($summary, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         $summary->value += $value;
@@ -35,6 +37,7 @@ final class SumAggregation implements AggregationInterface
      * @param SumSummary $left
      * @param SumSummary $right
      */
+    #[\Override]
     public function merge($left, $right): SumSummary
     {
         $sum = $left->value + $right->value;
@@ -48,6 +51,7 @@ final class SumAggregation implements AggregationInterface
      * @param SumSummary $left
      * @param SumSummary $right
      */
+    #[\Override]
     public function diff($left, $right): SumSummary
     {
         $sum = -$left->value + $right->value;
@@ -60,6 +64,7 @@ final class SumAggregation implements AggregationInterface
     /**
      * @param array<SumSummary> $summaries
      */
+    #[\Override]
     public function toData(
         array $attributes,
         array $summaries,

--- a/src/SDK/Metrics/AggregationInterface.php
+++ b/src/SDK/Metrics/AggregationInterface.php
@@ -42,9 +42,9 @@ interface AggregationInterface
 
     /**
      * @param array<AttributesInterface> $attributes
-     * @psalm-param array<T> $summaries
      * @param array<list<Exemplar>> $exemplars
      * @param string|Temporality $temporality
+     * @psalm-param array<T> $summaries
      */
     public function toData(
         array $attributes,

--- a/src/SDK/Metrics/AsynchronousInstruments.php
+++ b/src/SDK/Metrics/AsynchronousInstruments.php
@@ -18,6 +18,7 @@ final class AsynchronousInstruments
     /**
      * @param ArrayAccess<object, ObservableCallbackDestructor> $destructors
      * @param non-empty-list<Instrument> $instruments
+     * @psalm-suppress PossiblyNullArgument,PossiblyNullPropertyAssignment,PossiblyNullPropertyFetch
      */
     public static function observe(
         MetricWriterInterface $writer,

--- a/src/SDK/Metrics/AttributeProcessor/FilteredAttributeProcessor.php
+++ b/src/SDK/Metrics/AttributeProcessor/FilteredAttributeProcessor.php
@@ -18,6 +18,7 @@ final class FilteredAttributeProcessor implements AttributeProcessorInterface
     {
     }
 
+    #[\Override]
     public function process(AttributesInterface $attributes, ContextInterface $context): AttributesInterface
     {
         $filtered = [];

--- a/src/SDK/Metrics/AttributeProcessor/IdentityAttributeProcessor.php
+++ b/src/SDK/Metrics/AttributeProcessor/IdentityAttributeProcessor.php
@@ -13,6 +13,7 @@ use OpenTelemetry\SDK\Metrics\AttributeProcessorInterface;
  */
 final class IdentityAttributeProcessor implements AttributeProcessorInterface
 {
+    #[\Override]
     public function process(AttributesInterface $attributes, ContextInterface $context): AttributesInterface
     {
         return $attributes;

--- a/src/SDK/Metrics/Exemplar/ExemplarFilter/AllExemplarFilter.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilter/AllExemplarFilter.php
@@ -14,6 +14,7 @@ use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
  */
 final class AllExemplarFilter implements ExemplarFilterInterface
 {
+    #[\Override]
     public function accepts($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): bool
     {
         return true;

--- a/src/SDK/Metrics/Exemplar/ExemplarFilter/NoneExemplarFilter.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilter/NoneExemplarFilter.php
@@ -14,6 +14,7 @@ use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
  */
 final class NoneExemplarFilter implements ExemplarFilterInterface
 {
+    #[\Override]
     public function accepts($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): bool
     {
         return false;

--- a/src/SDK/Metrics/Exemplar/ExemplarFilter/WithSampledTraceExemplarFilter.php
+++ b/src/SDK/Metrics/Exemplar/ExemplarFilter/WithSampledTraceExemplarFilter.php
@@ -15,6 +15,7 @@ use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
  */
 final class WithSampledTraceExemplarFilter implements ExemplarFilterInterface
 {
+    #[\Override]
     public function accepts($value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): bool
     {
         return Span::fromContext($context)->getContext()->isSampled();

--- a/src/SDK/Metrics/Exemplar/FilteredReservoir.php
+++ b/src/SDK/Metrics/Exemplar/FilteredReservoir.php
@@ -19,6 +19,7 @@ final class FilteredReservoir implements ExemplarReservoirInterface
     ) {
     }
 
+    #[\Override]
     public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         if ($this->filter->accepts($value, $attributes, $context, $timestamp)) {
@@ -26,6 +27,7 @@ final class FilteredReservoir implements ExemplarReservoirInterface
         }
     }
 
+    #[\Override]
     public function collect(array $dataPointAttributes): array
     {
         return $this->reservoir->collect($dataPointAttributes);

--- a/src/SDK/Metrics/Exemplar/FixedSizeReservoir.php
+++ b/src/SDK/Metrics/Exemplar/FixedSizeReservoir.php
@@ -20,6 +20,7 @@ final class FixedSizeReservoir implements ExemplarReservoirInterface
         $this->size = $size;
     }
 
+    #[\Override]
     public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         $bucket = random_int(0, $this->measurements);
@@ -29,6 +30,7 @@ final class FixedSizeReservoir implements ExemplarReservoirInterface
         }
     }
 
+    #[\Override]
     public function collect(array $dataPointAttributes): array
     {
         $this->measurements = 0;

--- a/src/SDK/Metrics/Exemplar/HistogramBucketReservoir.php
+++ b/src/SDK/Metrics/Exemplar/HistogramBucketReservoir.php
@@ -25,6 +25,7 @@ final class HistogramBucketReservoir implements ExemplarReservoirInterface
         $this->boundaries = $boundaries;
     }
 
+    #[\Override]
     public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         $boundariesCount = count($this->boundaries);
@@ -33,6 +34,7 @@ final class HistogramBucketReservoir implements ExemplarReservoirInterface
         $this->storage->store($i, $index, $value, $attributes, $context, $timestamp);
     }
 
+    #[\Override]
     public function collect(array $dataPointAttributes): array
     {
         return $this->storage->collect($dataPointAttributes);

--- a/src/SDK/Metrics/Exemplar/NoopReservoir.php
+++ b/src/SDK/Metrics/Exemplar/NoopReservoir.php
@@ -9,11 +9,13 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesInterface;
 
 final class NoopReservoir implements ExemplarReservoirInterface
 {
+    #[\Override]
     public function offer($index, $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         // no-op
     }
 
+    #[\Override]
     public function collect(array $dataPointAttributes): array
     {
         return [];

--- a/src/SDK/Metrics/Meter.php
+++ b/src/SDK/Metrics/Meter.php
@@ -76,6 +76,7 @@ final class Meter implements MeterInterface, Configurable
     /**
      * @internal
      */
+    #[\Override]
     public function updateConfigurator(Configurator $configurator): void
     {
         $this->config = $configurator->resolve($this->instrumentationScope);
@@ -118,6 +119,7 @@ final class Meter implements MeterInterface, Configurable
         }
     }
 
+    #[\Override]
     public function batchObserve(callable $callback, AsynchronousInstrument $instrument, AsynchronousInstrument ...$instruments): ObservableCallbackInterface
     {
         $referenceCounters = [];
@@ -157,6 +159,7 @@ final class Meter implements MeterInterface, Configurable
         );
     }
 
+    #[\Override]
     public function createCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): CounterInterface
     {
         [$instrument, $referenceCounter] = $this->createSynchronousWriter(
@@ -170,6 +173,7 @@ final class Meter implements MeterInterface, Configurable
         return new Counter($this->writer, $instrument, $referenceCounter);
     }
 
+    #[\Override]
     public function createObservableCounter(string $name, ?string $unit = null, ?string $description = null, $advisory = [], callable ...$callbacks): ObservableCounterInterface
     {
         if (is_callable($advisory)) {
@@ -192,6 +196,7 @@ final class Meter implements MeterInterface, Configurable
         return new ObservableCounter($this->writer, $instrument, $referenceCounter, $this->destructors);
     }
 
+    #[\Override]
     public function createHistogram(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): HistogramInterface
     {
         [$instrument, $referenceCounter] = $this->createSynchronousWriter(
@@ -205,6 +210,7 @@ final class Meter implements MeterInterface, Configurable
         return new Histogram($this->writer, $instrument, $referenceCounter);
     }
 
+    #[\Override]
     public function createGauge(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): GaugeInterface
     {
         [$instrument, $referenceCounter] = $this->createSynchronousWriter(
@@ -218,6 +224,7 @@ final class Meter implements MeterInterface, Configurable
         return new Gauge($this->writer, $instrument, $referenceCounter);
     }
 
+    #[\Override]
     public function createObservableGauge(string $name, ?string $unit = null, ?string $description = null, $advisory = [], callable ...$callbacks): ObservableGaugeInterface
     {
         if (is_callable($advisory)) {
@@ -240,6 +247,7 @@ final class Meter implements MeterInterface, Configurable
         return new ObservableGauge($this->writer, $instrument, $referenceCounter, $this->destructors);
     }
 
+    #[\Override]
     public function createUpDownCounter(string $name, ?string $unit = null, ?string $description = null, array $advisory = []): UpDownCounterInterface
     {
         [$instrument, $referenceCounter] = $this->createSynchronousWriter(
@@ -253,6 +261,7 @@ final class Meter implements MeterInterface, Configurable
         return new UpDownCounter($this->writer, $instrument, $referenceCounter);
     }
 
+    #[\Override]
     public function createObservableUpDownCounter(string $name, ?string $unit = null, ?string $description = null, $advisory = [], callable ...$callbacks): ObservableUpDownCounterInterface
     {
         if (is_callable($advisory)) {

--- a/src/SDK/Metrics/MeterProvider.php
+++ b/src/SDK/Metrics/MeterProvider.php
@@ -56,6 +56,7 @@ final class MeterProvider implements MeterProviderInterface
         $this->meters = new WeakMap();
     }
 
+    #[\Override]
     public function getMeter(
         string $name,
         ?string $version = null,
@@ -86,6 +87,7 @@ final class MeterProvider implements MeterProviderInterface
         return $meter;
     }
 
+    #[\Override]
     public function shutdown(): bool
     {
         if ($this->closed) {
@@ -104,6 +106,7 @@ final class MeterProvider implements MeterProviderInterface
         return $success;
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         if ($this->closed) {
@@ -131,6 +134,7 @@ final class MeterProvider implements MeterProviderInterface
      *
      * @experimental
      */
+    #[\Override]
     public function updateConfigurator(Configurator $configurator): void
     {
         $this->configurator = $configurator;

--- a/src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php
+++ b/src/SDK/Metrics/MetricExporter/ConsoleMetricExporter.php
@@ -24,6 +24,7 @@ class ConsoleMetricExporter implements PushMetricExporterInterface, AggregationT
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function temporality(MetricMetadataInterface $metric): Temporality|string|null
     {
         return $this->temporality ?? $metric->temporality();
@@ -32,6 +33,7 @@ class ConsoleMetricExporter implements PushMetricExporterInterface, AggregationT
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function export(iterable $batch): bool
     {
         $resource = null;
@@ -56,11 +58,13 @@ class ConsoleMetricExporter implements PushMetricExporterInterface, AggregationT
         return true;
     }
 
+    #[\Override]
     public function shutdown(): bool
     {
         return true;
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         return true;

--- a/src/SDK/Metrics/MetricExporter/ConsoleMetricExporterFactory.php
+++ b/src/SDK/Metrics/MetricExporter/ConsoleMetricExporterFactory.php
@@ -9,6 +9,7 @@ use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 
 class ConsoleMetricExporterFactory implements MetricExporterFactoryInterface
 {
+    #[\Override]
     public function create(): MetricExporterInterface
     {
         return new ConsoleMetricExporter();

--- a/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
+++ b/src/SDK/Metrics/MetricExporter/InMemoryExporter.php
@@ -30,6 +30,7 @@ final class InMemoryExporter implements MetricExporterInterface, AggregationTemp
     ) {
     }
 
+    #[\Override]
     public function temporality(MetricMetadataInterface $metric): string|Temporality|null
     {
         return $this->temporality ?? $metric->temporality();
@@ -48,6 +49,7 @@ final class InMemoryExporter implements MetricExporterInterface, AggregationTemp
         return $metrics;
     }
 
+    #[\Override]
     public function export(iterable $batch): bool
     {
         if ($this->closed) {
@@ -61,6 +63,7 @@ final class InMemoryExporter implements MetricExporterInterface, AggregationTemp
         return true;
     }
 
+    #[\Override]
     public function shutdown(): bool
     {
         if ($this->closed) {
@@ -72,6 +75,7 @@ final class InMemoryExporter implements MetricExporterInterface, AggregationTemp
         return true;
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         return true;

--- a/src/SDK/Metrics/MetricExporter/InMemoryExporterFactory.php
+++ b/src/SDK/Metrics/MetricExporter/InMemoryExporterFactory.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 
 class InMemoryExporterFactory implements MetricExporterFactoryInterface
 {
+    #[\Override]
     public function create(): MetricExporterInterface
     {
         return new InMemoryExporter(InMemoryStorageManager::metrics());

--- a/src/SDK/Metrics/MetricExporter/NoopMetricExporter.php
+++ b/src/SDK/Metrics/MetricExporter/NoopMetricExporter.php
@@ -11,11 +11,13 @@ class NoopMetricExporter implements MetricExporterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function export(iterable $batch): bool
     {
         return true;
     }
 
+    #[\Override]
     public function shutdown(): bool
     {
         return true;

--- a/src/SDK/Metrics/MetricExporter/NoopMetricExporterFactory.php
+++ b/src/SDK/Metrics/MetricExporter/NoopMetricExporterFactory.php
@@ -9,6 +9,7 @@ use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 
 class NoopMetricExporterFactory implements MetricExporterFactoryInterface
 {
+    #[\Override]
     public function create(): MetricExporterInterface
     {
         return new NoopMetricExporter();

--- a/src/SDK/Metrics/MetricFactory/StreamFactory.php
+++ b/src/SDK/Metrics/MetricFactory/StreamFactory.php
@@ -36,6 +36,7 @@ use Throwable;
  */
 final class StreamFactory implements MetricFactoryInterface
 {
+    #[\Override]
     public function createAsynchronousObserver(
         MetricRegistryInterface $registry,
         ResourceInfo $resource,
@@ -78,6 +79,7 @@ final class StreamFactory implements MetricFactoryInterface
         return array_keys($streams);
     }
 
+    #[\Override]
     public function createSynchronousWriter(
         MetricRegistryInterface $registry,
         ResourceInfo $resource,

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSource.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSource.php
@@ -18,11 +18,13 @@ final class StreamMetricSource implements MetricSourceInterface
     ) {
     }
 
+    #[\Override]
     public function collectionTimestamp(): int
     {
         return $this->provider->stream->timestamp();
     }
 
+    #[\Override]
     public function collect(): Metric
     {
         return new Metric(

--- a/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
+++ b/src/SDK/Metrics/MetricFactory/StreamMetricSourceProvider.php
@@ -30,31 +30,37 @@ final class StreamMetricSourceProvider implements MetricSourceProviderInterface,
     ) {
     }
 
+    #[\Override]
     public function create($temporality): MetricSourceInterface
     {
         return new StreamMetricSource($this, $this->stream->register($temporality));
     }
 
+    #[\Override]
     public function instrumentType()
     {
         return $this->instrument->type;
     }
 
+    #[\Override]
     public function name(): string
     {
         return $this->view->name;
     }
 
+    #[\Override]
     public function unit(): ?string
     {
         return $this->view->unit;
     }
 
+    #[\Override]
     public function description(): ?string
     {
         return $this->view->description;
     }
 
+    #[\Override]
     public function temporality()
     {
         return $this->stream->temporality();

--- a/src/SDK/Metrics/MetricReader/ExportingReader.php
+++ b/src/SDK/Metrics/MetricReader/ExportingReader.php
@@ -39,6 +39,7 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
     {
     }
 
+    #[\Override]
     public function defaultAggregation($instrumentType, array $advisory = []): ?AggregationInterface
     {
         if ($this->exporter instanceof DefaultAggregationProviderInterface) {
@@ -49,6 +50,7 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
         return $this->_defaultAggregation($instrumentType, $advisory);
     }
 
+    #[\Override]
     public function add(MetricSourceProviderInterface $provider, MetricMetadataInterface $metadata, StalenessHandlerInterface $stalenessHandler): void
     {
         if ($this->closed) {
@@ -81,6 +83,7 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
         $this->streamIds[$registryId][$streamId][] = $sourceId;
     }
 
+    #[\Override]
     public function unregisterStream(MetricCollectorInterface $collector, int $streamId): void
     {
         $registryId = spl_object_id($collector);
@@ -115,6 +118,7 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
         return $this->exporter->export($metrics);
     }
 
+    #[\Override]
     public function collect(): bool
     {
         if ($this->closed) {
@@ -124,6 +128,7 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
         return $this->doCollect();
     }
 
+    #[\Override]
     public function shutdown(): bool
     {
         if ($this->closed) {
@@ -140,6 +145,7 @@ final class ExportingReader implements MetricReaderInterface, MetricSourceRegist
         return $collect && $shutdown;
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         if ($this->closed) {

--- a/src/SDK/Metrics/MetricRegistration/MultiRegistryRegistration.php
+++ b/src/SDK/Metrics/MetricRegistration/MultiRegistryRegistration.php
@@ -24,6 +24,7 @@ final class MultiRegistryRegistration implements MetricRegistrationInterface
     ) {
     }
 
+    #[\Override]
     public function register(MetricSourceProviderInterface $provider, MetricMetadataInterface $metadata): void
     {
         foreach ($this->registries as $registry) {

--- a/src/SDK/Metrics/MetricRegistration/RegistryRegistration.php
+++ b/src/SDK/Metrics/MetricRegistration/RegistryRegistration.php
@@ -21,6 +21,7 @@ final class RegistryRegistration implements MetricRegistrationInterface
     ) {
     }
 
+    #[\Override]
     public function register(MetricSourceProviderInterface $provider, MetricMetadataInterface $metadata): void
     {
         $this->registry->add($provider, $metadata, $this->stalenessHandler);

--- a/src/SDK/Metrics/MetricRegistry/MetricRegistry.php
+++ b/src/SDK/Metrics/MetricRegistry/MetricRegistry.php
@@ -46,6 +46,7 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
     ) {
     }
 
+    #[\Override]
     public function registerSynchronousStream(Instrument $instrument, MetricStreamInterface $stream, MetricAggregatorInterface $aggregator): int
     {
         $this->streams[] = $stream;
@@ -59,6 +60,7 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
         return $streamId;
     }
 
+    #[\Override]
     public function registerAsynchronousStream(Instrument $instrument, MetricStreamInterface $stream, MetricAggregatorFactoryInterface $aggregatorFactory): int
     {
         $this->streams[] = $stream;
@@ -72,6 +74,7 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
         return $streamId;
     }
 
+    #[\Override]
     public function unregisterStreams(Instrument $instrument): array
     {
         $instrumentId = spl_object_id($instrument);
@@ -90,6 +93,7 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
         return $streamIds;
     }
 
+    #[\Override]
     public function record(Instrument $instrument, $value, iterable $attributes = [], $context = null): void
     {
         $context = Context::resolve($context, $this->contextStorage);
@@ -103,6 +107,7 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
         }
     }
 
+    #[\Override]
     public function registerCallback(Closure $callback, Instrument $instrument, Instrument ...$instruments): int
     {
         $callbackId = array_key_last($this->asynchronousCallbacks) + 1;
@@ -120,6 +125,7 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
         return $callbackId;
     }
 
+    #[\Override]
     public function unregisterCallback(int $callbackId): void
     {
         $instrumentIds = $this->asynchronousCallbackArguments[$callbackId];
@@ -135,6 +141,7 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
         }
     }
 
+    #[\Override]
     public function collectAndPush(iterable $streamIds): void
     {
         $timestamp = $this->clock->now();
@@ -178,6 +185,7 @@ final class MetricRegistry implements MetricRegistryInterface, MetricWriterInter
         }
     }
 
+    #[\Override]
     public function enabled(Instrument $instrument): bool
     {
         return isset($this->instrumentToStreams[spl_object_id($instrument)]);

--- a/src/SDK/Metrics/MetricRegistry/MultiObserver.php
+++ b/src/SDK/Metrics/MetricRegistry/MultiObserver.php
@@ -23,6 +23,7 @@ final class MultiObserver implements ObserverInterface
     ) {
     }
 
+    #[\Override]
     public function observe($amount, iterable $attributes = []): void
     {
         $context = Context::getRoot();

--- a/src/SDK/Metrics/MetricRegistry/NoopObserver.php
+++ b/src/SDK/Metrics/MetricRegistry/NoopObserver.php
@@ -11,6 +11,7 @@ use OpenTelemetry\API\Metrics\ObserverInterface;
  */
 final class NoopObserver implements ObserverInterface
 {
+    #[\Override]
     public function observe($amount, iterable $attributes = []): void
     {
         // no-op

--- a/src/SDK/Metrics/NoopMeterProvider.php
+++ b/src/SDK/Metrics/NoopMeterProvider.php
@@ -10,21 +10,25 @@ use OpenTelemetry\SDK\Common\InstrumentationScope\Configurator;
 
 class NoopMeterProvider implements MeterProviderInterface
 {
+    #[\Override]
     public function shutdown(): bool
     {
         return true;
     }
 
+    #[\Override]
     public function forceFlush(): bool
     {
         return true;
     }
 
+    #[\Override]
     public function getMeter(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): MeterInterface
     {
         return new NoopMeter();
     }
 
+    #[\Override]
     public function updateConfigurator(Configurator $configurator): void
     {
         // no-op

--- a/src/SDK/Metrics/ObservableCallback.php
+++ b/src/SDK/Metrics/ObservableCallback.php
@@ -22,6 +22,7 @@ final class ObservableCallback implements ObservableCallbackInterface
     ) {
     }
 
+    #[\Override]
     public function detach(): void
     {
         if ($this->callbackId === null) {

--- a/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandler.php
+++ b/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandler.php
@@ -24,6 +24,7 @@ final class DelayedStalenessHandler implements StalenessHandlerInterface, Refere
     ) {
     }
 
+    #[\Override]
     public function acquire(bool $persistent = false): void
     {
         if ($this->count === 0) {
@@ -37,6 +38,7 @@ final class DelayedStalenessHandler implements StalenessHandlerInterface, Refere
         }
     }
 
+    #[\Override]
     public function release(): void
     {
         if (--$this->count || $this->onStale === null) {
@@ -46,6 +48,7 @@ final class DelayedStalenessHandler implements StalenessHandlerInterface, Refere
         ($this->stale)($this);
     }
 
+    #[\Override]
     public function onStale(Closure $callback): void
     {
         if ($this->onStale === null) {

--- a/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandlerFactory.php
+++ b/src/SDK/Metrics/StalenessHandler/DelayedStalenessHandlerFactory.php
@@ -41,6 +41,7 @@ final class DelayedStalenessHandlerFactory implements StalenessHandlerFactoryInt
         $this->staleHandlers = new WeakMap();
     }
 
+    #[\Override]
     public function create(): ReferenceCounterInterface&StalenessHandlerInterface
     {
         $this->triggerStaleHandlers();

--- a/src/SDK/Metrics/StalenessHandler/ImmediateStalenessHandler.php
+++ b/src/SDK/Metrics/StalenessHandler/ImmediateStalenessHandler.php
@@ -17,6 +17,7 @@ final class ImmediateStalenessHandler implements StalenessHandlerInterface, Refe
     private ?array $onStale = [];
     private int $count = 0;
 
+    #[\Override]
     public function acquire(bool $persistent = false): void
     {
         $this->count++;
@@ -26,6 +27,7 @@ final class ImmediateStalenessHandler implements StalenessHandlerInterface, Refe
         }
     }
 
+    #[\Override]
     public function release(): void
     {
         if (--$this->count !== 0 || !$this->onStale) {
@@ -39,6 +41,7 @@ final class ImmediateStalenessHandler implements StalenessHandlerInterface, Refe
         }
     }
 
+    #[\Override]
     public function onStale(Closure $callback): void
     {
         if ($this->onStale === null) {

--- a/src/SDK/Metrics/StalenessHandler/ImmediateStalenessHandlerFactory.php
+++ b/src/SDK/Metrics/StalenessHandler/ImmediateStalenessHandlerFactory.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Metrics\StalenessHandlerInterface;
 
 final class ImmediateStalenessHandlerFactory implements StalenessHandlerFactoryInterface
 {
+    #[\Override]
     public function create(): ReferenceCounterInterface&StalenessHandlerInterface
     {
         return new ImmediateStalenessHandler();

--- a/src/SDK/Metrics/StalenessHandler/MultiReferenceCounter.php
+++ b/src/SDK/Metrics/StalenessHandler/MultiReferenceCounter.php
@@ -18,6 +18,7 @@ final class MultiReferenceCounter implements ReferenceCounterInterface
     {
     }
 
+    #[\Override]
     public function acquire(bool $persistent = false): void
     {
         foreach ($this->referenceCounters as $referenceCounter) {
@@ -25,6 +26,7 @@ final class MultiReferenceCounter implements ReferenceCounterInterface
         }
     }
 
+    #[\Override]
     public function release(): void
     {
         foreach ($this->referenceCounters as $referenceCounter) {

--- a/src/SDK/Metrics/StalenessHandler/NoopStalenessHandler.php
+++ b/src/SDK/Metrics/StalenessHandler/NoopStalenessHandler.php
@@ -13,16 +13,19 @@ use OpenTelemetry\SDK\Metrics\StalenessHandlerInterface;
  */
 final class NoopStalenessHandler implements StalenessHandlerInterface, ReferenceCounterInterface
 {
+    #[\Override]
     public function acquire(bool $persistent = false): void
     {
         // no-op
     }
 
+    #[\Override]
     public function release(): void
     {
         // no-op
     }
 
+    #[\Override]
     public function onStale(Closure $callback): void
     {
         // no-op

--- a/src/SDK/Metrics/StalenessHandler/NoopStalenessHandlerFactory.php
+++ b/src/SDK/Metrics/StalenessHandler/NoopStalenessHandlerFactory.php
@@ -10,6 +10,7 @@ use OpenTelemetry\SDK\Metrics\StalenessHandlerInterface;
 
 final class NoopStalenessHandlerFactory implements StalenessHandlerFactoryInterface
 {
+    #[\Override]
     public function create(): ReferenceCounterInterface&StalenessHandlerInterface
     {
         static $instance;

--- a/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/AsynchronousMetricStream.php
@@ -28,21 +28,25 @@ final class AsynchronousMetricStream implements MetricStreamInterface
         $this->metric = new Metric([], [], $startTimestamp);
     }
 
+    #[\Override]
     public function temporality(): Temporality|string
     {
         return Temporality::CUMULATIVE;
     }
 
+    #[\Override]
     public function timestamp(): int
     {
         return $this->metric->timestamp;
     }
 
+    #[\Override]
     public function push(Metric $metric): void
     {
         $this->metric = $metric;
     }
 
+    #[\Override]
     public function register($temporality): int
     {
         if ($temporality === Temporality::CUMULATIVE) {
@@ -58,6 +62,7 @@ final class AsynchronousMetricStream implements MetricStreamInterface
         return $reader;
     }
 
+    #[\Override]
     public function unregister(int $reader): void
     {
         if (!isset($this->lastReads[$reader])) {
@@ -67,6 +72,7 @@ final class AsynchronousMetricStream implements MetricStreamInterface
         $this->lastReads[$reader] = null;
     }
 
+    #[\Override]
     public function collect(int $reader): DataInterface
     {
         $metric = $this->metric;

--- a/src/SDK/Metrics/Stream/MetricAggregator.php
+++ b/src/SDK/Metrics/Stream/MetricAggregator.php
@@ -27,6 +27,7 @@ final class MetricAggregator implements MetricAggregatorInterface
     ) {
     }
 
+    #[\Override]
     public function record(float|int $value, AttributesInterface $attributes, ContextInterface $context, int $timestamp): void
     {
         $filteredAttributes = $this->attributeProcessor !== null
@@ -48,6 +49,7 @@ final class MetricAggregator implements MetricAggregatorInterface
         }
     }
 
+    #[\Override]
     public function collect(int $timestamp): Metric
     {
         $exemplars = $this->exemplarReservoir

--- a/src/SDK/Metrics/Stream/MetricAggregatorFactory.php
+++ b/src/SDK/Metrics/Stream/MetricAggregatorFactory.php
@@ -18,6 +18,7 @@ final class MetricAggregatorFactory implements MetricAggregatorFactoryInterface
     ) {
     }
 
+    #[\Override]
     public function create(): MetricAggregatorInterface
     {
         return new MetricAggregator($this->attributeProcessor, $this->aggregation);

--- a/src/SDK/Metrics/Stream/SynchronousMetricStream.php
+++ b/src/SDK/Metrics/Stream/SynchronousMetricStream.php
@@ -39,22 +39,26 @@ final class SynchronousMetricStream implements MetricStreamInterface
         $this->delta = new DeltaStorage($this->aggregation);
     }
 
+    #[\Override]
     public function temporality(): Temporality|string
     {
         return Temporality::DELTA;
     }
 
+    #[\Override]
     public function timestamp(): int
     {
         return $this->timestamp;
     }
 
+    #[\Override]
     public function push(Metric $metric): void
     {
         [$this->timestamp, $metric->timestamp] = [$metric->timestamp, $this->timestamp];
         $this->delta->add($metric, $this->readers);
     }
 
+    #[\Override]
     public function register($temporality): int
     {
         $reader = 0;
@@ -81,6 +85,7 @@ final class SynchronousMetricStream implements MetricStreamInterface
         return $reader;
     }
 
+    #[\Override]
     public function unregister(int $reader): void
     {
         $readerMask = ($this->readers & 1 | 1) << $reader;
@@ -96,6 +101,7 @@ final class SynchronousMetricStream implements MetricStreamInterface
         }
     }
 
+    #[\Override]
     public function collect(int $reader): DataInterface
     {
         $cumulative = ($this->cumulative >> $reader & 1) != 0;

--- a/src/SDK/Metrics/View/CriteriaViewRegistry.php
+++ b/src/SDK/Metrics/View/CriteriaViewRegistry.php
@@ -25,6 +25,7 @@ final class CriteriaViewRegistry implements ViewRegistryInterface
     /**
      * @todo is null the best return type here? what about empty array or exception?
      */
+    #[\Override]
     public function find(Instrument $instrument, InstrumentationScopeInterface $instrumentationScope): ?iterable
     {
         $views = $this->generateViews($instrument, $instrumentationScope);

--- a/src/SDK/Metrics/View/SelectionCriteria/AllCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/AllCriteria.php
@@ -17,6 +17,7 @@ final class AllCriteria implements SelectionCriteriaInterface
     {
     }
 
+    #[\Override]
     public function accepts(Instrument $instrument, InstrumentationScopeInterface $instrumentationScope): bool
     {
         foreach ($this->criteria as $criterion) {

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentNameCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentNameCriteria.php
@@ -27,6 +27,7 @@ final class InstrumentNameCriteria implements SelectionCriteriaInterface
     /**
      * @psalm-suppress ArgumentTypeCoercion
      */
+    #[\Override]
     public function accepts(Instrument $instrument, InstrumentationScopeInterface $instrumentationScope): bool
     {
         return (bool) preg_match($this->pattern, $instrument->name);

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentTypeCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentTypeCriteria.php
@@ -22,6 +22,7 @@ final class InstrumentTypeCriteria implements SelectionCriteriaInterface
         $this->instrumentTypes = (array) $instrumentType;
     }
 
+    #[\Override]
     public function accepts(Instrument $instrument, InstrumentationScopeInterface $instrumentationScope): bool
     {
         return in_array($instrument->type, $this->instrumentTypes, true);

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeNameCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeNameCriteria.php
@@ -14,6 +14,7 @@ final class InstrumentationScopeNameCriteria implements SelectionCriteriaInterfa
     {
     }
 
+    #[\Override]
     public function accepts(Instrument $instrument, InstrumentationScopeInterface $instrumentationScope): bool
     {
         return $this->name === $instrumentationScope->getName();

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeSchemaUrlCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeSchemaUrlCriteria.php
@@ -14,6 +14,7 @@ final class InstrumentationScopeSchemaUrlCriteria implements SelectionCriteriaIn
     {
     }
 
+    #[\Override]
     public function accepts(Instrument $instrument, InstrumentationScopeInterface $instrumentationScope): bool
     {
         return $this->schemaUrl === $instrumentationScope->getSchemaUrl();

--- a/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeVersionCriteria.php
+++ b/src/SDK/Metrics/View/SelectionCriteria/InstrumentationScopeVersionCriteria.php
@@ -14,6 +14,7 @@ final class InstrumentationScopeVersionCriteria implements SelectionCriteriaInte
     {
     }
 
+    #[\Override]
     public function accepts(Instrument $instrument, InstrumentationScopeInterface $instrumentationScope): bool
     {
         return $this->version === $instrumentationScope->getVersion();

--- a/src/SDK/Propagation/LateBindingTextMapPropagator.php
+++ b/src/SDK/Propagation/LateBindingTextMapPropagator.php
@@ -23,6 +23,7 @@ final class LateBindingTextMapPropagator implements TextMapPropagatorInterface
     ) {
     }
 
+    #[\Override]
     public function fields(): array
     {
         if (!$this->propagator instanceof TextMapPropagatorInterface) {
@@ -32,6 +33,7 @@ final class LateBindingTextMapPropagator implements TextMapPropagatorInterface
         return $this->propagator->fields();
     }
 
+    #[\Override]
     public function inject(mixed &$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
     {
         if (!$this->propagator instanceof TextMapPropagatorInterface) {
@@ -41,6 +43,7 @@ final class LateBindingTextMapPropagator implements TextMapPropagatorInterface
         $this->propagator->inject($carrier, $setter, $context);
     }
 
+    #[\Override]
     public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
     {
         if (!$this->propagator instanceof TextMapPropagatorInterface) {

--- a/src/SDK/Resource/Detectors/Composer.php
+++ b/src/SDK/Resource/Detectors/Composer.php
@@ -17,6 +17,7 @@ use OpenTelemetry\SemConv\ResourceAttributes;
  */
 final class Composer implements ResourceDetectorInterface
 {
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         if (!class_exists(InstalledVersions::class)) {

--- a/src/SDK/Resource/Detectors/Composite.php
+++ b/src/SDK/Resource/Detectors/Composite.php
@@ -17,6 +17,7 @@ final class Composite implements ResourceDetectorInterface
     {
     }
 
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         $resource = ResourceInfoFactory::mandatoryResource();

--- a/src/SDK/Resource/Detectors/Constant.php
+++ b/src/SDK/Resource/Detectors/Constant.php
@@ -13,6 +13,7 @@ final class Constant implements ResourceDetectorInterface
     {
     }
 
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         return $this->resourceInfo;

--- a/src/SDK/Resource/Detectors/Environment.php
+++ b/src/SDK/Resource/Detectors/Environment.php
@@ -16,6 +16,7 @@ use OpenTelemetry\SemConv\ResourceAttributes;
  */
 final class Environment implements ResourceDetectorInterface
 {
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         $attributes = Configuration::has(Variables::OTEL_RESOURCE_ATTRIBUTES)

--- a/src/SDK/Resource/Detectors/Host.php
+++ b/src/SDK/Resource/Detectors/Host.php
@@ -29,6 +29,7 @@ final class Host implements ResourceDetectorInterface
     ) {
     }
 
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         $attributes = [

--- a/src/SDK/Resource/Detectors/OperatingSystem.php
+++ b/src/SDK/Resource/Detectors/OperatingSystem.php
@@ -12,6 +12,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
  */
 final class OperatingSystem implements ResourceDetectorInterface
 {
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         return ResourceInfo::emptyResource();

--- a/src/SDK/Resource/Detectors/Process.php
+++ b/src/SDK/Resource/Detectors/Process.php
@@ -23,6 +23,7 @@ final class Process implements ResourceDetectorInterface
     /**
      * @psalm-suppress PossiblyUndefinedArrayOffset
      */
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         $attributes = [

--- a/src/SDK/Resource/Detectors/ProcessRuntime.php
+++ b/src/SDK/Resource/Detectors/ProcessRuntime.php
@@ -12,6 +12,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
  */
 final class ProcessRuntime implements ResourceDetectorInterface
 {
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         return ResourceInfo::emptyResource();

--- a/src/SDK/Resource/Detectors/Sdk.php
+++ b/src/SDK/Resource/Detectors/Sdk.php
@@ -22,6 +22,7 @@ final class Sdk implements ResourceDetectorInterface
         'open-telemetry/opentelemetry',
     ];
 
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         $attributes = [

--- a/src/SDK/Resource/Detectors/SdkProvided.php
+++ b/src/SDK/Resource/Detectors/SdkProvided.php
@@ -12,6 +12,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfo;
  */
 final class SdkProvided implements ResourceDetectorInterface
 {
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         return ResourceInfo::emptyResource();

--- a/src/SDK/Resource/Detectors/Service.php
+++ b/src/SDK/Resource/Detectors/Service.php
@@ -17,6 +17,7 @@ use Ramsey\Uuid\Uuid;
  */
 final class Service implements ResourceDetectorInterface
 {
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         static $serviceInstanceId;

--- a/src/SDK/Trace/Event.php
+++ b/src/SDK/Trace/Event.php
@@ -16,21 +16,25 @@ final class Event implements EventInterface
     ) {
     }
 
+    #[\Override]
     public function getAttributes(): AttributesInterface
     {
         return $this->attributes;
     }
 
+    #[\Override]
     public function getName(): string
     {
         return $this->name;
     }
 
+    #[\Override]
     public function getEpochNanos(): int
     {
         return $this->timestamp;
     }
 
+    #[\Override]
     public function getTotalAttributeCount(): int
     {
         return count($this->attributes);

--- a/src/SDK/Trace/ImmutableSpan.php
+++ b/src/SDK/Trace/ImmutableSpan.php
@@ -34,93 +34,111 @@ final class ImmutableSpan implements SpanDataInterface
     ) {
     }
 
+    #[\Override]
     public function getKind(): int
     {
         return $this->span->getKind();
     }
 
+    #[\Override]
     public function getContext(): API\SpanContextInterface
     {
         return $this->span->getContext();
     }
 
+    #[\Override]
     public function getParentContext(): API\SpanContextInterface
     {
         return $this->span->getParentContext();
     }
 
+    #[\Override]
     public function getTraceId(): string
     {
         return $this->getContext()->getTraceId();
     }
 
+    #[\Override]
     public function getSpanId(): string
     {
         return $this->getContext()->getSpanId();
     }
 
+    #[\Override]
     public function getParentSpanId(): string
     {
         return $this->getParentContext()->getSpanId();
     }
 
+    #[\Override]
     public function getStartEpochNanos(): int
     {
         return $this->span->getStartEpochNanos();
     }
 
+    #[\Override]
     public function getEndEpochNanos(): int
     {
         return $this->endEpochNanos;
     }
 
+    #[\Override]
     public function getInstrumentationScope(): InstrumentationScopeInterface
     {
         return $this->span->getInstrumentationScope();
     }
 
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         return $this->span->getResource();
     }
 
+    #[\Override]
     public function getName(): string
     {
         return $this->name;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getLinks(): array
     {
         return $this->links;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getEvents(): array
     {
         return $this->events;
     }
 
+    #[\Override]
     public function getAttributes(): AttributesInterface
     {
         return $this->attributes;
     }
 
+    #[\Override]
     public function getTotalDroppedEvents(): int
     {
         return max(0, $this->totalRecordedEvents - count($this->events));
     }
 
+    #[\Override]
     public function getTotalDroppedLinks(): int
     {
         return max(0, $this->totalRecordedLinks - count($this->links));
     }
 
+    #[\Override]
     public function getStatus(): StatusDataInterface
     {
         return $this->status;
     }
 
+    #[\Override]
     public function hasEnded(): bool
     {
         return $this->hasEnded;

--- a/src/SDK/Trace/Link.php
+++ b/src/SDK/Trace/Link.php
@@ -15,11 +15,13 @@ final class Link implements LinkInterface
     ) {
     }
 
+    #[\Override]
     public function getSpanContext(): API\SpanContextInterface
     {
         return $this->context;
     }
 
+    #[\Override]
     public function getAttributes(): AttributesInterface
     {
         return $this->attributes;

--- a/src/SDK/Trace/NoopTracerProvider.php
+++ b/src/SDK/Trace/NoopTracerProvider.php
@@ -10,16 +10,19 @@ use OpenTelemetry\SDK\Common\InstrumentationScope\Configurator;
 
 class NoopTracerProvider extends API\Trace\NoopTracerProvider implements TracerProviderInterface
 {
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return true;
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return true;
     }
 
+    #[\Override]
     public function updateConfigurator(Configurator $configurator): void
     {
     }

--- a/src/SDK/Trace/RandomIdGenerator.php
+++ b/src/SDK/Trace/RandomIdGenerator.php
@@ -12,6 +12,7 @@ class RandomIdGenerator implements IdGeneratorInterface
     private const TRACE_ID_HEX_LENGTH = 32;
     private const SPAN_ID_HEX_LENGTH = 16;
 
+    #[\Override]
     public function generateTraceId(): string
     {
         do {
@@ -21,6 +22,7 @@ class RandomIdGenerator implements IdGeneratorInterface
         return $traceId;
     }
 
+    #[\Override]
     public function generateSpanId(): string
     {
         do {

--- a/src/SDK/Trace/Sampler/AlwaysOffSampler.php
+++ b/src/SDK/Trace/Sampler/AlwaysOffSampler.php
@@ -24,6 +24,7 @@ class AlwaysOffSampler implements SamplerInterface
      * Returns false because we never want to sample.
      * {@inheritdoc}
      */
+    #[\Override]
     public function shouldSample(
         ContextInterface $parentContext,
         string $traceId,
@@ -43,6 +44,7 @@ class AlwaysOffSampler implements SamplerInterface
         );
     }
 
+    #[\Override]
     public function getDescription(): string
     {
         return 'AlwaysOffSampler';

--- a/src/SDK/Trace/Sampler/AlwaysOnSampler.php
+++ b/src/SDK/Trace/Sampler/AlwaysOnSampler.php
@@ -24,6 +24,7 @@ class AlwaysOnSampler implements SamplerInterface
      * Returns true because we always want to sample.
      * {@inheritdoc}
      */
+    #[\Override]
     public function shouldSample(
         ContextInterface $parentContext,
         string $traceId,
@@ -43,6 +44,7 @@ class AlwaysOnSampler implements SamplerInterface
         );
     }
 
+    #[\Override]
     public function getDescription(): string
     {
         return 'AlwaysOnSampler';

--- a/src/SDK/Trace/Sampler/ParentBased.php
+++ b/src/SDK/Trace/Sampler/ParentBased.php
@@ -60,6 +60,7 @@ class ParentBased implements SamplerInterface
      * Invokes the respective delegate sampler when parent is set or uses root sampler for the root span.
      * {@inheritdoc}
      */
+    #[\Override]
     public function shouldSample(
         ContextInterface $parentContext,
         string $traceId,
@@ -87,6 +88,7 @@ class ParentBased implements SamplerInterface
             : $this->localParentNotSampler->shouldSample(...func_get_args());
     }
 
+    #[\Override]
     public function getDescription(): string
     {
         return 'ParentBased+' . $this->root->getDescription();

--- a/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -46,6 +46,7 @@ class TraceIdRatioBasedSampler implements SamplerInterface
         $this->tv = rtrim(bin2hex(substr(pack('J', self::computeTValue($probability, $precision, 4)), 1)), '0') ?: '0';
     }
 
+    #[\Override]
     public function shouldSample(
         ContextInterface $parentContext,
         string $traceId,
@@ -110,6 +111,7 @@ class TraceIdRatioBasedSampler implements SamplerInterface
         return $t - $m >> 1 & $m;
     }
 
+    #[\Override]
     public function getDescription(): string
     {
         return sprintf('%s{%.6F}', 'TraceIdRatioBasedSampler', $this->probability);

--- a/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/src/SDK/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -99,6 +99,7 @@ class TraceIdRatioBasedSampler implements SamplerInterface
         assert($precision >= 1);
         assert($wordSize >= 1 && ($wordSize & $wordSize - 1) === 0);
 
+        /** @psalm-suppress PossiblyInvalidArrayAccess */
         $b = unpack('J', pack('E', $probability))[1];
         $e = $b >> 52 & (1 << 11) - 1;
         $f = $b & (1 << 52) - 1 | ($e ? 1 << 52 : 0);

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -53,8 +53,8 @@ final class Span extends API\Span implements ReadWriteSpanInterface
      * End users should use a {@see API\TracerInterface} in order to create spans.
      *
      * @param non-empty-string $name
-     * @psalm-param API\SpanKind::KIND_* $kind
      * @param list<LinkInterface> $links
+     * @psalm-param API\SpanKind::KIND_* $kind
      *
      * @internal
      * @psalm-internal OpenTelemetry

--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -112,18 +112,21 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getContext(): API\SpanContextInterface
     {
         return $this->context;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function isRecording(): bool
     {
         return !$this->hasEnded;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setAttribute(string $key, $value): self
     {
         if ($this->hasEnded) {
@@ -136,6 +139,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setAttributes(iterable $attributes): self
     {
         foreach ($attributes as $key => $value) {
@@ -145,6 +149,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         return $this;
     }
 
+    #[\Override]
     public function addLink(SpanContextInterface $context, iterable $attributes = []): self
     {
         if ($this->hasEnded) {
@@ -169,6 +174,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function addEvent(string $name, iterable $attributes = [], ?int $timestamp = null): self
     {
         if ($this->hasEnded) {
@@ -187,6 +193,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function recordException(Throwable $exception, iterable $attributes = [], ?int $timestamp = null): self
     {
         if ($this->hasEnded) {
@@ -213,6 +220,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function updateName(string $name): self
     {
         if ($this->hasEnded) {
@@ -224,6 +232,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setStatus(string $code, ?string $description = null): self
     {
         if ($this->hasEnded) {
@@ -245,6 +254,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function end(?int $endEpochNanos = null): void
     {
         if ($this->hasEnded) {
@@ -260,26 +270,31 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getName(): string
     {
         return $this->name;
     }
 
+    #[\Override]
     public function getParentContext(): API\SpanContextInterface
     {
         return $this->parentSpanContext;
     }
 
+    #[\Override]
     public function getInstrumentationScope(): InstrumentationScopeInterface
     {
         return $this->instrumentationScope;
     }
 
+    #[\Override]
     public function hasEnded(): bool
     {
         return $this->hasEnded;
     }
 
+    #[\Override]
     public function toSpanData(): SpanDataInterface
     {
         return new ImmutableSpan(
@@ -297,18 +312,21 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getDuration(): int
     {
         return ($this->hasEnded ? $this->endEpochNanos : Clock::getDefault()->now()) - $this->startEpochNanos;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getKind(): int
     {
         return $this->kind;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getAttribute(string $key)
     {
         return $this->attributesBuilder[$key];

--- a/src/SDK/Trace/SpanBuilder.php
+++ b/src/SDK/Trace/SpanBuilder.php
@@ -37,6 +37,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setParent(ContextInterface|false|null $context): API\SpanBuilderInterface
     {
         $this->parentContext = $context;
@@ -45,6 +46,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function addLink(API\SpanContextInterface $context, iterable $attributes = []): API\SpanBuilderInterface
     {
         if (!$context->isValid()) {
@@ -70,6 +72,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setAttribute(string $key, mixed $value): API\SpanBuilderInterface
     {
         $this->attributesBuilder[$key] = $value;
@@ -78,6 +81,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setAttributes(iterable $attributes): API\SpanBuilderInterface
     {
         foreach ($attributes as $key => $value) {
@@ -92,6 +96,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
      *
      * @psalm-param API\SpanKind::KIND_* $spanKind
      */
+    #[\Override]
     public function setSpanKind(int $spanKind): API\SpanBuilderInterface
     {
         $this->spanKind = $spanKind;
@@ -100,6 +105,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function setStartTimestamp(int $timestampNanos): API\SpanBuilderInterface
     {
         if (0 > $timestampNanos) {
@@ -112,6 +118,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function startSpan(): API\SpanInterface
     {
         $parentContext = Context::resolve($this->parentContext);

--- a/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php
+++ b/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php
@@ -25,6 +25,7 @@ class ConsoleSpanExporter implements SpanExporterInterface
         $this->setSpanConverter($converter ?? new FriendlySpanConverter());
     }
 
+    #[\Override]
     public function export(iterable $batch, ?CancellationInterface $cancellation = null): FutureInterface
     {
         $payload = '';
@@ -44,11 +45,13 @@ class ConsoleSpanExporter implements SpanExporterInterface
             ->catch(fn () => false);
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return $this->transport->shutdown();
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return $this->transport->forceFlush();

--- a/src/SDK/Trace/SpanExporter/ConsoleSpanExporterFactory.php
+++ b/src/SDK/Trace/SpanExporter/ConsoleSpanExporterFactory.php
@@ -9,6 +9,7 @@ use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
 class ConsoleSpanExporterFactory implements SpanExporterFactoryInterface
 {
+    #[\Override]
     public function create(): SpanExporterInterface
     {
         $transport = Registry::transportFactory('stream')->create('php://stdout', 'application/json');

--- a/src/SDK/Trace/SpanExporter/FriendlySpanConverter.php
+++ b/src/SDK/Trace/SpanExporter/FriendlySpanConverter.php
@@ -37,6 +37,7 @@ class FriendlySpanConverter implements SpanConverterInterface
     private const LINKS_ATTR = 'links';
     private const SCHEMA_URL_ATTR = 'schema_url';
 
+    #[\Override]
     public function convert(iterable $spans): array
     {
         $aggregate = [];

--- a/src/SDK/Trace/SpanExporter/InMemoryExporter.php
+++ b/src/SDK/Trace/SpanExporter/InMemoryExporter.php
@@ -16,6 +16,7 @@ class InMemoryExporter implements SpanExporterInterface
     {
     }
 
+    #[\Override]
     protected function doExport(iterable $spans): bool
     {
         foreach ($spans as $span) {

--- a/src/SDK/Trace/SpanExporter/InMemorySpanExporterFactory.php
+++ b/src/SDK/Trace/SpanExporter/InMemorySpanExporterFactory.php
@@ -9,6 +9,7 @@ use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 
 class InMemorySpanExporterFactory implements SpanExporterFactoryInterface
 {
+    #[\Override]
     public function create(): SpanExporterInterface
     {
         return new InMemoryExporter(InMemoryStorageManager::spans());

--- a/src/SDK/Trace/SpanExporter/LoggerDecorator.php
+++ b/src/SDK/Trace/SpanExporter/LoggerDecorator.php
@@ -30,11 +30,13 @@ class LoggerDecorator implements SpanExporterInterface, LoggerAwareInterface
         $this->setSpanConverter($converter ?? new FriendlySpanConverter());
     }
 
+    #[\Override]
     protected function beforeExport(iterable $spans): iterable
     {
         return $spans;
     }
 
+    #[\Override]
     protected function afterExport(iterable $spans, bool $exportSuccess): void
     {
         if ($exportSuccess) {

--- a/src/SDK/Trace/SpanExporter/LoggerExporter.php
+++ b/src/SDK/Trace/SpanExporter/LoggerExporter.php
@@ -42,6 +42,7 @@ class LoggerExporter implements SpanExporterInterface, LoggerAwareInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function doExport(iterable $spans): bool
     {
         try {

--- a/src/SDK/Trace/SpanExporter/NullSpanConverter.php
+++ b/src/SDK/Trace/SpanExporter/NullSpanConverter.php
@@ -8,6 +8,7 @@ use OpenTelemetry\SDK\Trace\SpanConverterInterface;
 
 class NullSpanConverter implements SpanConverterInterface
 {
+    #[\Override]
     public function convert(iterable $spans): array
     {
         return [[]];

--- a/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -139,10 +139,12 @@ class BatchSpanProcessor implements SpanProcessorInterface
             });
     }
 
+    #[\Override]
     public function onStart(ReadWriteSpanInterface $span, ContextInterface $parentContext): void
     {
     }
 
+    #[\Override]
     public function onEnd(ReadableSpanInterface $span): void
     {
         if ($this->closed) {
@@ -170,6 +172,7 @@ class BatchSpanProcessor implements SpanProcessorInterface
         }
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         if ($this->closed) {
@@ -179,6 +182,7 @@ class BatchSpanProcessor implements SpanProcessorInterface
         return $this->flush(__FUNCTION__, $cancellation);
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         if ($this->closed) {

--- a/src/SDK/Trace/SpanProcessor/MultiSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/MultiSpanProcessor.php
@@ -38,6 +38,7 @@ final class MultiSpanProcessor implements SpanProcessorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function onStart(ReadWriteSpanInterface $span, ContextInterface $parentContext): void
     {
         foreach ($this->processors as $processor) {
@@ -46,6 +47,7 @@ final class MultiSpanProcessor implements SpanProcessorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function onEnd(ReadableSpanInterface $span): void
     {
         foreach ($this->processors as $processor) {
@@ -54,6 +56,7 @@ final class MultiSpanProcessor implements SpanProcessorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         $result = true;
@@ -66,6 +69,7 @@ final class MultiSpanProcessor implements SpanProcessorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         $result = true;

--- a/src/SDK/Trace/SpanProcessor/NoopSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/NoopSpanProcessor.php
@@ -24,22 +24,26 @@ class NoopSpanProcessor implements SpanProcessorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function onStart(ReadWriteSpanInterface $span, ContextInterface $parentContext): void
     {
     } //@codeCoverageIgnore
 
     /** @inheritDoc */
+    #[\Override]
     public function onEnd(ReadableSpanInterface $span): void
     {
     } //@codeCoverageIgnore
 
     /** @inheritDoc */
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return true;
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         return $this->forceFlush();

--- a/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/src/SDK/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -34,10 +34,12 @@ class SimpleSpanProcessor implements SpanProcessorInterface
         $this->queue = new SplQueue();
     }
 
+    #[\Override]
     public function onStart(ReadWriteSpanInterface $span, ContextInterface $parentContext): void
     {
     }
 
+    #[\Override]
     public function onEnd(ReadableSpanInterface $span): void
     {
         if ($this->closed) {
@@ -51,6 +53,7 @@ class SimpleSpanProcessor implements SpanProcessorInterface
         $this->flush(fn () => $this->exporter->export([$spanData])->await(), 'export', false, $this->exportContext);
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         if ($this->closed) {
@@ -60,6 +63,7 @@ class SimpleSpanProcessor implements SpanProcessorInterface
         return $this->flush(fn (): bool => $this->exporter->forceFlush($cancellation), __FUNCTION__, true, Context::getCurrent());
     }
 
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         if ($this->closed) {

--- a/src/SDK/Trace/StatusData.php
+++ b/src/SDK/Trace/StatusData.php
@@ -41,6 +41,7 @@ final class StatusData implements StatusDataInterface
         return new self($code, $description); /** @phan-suppress-current-line PhanTypeMismatchArgumentNullable */
     }
 
+    #[\Override]
     public static function ok(): self
     {
         if (null === self::$ok) {
@@ -50,6 +51,7 @@ final class StatusData implements StatusDataInterface
         return self::$ok;
     }
 
+    #[\Override]
     public static function error(): self
     {
         if (null === self::$error) {
@@ -59,6 +61,7 @@ final class StatusData implements StatusDataInterface
         return self::$error;
     }
 
+    #[\Override]
     public static function unset(): self
     {
         if (null === self::$unset) {
@@ -68,11 +71,13 @@ final class StatusData implements StatusDataInterface
         return self::$unset;
     }
 
+    #[\Override]
     public function getCode(): string
     {
         return $this->code;
     }
 
+    #[\Override]
     public function getDescription(): string
     {
         return $this->description;

--- a/src/SDK/Trace/Tracer.php
+++ b/src/SDK/Trace/Tracer.php
@@ -25,6 +25,7 @@ class Tracer implements API\TracerInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function spanBuilder(string $spanName): API\SpanBuilderInterface
     {
         if (ctype_space($spanName)) {
@@ -47,6 +48,7 @@ class Tracer implements API\TracerInterface
         return $this->instrumentationScope;
     }
 
+    #[\Override]
     public function isEnabled(): bool
     {
         return $this->config->isEnabled();

--- a/src/SDK/Trace/TracerProvider.php
+++ b/src/SDK/Trace/TracerProvider.php
@@ -52,6 +52,7 @@ final class TracerProvider implements TracerProviderInterface
         $this->tracers = new WeakMap();
     }
 
+    #[\Override]
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return $this->tracerSharedState->getSpanProcessor()->forceFlush($cancellation);
@@ -60,6 +61,7 @@ final class TracerProvider implements TracerProviderInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getTracer(
         string $name,
         ?string $version = null,
@@ -89,6 +91,7 @@ final class TracerProvider implements TracerProviderInterface
     /**
      * Returns `false` is the provider is already shutdown, otherwise `true`.
      */
+    #[\Override]
     public function shutdown(?CancellationInterface $cancellation = null): bool
     {
         if ($this->tracerSharedState->hasShutdown()) {
@@ -108,6 +111,7 @@ final class TracerProvider implements TracerProviderInterface
      * reconfigure all tracers created from the provider.
      * @experimental
      */
+    #[\Override]
     public function updateConfigurator(Configurator $configurator): void
     {
         $this->configurator = $configurator;

--- a/tests/Benchmark/OtlpBench.php
+++ b/tests/Benchmark/OtlpBench.php
@@ -64,21 +64,25 @@ class OtlpBench
                 $this->contentType = $contentType;
             }
 
+            #[\Override]
             public function contentType(): string
             {
                 return $this->contentType;
             }
 
+            #[\Override]
             public function send(string $payload, ?CancellationInterface $cancellation = null): FutureInterface
             {
                 return new CompletedFuture('');
             }
 
+            #[\Override]
             public function shutdown(?CancellationInterface $cancellation = null): bool
             {
                 return true;
             }
 
+            #[\Override]
             public function forceFlush(?CancellationInterface $cancellation = null): bool
             {
                 return true;

--- a/tests/Integration/Config/ComponentProvider/Detector/Container.php
+++ b/tests/Integration/Config/ComponentProvider/Detector/Container.php
@@ -18,9 +18,11 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 final class Container implements ComponentProvider
 {
+    #[\Override]
     public function createPlugin(array $properties, Context $context): ResourceDetectorInterface
     {
         return new class() implements ResourceDetectorInterface {
+            #[\Override]
             public function getResource(): ResourceInfo
             {
                 return ResourceInfoFactory::emptyResource();
@@ -28,6 +30,7 @@ final class Container implements ComponentProvider
         };
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('container');

--- a/tests/Integration/Config/ComponentProvider/Detector/Os.php
+++ b/tests/Integration/Config/ComponentProvider/Detector/Os.php
@@ -18,9 +18,11 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 final class Os implements ComponentProvider
 {
+    #[\Override]
     public function createPlugin(array $properties, Context $context): ResourceDetectorInterface
     {
         return new class() implements ResourceDetectorInterface {
+            #[\Override]
             public function getResource(): ResourceInfo
             {
                 return ResourceInfoFactory::emptyResource();
@@ -28,6 +30,7 @@ final class Os implements ComponentProvider
         };
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('os');

--- a/tests/Integration/Config/ComponentProvider/Metrics/AggregationResolverExplicitBucketHistogram.php
+++ b/tests/Integration/Config/ComponentProvider/Metrics/AggregationResolverExplicitBucketHistogram.php
@@ -24,6 +24,7 @@ final class AggregationResolverExplicitBucketHistogram implements ComponentProvi
      *      record_min_max: bool,
      *  } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): DefaultAggregationProviderInterface
     {
         return new class() implements DefaultAggregationProviderInterface {
@@ -31,6 +32,7 @@ final class AggregationResolverExplicitBucketHistogram implements ComponentProvi
         };
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('explicit_bucket_histogram');

--- a/tests/Integration/Config/ComponentProvider/Metrics/MetricExporterPrometheus.php
+++ b/tests/Integration/Config/ComponentProvider/Metrics/MetricExporterPrometheus.php
@@ -30,14 +30,17 @@ final class MetricExporterPrometheus implements ComponentProvider
      *     },
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporterInterface
     {
         return new class() implements MetricExporterInterface {
+            #[\Override]
             public function export(iterable $batch): bool
             {
                 return true;
             }
 
+            #[\Override]
             public function shutdown(): bool
             {
                 return true;
@@ -45,6 +48,7 @@ final class MetricExporterPrometheus implements ComponentProvider
         };
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('prometheus/development');

--- a/tests/Integration/Config/ComponentProvider/Metrics/MetricReaderPull.php
+++ b/tests/Integration/Config/ComponentProvider/Metrics/MetricReaderPull.php
@@ -25,19 +25,23 @@ final class MetricReaderPull implements ComponentProvider
      *     cardinality_limits: array,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricReaderInterface
     {
         return new class() implements MetricReaderInterface {
+            #[\Override]
             public function collect(): bool
             {
                 return true;
             }
 
+            #[\Override]
             public function shutdown(): bool
             {
                 return true;
             }
 
+            #[\Override]
             public function forceFlush(): bool
             {
                 return true;
@@ -45,6 +49,7 @@ final class MetricReaderPull implements ComponentProvider
         };
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('pull');

--- a/tests/Integration/Config/ComponentProvider/Propagator/TextMapPropagatorOtTrace.php
+++ b/tests/Integration/Config/ComponentProvider/Propagator/TextMapPropagatorOtTrace.php
@@ -20,19 +20,23 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 final class TextMapPropagatorOtTrace implements ComponentProvider
 {
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         return new class() implements TextMapPropagatorInterface {
+            #[\Override]
             public function fields(): array
             {
                 return [];
             }
 
+            #[\Override]
             public function inject(mixed &$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
             {
                 //no-op
             }
 
+            #[\Override]
             public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
             {
                 return $context ?? Ctx::getCurrent();
@@ -40,6 +44,7 @@ final class TextMapPropagatorOtTrace implements ComponentProvider
         };
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('ottrace');

--- a/tests/Integration/Config/ComponentProvider/Propagator/TextMapPropagatorXray.php
+++ b/tests/Integration/Config/ComponentProvider/Propagator/TextMapPropagatorXray.php
@@ -20,19 +20,23 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 final class TextMapPropagatorXray implements ComponentProvider
 {
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         return new class() implements TextMapPropagatorInterface {
+            #[\Override]
             public function fields(): array
             {
                 return [];
             }
 
+            #[\Override]
             public function inject(mixed &$carrier, ?PropagationSetterInterface $setter = null, ?ContextInterface $context = null): void
             {
                 //no-op
             }
 
+            #[\Override]
             public function extract($carrier, ?PropagationGetterInterface $getter = null, ?ContextInterface $context = null): ContextInterface
             {
                 return $context ?? Ctx::getCurrent();
@@ -40,6 +44,7 @@ final class TextMapPropagatorXray implements ComponentProvider
         };
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('xray');

--- a/tests/Integration/Config/ConfigurationTest.php
+++ b/tests/Integration/Config/ConfigurationTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversNothing]
 final class ConfigurationTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         // set up mock file system with /var/log directory, for otlp_file exporter.
@@ -26,6 +27,7 @@ final class ConfigurationTest extends TestCase
         OutputStreamParser::setRoot($root);
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         OutputStreamParser::reset();

--- a/tests/Integration/SDK/Common/InMemoryStorageManagerWithSKDAutoload.php
+++ b/tests/Integration/SDK/Common/InMemoryStorageManagerWithSKDAutoload.php
@@ -24,6 +24,7 @@ class InMemoryStorageManagerWithSKDAutoload extends TestCase
 
     protected LoggerInterface&MockObject $logger;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->logger = $this->createMock(LoggerInterface::class);

--- a/tests/Integration/SDK/LocalRootSpanTest.php
+++ b/tests/Integration/SDK/LocalRootSpanTest.php
@@ -17,6 +17,7 @@ class LocalRootSpanTest extends TestCase
 {
     private SpanInterface $span;
 
+    #[\Override]
     public function setUp(): void
     {
         $tracerProvider = new TracerProvider();

--- a/tests/Integration/SDK/SpanBuilderTest.php
+++ b/tests/Integration/SDK/SpanBuilderTest.php
@@ -40,6 +40,7 @@ class SpanBuilderTest extends MockeryTestCase
     /** @var MockInterface&SpanProcessorInterface  */
     private $spanProcessor;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->spanProcessor = Mockery::spy(SpanProcessorInterface::class);
@@ -335,6 +336,7 @@ class SpanBuilderTest extends MockeryTestCase
     public function test_add_attributes_via_sampler(): void
     {
         $sampler = new class() implements SamplerInterface {
+            #[\Override]
             public function shouldSample(
                 ContextInterface $parentContext,
                 string $traceId,
@@ -346,6 +348,7 @@ class SpanBuilderTest extends MockeryTestCase
                 return new SamplingResult(SamplingResult::RECORD_AND_SAMPLE, ['cat' => 'meow']);
             }
 
+            #[\Override]
             public function getDescription(): string
             {
                 return 'test';

--- a/tests/Unit/API/Baggage/Propagation/ParserTest.php
+++ b/tests/Unit/API/Baggage/Propagation/ParserTest.php
@@ -18,6 +18,7 @@ class ParserTest extends TestCase
     /** @var BaggageBuilderInterface&MockObject */
     private BaggageBuilderInterface $builder;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->builder = $this->createMock(BaggageBuilderInterface::class);

--- a/tests/Unit/API/Behavior/Internal/LogWriterFactoryTest.php
+++ b/tests/Unit/API/Behavior/Internal/LogWriterFactoryTest.php
@@ -21,6 +21,7 @@ class LogWriterFactoryTest extends TestCase
 {
     use TestState;
 
+    #[\Override]
     public function setUp(): void
     {
         LoggerHolder::unset();

--- a/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
@@ -22,6 +22,7 @@ class LogsMessagesTraitTest extends TestCase
 
     protected MockObject $writer;
 
+    #[\Override]
     public function setUp(): void
     {
         Logging::reset();

--- a/tests/Unit/API/Common/Time/ClockTest.php
+++ b/tests/Unit/API/Common/Time/ClockTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Clock::class)]
 class ClockTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         Clock::reset();

--- a/tests/Unit/API/Instrumentation/AutoInstrumentation/ExtensionHookManagerTest.php
+++ b/tests/Unit/API/Instrumentation/AutoInstrumentation/ExtensionHookManagerTest.php
@@ -28,6 +28,7 @@ class ExtensionHookManagerTest extends TestCase
     private HookManagerInterface $hookManager;
     private InstrumentationContext $context;
 
+    #[\Override]
     public function setUp(): void
     {
         if (!extension_loaded('opentelemetry')) {
@@ -46,6 +47,7 @@ class ExtensionHookManagerTest extends TestCase
         );
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         $this->scope->detach();
@@ -133,6 +135,7 @@ class ExtensionHookManagerTest extends TestCase
                 $this->post = $post;
             }
 
+            #[\Override]
             public function register(HookManagerInterface $hookManager, ConfigProperties $configuration, InstrumentationContext $context): void
             {
                 $hookManager->hook($this->class, $this->method, $this->pre, $this->post);

--- a/tests/Unit/API/Instrumentation/AutoInstrumentation/LateBindingProviderTest.php
+++ b/tests/Unit/API/Instrumentation/AutoInstrumentation/LateBindingProviderTest.php
@@ -51,6 +51,7 @@ class LateBindingProviderTest extends TestCase
     use TestState;
     use ProphecyTrait;
 
+    #[\Override]
     public function setUp(): void
     {
         Logging::disable();
@@ -60,6 +61,7 @@ class LateBindingProviderTest extends TestCase
     {
         $instrumentation = new class() implements Instrumentation {
             private static ?Context $context;
+            #[\Override]
             public function register(HookManagerInterface $hookManager, ConfigProperties $configuration, Context $context): void
             {
                 self::$context = $context;

--- a/tests/Unit/API/Instrumentation/ConfigurationResolverTest.php
+++ b/tests/Unit/API/Instrumentation/ConfigurationResolverTest.php
@@ -17,6 +17,7 @@ class ConfigurationResolverTest extends TestCase
 
     private ConfigurationResolver $resolver;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->resolver = new ConfigurationResolver();

--- a/tests/Unit/API/Instrumentation/InstrumentationTest.php
+++ b/tests/Unit/API/Instrumentation/InstrumentationTest.php
@@ -39,12 +39,14 @@ final class InstrumentationTest extends TestCase
 {
     private LogWriterInterface&MockObject $logWriter;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->logWriter = $this->createMock(LogWriterInterface::class);
         Logging::setLogWriter($this->logWriter);
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         Globals::reset();

--- a/tests/Unit/API/Instrumentation/InstrumentationTraitTest.php
+++ b/tests/Unit/API/Instrumentation/InstrumentationTraitTest.php
@@ -128,21 +128,25 @@ class ValidInstrumentation implements InstrumentationInterface
 {
     use InstrumentationTrait;
 
+    #[\Override]
     public function getName(): string
     {
         return InstrumentationTraitTest::INSTRUMENTATION_NAME;
     }
 
+    #[\Override]
     public function getVersion(): ?string
     {
         return InstrumentationTraitTest::INSTRUMENTATION_VERSION;
     }
 
+    #[\Override]
     public function getSchemaUrl(): ?string
     {
         return InstrumentationTraitTest::INSTRUMENTATION_SCHEMA_URL;
     }
 
+    #[\Override]
     public function init(): bool
     {
         return true;
@@ -153,21 +157,25 @@ class InvalidInstrumentation
 {
     use InstrumentationTrait;
 
+    #[\Override]
     public function getName(): string
     {
         return InstrumentationTraitTest::INSTRUMENTATION_NAME;
     }
 
+    #[\Override]
     public function getVersion(): ?string
     {
         return InstrumentationTraitTest::INSTRUMENTATION_VERSION;
     }
 
+    #[\Override]
     public function getSchemaUrl(): ?string
     {
         return InstrumentationTraitTest::INSTRUMENTATION_SCHEMA_URL;
     }
 
+    #[\Override]
     public function init(): bool
     {
         return true;

--- a/tests/Unit/API/Instrumentation/WithSpanHandlerTest.php
+++ b/tests/Unit/API/Instrumentation/WithSpanHandlerTest.php
@@ -23,6 +23,7 @@ class WithSpanHandlerTest extends TestCase
     private ScopeInterface $scope;
     private ArrayObject $storage;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->storage = new ArrayObject();
@@ -37,6 +38,7 @@ class WithSpanHandlerTest extends TestCase
             ->activate();
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         $this->scope->detach();

--- a/tests/Unit/API/LoggerHolderTest.php
+++ b/tests/Unit/API/LoggerHolderTest.php
@@ -13,6 +13,7 @@ use Psr\Log\NullLogger;
 #[CoversClass(LoggerHolder::class)]
 class LoggerHolderTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         LoggerHolder::unset();

--- a/tests/Unit/API/Trace/Propagation/TraceContextPropagatorTest.php
+++ b/tests/Unit/API/Trace/Propagation/TraceContextPropagatorTest.php
@@ -31,6 +31,7 @@ class TraceContextPropagatorTest extends TestCase
     private TraceContextPropagator $traceContextPropagator;
     private TraceStateInterface $traceState;
 
+    #[\Override]
     protected function setUp(): void
     {
         Logging::disable();

--- a/tests/Unit/API/Trace/SpanContextTest.php
+++ b/tests/Unit/API/Trace/SpanContextTest.php
@@ -23,6 +23,7 @@ class SpanContextTest extends TestCase
     private API\SpanContextInterface $second;
     private API\SpanContextInterface $remote;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->first = SpanContext::create(self::FIRST_TRACE_ID, self::FIRST_SPAN_ID, API\TraceFlags::DEFAULT, new TraceState('foo=bar'));

--- a/tests/Unit/API/Trace/TraceStateTest.php
+++ b/tests/Unit/API/Trace/TraceStateTest.php
@@ -22,6 +22,7 @@ class TraceStateTest extends TestCase
 {
     private LoggerInterface $logger;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->logger = $this->createMock(LoggerInterface::class);

--- a/tests/Unit/Config/SDK/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Unit/Config/SDK/Configuration/ConfigurationFactoryTest.php
@@ -30,11 +30,13 @@ final class ConfigurationFactoryTest extends TestCase
     public string $cacheDir;
     public $properties;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->cacheDir = __DIR__ . '/configurations';
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         array_map('unlink', array_filter((array) glob($this->cacheDir . '/*cache*')));
@@ -49,6 +51,7 @@ final class ConfigurationFactoryTest extends TestCase
         $factory = new ConfigurationFactory(
             [],
             new class() implements \OpenTelemetry\API\Configuration\Config\ComponentProvider {
+                #[\Override]
                 public function createPlugin(array $properties, Context $context): mixed
                 {
                     throw new BadMethodCallException();
@@ -57,6 +60,7 @@ final class ConfigurationFactoryTest extends TestCase
                 /**
                  * @psalm-suppress UndefinedInterfaceMethod,PossiblyNullReference
                  */
+                #[\Override]
                 public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
                 {
                     $node = new ArrayNodeDefinition('env_substitution');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Logs/LogRecordExporterConsole.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Logs/LogRecordExporterConsole.php
@@ -17,11 +17,13 @@ final class LogRecordExporterConsole implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordExporter
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('console');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Logs/LogRecordExporterOtlp.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Logs/LogRecordExporterOtlp.php
@@ -27,11 +27,13 @@ final class LogRecordExporterOtlp implements ComponentProvider
      *     timeout: int<0, max>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordExporter
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Logs/LogRecordProcessorBatch.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Logs/LogRecordProcessorBatch.php
@@ -25,11 +25,13 @@ final class LogRecordProcessorBatch implements ComponentProvider
      *     exporter: ComponentPlugin<LogRecordExporter>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordProcessor
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('batch');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Logs/LogRecordProcessorSimple.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Logs/LogRecordProcessorSimple.php
@@ -21,11 +21,13 @@ final class LogRecordProcessorSimple implements ComponentProvider
      *     exporter: ComponentPlugin<LogRecordExporter>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): LogRecordProcessor
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('simple');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverDefault.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverDefault.php
@@ -17,11 +17,13 @@ final class AggregationResolverDefault implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): AggregationResolver
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('default');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverDrop.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverDrop.php
@@ -17,11 +17,13 @@ final class AggregationResolverDrop implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): AggregationResolver
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('drop');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverExplicitBucketHistogram.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverExplicitBucketHistogram.php
@@ -21,11 +21,13 @@ final class AggregationResolverExplicitBucketHistogram implements ComponentProvi
      *     record_min_max: bool,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): AggregationResolver
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('explicit_bucket_histogram');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverLastValue.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverLastValue.php
@@ -17,11 +17,13 @@ final class AggregationResolverLastValue implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): AggregationResolver
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('last_value');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverSum.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/AggregationResolverSum.php
@@ -17,11 +17,13 @@ final class AggregationResolverSum implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): AggregationResolver
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('sum');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricExporterConsole.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricExporterConsole.php
@@ -17,11 +17,13 @@ final class MetricExporterConsole implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporter
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('console');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricExporterOtlp.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricExporterOtlp.php
@@ -29,11 +29,13 @@ final class MetricExporterOtlp implements ComponentProvider
      *     default_histogram_aggregation: 'explicit_bucket_histogram',
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporter
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricExporterPrometheus.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricExporterPrometheus.php
@@ -24,11 +24,13 @@ final class MetricExporterPrometheus implements ComponentProvider
      *     without_scope_info: bool,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricExporter
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('prometheus');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricReaderPeriodic.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricReaderPeriodic.php
@@ -23,11 +23,13 @@ final class MetricReaderPeriodic implements ComponentProvider
      *     exporter: ComponentPlugin<MetricExporter>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricReader
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('periodic');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricReaderPull.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Metrics/MetricReaderPull.php
@@ -21,11 +21,13 @@ final class MetricReaderPull implements ComponentProvider
      *     exporter: ComponentPlugin<MetricExporter>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): MetricReader
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('pull');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/OpenTelemetryConfiguration.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/OpenTelemetryConfiguration.php
@@ -75,11 +75,13 @@ final class OpenTelemetryConfiguration implements ComponentProvider
      *     },
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): Configuration
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('open_telemetry');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorB3.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorB3.php
@@ -17,11 +17,13 @@ final class TextMapPropagatorB3 implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('b3');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorB3Multi.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorB3Multi.php
@@ -17,11 +17,13 @@ final class TextMapPropagatorB3Multi implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('b3multi');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorBaggage.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorBaggage.php
@@ -17,11 +17,13 @@ final class TextMapPropagatorBaggage implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('baggage');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorComposite.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorComposite.php
@@ -18,11 +18,13 @@ final class TextMapPropagatorComposite implements ComponentProvider
     /**
      * @param list<ComponentPlugin<TextMapPropagatorInterface>> $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $registry->componentNames('composite', TextMapPropagatorInterface::class);

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorJaeger.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorJaeger.php
@@ -17,11 +17,13 @@ final class TextMapPropagatorJaeger implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('jaeger');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorOTTrace.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorOTTrace.php
@@ -17,11 +17,13 @@ final class TextMapPropagatorOTTrace implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('ottrace');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorTraceContext.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorTraceContext.php
@@ -17,11 +17,13 @@ final class TextMapPropagatorTraceContext implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('tracecontext');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorXRay.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Propagator/TextMapPropagatorXRay.php
@@ -17,11 +17,13 @@ final class TextMapPropagatorXRay implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): TextMapPropagatorInterface
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('xray');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SamplerAlwaysOff.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SamplerAlwaysOff.php
@@ -17,11 +17,13 @@ final class SamplerAlwaysOff implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): Sampler
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('always_off');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SamplerAlwaysOn.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SamplerAlwaysOn.php
@@ -17,11 +17,13 @@ final class SamplerAlwaysOn implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): Sampler
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('always_on');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SamplerParentBased.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SamplerParentBased.php
@@ -24,11 +24,13 @@ final class SamplerParentBased implements ComponentProvider
      *     local_parent_not_sampled: ?ComponentPlugin<Sampler>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): Sampler
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('parent_based');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SamplerTraceIdRatioBased.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SamplerTraceIdRatioBased.php
@@ -19,11 +19,13 @@ final class SamplerTraceIdRatioBased implements ComponentProvider
      *     ratio: float,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): Sampler
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('trace_id_ratio_based');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanExporterConsole.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanExporterConsole.php
@@ -17,11 +17,13 @@ final class SpanExporterConsole implements ComponentProvider
     /**
      * @param array{} $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporter
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         return $builder->arrayNode('console');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanExporterOtlp.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanExporterOtlp.php
@@ -27,11 +27,13 @@ final class SpanExporterOtlp implements ComponentProvider
      *     timeout: int<0, max>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporter
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('otlp');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanExporterZipkin.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanExporterZipkin.php
@@ -21,11 +21,13 @@ final class SpanExporterZipkin implements ComponentProvider
      *     timeout: int<0, max>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanExporter
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('zipkin');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanProcessorBatch.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanProcessorBatch.php
@@ -25,11 +25,13 @@ final class SpanProcessorBatch implements ComponentProvider
      *     exporter: ComponentPlugin<SpanExporter>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanProcessor
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('batch');

--- a/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanProcessorSimple.php
+++ b/tests/Unit/Config/SDK/Configuration/ExampleSdk/Trace/SpanProcessorSimple.php
@@ -21,11 +21,13 @@ final class SpanProcessorSimple implements ComponentProvider
      *     exporter: ComponentPlugin<SpanExporter>,
      * } $properties
      */
+    #[\Override]
     public function createPlugin(array $properties, Context $context): SpanProcessor
     {
         throw new BadMethodCallException('not implemented');
     }
 
+    #[\Override]
     public function getConfig(ComponentProviderRegistry $registry, NodeBuilder $builder): ArrayNodeDefinition
     {
         $node = $builder->arrayNode('simple');

--- a/tests/Unit/Context/DebugScopeTest.php
+++ b/tests/Unit/Context/DebugScopeTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Context::class)]
 final class DebugScopeTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         set_error_handler(static function (int $errno, string $errstr): never {
@@ -24,6 +25,7 @@ final class DebugScopeTest extends TestCase
         }, E_USER_NOTICE);
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         restore_error_handler();

--- a/tests/Unit/Context/Propagation/MultiTextMapPropagatorTest.php
+++ b/tests/Unit/Context/Propagation/MultiTextMapPropagatorTest.php
@@ -23,6 +23,7 @@ class MultiTextMapPropagatorTest extends MockeryTestCase
     /** @var Mockery\MockInterface&TextMapPropagatorInterface */
     private $propagator3;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->propagator1 = Mockery::mock(TextMapPropagatorInterface::class);

--- a/tests/Unit/Context/Propagation/SanitizeCombinedHeadersPropagationGetterTest.php
+++ b/tests/Unit/Context/Propagation/SanitizeCombinedHeadersPropagationGetterTest.php
@@ -20,6 +20,7 @@ class SanitizeCombinedHeadersPropagationGetterTest extends MockeryTestCase
     /** @var Mockery\MockInterface&ExtendedPropagationGetterInterface */
     private $extendedPropagationGetter;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->propagationGetter = Mockery::mock(PropagationGetterInterface::class);

--- a/tests/Unit/Contrib/Grpc/GrpcTransportTest.php
+++ b/tests/Unit/Contrib/Grpc/GrpcTransportTest.php
@@ -16,6 +16,7 @@ final class GrpcTransportTest extends TestCase
 {
     private GrpcTransport $transport;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->transport = new GrpcTransport('http://localhost:4317', [], '/method', [], 123);

--- a/tests/Unit/Contrib/Otlp/LogsConverterTest.php
+++ b/tests/Unit/Contrib/Otlp/LogsConverterTest.php
@@ -24,6 +24,7 @@ class LogsConverterTest extends TestCase
     private $record;
     private LogsConverter $converter;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->converter = new LogsConverter();

--- a/tests/Unit/Contrib/Otlp/LogsExporterFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/LogsExporterFactoryTest.php
@@ -26,6 +26,7 @@ class LogsExporterFactoryTest extends TestCase
     /** @var TransportInterface&MockObject $record */
     private TransportInterface $transport;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->transportFactory = $this->createMock(TransportFactoryInterface::class);

--- a/tests/Unit/Contrib/Otlp/LogsExporterTest.php
+++ b/tests/Unit/Contrib/Otlp/LogsExporterTest.php
@@ -19,6 +19,7 @@ class LogsExporterTest extends TestCase
     private MockObject $transport;
     private LogsExporter $exporter;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->transport = $this->createMock(TransportInterface::class);

--- a/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/MetricExporterFactoryTest.php
@@ -28,6 +28,7 @@ class MetricExporterFactoryTest extends TestCase
     private TransportFactoryInterface $transportFactory;
     private TransportInterface $transport;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->transportFactory = $this->createMock(TransportFactoryInterface::class);

--- a/tests/Unit/Contrib/Otlp/MetricExporterTest.php
+++ b/tests/Unit/Contrib/Otlp/MetricExporterTest.php
@@ -25,6 +25,7 @@ final class MetricExporterTest extends TestCase
     private $stream;
     private MetricExporter $exporter;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->stream = fopen('php://memory', 'a+b');

--- a/tests/Unit/Contrib/Otlp/OtlpHttpTransportFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/OtlpHttpTransportFactoryTest.php
@@ -14,6 +14,7 @@ class OtlpHttpTransportFactoryTest extends TestCase
 {
     private OtlpHttpTransportFactory $factory;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->factory = new OtlpHttpTransportFactory();

--- a/tests/Unit/Contrib/Otlp/SpanExporterFactoryTest.php
+++ b/tests/Unit/Contrib/Otlp/SpanExporterFactoryTest.php
@@ -25,6 +25,7 @@ class SpanExporterFactoryTest extends TestCase
     private TransportFactoryInterface $transportFactory;
     private TransportInterface $transport;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->transportFactory = $this->createMock(TransportFactoryInterface::class);

--- a/tests/Unit/Contrib/Otlp/SpanExporterTest.php
+++ b/tests/Unit/Contrib/Otlp/SpanExporterTest.php
@@ -24,6 +24,7 @@ class SpanExporterTest extends TestCase
     private MockObject $transport;
     private SpanExporter $exporter;
 
+    #[\Override]
     public function setUp(): void
     {
         Logging::disable();

--- a/tests/Unit/Contrib/Zipkin/ZipkinExporterTest.php
+++ b/tests/Unit/Contrib/Zipkin/ZipkinExporterTest.php
@@ -16,6 +16,7 @@ class ZipkinExporterTest extends AbstractExporterTestCase
     /**
      * @psalm-suppress PossiblyInvalidArgument
      */
+    #[\Override]
     public function createExporterWithTransport(TransportInterface $transport): Exporter
     {
         return new Exporter(
@@ -23,6 +24,7 @@ class ZipkinExporterTest extends AbstractExporterTestCase
         );
     }
 
+    #[\Override]
     public function getExporterClass(): string
     {
         return Exporter::class;

--- a/tests/Unit/Extension/Propagator/B3/B3MultiPropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/B3/B3MultiPropagatorTest.php
@@ -32,6 +32,7 @@ class B3MultiPropagatorTest extends TestCase
 
     private B3MultiPropagator $b3MultiPropagator;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->b3MultiPropagator = B3MultiPropagator::getInstance();

--- a/tests/Unit/Extension/Propagator/B3/B3PropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/B3/B3PropagatorTest.php
@@ -36,6 +36,7 @@ class B3PropagatorTest extends TestCase
     /**
      * @psalm-suppress PossiblyUndefinedArrayOffset
      */
+    #[\Override]
     public function setUp(): void
     {
         [$this->b3] = B3SinglePropagator::getInstance()->fields();

--- a/tests/Unit/Extension/Propagator/B3/B3SinglePropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/B3/B3SinglePropagatorTest.php
@@ -35,6 +35,7 @@ class B3SinglePropagatorTest extends TestCase
     /**
      * @psalm-suppress PossiblyUndefinedArrayOffset
      */
+    #[\Override]
     protected function setUp(): void
     {
         $this->b3SinglePropagator = B3SinglePropagator::getInstance();

--- a/tests/Unit/Extension/Propagator/CloudTrace/CloudTracePropagatorOneWayTest.php
+++ b/tests/Unit/Extension/Propagator/CloudTrace/CloudTracePropagatorOneWayTest.php
@@ -32,6 +32,7 @@ class CloudTracePropagatorOneWayTest extends TestCase
     /**
      * @psalm-suppress PossiblyUndefinedArrayOffset
      */
+    #[\Override]
     protected function setUp(): void
     {
         $this->cloudTracePropagator = CloudTracePropagator::getOneWayInstance();

--- a/tests/Unit/Extension/Propagator/CloudTrace/CloudTracePropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/CloudTrace/CloudTracePropagatorTest.php
@@ -32,6 +32,7 @@ class CloudTracePropagatorTest extends TestCase
     /**
      * @psalm-suppress PossiblyUndefinedArrayOffset
      */
+    #[\Override]
     protected function setUp(): void
     {
         $this->cloudTracePropagator = CloudTracePropagator::getInstance();

--- a/tests/Unit/Extension/Propagator/Jaeger/JaegerBaggagePropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/Jaeger/JaegerBaggagePropagatorTest.php
@@ -16,6 +16,7 @@ class JaegerBaggagePropagatorTest extends TestCase
 {
     private TextMapPropagatorInterface $propagator;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->propagator = JaegerBaggagePropagator::getInstance();

--- a/tests/Unit/Extension/Propagator/Jaeger/JaegerPropagatorTest.php
+++ b/tests/Unit/Extension/Propagator/Jaeger/JaegerPropagatorTest.php
@@ -50,6 +50,7 @@ class JaegerPropagatorTest extends TestCase
     /**
      * @psalm-suppress PossiblyUndefinedArrayOffset
      */
+    #[\Override]
     protected function setUp(): void
     {
         $this->propagator = JaegerPropagator::getInstance();

--- a/tests/Unit/SDK/Common/Adapter/HttpDiscovery/MessageFactoryResolverTest.php
+++ b/tests/Unit/SDK/Common/Adapter/HttpDiscovery/MessageFactoryResolverTest.php
@@ -32,6 +32,7 @@ class MessageFactoryResolverTest extends TestCase
         UriFactoryInterface::class,
     ];
 
+    #[\Override]
     public function setUp(): void
     {
         Psr18ClientDiscovery::prependStrategy(MockClientStrategy::class);

--- a/tests/Unit/SDK/Common/Adapter/HttpDiscovery/PsrClientResolverTest.php
+++ b/tests/Unit/SDK/Common/Adapter/HttpDiscovery/PsrClientResolverTest.php
@@ -14,6 +14,7 @@ use Psr\Http\Client\ClientInterface;
 #[CoversClass(PsrClientResolver::class)]
 class PsrClientResolverTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         HttpClientDiscovery::prependStrategy(MockClientStrategy::class);

--- a/tests/Unit/SDK/Common/Attribute/AttributeValidatorTest.php
+++ b/tests/Unit/SDK/Common/Attribute/AttributeValidatorTest.php
@@ -14,6 +14,7 @@ class AttributeValidatorTest extends TestCase
 {
     private AttributeValidator $validator;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->validator = new AttributeValidator();

--- a/tests/Unit/SDK/Common/Configuration/Resolver/CompositeResolverTest.php
+++ b/tests/Unit/SDK/Common/Configuration/Resolver/CompositeResolverTest.php
@@ -22,6 +22,7 @@ class CompositeResolverTest extends TestCase
     private ResolverInterface $two;
     private CompositeResolver $resolver;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->one = $this->createMock(ResolverInterface::class);

--- a/tests/Unit/SDK/Common/Configuration/Resolver/EnvironmentResolverTest.php
+++ b/tests/Unit/SDK/Common/Configuration/Resolver/EnvironmentResolverTest.php
@@ -25,6 +25,7 @@ class EnvironmentResolverTest extends TestCase
 
     private EnvironmentResolver $resolver;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->resolver = new EnvironmentResolver();

--- a/tests/Unit/SDK/Common/Configuration/Resolver/PhpIniResolverTest.php
+++ b/tests/Unit/SDK/Common/Configuration/Resolver/PhpIniResolverTest.php
@@ -19,6 +19,7 @@ class PhpIniResolverTest extends TestCase
     private PhpIniAccessor $accessor;
     private PhpIniResolver $resolver;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->accessor = $this->createMock(PhpIniAccessor::class);

--- a/tests/Unit/SDK/Common/Dev/Compatibility/UtilTest.php
+++ b/tests/Unit/SDK/Common/Dev/Compatibility/UtilTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Util::class)]
 class UtilTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         set_error_handler(static function (int $errno, string $errstr): never {
@@ -21,6 +22,7 @@ class UtilTest extends TestCase
         }, E_USER_WARNING|E_USER_NOTICE|E_USER_ERROR|E_USER_DEPRECATED);
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         Util::setErrorLevel();

--- a/tests/Unit/SDK/Common/Export/Http/PsrTransportTest.php
+++ b/tests/Unit/SDK/Common/Export/Http/PsrTransportTest.php
@@ -30,6 +30,7 @@ final class PsrTransportTest extends TestCase
     private MockObject $client;
     private PsrTransportFactory $factory;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->client = $this->createMock(ClientInterface::class);
@@ -157,6 +158,7 @@ final class PsrTransportTest extends TestCase
     public function test_send_retry_network_exception_returns_error(): void
     {
         $e = new class('network error') extends \Exception implements NetworkExceptionInterface {
+            #[\Override]
             public function getRequest(): RequestInterface
             {
                 return new Request('GET', 'http://localhost');

--- a/tests/Unit/SDK/Common/Http/Psr/Client/Discovery/BuzzTest.php
+++ b/tests/Unit/SDK/Common/Http/Psr/Client/Discovery/BuzzTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Buzz::class)]
 class BuzzTest extends AbstractDiscoveryTestCase
 {
+    #[\Override]
     public function getInstance(): DiscoveryInterface
     {
         return new Buzz();

--- a/tests/Unit/SDK/Common/Http/Psr/Client/Discovery/CurlClientTest.php
+++ b/tests/Unit/SDK/Common/Http/Psr/Client/Discovery/CurlClientTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(CurlClient::class)]
 class CurlClientTest extends AbstractDiscoveryTestCase
 {
+    #[\Override]
     public function getInstance(): DiscoveryInterface
     {
         return new CurlClient();

--- a/tests/Unit/SDK/Common/Http/Psr/Client/Discovery/GuzzleTest.php
+++ b/tests/Unit/SDK/Common/Http/Psr/Client/Discovery/GuzzleTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Guzzle::class)]
 class GuzzleTest extends AbstractDiscoveryTestCase
 {
+    #[\Override]
     public function getInstance(): DiscoveryInterface
     {
         return new Guzzle();

--- a/tests/Unit/SDK/Common/Http/Psr/Client/Discovery/SymfonyTest.php
+++ b/tests/Unit/SDK/Common/Http/Psr/Client/Discovery/SymfonyTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Symfony::class)]
 class SymfonyTest extends AbstractDiscoveryTestCase
 {
+    #[\Override]
     public function getInstance(): DiscoveryInterface
     {
         return new Symfony();

--- a/tests/Unit/SDK/Common/InstrumentationScope/ConfigTest.php
+++ b/tests/Unit/SDK/Common/InstrumentationScope/ConfigTest.php
@@ -16,6 +16,7 @@ class ConfigTest extends TestCase
 {
     private Config $config;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->config = new class() implements Config {

--- a/tests/Unit/SDK/Common/InstrumentationScope/ConfiguratorTest.php
+++ b/tests/Unit/SDK/Common/InstrumentationScope/ConfiguratorTest.php
@@ -17,14 +17,17 @@ class ConfiguratorTest extends TestCase
     private Configurator $configurator;
     private InstrumentationScope $scope;
 
+    #[\Override]
     public function setUp(): void
     {
         $config = new class() implements Config {
             private bool $disabled = false;
+            #[\Override]
             public function setDisabled(bool $disabled): void
             {
                 $this->disabled = $disabled;
             }
+            #[\Override]
             public function isEnabled(): bool
             {
                 return $this->disabled === false;

--- a/tests/Unit/SDK/Logs/EventLoggerProviderTest.php
+++ b/tests/Unit/SDK/Logs/EventLoggerProviderTest.php
@@ -19,6 +19,7 @@ class EventLoggerProviderTest extends TestCase
     private LoggerProviderInterface $loggerProvider;
     private LoggerInterface $logger;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->loggerProvider = $this->createMock(LoggerProviderInterface::class);

--- a/tests/Unit/SDK/Logs/EventLoggerTest.php
+++ b/tests/Unit/SDK/Logs/EventLoggerTest.php
@@ -24,6 +24,7 @@ class EventLoggerTest extends TestCase
     private EventLoggerProvider $eventLoggerProvider;
     private TestClock $clock;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->clock = new TestClock();

--- a/tests/Unit/SDK/Logs/Exporter/ConsoleExporterTest.php
+++ b/tests/Unit/SDK/Logs/Exporter/ConsoleExporterTest.php
@@ -22,6 +22,7 @@ class ConsoleExporterTest extends TestCase
     private TransportInterface $transport;
     private ConsoleExporter $exporter;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->transport = $this->createMock(TransportInterface::class);

--- a/tests/Unit/SDK/Logs/Exporter/NoopExporterTest.php
+++ b/tests/Unit/SDK/Logs/Exporter/NoopExporterTest.php
@@ -13,6 +13,7 @@ class NoopExporterTest extends TestCase
 {
     private NoopExporter $exporter;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->exporter = new NoopExporter();

--- a/tests/Unit/SDK/Logs/LoggerProviderTest.php
+++ b/tests/Unit/SDK/Logs/LoggerProviderTest.php
@@ -32,6 +32,7 @@ class LoggerProviderTest extends TestCase
     /** @var Config&MockObject */
     private Config $config;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->processor = $this->createMock(LogRecordProcessorInterface::class);

--- a/tests/Unit/SDK/Logs/LoggerSharedStateTest.php
+++ b/tests/Unit/SDK/Logs/LoggerSharedStateTest.php
@@ -22,6 +22,7 @@ class LoggerSharedStateTest extends TestCase
     private LogRecordLimits $limits;
     private LoggerSharedState $loggerSharedState;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->resource = $this->createMock(ResourceInfo::class);

--- a/tests/Unit/SDK/Logs/LoggerTest.php
+++ b/tests/Unit/SDK/Logs/LoggerTest.php
@@ -33,6 +33,7 @@ class LoggerTest extends TestCase
     private LogRecordProcessorInterface $processor;
     private InstrumentationScope $scope;
 
+    #[\Override]
     public function setUp(): void
     {
         $limits = (new LogRecordLimitsBuilder())->setAttributeCountLimit(1)->build();
@@ -46,6 +47,7 @@ class LoggerTest extends TestCase
         Logging::setLogWriter($this->logWriter);
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         Logging::reset();

--- a/tests/Unit/SDK/Logs/Processor/BatchLogRecordProcessorTest.php
+++ b/tests/Unit/SDK/Logs/Processor/BatchLogRecordProcessorTest.php
@@ -39,6 +39,7 @@ class BatchLogRecordProcessorTest extends MockeryTestCase
     /** @var LogWriterInterface&MockObject $logWriter */
     private LogWriterInterface $logWriter;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->logWriter = $this->createMock(LogWriterInterface::class);

--- a/tests/Unit/SDK/Logs/Processor/MultiLogRecordProcessorTest.php
+++ b/tests/Unit/SDK/Logs/Processor/MultiLogRecordProcessorTest.php
@@ -19,6 +19,7 @@ class MultiLogRecordProcessorTest extends MockeryTestCase
     private array $processors;
     private MultiLogRecordProcessor $multi;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->processors = [

--- a/tests/Unit/SDK/Logs/Processor/SimpleLogRecordProcessorTest.php
+++ b/tests/Unit/SDK/Logs/Processor/SimpleLogRecordProcessorTest.php
@@ -23,6 +23,7 @@ class SimpleLogRecordProcessorTest extends TestCase
     private LogRecordExporterInterface $exporter;
     private ReadWriteLogRecord $readWriteLogRecord;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->exporter = $this->createMock(LogRecordExporterInterface::class);

--- a/tests/Unit/SDK/Logs/ReadableLogRecordTest.php
+++ b/tests/Unit/SDK/Logs/ReadableLogRecordTest.php
@@ -23,6 +23,7 @@ class ReadableLogRecordTest extends TestCase
     private ContextInterface $context;
     private LoggerSharedState $sharedState;
     private ResourceInfo $resource;
+    #[\Override]
     public function setUp(): void
     {
         $this->scope = $this->createMock(InstrumentationScopeInterface::class);

--- a/tests/Unit/SDK/Logs/SimplePsrFileLoggerTest.php
+++ b/tests/Unit/SDK/Logs/SimplePsrFileLoggerTest.php
@@ -33,6 +33,7 @@ class SimplePsrFileLoggerTest extends TestCase
     private SimplePsrFileLogger $logger;
     private vfsStreamDirectory $root;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->root = vfsStream::setup(self::ROOT_DIR);

--- a/tests/Unit/SDK/Metrics/MeterProviderFactoryTest.php
+++ b/tests/Unit/SDK/Metrics/MeterProviderFactoryTest.php
@@ -19,6 +19,7 @@ class MeterProviderFactoryTest extends TestCase
 {
     use TestState;
 
+    #[\Override]
     public function setUp(): void
     {
         Logging::disable();

--- a/tests/Unit/SDK/Metrics/MetricFactory/StreamFactoryTest.php
+++ b/tests/Unit/SDK/Metrics/MetricFactory/StreamFactoryTest.php
@@ -171,6 +171,7 @@ final class CollectingSourceRegistry implements MetricSourceRegistryInterface
     /**
      * @psalm-suppress InvalidPropertyAssignmentValue
      */
+    #[\Override]
     public function add(MetricSourceProviderInterface $provider, MetricMetadataInterface $metadata, StalenessHandlerInterface $stalenessHandler): void
     {
         $this->sources[] = func_get_args();

--- a/tests/Unit/SDK/Metrics/Stream/MetricStreamTest.php
+++ b/tests/Unit/SDK/Metrics/Stream/MetricStreamTest.php
@@ -45,6 +45,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(AttributesFactory::class)]
 final class MetricStreamTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         Logging::disable();

--- a/tests/Unit/SDK/Propagation/PropagatorFactoryTest.php
+++ b/tests/Unit/SDK/Propagation/PropagatorFactoryTest.php
@@ -27,6 +27,7 @@ class PropagatorFactoryTest extends TestCase
 {
     use TestState;
 
+    #[\Override]
     public function setUp(): void
     {
         LoggerHolder::disable();

--- a/tests/Unit/SDK/Resource/Detectors/EnvironmentTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/EnvironmentTest.php
@@ -18,6 +18,7 @@ class EnvironmentTest extends TestCase
 
     private Environment $detector;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->detector = new Environment();

--- a/tests/Unit/SDK/Resource/Detectors/HostTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/HostTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Host::class)]
 class HostTest extends TestCase
 {
+    #[\Override]
     public function setUp(): void
     {
         //reset vfs between tests

--- a/tests/Unit/SDK/Resource/Detectors/SdkTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/SdkTest.php
@@ -19,6 +19,7 @@ class SdkTest extends TestCase
 
     private ResourceDetectorInterface $detector;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->detector = new Sdk();

--- a/tests/Unit/SDK/Resource/Detectors/ServiceTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ServiceTest.php
@@ -19,6 +19,7 @@ class ServiceTest extends TestCase
 
     private Detectors\Service $detector;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->detector = new Detectors\Service();

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -30,6 +30,7 @@ class ResourceInfoFactoryTest extends TestCase
     private LogWriterInterface $logWriter;
     private const UNDEFINED = '__undefined';
 
+    #[\Override]
     public function setUp(): void
     {
         $this->logWriter = $this->createMock(LogWriterInterface::class);

--- a/tests/Unit/SDK/Resource/ResourceInfoTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoTest.php
@@ -23,6 +23,7 @@ class ResourceInfoTest extends TestCase
 {
     use TestState;
 
+    #[\Override]
     public function setUp(): void
     {
         Logging::disable();

--- a/tests/Unit/SDK/SdkAutoloaderTest.php
+++ b/tests/Unit/SDK/SdkAutoloaderTest.php
@@ -33,6 +33,7 @@ class SdkAutoloaderTest extends TestCase
      */
     private LoggerInterface $logger;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->logger = $this->createMock(LoggerInterface::class);

--- a/tests/Unit/SDK/SdkBuilderTest.php
+++ b/tests/Unit/SDK/SdkBuilderTest.php
@@ -24,6 +24,7 @@ class SdkBuilderTest extends TestCase
     private EventLoggerProviderInterface $eventLoggerProvider;
     private SdkBuilder $builder;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->propagator = $this->createMock(TextMapPropagatorInterface::class);

--- a/tests/Unit/SDK/SdkTest.php
+++ b/tests/Unit/SDK/SdkTest.php
@@ -28,6 +28,7 @@ class SdkTest extends TestCase
     private LoggerProviderInterface $loggerProvider;
     private EventLoggerProviderInterface $eventLoggerProvider;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->propagator = $this->createMock(TextMapPropagatorInterface::class);
@@ -37,6 +38,7 @@ class SdkTest extends TestCase
         $this->eventLoggerProvider = $this->createMock(EventLoggerProviderInterface::class);
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         self::restoreEnvironmentVariables();

--- a/tests/Unit/SDK/Trace/AutoRootSpanTest.php
+++ b/tests/Unit/SDK/Trace/AutoRootSpanTest.php
@@ -35,6 +35,7 @@ class AutoRootSpanTest extends TestCase
     private TracerInterface $tracer;
     private ScopeInterface $scope;
 
+    #[\Override]
     public function setUp(): void
     {
         $tracerProvider = $this->createMock(TracerProviderInterface::class);
@@ -47,6 +48,7 @@ class AutoRootSpanTest extends TestCase
             ->activate();
     }
 
+    #[\Override]
     public function tearDown(): void
     {
         $this->scope->detach();

--- a/tests/Unit/SDK/Trace/ExporterFactoryTest.php
+++ b/tests/Unit/SDK/Trace/ExporterFactoryTest.php
@@ -21,6 +21,7 @@ class ExporterFactoryTest extends TestCase
 {
     use TestState;
 
+    #[\Override]
     public function setUp(): void
     {
         Psr18ClientDiscovery::prependStrategy(MockClientStrategy::class);

--- a/tests/Unit/SDK/Trace/ImmutableSpanTest.php
+++ b/tests/Unit/SDK/Trace/ImmutableSpanTest.php
@@ -34,6 +34,7 @@ class ImmutableSpanTest extends TestCase
     private int $totalRecordedEvents = 1;
     private int $totalRecordedLinks = 1;
 
+    #[\Override]
     protected function setUp():void
     {
         $this->context = $this->createMock(API\SpanContextInterface::class);

--- a/tests/Unit/SDK/Trace/LinkTest.php
+++ b/tests/Unit/SDK/Trace/LinkTest.php
@@ -16,6 +16,7 @@ class LinkTest extends TestCase
     private API\SpanContextInterface $context;
     private AttributesInterface $attributes;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->context = $this->createMock(API\SpanContextInterface::class);

--- a/tests/Unit/SDK/Trace/Sampler/ParentBasedTest.php
+++ b/tests/Unit/SDK/Trace/Sampler/ParentBasedTest.php
@@ -24,6 +24,7 @@ class ParentBasedTest extends MockeryTestCase
 {
     private SamplerInterface $rootSampler;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->rootSampler = $this->createMock(SamplerInterface::class);

--- a/tests/Unit/SDK/Trace/SpanBuilderTest.php
+++ b/tests/Unit/SDK/Trace/SpanBuilderTest.php
@@ -34,6 +34,7 @@ class SpanBuilderTest extends TestCase
     private IdGeneratorInterface $idGenerator;
     /** @var SpanProcessorInterface&MockObject $spanProcessor */
     private SpanProcessorInterface $spanProcessor;
+    #[\Override]
     public function setUp(): void
     {
         $instrumentationScope = new InstrumentationScope(

--- a/tests/Unit/SDK/Trace/SpanExporter/AbstractExporterTestCase.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/AbstractExporterTestCase.php
@@ -23,6 +23,7 @@ abstract class AbstractExporterTestCase extends MockeryTestCase
     protected TransportInterface $transport;
     protected FutureInterface $future;
 
+    #[\Override]
     public function setUp(): void
     {
         Logging::disable();

--- a/tests/Unit/SDK/Trace/SpanExporter/ConsoleSpanExporterTest.php
+++ b/tests/Unit/SDK/Trace/SpanExporter/ConsoleSpanExporterTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(ConsoleSpanExporter::class)]
 class ConsoleSpanExporterTest extends AbstractExporterTestCase
 {
+    #[\Override]
     public function createExporter(): ConsoleSpanExporter
     {
         return new ConsoleSpanExporter($this->transport);
@@ -77,11 +78,13 @@ class ConsoleSpanExporterTest extends AbstractExporterTestCase
         $this->transport->shouldHaveReceived('send')->with($expected);
     }
 
+    #[\Override]
     public function createExporterWithTransport(TransportInterface $transport): SpanExporterInterface
     {
         return new ConsoleSpanExporter($transport);
     }
 
+    #[\Override]
     public function getExporterClass(): string
     {
         return ConsoleSpanExporter::class;

--- a/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/BatchSpanProcessorTest.php
@@ -43,6 +43,7 @@ class BatchSpanProcessorTest extends MockeryTestCase
     /** @var LogWriterInterface&MockObject $logWriter */
     private LogWriterInterface $logWriter;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->logWriter = $this->createMock(LogWriterInterface::class);

--- a/tests/Unit/SDK/Trace/SpanProcessor/SimpleSpanProcessorTest.php
+++ b/tests/Unit/SDK/Trace/SpanProcessor/SimpleSpanProcessorTest.php
@@ -44,6 +44,7 @@ class SimpleSpanProcessorTest extends MockeryTestCase
     private SpanContextInterface $sampledSpanContext;
     private SpanContextInterface $nonSampledSpanContext;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->logWriter = $this->createMock(LogWriterInterface::class);

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -831,8 +831,8 @@ class SpanTest extends MockeryTestCase
     }
 
     /**
-     * @psalm-param API\SpanKind::KIND_* $kind
      * @param list<LinkInterface> $links
+     * @psalm-param API\SpanKind::KIND_* $kind
      */
     private function createTestSpan(
         int $kind = API\SpanKind::KIND_INTERNAL,

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -77,6 +77,7 @@ class SpanTest extends MockeryTestCase
     private string $spanId;
     private string $parentSpanId;
 
+    #[\Override]
     protected function setUp():void
     {
         $this->idGenerator = new RandomIdGenerator();

--- a/tests/Unit/SDK/Trace/TracerProviderFactoryTest.php
+++ b/tests/Unit/SDK/Trace/TracerProviderFactoryTest.php
@@ -24,6 +24,7 @@ class TracerProviderFactoryTest extends TestCase
     /** @var LogWriterInterface&MockObject $logWriter */
     private LogWriterInterface $logWriter;
 
+    #[\Override]
     public function setUp(): void
     {
         $this->logWriter = $this->createMock(LogWriterInterface::class);

--- a/tests/Unit/SDK/Trace/TracerSharedStateTest.php
+++ b/tests/Unit/SDK/Trace/TracerSharedStateTest.php
@@ -23,6 +23,7 @@ class TracerSharedStateTest extends TestCase
     private SamplerInterface $sampler;
     private SpanLimits $spanLimits;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->idGenerator = $this->createMock(IdGeneratorInterface::class);

--- a/tests/Unit/SDK/Trace/TracerTest.php
+++ b/tests/Unit/SDK/Trace/TracerTest.php
@@ -20,6 +20,7 @@ class TracerTest extends TestCase
     private TracerSharedState $tracerSharedState;
     private InstrumentationScope $instrumentationScope;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->tracerSharedState = $this->createMock(TracerSharedState::class);

--- a/tests/Unit/SDK/Util/SpanData.php
+++ b/tests/Unit/SDK/Util/SpanData.php
@@ -54,6 +54,7 @@ class SpanData implements SDK\SpanDataInterface
         $this->parentContext = API\SpanContext::getInvalid();
     }
 
+    #[\Override]
     public function getName(): string
     {
         return $this->name;
@@ -68,6 +69,7 @@ class SpanData implements SDK\SpanDataInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getLinks(): array
     {
         return $this->links;
@@ -89,6 +91,7 @@ class SpanData implements SDK\SpanDataInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function getEvents(): array
     {
         return $this->events;
@@ -109,6 +112,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getAttributes(): AttributesInterface
     {
         return $this->attributesBuilder->build();
@@ -121,6 +125,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getTotalDroppedEvents(): int
     {
         return max(0, $this->totalRecordedEvents - count($this->events));
@@ -133,6 +138,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getTotalDroppedLinks(): int
     {
         return max(0, $this->totalRecordedLinks - count($this->links));
@@ -145,6 +151,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getKind(): int
     {
         return $this->kind;
@@ -157,6 +164,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getStatus(): StatusData
     {
         return $this->status;
@@ -169,6 +177,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getEndEpochNanos(): int
     {
         return $this->endEpochNanos;
@@ -181,6 +190,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getStartEpochNanos(): int
     {
         return $this->startEpochNanos;
@@ -193,6 +203,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function hasEnded(): bool
     {
         return $this->hasEnded;
@@ -205,6 +216,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getResource(): ResourceInfo
     {
         return $this->resource;
@@ -217,6 +229,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getInstrumentationScope(): InstrumentationScope
     {
         return $this->instrumentationScope;
@@ -229,6 +242,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getContext(): API\SpanContextInterface
     {
         return $this->context;
@@ -241,6 +255,7 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getParentContext(): API\SpanContextInterface
     {
         return $this->parentContext;
@@ -253,16 +268,19 @@ class SpanData implements SDK\SpanDataInterface
         return $this;
     }
 
+    #[\Override]
     public function getTraceId(): string
     {
         return $this->getContext()->getTraceId();
     }
 
+    #[\Override]
     public function getSpanId(): string
     {
         return $this->getContext()->getSpanId();
     }
 
+    #[\Override]
     public function getParentSpanId(): string
     {
         return $this->getParentContext()->getSpanId();

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,7 +1,7 @@
 {
     "require-dev": {
-        "vimeo/psalm": "^5.24",
+        "vimeo/psalm": "^6",
         "psalm/plugin-mockery": "^1",
-        "psalm/plugin-phpunit": "^0.18.4"
+        "psalm/plugin-phpunit": "^0.19"
     }
 }


### PR DESCRIPTION
To fix up the big list of psalm complaints in our github actions, upgrade psalm to latest. This fixes the issues complaining about repeated attributes, but also has some new things to complain about:
- add Override attributes as required (using rector and psalm to do the work - psalm picked up a bunch that rector missed)
- add symfony/polyfill-php83 to provide Override for earlier PHP versions
- add symfony/polyfill-php84 for good measure
- be explicit about operations on int|float (if either operand is a float, cast both to float)