### PR TITLE
Fix(SDK): Auto root span start timestamps precision

### DIFF
--- a/src/SDK/Trace/AutoRootSpan.php
+++ b/src/SDK/Trace/AutoRootSpan.php
@@ -43,12 +43,12 @@ class AutoRootSpan
             Version::VERSION_1_25_0->url(),
         );
         $parent = Globals::propagator()->extract($request->getHeaders());
-        $startTime = array_key_exists('REQUEST_TIME_FLOAT', $request->getServerParams())
-            ? $request->getServerParams()['REQUEST_TIME_FLOAT']
-            : (int) microtime(true);
+        $startTimeInNanos = array_key_exists('REQUEST_TIME_FLOAT', $request->getServerParams())
+            ? (int) ($request->getServerParams()['REQUEST_TIME_FLOAT'] * ClockInterface::NANOS_PER_SECOND)
+            : (int) (microtime(true) * ClockInterface::NANOS_PER_SECOND);
         $span = $tracer->spanBuilder($request->getMethod())
             ->setSpanKind(SpanKind::KIND_SERVER)
-            ->setStartTimestamp((int) ($startTime*ClockInterface::NANOS_PER_SECOND))
+            ->setStartTimestamp($startTimeInNanos)
             ->setParent($parent)
             ->setAttribute(TraceAttributes::URL_FULL, (string) $request->getUri())
             ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())

--- a/src/SDK/Trace/AutoRootSpan.php
+++ b/src/SDK/Trace/AutoRootSpan.php
@@ -44,8 +44,8 @@ class AutoRootSpan
         );
         $parent = Globals::propagator()->extract($request->getHeaders());
         $startTimeInNanos = array_key_exists('REQUEST_TIME_FLOAT', $request->getServerParams())
-            ? (int) ($request->getServerParams()['REQUEST_TIME_FLOAT'] * ClockInterface::NANOS_PER_SECOND)
-            : (int) (microtime(true) * ClockInterface::NANOS_PER_SECOND);
+            ? (int) ((float) $request->getServerParams()['REQUEST_TIME_FLOAT'] * (float) ClockInterface::NANOS_PER_SECOND)
+            : (int) (microtime(true) * (float) ClockInterface::NANOS_PER_SECOND);
         $span = $tracer->spanBuilder($request->getMethod())
             ->setSpanKind(SpanKind::KIND_SERVER)
             ->setStartTimestamp($startTimeInNanos)

--- a/tests/Unit/SDK/Trace/AutoRootSpanTest.php
+++ b/tests/Unit/SDK/Trace/AutoRootSpanTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\SDK\Trace;
 
 use Nyholm\Psr7\ServerRequest;
+use OpenTelemetry\API\Common\Time\ClockInterface;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\Span;
@@ -131,6 +132,73 @@ class AutoRootSpanTest extends TestCase
         $scope = Context::storage()->scope();
         $this->assertNotNull($scope);
         $scope->detach();
+    }
+
+    public function test_create_converts_request_time_float_to_nanoseconds(): void
+    {
+        $requestTimeFloat = 1700000000.5;
+        $expectedNanos = (int) ($requestTimeFloat * ClockInterface::NANOS_PER_SECOND);
+
+        $request = new ServerRequest(
+            'GET',
+            'https://example.com/',
+            [],
+            null,
+            '1.1',
+            ['REQUEST_TIME_FLOAT' => $requestTimeFloat],
+        );
+
+        $span = $this->createMock(SpanInterface::class);
+        $spanBuilder = $this->createMock(SpanBuilderInterface::class);
+        $spanBuilder->method('setSpanKind')->willReturnSelf();
+        $spanBuilder->method('setParent')->willReturnSelf();
+        $spanBuilder->method('setAttribute')->willReturnSelf();
+        $spanBuilder->method('startSpan')->willReturn($span);
+        $spanBuilder
+            ->expects($this->once())
+            ->method('setStartTimestamp')
+            ->with($this->identicalTo($expectedNanos))
+            ->willReturnSelf();
+
+        $this->tracer->method('spanBuilder')->willReturn($spanBuilder);
+
+        AutoRootSpan::create($request);
+
+        Context::storage()->scope()?->detach();
+    }
+
+    public function test_create_start_timestamp_preserves_sub_second_precision_without_request_time_float(): void
+    {
+        $request = new ServerRequest('GET', 'https://example.com/');
+
+        $capturedTimestamp = null;
+        $span = $this->createMock(SpanInterface::class);
+        $spanBuilder = $this->createMock(SpanBuilderInterface::class);
+        $spanBuilder->method('setSpanKind')->willReturnSelf();
+        $spanBuilder->method('setParent')->willReturnSelf();
+        $spanBuilder->method('setAttribute')->willReturnSelf();
+        $spanBuilder->method('startSpan')->willReturn($span);
+        $spanBuilder
+            ->expects($this->once())
+            ->method('setStartTimestamp')
+            ->with($this->callback(function (int $timestamp) use (&$capturedTimestamp): bool {
+                $capturedTimestamp = $timestamp;
+
+                return true;
+            }))
+            ->willReturnSelf();
+
+        $this->tracer->method('spanBuilder')->willReturn($spanBuilder);
+
+        $before = (int) (microtime(true) * ClockInterface::NANOS_PER_SECOND);
+        AutoRootSpan::create($request);
+        $after = (int) (microtime(true) * ClockInterface::NANOS_PER_SECOND);
+
+        $this->assertNotNull($capturedTimestamp);
+        $this->assertGreaterThanOrEqual($before, $capturedTimestamp);
+        $this->assertLessThanOrEqual($after, $capturedTimestamp);
+
+        Context::storage()->scope()?->detach();
     }
 
     public function test_shutdown_handler(): void

--- a/tests/Unit/SDK/Trace/AutoRootSpanTest.php
+++ b/tests/Unit/SDK/Trace/AutoRootSpanTest.php
@@ -137,7 +137,7 @@ class AutoRootSpanTest extends TestCase
     public function test_create_converts_request_time_float_to_nanoseconds(): void
     {
         $requestTimeFloat = 1700000000.5;
-        $expectedNanos = (int) ($requestTimeFloat * ClockInterface::NANOS_PER_SECOND);
+        $expectedNanos = (int) ($requestTimeFloat * (float) ClockInterface::NANOS_PER_SECOND);
 
         $request = new ServerRequest(
             'GET',
@@ -190,9 +190,9 @@ class AutoRootSpanTest extends TestCase
 
         $this->tracer->method('spanBuilder')->willReturn($spanBuilder);
 
-        $before = (int) (microtime(true) * ClockInterface::NANOS_PER_SECOND);
+        $before = (int) (microtime(true) * (float) ClockInterface::NANOS_PER_SECOND);
         AutoRootSpan::create($request);
-        $after = (int) (microtime(true) * ClockInterface::NANOS_PER_SECOND);
+        $after = (int) (microtime(true) * (float) ClockInterface::NANOS_PER_SECOND);
 
         $this->assertNotNull($capturedTimestamp);
         $this->assertGreaterThanOrEqual($before, $capturedTimestamp);


### PR DESCRIPTION
## Summary

### Content
Fixed a precision loss bug in `AutoRootSpan::create()` where the start timestamp was calculated incorrectly when `REQUEST_TIME_FLOAT` is not available.

### Root Cause
The original code cast `microtime(true)` to `int` before multiplying via `NANOS_PER_SECOND`:

```php
$startTime = array_key_exists('REQUEST_TIME_FLOAT', $request->getServerParams())
    ? $request->getServerParams()['REQUEST_TIME_FLOAT'] : (int) microtime(true);          // ← precision loss here
->setStartTimestamp((int) ($startTime * ClockInterface::NANOS_PER_SECOND))
```

This caused up to 999,999,999ns (~1 second) of error because the sub-second precision was discarded before nanosecond conversioning.

- `GET /?foo=bar` with `microtime(true)` = `1718123456.789` → cast to `1718123456` → multiplied by `1e9` → last 9 digits always `000000000`

### What I have done
Multiply first, then cast to `int` to preserve sub-second precision like:

```php
$startTimeInNanos = array_key_exists('REQUEST_TIME_FLOAT', $request->getServerParams())
? (int) ($request->getServerParams()['REQUEST_TIME_FLOAT'] * ClockInterface::NANOS_PER_SECOND)
    : (int) (microtime(true) * ClockInterface::NANOS_PER_SECOND)
->setStartTimestamp($startTimeInNanos)
```

### Test Results
<img width="747" height="223" alt="screenshot 2026-06-11 23 33 52" src="https://github.com/user-attachments/assets/114b0c76-e6ae-42e0-811e-5392294ce47f" />

