### PR TITLE
Add W3C Baggage boundary tests and entry-counter comment (follow-up to #1975)

### DIFF
--- a/src/API/Baggage/Propagation/Parser.php
+++ b/src/API/Baggage/Propagation/Parser.php
@@ -33,6 +33,8 @@ final class Parser
             return;
         }
 
+        // Counts only ACCEPTED entries (incremented at the bottom of the loop), not raw
+        // comma-separated list-members, so empty/invalid pairs do not consume the W3C cap.
         $entries = 0;
         foreach (explode(',', $this->baggageHeader) as $baggageString) {
             if ($entries >= self::MAX_BAGGAGE_ENTRIES) {

--- a/tests/Unit/API/Baggage/Propagation/ParserTest.php
+++ b/tests/Unit/API/Baggage/Propagation/ParserTest.php
@@ -138,4 +138,75 @@ class ParserTest extends TestCase
 
         $parser->parseInto($this->builder);
     }
+
+    public function test_parse_into_accepts_header_at_exactly_w3c_byte_limit(): void
+    {
+        // The byte cap is inclusive: strlen() > 8192 is rejected, so exactly 8192 is accepted.
+        // Single valid pair padded to exactly 8192 bytes with a non-excluded value char.
+        $prefix = 'key=';
+        $header = $prefix . str_repeat('a', 8192 - strlen($prefix));
+        $this->assertSame(8192, strlen($header));
+
+        $parser = new Parser($header);
+
+        $this->builder
+            ->expects($this->once())
+            ->method('set');
+
+        $parser->parseInto($this->builder);
+    }
+
+    public function test_parse_into_rejects_header_one_byte_over_w3c_byte_limit(): void
+    {
+        // One byte past the inclusive cap (8193 > 8192) discards the entire header.
+        $prefix = 'key=';
+        $header = $prefix . str_repeat('a', 8193 - strlen($prefix));
+        $this->assertSame(8193, strlen($header));
+
+        $parser = new Parser($header);
+
+        $this->builder
+            ->expects($this->never())
+            ->method('set');
+
+        $parser->parseInto($this->builder);
+    }
+
+    public function test_parse_into_accepts_exactly_w3c_list_member_limit(): void
+    {
+        // 180 valid list-members are all accepted; the >= cap only trips on the 181st.
+        $pairs = [];
+        for ($i = 0; $i < 180; $i++) {
+            $pairs[] = "k{$i}=v{$i}";
+        }
+        $header = implode(',', $pairs);
+        $this->assertLessThanOrEqual(8192, strlen($header));
+
+        $parser = new Parser($header);
+
+        $this->builder
+            ->expects($this->exactly(180))
+            ->method('set');
+
+        $parser->parseInto($this->builder);
+    }
+
+    public function test_parse_into_caps_at_w3c_list_member_limit_plus_one(): void
+    {
+        // 181 valid list-members: the 181st is dropped once $entries reaches 180.
+        $pairs = [];
+        for ($i = 0; $i < 181; $i++) {
+            $pairs[] = "k{$i}=v{$i}";
+        }
+        $header = implode(',', $pairs);
+        $this->assertLessThanOrEqual(8192, strlen($header));
+
+        $parser = new Parser($header);
+
+        $this->builder
+            ->expects($this->exactly(180))
+            ->method('set');
+
+        $parser->parseInto($this->builder);
+    }
 }


### PR DESCRIPTION
Fast-follow to #1975, addressing @bobstrecansky's non-blocking review suggestions.

## What's changed

**1. Boundary tests (`tests/Unit/API/Baggage/Propagation/ParserTest.php`)**

The existing caps tests fire well past the limits (1024 pairs / 500 pairs), which proves the caps engage but does not pin the `>` vs `>=` edge. These four cases lock the off-by-one against the *actual implemented* semantics:

- `test_parse_into_accepts_header_at_exactly_w3c_byte_limit` — exactly 8192 bytes is **accepted** (the cap is inclusive: `strlen() > MAX_BAGGAGE_BYTES`).
- `test_parse_into_rejects_header_one_byte_over_w3c_byte_limit` — 8193 bytes discards the whole header.
- `test_parse_into_accepts_exactly_w3c_list_member_limit` — 180 valid list-members are all accepted.
- `test_parse_into_caps_at_w3c_list_member_limit_plus_one` — the 181st valid member is dropped once `$entries` reaches 180 (`$entries >= MAX_BAGGAGE_ENTRIES`).

**2. Intent comment (`src/API/Baggage/Propagation/Parser.php`)**

One line documenting that `$entries` counts only *accepted* pairs (incremented at the bottom of the loop), not raw comma-separated list-members, so the counter isn't silently relocated in a future refactor.

The silent-drop observability idea is intentionally deferred — discarding an over-cap header matches the W3C spec ("MAY truncate or discard") and the behaviour of the sibling SDKs, so it's not wired in here.

## Testing

`vendor/bin/phpunit --filter ParserTest tests/Unit/API/Baggage/Propagation/ParserTest.php`

```
OK (17 tests, 43 assertions)
```