### PR TITLE
Avoid collecting unsanitized process arguments

### DIFF
--- a/src/SDK/Resource/Detectors/Process.php
+++ b/src/SDK/Resource/Detectors/Process.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\SDK\Resource\Detectors;
 
+use function count;
 use function extension_loaded;
 use function getmypid;
+use function is_array;
+use function is_string;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
@@ -21,9 +24,6 @@ use const PHP_VERSION;
  */
 final class Process implements ResourceDetectorInterface
 {
-    /**
-     * @psalm-suppress PossiblyUndefinedArrayOffset
-     */
     #[\Override]
     public function getResource(): ResourceInfo
     {
@@ -34,12 +34,13 @@ final class Process implements ResourceDetectorInterface
             ProcessIncubatingAttributes::PROCESS_EXECUTABLE_PATH => PHP_BINARY,
         ];
 
-        /**
-         * @psalm-suppress PossiblyUndefinedArrayOffset
-         */
-        if ($_SERVER['argv'] ?? null) {
-            $attributes[ProcessIncubatingAttributes::PROCESS_COMMAND] = $_SERVER['argv'][0];
-            $attributes[ProcessIncubatingAttributes::PROCESS_COMMAND_ARGS] = $_SERVER['argv'];
+        $argv = $_SERVER['argv'] ?? null;
+        if (is_array($argv)) {
+            $command = $argv[0] ?? null;
+            if (is_string($command)) {
+                $attributes[ProcessIncubatingAttributes::PROCESS_COMMAND] = $command;
+                $attributes[ProcessIncubatingAttributes::PROCESS_ARGS_COUNT] = count($argv);
+            }
         }
 
         /** @phan-suppress-next-line PhanTypeComparisonFromArray */

--- a/tests/Integration/Config/ConfigurationTest.php
+++ b/tests/Integration/Config/ConfigurationTest.php
@@ -102,6 +102,7 @@ final class ConfigurationTest extends TestCase
             'process.pid',
             'process.executable.path',
             'process.command',
+            'process.args_count',
             'process.owner',
             'service.name',
             'service.namespace',
@@ -140,6 +141,7 @@ final class ConfigurationTest extends TestCase
         $expectedKeys = [
             'process.pid',
             'process.executable.path',
+            'process.args_count',
             'process.owner',
             'process.runtime.name',
             'service.name',

--- a/tests/Integration/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Integration/SDK/Resource/ResourceInfoFactoryTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Integration\SDK\Resource;
 
 use Composer\InstalledVersions;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
+use OpenTelemetry\SemConv\Incubating\Attributes\ProcessIncubatingAttributes;
 use OpenTelemetry\SemConv\ResourceAttributes;
 use OpenTelemetry\Tests\TestState;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -31,7 +32,9 @@ class ResourceInfoFactoryTest extends TestCase
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertNotNull($resource->getAttributes()->get(ProcessIncubatingAttributes::PROCESS_ARGS_COUNT));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_LINE));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_NAME));
@@ -70,6 +73,7 @@ class ResourceInfoFactoryTest extends TestCase
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
+        $this->assertNull($resource->getAttributes()->get(ProcessIncubatingAttributes::PROCESS_ARGS_COUNT));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
@@ -98,6 +102,7 @@ class ResourceInfoFactoryTest extends TestCase
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
+        $this->assertNull($resource->getAttributes()->get(ProcessIncubatingAttributes::PROCESS_ARGS_COUNT));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
@@ -125,6 +130,7 @@ class ResourceInfoFactoryTest extends TestCase
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
+        $this->assertNull($resource->getAttributes()->get(ProcessIncubatingAttributes::PROCESS_ARGS_COUNT));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
@@ -151,7 +157,9 @@ class ResourceInfoFactoryTest extends TestCase
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertNotNull($resource->getAttributes()->get(ProcessIncubatingAttributes::PROCESS_ARGS_COUNT));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_LINE));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_NAME));

--- a/tests/Unit/SDK/Resource/Detectors/ProcessTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ProcessTest.php
@@ -5,23 +5,30 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Unit\SDK\Resource\Detectors;
 
 use OpenTelemetry\SDK\Resource\Detectors\Process;
+use OpenTelemetry\SemConv\Incubating\Attributes\ProcessIncubatingAttributes;
 use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Process::class)]
 class ProcessTest extends TestCase
 {
+    #[BackupGlobals(true)]
     public function test_process_get_resource(): void
     {
+        $_SERVER['argv'] = ['artisan', '--password=secret'];
+
         $resourceDetector = new Process();
         $resource = $resourceDetector->getResource();
 
         $this->assertStringMatchesFormat('https://opentelemetry.io/schemas/%d.%d.%d', $resource->getSchemaUrl() ?? '');
         $this->assertIsInt($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
-        $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
-        $this->assertIsArray($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertSame('artisan', $resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
+        $this->assertSame(2, $resource->getAttributes()->get(ProcessIncubatingAttributes::PROCESS_ARGS_COUNT));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_LINE));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
     }


### PR DESCRIPTION
## Summary

- stop collecting raw `process.command_args` by default because arguments may contain sensitive data
- retain `process.command` and report `process.args_count` as the non-sensitive fallback
- verify `process.command_args` and `process.command_line` remain unset

Closes #1604.

## Validation

- targeted PHPUnit tests: 156 tests, 309 assertions
- unit suite: 1,756 tests, 2 skipped
- integration suite: 115 tests, 392 assertions
- PHP CS Fixer
- Deptrac
- package Composer validation
- Phan
- Psalm
- PHPStan
- SPI dependency check

`make all-checks` does not currently complete on a clean `main` checkout because the unpinned local Rector installation reports 22 pre-existing dry-run suggestions. The checks above were run individually; Rector is not part of the upstream CI workflow.