### PR TITLE
Suppress Psalm UndefinedDocblockClass for Internal\RepeatedField

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -35,6 +35,11 @@
                 <referencedMethod name="Google\Protobuf\Internal\RepeatedField::offsetSet"/>
             </errorLevel>
         </UndefinedMethod>
+        <UndefinedDocblockClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Google\Protobuf\Internal\RepeatedField"/>
+            </errorLevel>
+        </UndefinedDocblockClass>
         <ArgumentTypeCoercion>
             <errorLevel type="suppress">
                 <directory name="./examples"/>


### PR DESCRIPTION
  ## Summary
  - Suppress Psalm `UndefinedDocblockClass` issues that reference
  `Google\Protobuf\Internal\RepeatedField`.

  ## Why
  google/protobuf 4.x deprecated `Google\Protobuf\Internal\RepeatedField` in
  favor of `Google\Protobuf\RepeatedField`. The Internal class is now defined
  as an `if (false) { class RepeatedField extends
  \Google\Protobuf\RepeatedField {} }` stub plus a runtime `class_alias`.
  Psalm's static parser can see only the stub, not the alias, so getters on the
   generated proto messages that return `Internal\RepeatedField` (e.g.
  `ExportMetricsServiceRequest::getResourceMetrics()`) trigger
  `UndefinedDocblockClass` on every Otlp converter file.

  This is the same workaround pattern already used for `offsetGet`/`offsetSet`
  on the same class. No source changes; once `google/protobuf` removes the
  Internal stub entirely we can revisit.

  Unblocks PHP QA on PHP 8.2/8.3/8.4 main builds.

  ## Test plan
  - [ ] PHP QA workflow goes green on 8.2/8.3/8.4