### PR TITLE
fix(sdk): skip absent keys in FilteredAttributeProcessor

### DIFF
--- a/src/SDK/Metrics/AttributeProcessor/FilteredAttributeProcessor.php
+++ b/src/SDK/Metrics/AttributeProcessor/FilteredAttributeProcessor.php
@@ -23,7 +23,9 @@ final class FilteredAttributeProcessor implements AttributeProcessorInterface
     {
         $filtered = [];
         foreach ($this->attributeKeys as $key) {
-            $filtered[$key] = $attributes->get($key);
+            if ($attributes->has($key)) {
+                $filtered[$key] = $attributes->get($key);
+            }
         }
 
         return new Attributes($filtered, 0);

--- a/tests/Unit/SDK/Metrics/AttributeProcessor/FilteredAttributeProcessorTest.php
+++ b/tests/Unit/SDK/Metrics/AttributeProcessor/FilteredAttributeProcessorTest.php
@@ -22,4 +22,14 @@ final class FilteredAttributeProcessorTest extends TestCase
                 ->toArray(),
         );
     }
+
+    public function test_attribute_processor_skips_missing_keys(): void
+    {
+        $this->assertEquals(
+            ['foo' => 3],
+            (new FilteredAttributeProcessor(['foo', 'baz']))
+                ->process(Attributes::create(['foo' => 3, 'bar' => 5]), Context::getRoot())
+                ->toArray(),
+        );
+    }
 }


### PR DESCRIPTION
`Attributes::get()` returns null for missing keys, and the raw array is stored verbatim, so allow-listed keys not present on the measurement were kept as `key => null` instead of being dropped.