### PR TITLE
Add trigger_error as Log Destination Option

### DIFF
--- a/src/API/Behavior/Internal/LogWriter/TriggerErrorLogWriter.php
+++ b/src/API/Behavior/Internal/LogWriter/TriggerErrorLogWriter.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\API\Behavior\Internal\LogWriter;
+
+class TriggerErrorLogWriter implements LogWriterInterface
+{
+    #[\Override]
+    public function write($level, string $message, array $context): void
+    {
+        trigger_error(Formatter::format($level, $message, $context));
+    }
+}

--- a/src/API/Behavior/Internal/LogWriterFactory.php
+++ b/src/API/Behavior/Internal/LogWriterFactory.php
@@ -9,6 +9,7 @@ use OpenTelemetry\API\Behavior\Internal\LogWriter\LogWriterInterface;
 use OpenTelemetry\API\Behavior\Internal\LogWriter\NoopLogWriter;
 use OpenTelemetry\API\Behavior\Internal\LogWriter\Psr3LogWriter;
 use OpenTelemetry\API\Behavior\Internal\LogWriter\StreamLogWriter;
+use OpenTelemetry\API\Behavior\Internal\LogWriter\TriggerErrorLogWriter;
 use OpenTelemetry\API\Instrumentation\ConfigurationResolver;
 use OpenTelemetry\API\LoggerHolder;
 
@@ -39,6 +40,8 @@ class LogWriterFactory
                 return new ErrorLogWriter();
             case 'error_log':
                 return new ErrorLogWriter();
+            case 'trigger_error':
+                return new TriggerErrorLogWriter();
             default:
                 if ($logger) {
                     return new Psr3LogWriter($logger);

--- a/tests/Unit/API/Behavior/Internal/LogWriterFactoryTest.php
+++ b/tests/Unit/API/Behavior/Internal/LogWriterFactoryTest.php
@@ -55,5 +55,4 @@ class LogWriterFactoryTest extends TestCase
         LoggerHolder::set($this->createMock(LoggerInterface::class));
         $this->assertInstanceOf(Psr3LogWriter::class, (new LogWriterFactory())->create());
     }
-
 }

--- a/tests/Unit/API/Behavior/Internal/LogWriterFactoryTest.php
+++ b/tests/Unit/API/Behavior/Internal/LogWriterFactoryTest.php
@@ -8,6 +8,7 @@ use OpenTelemetry\API\Behavior\Internal\LogWriter\ErrorLogWriter;
 use OpenTelemetry\API\Behavior\Internal\LogWriter\NoopLogWriter;
 use OpenTelemetry\API\Behavior\Internal\LogWriter\Psr3LogWriter;
 use OpenTelemetry\API\Behavior\Internal\LogWriter\StreamLogWriter;
+use OpenTelemetry\API\Behavior\Internal\LogWriter\TriggerErrorLogWriter;
 use OpenTelemetry\API\Behavior\Internal\LogWriterFactory;
 use OpenTelemetry\API\LoggerHolder;
 use OpenTelemetry\Tests\TestState;
@@ -41,6 +42,7 @@ class LogWriterFactoryTest extends TestCase
     {
         return [
             ['error_log', ErrorLogWriter::class],
+            ['trigger_error', TriggerErrorLogWriter::class],
             ['stdout', StreamLogWriter::class],
             ['stderr', StreamLogWriter::class],
             ['none', NoopLogWriter::class],
@@ -53,4 +55,5 @@ class LogWriterFactoryTest extends TestCase
         LoggerHolder::set($this->createMock(LoggerInterface::class));
         $this->assertInstanceOf(Psr3LogWriter::class, (new LogWriterFactory())->create());
     }
+
 }


### PR DESCRIPTION
This PR adds `trigger_error` as an additional option for `OTEL_PHP_LOG_DESTINATION`.

I will add a corresponding PR to https://github.com/open-telemetry/opentelemetry.io to document this new option and will reference this PR here as soon as that is done.

Fixes #1473