### PR TITLE
Fix getLabel() deprecation warning with Protobuf 4.33+

### DIFF
--- a/src/Contrib/Otlp/ProtobufSerializer.php
+++ b/src/Contrib/Otlp/ProtobufSerializer.php
@@ -10,7 +10,6 @@ use Exception;
 use Google\Protobuf\Descriptor;
 use Google\Protobuf\DescriptorPool;
 use Google\Protobuf\FieldDescriptor;
-use Google\Protobuf\Internal\GPBLabel;
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\Message;
 use InvalidArgumentException;


### PR DESCRIPTION
getLabel is deprecated. Use isRequired or isRepeated instead.