### PR TITLE
Added sqlite3 for tests in contrib that depend on it

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get install -y \
     php${PHP_VERSION}-rdkafka \
     php${PHP_VERSION}-mysqli \
     php${PHP_VERSION}-pgsql \
+    php${PHP_VERSION}-sqlite3 \
     unzip
 
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer


### PR DESCRIPTION
Added missing sqlite3 dependency for local testing.

eg:

`make test PROJECT=Instrumentation/Laravel PHP_VERSION=8.1` produced the following:


<img width="1176" height="314" alt="image" src="https://github.com/user-attachments/assets/eb84f91c-5a8f-4ebd-89b7-fc8aa8705a1f" />


