### PR TITLE
Require sem-conv >= 1.38 to prevent fatal errors from missing classes

### DIFF
--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -22,7 +22,7 @@
         "nyholm/psr7-server": "^1.1",
         "open-telemetry/api": "^1.8",
         "open-telemetry/context": "^1.4",
-        "open-telemetry/sem-conv": "^1.0",
+        "open-telemetry/sem-conv": "^1.38",
         "php-http/discovery": "^1.14",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",


### PR DESCRIPTION
This PR updates the `composer.json` constraint for `opentelemetry-php/sem-conv` to require version `1.38`. The `HostIncubatingAttributes` and `OsIncubatingAttributes` classes used by the `Host` resource detector were introduced in #1659 and first used in #1855. If a project upgrades the SDK while `sem-conv` remains outdated, it can lead to fatal errors when the detector tries to load classes that aren't available. This is exactly what happened in my case: Renovate updated the SDK because it was required in the project’s root `composer.json`, but `sem-conv` was only a transitive dependency and was therefore ignored, leaving an incompatible version installed.

```
Fatal error: Uncaught Error: Class "OpenTelemetry\SemConv\Incubating\Attributes\HostIncubatingAttributes" not found
in /var/www/app/vendor/open-telemetry/sdk/Resource/Detectors/Host.php:38
```

While version `1.36` technically contains the required classes, the SDK calls `ResourceInfo::create` with version `1.38`, so I updated the requirement to that version to stay consistent with what the SDK expects.