### PR TITLE
chore: Update Renovate configuration for package rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,12 +7,24 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["digest", "patch"],
       "schedule": ["before 8am every weekday"]
     },
     {
       "matchUpdateTypes": ["minor", "major"],
       "schedule": ["before 8am on Monday"]
+    },
+    {
+      groupName: "infra [minor]",
+      matchCategories: ["ci", "docker"],
+      matchManagers: ['!dockerfile'],
+      matchUpdateTypes: ["minor"],
+      schedule: ["before 7am on Monday"],
+    },
+    {
+      matchUpdateTypes: ['major'],
+      matchManagers: ['docker-compose'],
+      dependencyDashboardApproval: true,
     }
   ],
   "labels": [


### PR DESCRIPTION
Add more rules to reduce the qty of renovate pr’s and bring down the queue.

key thing is that:

- all minor ci & docker updates are grouped together except for dockerfile dependencies
- All major docker compose updates need approval
- digest updates are now grouped with patches