### PR TITLE
Handle env substitution escape sequences

### DIFF
--- a/src/Config/SDK/Configuration/Internal/EnvSubstitutionNormalization.php
+++ b/src/Config/SDK/Configuration/Internal/EnvSubstitutionNormalization.php
@@ -13,7 +13,6 @@ use function filter_var;
 use function is_array;
 use function is_string;
 use OpenTelemetry\Config\SDK\Configuration\Environment\EnvReader;
-use function preg_replace_callback;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\FloatNodeDefinition;
@@ -64,15 +63,9 @@ final class EnvSubstitutionNormalization implements Normalization
 
     private function replaceEnvVariables(string $value, int $filter = FILTER_DEFAULT): mixed
     {
-        $replaced = preg_replace_callback(
-            '/\$\{(?:env:)?(?<ENV_NAME>[a-zA-Z_]\w*)(?::-(?<DEFAULT_VALUE>[^\n]*))?}/',
-            fn (array $matches): string => $this->envReader->read($matches['ENV_NAME']) ?? $matches['DEFAULT_VALUE'] ?? '',
-            $value,
-            -1,
-            $count,
-        );
+        $replaced = Substitution::process($value, $this->envReader);
 
-        if (!$count) {
+        if ($value === $replaced) {
             return $value;
         }
         if ($replaced === '') {

--- a/src/Config/SDK/Configuration/Internal/Substitution.php
+++ b/src/Config/SDK/Configuration/Internal/Substitution.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Config\SDK\Configuration\Internal;
+
+use Closure;
+use InvalidArgumentException;
+use function levenshtein;
+use OpenTelemetry\Config\SDK\Configuration\Environment\EnvReader;
+use OpenTelemetry\Config\SDK\Configuration\Environment\EnvSourceReader;
+use function preg_match;
+use function strcspn;
+use function strlen;
+use function strpos;
+use function strrpos;
+use function strtolower;
+use function substr;
+use function substr_count;
+
+/**
+ * @internal
+ */
+final class Substitution
+{
+    public static function process(string $s, EnvReader $envReader): string
+    {
+        if (!str_contains($s, '$')) {
+            return $s;
+        }
+
+        $r = '';
+        $terminalSink = static function (string $s, int $i, int $n) use (&$r): void {
+            $r .= substr($s, $i, $n - $i);
+        };
+        $substitutionSink = static fn (string $s, int $i, int $n) => self::processSubstitution($s, $i, $n, $envReader, $terminalSink);
+        $escapeSequenceSink = static fn (string $s, int $i, int $n) => self::processEscapeSequence($s, $i, $n, $substitutionSink);
+
+        $escapeSequenceSink($s, 0, strlen($s));
+
+        return $r;
+    }
+
+    public static function processEscapeSequence(string $s, int $i, int $n, Closure $sink): void
+    {
+        for ($t = $i; ($p = strcspn($s, '$', $t, $n - $t - 1) + $t + 1) < $n; $t = $p + 1) {
+            if ($s[$p] !== '$') {
+                continue;
+            }
+
+            $sink($s, $i, $p - 1);
+            $sink('$', 0, 1);
+            $i = $p + 1;
+        }
+        $sink($s, $i, $n);
+    }
+
+    public static function processSubstitution(string $s, int $i, int $n, EnvReader $envReader, Closure $sink): void
+    {
+        for ($t = $i; ($p = strcspn($s, '$', $t, $n - $t - 1) + $t + 1) < $n; $t = $p + 1) {
+            if ($s[$p] !== '{' || ($s[($e = strcspn($s, "}\n", $p + 1, $n - $p - 1) + $p + 1)] ?? null) !== '}') {
+                continue;
+            }
+
+            $v = self::performSubstitution($s, $p + 1, $e, $envReader);
+            $sink($s, $i, $p - 1);
+            $sink($v, 0, strlen($v));
+            $i = ($p = $e) + 1;
+        }
+        $sink($s, $i, $n);
+    }
+
+    private static function performSubstitution(string $s, int $i, int $n, EnvReader $envReader, bool $resolvePrefix = true): string
+    {
+        if ($i === $n) {
+            throw new InvalidArgumentException(self::formatErrorMessage('Missing environment variable name', $s, $i, 1, 'cannot be empty'));
+        }
+
+        preg_match('/\G[[:alpha:]_][[:alnum:]_]*+/', $s, $matches, 0, $i);
+        $envName = $matches[0] ?? '';
+        $d = $i + strlen($envName);
+        if ($d === $n) {
+            return $envReader->read($envName) ?? '';
+        }
+
+        if (!$matches || $s[$d] !== ':') {
+            throw new InvalidArgumentException(self::formatErrorMessage('Invalid character in environment variable name', $s, $i, strcspn($s, ':', $i, $n - $i), 'has to match [a-zA-Z_][a-zA-Z0-9_]*'));
+        }
+
+        if ($s[$d + 1] === '-') {
+            return $envReader->read($envName) ?? substr($s, $d + 2, $n - $d - 2);
+        }
+
+        if ($resolvePrefix) {
+            $processors = [
+                'env' => static fn (string $s, int $i, int $n, EnvReader $envReader) => self::performSubstitution($s, $i, $n, $envReader, false),
+            ];
+            if ($processor = $processors[$envName] ?? null) {
+                return $processor($s, $d + 1, $n, $envReader);
+            }
+
+            $candidate = null;
+            $minScore = 3;
+            foreach ($processors as $name => $processor) {
+                if (($score = levenshtein($name, strtolower($envName))) >= $minScore) {
+                    continue;
+                }
+
+                try {
+                    $processor($s, $d + 1, $n, new EnvSourceReader([]));
+                    $candidate = $name;
+                    $minScore = $score;
+                } catch (InvalidArgumentException) {
+                }
+            }
+
+            if ($candidate !== null) {
+                throw new InvalidArgumentException(self::formatErrorMessage('Invalid substitution prefix', $s, $i, strlen($envName), sprintf('did you mean "%s"?', $candidate)));
+            }
+        }
+
+        throw new InvalidArgumentException(self::formatErrorMessage('Invalid substitution', $s, $d, 1, 'did you mean :-?'));
+    }
+
+    private static function formatErrorMessage(string $message, string $s, int $position, int $length = 1, ?string $subMessage = null): string
+    {
+        $start = strrpos($s, "\n", $position - strlen($s));
+        $start = $start === false ? 0 : $start + 1;
+        $next = strpos($s, "\n", $position) ?: strlen($s);
+
+        $message .= ' (at ';
+        if ($line = substr_count($s, "\n", 0, $start)) {
+            $message .= 'ln=';
+            $message .= $line + 1;
+            $message .= ',';
+        }
+        $message .= 'col=';
+        $message .= $position - $start + 1;
+        $message .= ')';
+        $message .= "\n\t";
+        $message .= substr($s, $start, $next - $start);
+        $message .= "\n\t";
+        for ($i = 0; $i < $position - $start; $i++) {
+            $message .= ' ';
+        }
+        for ($i = 0; $i < $length; $i++) {
+            $message .= '^';
+        }
+        if ($subMessage !== null) {
+            $message .= ' --- ';
+            $message .= $subMessage;
+        }
+
+        return $message;
+    }
+}

--- a/tests/Unit/Config/SDK/Configuration/SubstitutionTest.php
+++ b/tests/Unit/Config/SDK/Configuration/SubstitutionTest.php
@@ -9,6 +9,7 @@ use OpenTelemetry\Config\SDK\Configuration\Environment\ArrayEnvSource;
 use OpenTelemetry\Config\SDK\Configuration\Environment\EnvSourceReader;
 use OpenTelemetry\Config\SDK\Configuration\Internal\EnvSubstitutionNormalization;
 use OpenTelemetry\Config\SDK\Configuration\Internal\NodeDefinition\ArrayNodeDefinition;
+use OpenTelemetry\Config\SDK\Configuration\Internal\Substitution;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +19,7 @@ use Symfony\Component\Config\Definition\Processor;
  * @see https://opentelemetry.io/docs/specs/otel/configuration/data-model/#environment-variable-substitution
  */
 #[CoversClass(EnvSubstitutionNormalization::class)]
+#[CoversClass(Substitution::class)]
 final class SubstitutionTest extends TestCase
 {
     #[DataProvider('substitutionDataProvider')]


### PR DESCRIPTION
See https://opentelemetry.io/docs/specs/otel/configuration/data-model/#environment-variable-substitution.

> The `$` character is an escape sequence, such that `$$` in the input is translated to a single `$` in the output. The resolved `$` from an escape sequence MUST NOT be considered when matching input against the environment variable substitution regular expression.