### PR TITLE
Enforce W3C Baggage size and entry-count caps in Parser

### DIFF
--- a/src/API/Baggage/Propagation/Parser.php
+++ b/src/API/Baggage/Propagation/Parser.php
@@ -8,6 +8,7 @@ use function explode;
 use OpenTelemetry\API\Baggage\BaggageBuilderInterface;
 use OpenTelemetry\API\Baggage\Metadata;
 use function str_replace;
+use function strlen;
 use function trim;
 use function urldecode;
 
@@ -17,6 +18,10 @@ final class Parser
     private const EXCLUDED_VALUE_CHARS = [' ', '"', ',', ';', '\\'];
     private const EQUALS = '=';
 
+    /** @see https://www.w3.org/TR/baggage/#limits */
+    private const MAX_BAGGAGE_BYTES = 8192;
+    private const MAX_BAGGAGE_ENTRIES = 180;
+
     public function __construct(
         private readonly string $baggageHeader,
     ) {
@@ -24,7 +29,15 @@ final class Parser
 
     public function parseInto(BaggageBuilderInterface $baggageBuilder): void
     {
+        if (strlen($this->baggageHeader) > self::MAX_BAGGAGE_BYTES) {
+            return;
+        }
+
+        $entries = 0;
         foreach (explode(',', $this->baggageHeader) as $baggageString) {
+            if ($entries >= self::MAX_BAGGAGE_ENTRIES) {
+                break;
+            }
             if (empty(trim($baggageString))) {
                 continue;
             }
@@ -62,6 +75,7 @@ final class Parser
             }
 
             $baggageBuilder->set($key, $value, $metadata);
+            $entries++;
         }
     }
 }

--- a/tests/Unit/API/Baggage/Propagation/ParserTest.php
+++ b/tests/Unit/API/Baggage/Propagation/ParserTest.php
@@ -100,4 +100,42 @@ class ParserTest extends TestCase
             'missing value' => ['key1='],
         ];
     }
+
+    public function test_parse_into_rejects_header_exceeding_w3c_byte_limit(): void
+    {
+        // https://www.w3.org/TR/baggage/#limits, max total bytes 8192
+        $pairs = [];
+        for ($i = 0; $i < 1024; $i++) {
+            $pairs[] = "k{$i}=v{$i}";
+        }
+        $header = implode(',', $pairs);
+        $this->assertGreaterThan(8192, strlen($header));
+
+        $parser = new Parser($header);
+
+        $this->builder
+            ->expects($this->never())
+            ->method('set');
+
+        $parser->parseInto($this->builder);
+    }
+
+    public function test_parse_into_caps_entries_at_w3c_list_member_limit(): void
+    {
+        // https://www.w3.org/TR/baggage/#limits, max list-members 180
+        $pairs = [];
+        for ($i = 0; $i < 500; $i++) {
+            $pairs[] = "k{$i}=v{$i}";
+        }
+        $header = implode(',', $pairs);
+        $this->assertLessThanOrEqual(8192, strlen($header));
+
+        $parser = new Parser($header);
+
+        $this->builder
+            ->expects($this->exactly(180))
+            ->method('set');
+
+        $parser->parseInto($this->builder);
+    }
 }


### PR DESCRIPTION
Fixes #1974.

### What

`BaggagePropagator::extract` walked the entire `explode(',', $header)`
result with no cap on header byte size, no cap on entry count, and no
per-entry length cap. This change adds two private constants to
`Parser` and enforces them inside `parseInto`.

### Change

- `Parser::MAX_BAGGAGE_BYTES = 8192`
- `Parser::MAX_BAGGAGE_ENTRIES = 180`
- `parseInto` returns early when
  `strlen($header) > MAX_BAGGAGE_BYTES` (cheap, prevents the per-entry
  allocation loop running at all).
- `parseInto` `break`s once `MAX_BAGGAGE_ENTRIES` accepted entries
  have been processed.

Values are taken from the W3C Baggage spec
([`#limits`](https://www.w3.org/TR/baggage/#limits)) and match what
the other SDKs already do:

| SDK    | max bytes | max entries |
| ------ | --------- | ----------- |
| java (1.62.0) | 8192 | 180 |
| go     | 8192      | 64          |
| dotnet | 8192      | 180         |
| cpp    | 8192      | 180         |

### Tests

Two regression tests added in `tests/Unit/API/Baggage/Propagation/ParserTest.php`:

- `test_parse_into_rejects_header_exceeding_w3c_byte_limit` builds a
  ~10 KiB header from 1024 pairs and asserts the builder is never
  invoked.
- `test_parse_into_caps_entries_at_w3c_list_member_limit` builds a
  500-pair header (under 8192 bytes) and asserts the builder receives
  exactly 180 `set` calls.

`vendor/bin/phpunit tests/Unit/API/Baggage` passes 63/63 locally on
PHP 8.5.6.

### Static analysis

- `vendor/bin/phpstan analyse src/API/Baggage/Propagation/Parser.php`
  no errors.
- `vendor-bin/rector/vendor/bin/rector process ... --dry-run` no
  changes.
- `vendor-bin/php-cs-fixer/vendor/bin/php-cs-fixer fix ... --dry-run`
  no changes.

### Context

Originally filed as a private security advisory
([GHSA-7f5h-mpj3-v3hf](https://github.com/open-telemetry/opentelemetry-php/security/advisories/GHSA-7f5h-mpj3-v3hf),
now closed). Per the project security policy the maintainers prefer
to handle this through the standard issue/PR workflow as a hardening
bug.

### References

- W3C Baggage limits: https://www.w3.org/TR/baggage/#limits
- Java sibling: https://github.com/open-telemetry/opentelemetry-java/security/advisories/GHSA-rcgg-9c38-7xpx
- JS sibling: https://github.com/open-telemetry/opentelemetry-js/security/advisories/GHSA-8988-4f7v-96qf