### PR TITLE
update collector to listen on all interfaces

### DIFF
--- a/files/collector/otel-collector-config.yml
+++ b/files/collector/otel-collector-config.yml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: "0.0.0.0:4317"
       http:
+        endpoint: "0.0.0.0:4318"
   zipkin:
 
 exporters:


### PR DESCRIPTION
by default, the collector only listens on localhost now, and so is not reachable from dev containers when running examples