### PR TITLE
chore: docker image housekeeping

### DIFF
--- a/docker-compose.collector.yaml
+++ b/docker-compose.collector.yaml
@@ -12,8 +12,6 @@ services:
     - 9411:9411
   jaeger:
     image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
-    environment:
-      COLLECTOR_ZIPKIN_HOST_PORT: 9412
     ports:
     - 9412:9412
     - 16686:16686

--- a/docker-compose.collector.yaml
+++ b/docker-compose.collector.yaml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - collector
   zipkin:
-    image: openzipkin/zipkin-slim3:6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
+    image: openzipkin/zipkin-slim:3:6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
     ports:
     - 9411:9411
   jaeger:

--- a/docker-compose.collector.yaml
+++ b/docker-compose.collector.yaml
@@ -7,18 +7,18 @@ services:
     depends_on:
       - collector
   zipkin:
-    image: openzipkin/zipkin-slim@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
+    image: openzipkin/zipkin-slim3:6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
     ports:
     - 9411:9411
   jaeger:
-    image: jaegertracing/all-in-one@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
     environment:
       COLLECTOR_ZIPKIN_HOST_PORT: 9412
     ports:
     - 9412:9412
     - 16686:16686
   collector:
-    image: otel/opentelemetry-collector-contrib@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108
+    image: otel/opentelemetry-collector-contrib:0.156.0@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108
     command: ["--config=/etc/otel-collector-config.yml"]
     volumes:
       - ./files/collector/otel-collector-config.yml:/etc/otel-collector-config.yml

--- a/docker-compose.collector.yaml
+++ b/docker-compose.collector.yaml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - collector
   zipkin:
-    image: openzipkin/zipkin-slim:3:6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
+    image: openzipkin/zipkin-slim:3.6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
     ports:
     - 9411:9411
   jaeger:

--- a/docker-compose.fiber-ffi.yaml
+++ b/docker-compose.fiber-ffi.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   web:
-    image: nginx:alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa
+    image: nginx:1.30.4-alpine@sha256:sha256:59d10bca5c674965ef4ff884715000dd60ef5567c36663523f108eec8e4105d4
     ports:
       - '8080:80'
     depends_on:

--- a/docker-compose.fiber-ffi.yaml
+++ b/docker-compose.fiber-ffi.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   web:
-    image: nginx:1.30.4-alpine@sha256:sha256:59d10bca5c674965ef4ff884715000dd60ef5567c36663523f108eec8e4105d4
+    image: nginx:1.30.4-alpine@sha256:59d10bca5c674965ef4ff884715000dd60ef5567c36663523f108eec8e4105d4
     ports:
       - '8080:80'
     depends_on:

--- a/docker-compose.phpDocumentor.yaml
+++ b/docker-compose.phpDocumentor.yaml
@@ -1,6 +1,6 @@
 services:
   phpdoc:
-    image: phpdoc/phpdoc:3@sha256:312ebf61ed88a6ea79aac768e43c9e9af0dd5bf3e710ed6d40ab8e53bfeeb121
+    image: phpdoc/phpdoc:3.10.0@sha256:312ebf61ed88a6ea79aac768e43c9e9af0dd5bf3e710ed6d40ab8e53bfeeb121
     volumes:
       - ./:/data
   preview:

--- a/docker-compose.prometheus.yaml
+++ b/docker-compose.prometheus.yaml
@@ -1,17 +1,17 @@
 version: '3.7'
 services:
   prometheus:
-    image: prom/prometheus@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
+    image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
     ports:
       - 9090:9090
     volumes:
       - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
   redis:
-    image: redis@sha256:0b13f549ab871acafaa84b673c4e29bd7dce8d12526aaafe3b4ea3366c322daf
+    image: redis:8.8.0@sha256:234c902a2db49461a129e2d4aeff85b28cf20187ed274a67f6e50995fa713c7b
     ports:
         - 6379:6379
   web:
-    image: nginx:alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa
+    image: nginx:1.30.4-alpine@sha256:59d10bca5c674965ef4ff884715000dd60ef5567c36663523f108eec8e4105d4
     ports:
       - 8080:80
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,6 @@ services:
     - 9411:9411
   jaeger:
     image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
-    environment:
-      COLLECTOR_ZIPKIN_HOST_PORT: 9412
     ports:
     - 9412:9412
     - 16686:16686

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     - 9412:9412
     - 16686:16686
   collector:
-    image: otel/opentelemetry-collector:0.156.0@sha256:0beba82d63792511591522a8d582904b9a8ae81710357bfcab731607b8b0ffe2
+    image: otel/opentelemetry-collector-contrib:0.156.0@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108
     command: [ "--config=/etc/otel-collector-config.yml" ]
     volumes:
       - ./files/collector/otel-collector-config.yml:/etc/otel-collector-config.yml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,18 +7,18 @@ services:
     env_file:
       - .env
   zipkin:
-    image: openzipkin/zipkin-slim@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
+    image: openzipkin/zipkin-slim:3.6.1@sha256:fc29b9862c14f4fc241cf0259c585e1cfd4e9b18f01ad36d86adaabb7d01815c
     ports:
     - 9411:9411
   jaeger:
-    image: jaegertracing/all-in-one@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
     environment:
       COLLECTOR_ZIPKIN_HOST_PORT: 9412
     ports:
     - 9412:9412
     - 16686:16686
   collector:
-    image: otel/opentelemetry-collector-contrib@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108
+    image: otel/opentelemetry-collector:0.156.0@sha256:0beba82d63792511591522a8d582904b9a8ae81710357bfcab731607b8b0ffe2
     command: [ "--config=/etc/otel-collector-config.yml" ]
     volumes:
       - ./files/collector/otel-collector-config.yml:/etc/otel-collector-config.yml

--- a/docs/laravel-quickstart.md
+++ b/docs/laravel-quickstart.md
@@ -73,7 +73,7 @@ services:
         ports:
             - "9411:9411"
     jaeger:
-        image: jaegertracing/all-in-one
+        image: jaegertracing/jaeger
         environment:
             COLLECTOR_ZIPKIN_HOST_PORT: 9412
 

--- a/docs/laravel-quickstart.md
+++ b/docs/laravel-quickstart.md
@@ -74,9 +74,6 @@ services:
             - "9411:9411"
     jaeger:
         image: jaegertracing/jaeger
-        environment:
-            COLLECTOR_ZIPKIN_HOST_PORT: 9412
-
         ports:
             - "9412:9412"
             - "16686:16686"


### PR DESCRIPTION
Explicitly pin docker version to improve info/context available to renovate.

The jaegar tracing image has been switched as existing image is eol https://github.com/jaegertracing/jaeger/issues/6321