### PR TITLE
Fix missing Symfony ^8.0 dependency declaration

### DIFF
--- a/src/Config/SDK/Configuration/Environment/Adapter/SymfonyDotenvProvider.php
+++ b/src/Config/SDK/Configuration/Environment/Adapter/SymfonyDotenvProvider.php
@@ -13,7 +13,7 @@ use OpenTelemetry\Config\SDK\Configuration\Environment\EnvSourceProvider;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Dotenv\Exception\PathException;
 
-#[PackageDependency('symfony/dotenv', '^5.4 || ^6.4 || ^7.0')]
+#[PackageDependency('symfony/dotenv', '^5.4 || ^6.4 || ^7.0 || ^8.0')]
 final class SymfonyDotenvProvider implements EnvSourceProvider
 {
     /** @psalm-suppress UndefinedClass */


### PR DESCRIPTION
Symfony 8 support has been added earlier but the Symfony dotenv provider did not yet declare that it supports `symfony/dotenv:^8.0`. This means that otel setups that rely on loading the configuration from a `.env.dev` won't work as the Symfony dotenv provider won't be one included. This addition should fix that.