### PR TITLE
Revert "Fix getLabel() deprecation warning with Protobuf 4.33+"

### DIFF
--- a/src/Contrib/Otlp/ProtobufSerializer.php
+++ b/src/Contrib/Otlp/ProtobufSerializer.php
@@ -10,6 +10,7 @@ use Exception;
 use Google\Protobuf\Descriptor;
 use Google\Protobuf\DescriptorPool;
 use Google\Protobuf\FieldDescriptor;
+use Google\Protobuf\Internal\GPBLabel;
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\Message;
 use InvalidArgumentException;
@@ -139,7 +140,7 @@ final class ProtobufSerializer
                 continue;
             }
 
-            if ($field->isRepeated()) {
+            if ($field->getLabel() === GPBLabel::REPEATED) {
                 foreach ($data->$name as $key => $value) {
                     $data->$name[$key] = self::traverseFieldDescriptor($value, $field);
                 }


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-php#1854 / resolves https://github.com/open-telemetry/opentelemetry-php/issues/1879.
The `::getLabel()` method was deprecated in protobuf `4.31`, `::traverseDescriptor()` (which uses `::getLabel()`) won't be called with protobuf `^4.31` due to #1593. Related earlier PR that was closed for to the same reason: https://github.com/open-telemetry/opentelemetry-php/pull/1596