### PR TITLE
fix(ResourceInfoFactory): Align ResourceInfoFactory detectors to otel specification

### DIFF
--- a/src/SDK/Resource/ResourceInfoFactory.php
+++ b/src/SDK/Resource/ResourceInfoFactory.php
@@ -29,24 +29,23 @@ class ResourceInfoFactory
             return (new Detectors\Composite([
                 new Detectors\Host(),
                 new Detectors\Process(),
+                ...Registry::resourceDetectors(),
                 new Detectors\Environment(),
                 new Detectors\Sdk(),
                 new Detectors\Service(),
-                ...Registry::resourceDetectors(),
             ]))->getResource();
         }
 
         /**
          * Process env-provided detectors:
-         * - host, process, environment, composer first if requested
-         * - sdk, service always
+         * - host, process, composer, service instance first if requested
          * - any other detectors registered in the registry if requested
+         * - environment, sdk, service always
          */
         $resourceDetectors = [];
         foreach ([
             Values::VALUE_DETECTORS_HOST => Detectors\Host::class,
             Values::VALUE_DETECTORS_PROCESS => Detectors\Process::class,
-            Values::VALUE_DETECTORS_ENVIRONMENT => Detectors\Environment::class,
             Values::VALUE_DETECTORS_COMPOSER => Detectors\Composer::class,
             Values::VALUE_DETECTORS_SERVICE_INSTANCE => Detectors\ServiceInstance::class,
         ] as $detector => $class) {
@@ -55,10 +54,9 @@ class ResourceInfoFactory
                 $detectors = array_diff($detectors, [$detector]);
             }
         }
-        $resourceDetectors [] = new Detectors\Sdk();
-        $resourceDetectors [] = new Detectors\Service();
         // Don't try to load mandatory + deprecated detectors
         $detectors = array_diff($detectors, [
+            Values::VALUE_DETECTORS_ENVIRONMENT,
             Values::VALUE_DETECTORS_SDK,
             Values::VALUE_DETECTORS_SERVICE,
             Values::VALUE_DETECTORS_SDK_PROVIDED, //deprecated
@@ -74,6 +72,10 @@ class ResourceInfoFactory
                 self::logWarning($e->getMessage());
             }
         }
+
+        $resourceDetectors [] = new Detectors\Environment();
+        $resourceDetectors [] = new Detectors\Sdk();
+        $resourceDetectors [] = new Detectors\Service();
 
         return (new Detectors\Composite($resourceDetectors))->getResource();
     }

--- a/src/SDK/Resource/ResourceInfoFactory.php
+++ b/src/SDK/Resource/ResourceInfoFactory.php
@@ -73,9 +73,9 @@ class ResourceInfoFactory
             }
         }
 
-        $resourceDetectors [] = new Detectors\Environment();
-        $resourceDetectors [] = new Detectors\Sdk();
-        $resourceDetectors [] = new Detectors\Service();
+        $resourceDetectors[] = new Detectors\Environment();
+        $resourceDetectors[] = new Detectors\Sdk();
+        $resourceDetectors[] = new Detectors\Service();
 
         return (new Detectors\Composite($resourceDetectors))->getResource();
     }

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -143,7 +143,8 @@ class ResourceInfoFactoryTest extends TestCase
         ResourceInfoFactory::defaultResource();
     }
 
-    #[DataProvider('registryDetectorModesProvider')]
+#[Group('compliance')]
+#[DataProvider('registryDetectorModesProvider')]
     public function test_registry_detector_service_name_does_not_override_service_name_from_env(string $detectors): void
     {
         $this->setEnvironmentVariable('OTEL_PHP_DETECTORS', $detectors);

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -154,12 +154,13 @@ class ResourceInfoFactoryTest extends TestCase
             ->willReturn(ResourceInfo::create(Attributes::create([ResourceAttributes::SERVICE_NAME => 'from-registry'])));
 
         Registry::registerResourceDetector('registry-service-name', $detector);
+
         try {
             $resource = ResourceInfoFactory::defaultResource();
 
             $this->assertSame('from-env', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
         } finally {
-            Registry::registerResourceDetector('registry-service-name', new class implements ResourceDetectorInterface {
+            Registry::registerResourceDetector('registry-service-name', new class() implements ResourceDetectorInterface {
                 public function getResource(): ResourceInfo
                 {
                     return ResourceInfoFactory::emptyResource();

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -153,6 +153,11 @@ class ResourceInfoFactoryTest extends TestCase
             ->method('getResource')
             ->willReturn(ResourceInfo::create(Attributes::create([ResourceAttributes::SERVICE_NAME => 'from-registry'])));
 
+        $resourceDetectorsProperty = new \ReflectionProperty(Registry::class, 'resourceDetectors');
+        $resourceDetectorsProperty->setAccessible(true);
+        $originalResourceDetectors = $resourceDetectorsProperty->getValue();
+        $resourceDetectorsProperty->setValue([]);
+
         Registry::registerResourceDetector('registry-service-name', $detector);
 
         try {
@@ -160,13 +165,7 @@ class ResourceInfoFactoryTest extends TestCase
 
             $this->assertSame('from-env', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
         } finally {
-            Registry::registerResourceDetector('registry-service-name', new class() implements ResourceDetectorInterface {
-                #[\Override]
-                public function getResource(): ResourceInfo
-                {
-                    return ResourceInfoFactory::emptyResource();
-                }
-            });
+            $resourceDetectorsProperty->setValue($originalResourceDetectors);
         }
     }
 

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -156,11 +156,11 @@ class ResourceInfoFactoryTest extends TestCase
         $resourceDetectorsProperty = new \ReflectionProperty(Registry::class, 'resourceDetectors');
         $resourceDetectorsProperty->setAccessible(true);
         $originalResourceDetectors = $resourceDetectorsProperty->getValue();
-        $resourceDetectorsProperty->setValue([]);
-
-        Registry::registerResourceDetector('registry-service-name', $detector);
 
         try {
+            $resourceDetectorsProperty->setValue([]);
+            Registry::registerResourceDetector('registry-service-name', $detector);
+
             $resource = ResourceInfoFactory::defaultResource();
 
             $this->assertSame('from-env', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -166,6 +166,7 @@ class ResourceInfoFactoryTest extends TestCase
                 }
             });
         }
+    }
 
     public static function registryDetectorModesProvider(): Generator
     {

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -161,6 +161,7 @@ class ResourceInfoFactoryTest extends TestCase
             $this->assertSame('from-env', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
         } finally {
             Registry::registerResourceDetector('registry-service-name', new class() implements ResourceDetectorInterface {
+                #[\Override]
                 public function getResource(): ResourceInfo
                 {
                     return ResourceInfoFactory::emptyResource();

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -154,10 +154,18 @@ class ResourceInfoFactoryTest extends TestCase
             ->willReturn(ResourceInfo::create(Attributes::create([ResourceAttributes::SERVICE_NAME => 'from-registry'])));
 
         Registry::registerResourceDetector('registry-service-name', $detector);
-        $resource = ResourceInfoFactory::defaultResource();
+        try {
+            $resource = ResourceInfoFactory::defaultResource();
 
-        $this->assertSame('from-env', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
-    }
+            $this->assertSame('from-env', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+        } finally {
+            Registry::registerResourceDetector('registry-service-name', new class implements ResourceDetectorInterface {
+                public function getResource(): ResourceInfo
+                {
+                    return ResourceInfoFactory::emptyResource();
+                }
+            });
+        }
 
     public static function registryDetectorModesProvider(): Generator
     {

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -143,6 +143,28 @@ class ResourceInfoFactoryTest extends TestCase
         ResourceInfoFactory::defaultResource();
     }
 
+    #[DataProvider('registryDetectorModesProvider')]
+    public function test_registry_detector_service_name_does_not_override_service_name_from_env(string $detectors): void
+    {
+        $this->setEnvironmentVariable('OTEL_PHP_DETECTORS', $detectors);
+        $this->setEnvironmentVariable('OTEL_SERVICE_NAME', 'from-env');
+        $detector = $this->createMock(ResourceDetectorInterface::class);
+        $detector->expects($this->once())
+            ->method('getResource')
+            ->willReturn(ResourceInfo::create(Attributes::create([ResourceAttributes::SERVICE_NAME => 'from-registry'])));
+
+        Registry::registerResourceDetector('registry-service-name', $detector);
+        $resource = ResourceInfoFactory::defaultResource();
+
+        $this->assertSame('from-env', $resource->getAttributes()->get(ResourceAttributes::SERVICE_NAME));
+    }
+
+    public static function registryDetectorModesProvider(): Generator
+    {
+        yield 'all detectors' => ['all'];
+        yield 'explicit registry detector' => ['registry-service-name'];
+    }
+
     public function test_composite_default_with_extra_resource_from_registry(): void
     {
         $this->setEnvironmentVariable('OTEL_PHP_DETECTORS', 'foo,env');

--- a/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/SDK/Resource/ResourceInfoFactoryTest.php
@@ -143,8 +143,8 @@ class ResourceInfoFactoryTest extends TestCase
         ResourceInfoFactory::defaultResource();
     }
 
-#[Group('compliance')]
-#[DataProvider('registryDetectorModesProvider')]
+    #[Group('compliance')]
+    #[DataProvider('registryDetectorModesProvider')]
     public function test_registry_detector_service_name_does_not_override_service_name_from_env(string $detectors): void
     {
         $this->setEnvironmentVariable('OTEL_PHP_DETECTORS', $detectors);


### PR DESCRIPTION
## Problem
From https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable, user provided resource information has higher priority and `OTEL_SERVICE_NAME` has the highest priority. However, with current implementation, the `service.name` detected by the `open-telemetry/detector-azure` will replace the `service.name` from `OTEL_SERVICE_NAME` which doesn't meet the specification.

## Fix
Corrected the ordering of the resource detectors in default and env-provided detectors.