### PR TITLE
fix(sdk): guard Span::setAttributes() against mutation after end()

### DIFF
--- a/src/SDK/Trace/Span.php
+++ b/src/SDK/Trace/Span.php
@@ -163,6 +163,10 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     #[\Override]
     public function setAttributes(iterable $attributes): self
     {
+        if ($this->hasEnded) {
+            return $this;
+        }
+
         foreach ($attributes as $key => $value) {
             $this->attributesBuilder[$key] = $value;
         }

--- a/tests/Unit/SDK/Trace/SpanTest.php
+++ b/tests/Unit/SDK/Trace/SpanTest.php
@@ -484,6 +484,14 @@ class SpanTest extends MockeryTestCase
         $this->assertEmpty($span->toSpanData()->getAttributes());
     }
 
+    public function test_set_attributes_noop_after_end(): void
+    {
+        $span = $this->createTestRootSpan();
+        $span->end();
+        $span->setAttributes(['string' => 'str']);
+        $this->assertEmpty($span->toSpanData()->getAttributes());
+    }
+
     #[DataProvider('nonHomogeneousArrayProvider')]
     public function test_set_attribute_drops_non_homogeneous_array(array $values): void
     {


### PR DESCRIPTION
setAttribute() already no-ops once a span has ended, but setAttributes() lacked the same hasEnded guard, letting attributes leak in after end() in violation of the OTel spec.