### PR TITLE
chore: Add exemption for recent release

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -2,3 +2,5 @@
 exemptions:
   - check: artifacthub_badge
     reason: "Artifact Hub doesn't support php packages"
+  - check: recent_release
+    reason: "Packages are individually tagged in read-only mirror repositories under https://github.com/opentelemetry-php"


### PR DESCRIPTION
This adds an exemption for the recent release check which is required due to releases being tagged in a different repository.

Once confirmed this will be replicated into the contrib repo.