### PR TITLE
Chore: fix docs url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "OpenTelemetry makes robust, portable telemetry a built-in feature of cloud-native software.",
     "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "logging", "metrics"],
     "type": "library",
-    "homepage": "https://opentelemetry.io/docs/php",
+    "homepage": "https://opentelemetry.io/docs/languages/php",
     "readme": "./README.md",
     "license": "Apache-2.0",
     "require": {

--- a/examples/traces/demo/src/composer.json
+++ b/examples/traces/demo/src/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "open-telemetry/distributed-tracing-example",
   "type": "application",
-  "homepage": "https://opentelemetry.io/docs/php",
+  "homepage": "https://opentelemetry.io/docs/languages/php",
   "license": "Apache-2.0",
   "repositories": [
     {

--- a/proto/otel/composer.json
+++ b/proto/otel/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",

--- a/src/API/composer.json
+++ b/src/API/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",

--- a/src/Config/SDK/composer.json
+++ b/src/Config/SDK/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",

--- a/src/Context/composer.json
+++ b/src/Context/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",

--- a/src/Contrib/Grpc/composer.json
+++ b/src/Contrib/Grpc/composer.json
@@ -6,7 +6,7 @@
   "support": {
     "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
     "source": "https://github.com/open-telemetry/opentelemetry-php",
-    "docs": "https://opentelemetry.io/docs/php",
+    "docs": "https://opentelemetry.io/docs/languages/php",
     "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
   },
   "license": "Apache-2.0",

--- a/src/Contrib/Otlp/composer.json
+++ b/src/Contrib/Otlp/composer.json
@@ -6,7 +6,7 @@
   "support": {
     "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
     "source": "https://github.com/open-telemetry/opentelemetry-php",
-    "docs": "https://opentelemetry.io/docs/php",
+    "docs": "https://opentelemetry.io/docs/languages/php",
     "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
   },
   "license": "Apache-2.0",

--- a/src/Contrib/Zipkin/composer.json
+++ b/src/Contrib/Zipkin/composer.json
@@ -6,7 +6,7 @@
   "support": {
     "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
     "source": "https://github.com/open-telemetry/opentelemetry-php",
-    "docs": "https://opentelemetry.io/docs/php",
+    "docs": "https://opentelemetry.io/docs/languages/php",
     "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
   },
   "license": "Apache-2.0",

--- a/src/Extension/Propagator/B3/composer.json
+++ b/src/Extension/Propagator/B3/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",

--- a/src/Extension/Propagator/CloudTrace/composer.json
+++ b/src/Extension/Propagator/CloudTrace/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",

--- a/src/Extension/Propagator/Jaeger/composer.json
+++ b/src/Extension/Propagator/Jaeger/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",

--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",

--- a/src/SemConv/composer.json
+++ b/src/SemConv/composer.json
@@ -6,7 +6,7 @@
     "support": {
         "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
         "source": "https://github.com/open-telemetry/opentelemetry-php",
-        "docs": "https://opentelemetry.io/docs/php",
+        "docs": "https://opentelemetry.io/docs/languages/php",
         "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V"
     },
     "license": "Apache-2.0",


### PR DESCRIPTION
When on packagist having followed a link from a colleague, clicked on the homepage and got a bit of a deadlink. So instead of moaning about it or ignoring it, created this PR.

Think this adheres to all the contributing rules (and yes, this does look like a lot like https://github.com/open-telemetry/opentelemetry-php-contrib/pull/448)