### PR TITLE
chore: Add clo monitor exemption for artifact hub

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,4 @@
+# see https://github.com/cncf/clomonitor/blob/main/docs/checks.md#exemptions
+exemptions:
+  - check: artifacthub_badge
+    reason: "Artifact Hub doesn't support php packages"


### PR DESCRIPTION
This defines a .clomonitor.yml file which is used by [clo monitor](https://clomonitor.io/projects/cncf/open-telemetry#opentelemetry-network).

This file contains an exemption for artifact hub as artifact's produced by this library are not supported by artifact hub. By including the exemption we can improve the score for this project and the organisation. File contents have been copied from other repos where the exemption has been applied.