### PR TITLE
fix(sdk): don't emit placeholder service.version in Composer detector

### DIFF
--- a/src/SDK/Resource/Detectors/Composer.php
+++ b/src/SDK/Resource/Detectors/Composer.php
@@ -18,17 +18,42 @@ use OpenTelemetry\SemConv\Version;
  */
 final class Composer implements ResourceDetectorInterface
 {
+    /**
+     * Placeholder version that Composer reports for a root package with no explicit
+     * version (Composer\Package\RootPackage::DEFAULT_PRETTY_VERSION).
+     */
+    private const UNSET_VERSION = '1.0.0+no-version-set';
+
+    /**
+     * @param array{name?: string, pretty_version?: ?string}|null $rootPackage overrides
+     *        the detected Composer root package; used for testing
+     */
+    public function __construct(private readonly ?array $rootPackage = null)
+    {
+    }
+
     #[\Override]
     public function getResource(): ResourceInfo
     {
-        if (!class_exists(InstalledVersions::class)) {
-            return ResourceInfoFactory::emptyResource();
+        $rootPackage = $this->rootPackage;
+        if ($rootPackage === null) {
+            if (!class_exists(InstalledVersions::class)) {
+                return ResourceInfoFactory::emptyResource();
+            }
+            $rootPackage = InstalledVersions::getRootPackage();
         }
 
         $attributes = [
-            ServiceAttributes::SERVICE_NAME => InstalledVersions::getRootPackage()['name'],
-            ServiceAttributes::SERVICE_VERSION => InstalledVersions::getRootPackage()['pretty_version'],
+            ServiceAttributes::SERVICE_NAME => $rootPackage['name'] ?? null,
         ];
+
+        // Only report service.version when the root package has an explicit version.
+        // Composer substitutes a placeholder ("1.0.0+no-version-set") when none is set,
+        // and other OpenTelemetry SDKs do not set service.version by default. See #1320.
+        $version = $rootPackage['pretty_version'] ?? null;
+        if ($version !== null && $version !== self::UNSET_VERSION) {
+            $attributes[ServiceAttributes::SERVICE_VERSION] = $version;
+        }
 
         return ResourceInfo::create(Attributes::create($attributes), Version::VERSION_1_38_0->url());
     }

--- a/src/SDK/Resource/Detectors/Composer.php
+++ b/src/SDK/Resource/Detectors/Composer.php
@@ -19,40 +19,38 @@ use OpenTelemetry\SemConv\Version;
 final class Composer implements ResourceDetectorInterface
 {
     /**
+     * Placeholder name that Composer reports for a root package with no `name`
+     * set in composer.json (Composer\Package\Loader\RootPackageLoader).
+     */
+    private const UNSET_NAME = '__root__';
+
+    /**
      * Placeholder version that Composer reports for a root package with no explicit
      * version (Composer\Package\RootPackage::DEFAULT_PRETTY_VERSION).
      */
     private const UNSET_VERSION = '1.0.0+no-version-set';
 
-    /**
-     * @param array{name?: string, pretty_version?: ?string}|null $rootPackage overrides
-     *        the detected Composer root package; used for testing
-     */
-    public function __construct(private readonly ?array $rootPackage = null)
-    {
-    }
-
     #[\Override]
     public function getResource(): ResourceInfo
     {
-        $rootPackage = $this->rootPackage;
-        if ($rootPackage === null) {
-            if (!class_exists(InstalledVersions::class)) {
-                return ResourceInfoFactory::emptyResource();
-            }
-            $rootPackage = InstalledVersions::getRootPackage();
+        if (!class_exists(InstalledVersions::class)) {
+            return ResourceInfoFactory::emptyResource();
         }
+        $rootPackage = InstalledVersions::getRootPackage();
 
-        $attributes = [
-            ServiceAttributes::SERVICE_NAME => $rootPackage['name'] ?? null,
-        ];
+        $attributes = [];
+
+        // Only report service.name when the root package has an explicit name.
+        // Composer substitutes a placeholder ("__root__") when none is set. See #1320.
+        if ($rootPackage['name'] !== self::UNSET_NAME) {
+            $attributes[ServiceAttributes::SERVICE_NAME] = $rootPackage['name'];
+        }
 
         // Only report service.version when the root package has an explicit version.
         // Composer substitutes a placeholder ("1.0.0+no-version-set") when none is set,
         // and other OpenTelemetry SDKs do not set service.version by default. See #1320.
-        $version = $rootPackage['pretty_version'] ?? null;
-        if ($version !== null && $version !== self::UNSET_VERSION) {
-            $attributes[ServiceAttributes::SERVICE_VERSION] = $version;
+        if ($rootPackage['pretty_version'] !== self::UNSET_VERSION) {
+            $attributes[ServiceAttributes::SERVICE_VERSION] = $rootPackage['pretty_version'];
         }
 
         return ResourceInfo::create(Attributes::create($attributes), Version::VERSION_1_38_0->url());

--- a/tests/Unit/SDK/Resource/Detectors/ComposerTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ComposerTest.php
@@ -9,10 +9,20 @@ use OpenTelemetry\SDK\Resource\Detectors\Composer;
 use OpenTelemetry\SemConv\ResourceAttributes;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 #[CoversClass(Composer::class)]
 class ComposerTest extends TestCase
 {
+    private const REAL_INSTALLED_PHP = __DIR__ . '/../../../../../vendor/composer/installed.php';
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        InstalledVersions::reload(require self::REAL_INSTALLED_PHP);
+        (new ReflectionProperty(InstalledVersions::class, 'canGetVendors'))->setValue(null, null);
+    }
+
     public function test_composer_get_resource(): void
     {
         $resourceDetector = new Composer();
@@ -35,7 +45,9 @@ class ComposerTest extends TestCase
 
     public function test_reports_service_version_when_set(): void
     {
-        $resource = (new Composer(['name' => 'foo/bar', 'pretty_version' => '2.3.4']))->getResource();
+        self::reloadInstalledVersions('foo/bar', '2.3.4');
+
+        $resource = (new Composer())->getResource();
 
         $this->assertSame('foo/bar', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
         $this->assertSame('2.3.4', $resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
@@ -43,9 +55,44 @@ class ComposerTest extends TestCase
 
     public function test_omits_service_version_when_composer_reports_placeholder(): void
     {
-        $resource = (new Composer(['name' => 'foo/bar', 'pretty_version' => '1.0.0+no-version-set']))->getResource();
+        self::reloadInstalledVersions('foo/bar', '1.0.0+no-version-set');
+
+        $resource = (new Composer())->getResource();
 
         $this->assertSame('foo/bar', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
         $this->assertNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
+    }
+
+    public function test_omits_service_name_when_composer_reports_placeholder(): void
+    {
+        self::reloadInstalledVersions('__root__', '2.3.4');
+
+        $resource = (new Composer())->getResource();
+
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        $this->assertSame('2.3.4', $resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
+    }
+
+    private static function reloadInstalledVersions(string $name, string $prettyVersion): void
+    {
+        InstalledVersions::reload([
+            'root' => [
+                'name' => $name,
+                'pretty_version' => $prettyVersion,
+                'version' => $prettyVersion,
+                'reference' => null,
+                'type' => 'library',
+                'install_path' => __DIR__,
+                'aliases' => [],
+                'dev' => true,
+            ],
+            'versions' => [],
+        ]);
+
+        // InstalledVersions::getRootPackage() otherwise re-reads the real
+        // vendor/composer/installed.php via the registered class loader, ignoring
+        // the data just passed to reload(); disabling this lookup forces it to use
+        // the reloaded dataset instead.
+        (new ReflectionProperty(InstalledVersions::class, 'canGetVendors'))->setValue(null, false);
     }
 }

--- a/tests/Unit/SDK/Resource/Detectors/ComposerTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ComposerTest.php
@@ -32,4 +32,20 @@ class ComposerTest extends TestCase
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
     }
+
+    public function test_reports_service_version_when_set(): void
+    {
+        $resource = (new Composer(['name' => 'foo/bar', 'pretty_version' => '2.3.4']))->getResource();
+
+        $this->assertSame('foo/bar', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        $this->assertSame('2.3.4', $resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
+    }
+
+    public function test_omits_service_version_when_composer_reports_placeholder(): void
+    {
+        $resource = (new Composer(['name' => 'foo/bar', 'pretty_version' => '1.0.0+no-version-set']))->getResource();
+
+        $this->assertSame('foo/bar', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::SERVICE_VERSION));
+    }
 }


### PR DESCRIPTION
## Problem

Closes #1320.

When a Composer root package has no explicit `version`, Composer substitutes the placeholder pretty version `1.0.0+no-version-set` (`Composer\Package\RootPackage::DEFAULT_PRETTY_VERSION`). The `Composer` resource detector passed `pretty_version` straight through, so any application that never declares a version — e.g. the [OpenTelemetry demo](https://github.com/open-telemetry/opentelemetry-demo) — ended up with a misleading `service.version = 1.0.0+no-version-set`.

Likewise, when no package `name` is set Composer substitutes the placeholder `__root__`, which should not surface as `service.name`.

Other language SDKs do not set `service.version` by default, as discussed in the issue.

## Fix

- Skip the `service.version` attribute when Composer reports the `1.0.0+no-version-set` placeholder.
- Skip the `service.name` attribute when Composer reports the `__root__` placeholder.
- A real, explicitly-set name/version is still reported as before.

The detector reads `InstalledVersions::getRootPackage()` directly (no constructor injection). Tests drive the placeholder paths by swapping the installed-versions dataset via `InstalledVersions::reload()`, restoring the real data in `tearDown()`.

## Tests

- `test_reports_service_version_when_set` — explicit version is emitted.
- `test_omits_service_version_when_composer_reports_placeholder` — `1.0.0+no-version-set` is dropped.
- `test_omits_service_name_when_composer_reports_placeholder` — `__root__` is dropped.
- Existing detector tests still pass; no state leaks across the suite.