### PR TITLE
fix(sdk): require sem-conv ^1.38 for VERSION_1_38_0 constant

### DIFF
--- a/src/SDK/composer.json
+++ b/src/SDK/composer.json
@@ -22,7 +22,7 @@
         "nyholm/psr7-server": "^1.1",
         "open-telemetry/api": "^1.8",
         "open-telemetry/context": "^1.4",
-        "open-telemetry/sem-conv": "^1.36.0",
+        "open-telemetry/sem-conv": "^1.38.0",
         "php-http/discovery": "^1.14",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",


### PR DESCRIPTION
## Problem

Closes #1922.

SDK resource detectors (`Environment`, `Host`, `Sdk`, `Process`, `Service`, `ServiceInstance`, `Composer`) reference `OpenTelemetry\SemConv\Version::VERSION_1_38_0`, which was introduced in `open-telemetry/sem-conv` **1.38.0**. However `src/SDK/composer.json` only required `^1.36.0`.

Resolving `sem-conv` to 1.36 or 1.37 (easy to hit via `composer update --minimal-changes`) produces a fatal error at runtime:

```
Undefined constant OpenTelemetry\SemConv\Version::VERSION_1_38_0
  in vendor/open-telemetry/sdk/Resource/Detectors/Environment.php:26
```

## Fix

Bump the `open-telemetry/sem-conv` constraint in the SDK package from `^1.36.0` to `^1.38.0` so the referenced constant is guaranteed to exist.

`Contrib` does not reference any `Version::VERSION_1_3x` constant, so its constraint is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)