### PR TITLE
fix: preserve debug log level priority in Logging::level()

### DIFF
--- a/src/API/Behavior/Internal/Logging.php
+++ b/src/API/Behavior/Internal/Logging.php
@@ -55,7 +55,7 @@ class Logging
     {
         $value = array_search($level, self::LEVELS);
 
-        return $value ?: 1; //'info'
+        return $value !== false ? $value : 1; //'info'
     }
 
     /**

--- a/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
+++ b/tests/Unit/API/Behavior/LogsMessagesTraitTest.php
@@ -56,6 +56,7 @@ class LogsMessagesTraitTest extends TestCase
     #[TestDox('Proxies logging methods through to logger')]
     public function test_log_methods(string $method, string $expectedLogLevel): void
     {
+        $this->setEnvironmentVariable('OTEL_LOG_LEVEL', LogLevel::DEBUG);
         $instance = $this->createInstance();
         $this->writer->expects($this->once())->method('write')->with(
             $this->equalTo($expectedLogLevel),


### PR DESCRIPTION
array_search returns 0 for debug (first in the LEVELS array) and false when not found; the old ?: 1 collapsed both to 1 (info), silently ignoring debug-level messages. Use !== false to distinguish the two.