### PR TITLE
Allow installing SDK with API v1.5

### DIFF
--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.1",
         "ext-json": "*",
         "nyholm/psr7-server": "^1.1",
-        "open-telemetry/api": "~1.4.0",
+        "open-telemetry/api": "^1.4",
         "open-telemetry/context": "^1.0",
         "open-telemetry/sem-conv": "^1.0",
         "php-http/discovery": "^1.14",


### PR DESCRIPTION
Currently `open-telemetry/sdk` locks `open-telemetry/api` at `1.4.0` and does not allow upgrades to `1.5.0` due to incorrect version constraint. Fixes #1706 


```
  Problem 1
    - Root composer.json requires open-telemetry/sdk ^1.7 -> satisfiable by open-telemetry/sdk[1.7.0].
    - open-telemetry/sdk 1.7.0 requires open-telemetry/api ~1.4.0 -> found open-telemetry/api[1.4.0] but the package is fixed to 1.5.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
  Problem 2
    - open-telemetry/exporter-otlp is locked to version 1.3.2 and an update of this package was not requested.
    - open-telemetry/exporter-otlp 1.3.2 requires open-telemetry/sdk ^1.0 -> satisfiable by open-telemetry/sdk[1.7.0].
    - open-telemetry/sdk 1.7.0 requires open-telemetry/api ~1.4.0 -> found open-telemetry/api[1.4.0] but the package is fixed to 1.5.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```

the only way to update at the moment is to downgrade the API package:
```
$ composer u open-telemetry/sdk -W
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Downgrading open-telemetry/api (1.5.0 => 1.4.0)
  - Upgrading open-telemetry/sdk (1.5.0 => 1.7.0)
Writing lock file
```