### PR TITLE
Update open-telemetry/api version to ^1.8

### DIFF
--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.1",
         "ext-json": "*",
         "nyholm/psr7-server": "^1.1",
-        "open-telemetry/api": "^1.7",
+        "open-telemetry/api": "^1.8",
         "open-telemetry/context": "^1.4",
         "open-telemetry/sem-conv": "^1.0",
         "php-http/discovery": "^1.14",


### PR DESCRIPTION
This was causing an error for me because the LoggerInterface changed
```
PHP Fatal error:  OpenTelemetry\SDK\Logs\Logger::logRecordBuilder() has #[\Override] attribute, but no matching parent method exists in ... /vendor/open-telemetry/sdk/Logs/Logger.php on line 34
```