### PR TITLE
Allow google/protobuf 5

### DIFF
--- a/proto/otel/composer.json
+++ b/proto/otel/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "google/protobuf": "^3.22 || ^4.0"
+        "google/protobuf": "^3.22 || ^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
#1904 enabled the usage of google/protobuf 5, but apparently the composer.json file of the subtree split was forgotten. Because of that, downstream projects can't use `open-telemetry/gen-otlp-protobuf` together with google/protobuf 5.