### PR TITLE
chore: Add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-php.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-php?ref=badge_shield&issueType=license)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-php.svg?type=shield&issueType=security)](https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fopen-telemetry%2Fopentelemetry-php?ref=badge_shield&issueType=security)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/open-telemetry/opentelemetry-php/badge)](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-php)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11534/badge)](https://www.bestpractices.dev/projects/11534)
 
 This is the **[monorepo](https://en.wikipedia.org/wiki/Monorepo)** for the **main** components of [OpenTelemetry](https://opentelemetry.io/) for PHP.
 


### PR DESCRIPTION
This adds the ossf scorecard badge to the readme to improve the clo monitor score and make it easily accessible to those interested.

~~Can a maintainer register this repo on https://www.bestpractices.dev/en/projects?q=Opentelemetry & we can add that badge as part of this PR.~~

Also added is the fossa badges & best practices badge which also improves the clo monitor score.