### PR TITLE
docs: explain OpenTelemetry lifecycle in long-lived workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Please read the official documentation: https://opentelemetry.io/docs/instrument
 
 API Documentation is available here: https://open-telemetry.github.io/opentelemetry-php/
 
+For applications using FrankenPHP worker mode, RoadRunner, queue workers, or
+another long-lived PHP runtime, see the [worker-mode guide](docs/worker-mode.md).
+
 ## AI Assistance
 If you're planning on using AI to contribute to the OpenTelemetry PHP repositories, please follow the [OpenTelemetry GenAI Policies](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
 ## Packages and versions

--- a/docs/worker-mode.md
+++ b/docs/worker-mode.md
@@ -1,0 +1,84 @@
+# Long-lived PHP workers
+
+Traditional PHP applications start a process for a request and run shutdown
+handlers at the end of that request. Long-lived worker runtimes keep the PHP
+process alive for multiple units of work. This includes FrankenPHP worker mode,
+RoadRunner, queue workers, and custom daemon processes.
+
+OpenTelemetry state must therefore be completed explicitly at the end of every
+unit of work. Do not rely on PHP process shutdown to finish a request span or
+export its telemetry.
+
+## Per-request lifecycle
+
+For each request or job, establish a fresh root context before application work
+begins. Start and activate the request span inside that context, then end the
+span and detach both scopes before accepting another unit of work.
+
+```php
+use OpenTelemetry\Context\Context;
+
+$rootScope = Context::getRoot()->activate();
+
+try {
+    $span = $tracer->spanBuilder('worker.request')->startSpan();
+    $spanScope = $span->activate();
+
+    try {
+        // Handle exactly one request or job.
+    } finally {
+        $span->end();
+        $spanScope->detach();
+    }
+} finally {
+    $rootScope->detach();
+}
+```
+
+Using `Context::getRoot()` prevents telemetry from a previous unit of work from
+becoming the parent of the next one. If your application deliberately keeps a
+trace across units of work, use the context propagation rules appropriate for
+that application instead.
+
+## Flush after each unit of work
+
+After completing the request or job, flush the providers owned by the
+application. The SDK exposes `forceFlush()` on the tracer, meter, and logger
+providers. Flush every signal provider that the application configured.
+
+```php
+$tracerProvider->forceFlush();
+$meterProvider->forceFlush();
+$loggerProvider->forceFlush();
+```
+
+`forceFlush()` requests export of pending data; it does not replace the normal
+process-level shutdown. Call `shutdown()` when the worker itself is stopping,
+not after every request, because shutdown makes a provider unavailable for
+future work.
+
+## Configuration timing
+
+Automatic instrumentation and SDK configuration can be initialized before a
+framework loads its `.env` files. Set `OTEL_*` configuration in the worker
+process environment (for example, the container or process-manager
+configuration) before Composer autoloading starts. A framework-specific `.env`
+file may be visible to application code yet still be too late for OpenTelemetry
+initialization.
+
+## Troubleshooting checklist
+
+When telemetry is missing, delayed, or repeated between requests:
+
+1. Confirm the `OTEL_*` variables exist in the worker's real process
+   environment at startup.
+2. Confirm every request or job starts from a fresh root context unless a
+   shared trace is intentional.
+3. Confirm request spans are ended and all attached scopes are detached.
+4. Call `forceFlush()` for each configured signal provider after the unit of
+   work completes.
+5. Call provider `shutdown()` only as part of worker termination.
+
+This lifecycle is independent of web-server tracing such as Caddy's tracing:
+server telemetry and PHP application telemetry are separate instrumentation
+concerns.

--- a/docs/worker-mode.md
+++ b/docs/worker-mode.md
@@ -60,7 +60,10 @@ future work.
 ## Configuration timing
 
 Automatic instrumentation and SDK configuration can be initialized before a
-framework loads its `.env` files. Set `OTEL_*` configuration in the worker
+framework loads its `.env` files. A `.env` file can provide `OTEL_*`
+configuration when its loader runs before OpenTelemetry initialization; whether
+that is true depends on the installed packages and their initialization order.
+For predictable worker startup, set `OTEL_*` configuration in the worker
 process environment (for example, the container or process-manager
 configuration) before Composer autoloading starts. A framework-specific `.env`
 file may be visible to application code yet still be too late for OpenTelemetry


### PR DESCRIPTION
## Summary

- add a worker-mode guide for FrankenPHP, RoadRunner, queue workers, and other persistent PHP runtimes
- document per-unit root-context cleanup and provider flushing
- explain why OpenTelemetry configuration must be available before Composer autoloading

Fixes #1611

## Validation

- `npx --yes markdownlint-cli2 docs/worker-mode.md`
- `git diff --check`

## AI assistance

Prepared with GPT-5.6 assistance. I reviewed the current issue discussion and SDK interfaces before submission; the commit includes an `Assisted-by` trailer.