### PR TITLE
fix(sdk): stop collecting process.command_args by default

### DIFF
--- a/src/SDK/Resource/Detectors/Process.php
+++ b/src/SDK/Resource/Detectors/Process.php
@@ -35,11 +35,15 @@ final class Process implements ResourceDetectorInterface
         ];
 
         /**
+         * process.command_args (and process.command_line) may contain sensitive data such
+         * as secrets or tokens passed as command-line arguments. Per semantic conventions
+         * 1.34.0 they SHOULD NOT be collected by default unless sanitized, so only the
+         * command name (argv[0]) is reported here. See #1604.
+         *
          * @psalm-suppress PossiblyUndefinedArrayOffset
          */
-        if ($_SERVER['argv'] ?? null) {
+        if ($_SERVER['argv'][0] ?? null) {
             $attributes[ProcessIncubatingAttributes::PROCESS_COMMAND] = $_SERVER['argv'][0];
-            $attributes[ProcessIncubatingAttributes::PROCESS_COMMAND_ARGS] = $_SERVER['argv'];
         }
 
         /** @phan-suppress-next-line PhanTypeComparisonFromArray */

--- a/tests/Integration/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Integration/SDK/Resource/ResourceInfoFactoryTest.php
@@ -31,7 +31,7 @@ class ResourceInfoFactoryTest extends TestCase
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_NAME));
@@ -151,7 +151,7 @@ class ResourceInfoFactoryTest extends TestCase
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
-        $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
         $this->assertNotNull($resource->getAttributes()->get(ResourceAttributes::TELEMETRY_SDK_NAME));

--- a/tests/Unit/SDK/Resource/Detectors/ProcessTest.php
+++ b/tests/Unit/SDK/Resource/Detectors/ProcessTest.php
@@ -21,7 +21,10 @@ class ProcessTest extends TestCase
         $this->assertIsInt($resource->getAttributes()->get(ResourceAttributes::PROCESS_PID));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_EXECUTABLE_PATH));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND));
-        $this->assertIsArray($resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS));
+        $this->assertNull(
+            $resource->getAttributes()->get(ResourceAttributes::PROCESS_COMMAND_ARGS),
+            'process.command_args is not collected by default (may contain sensitive data)',
+        );
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_NAME));
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::PROCESS_RUNTIME_VERSION));
     }


### PR DESCRIPTION
## Problem

Closes #1604.

Semantic conventions [1.34.0](https://github.com/open-telemetry/semantic-conventions/pull/2190) state that `process.command_args` and `process.command_line`:

> SHOULD NOT be collected by default unless there is sanitization that excludes sensitive data.

Command-line arguments frequently contain secrets, API tokens, DB passwords, etc. The `Process` resource detector emitted the full `$_SERVER['argv']` as `process.command_args` unconditionally, which can leak sensitive data into telemetry.

## Fix

Drop `process.command_args` from the default detector output. The non-sensitive command name (`argv[0]`) is still reported as `process.command`, which the spec does not restrict.

## Tests

- `ProcessTest` now asserts `process.command_args` is `null` and `process.command` is still present.
- `ResourceInfoFactoryTest` default-resource assertions updated to expect `process.command_args` absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)