### PR TITLE
Remove static state in SystemClock

### DIFF
--- a/src/API/Common/Time/SystemClock.php
+++ b/src/API/Common/Time/SystemClock.php
@@ -12,11 +12,14 @@ use function microtime;
  */
 final class SystemClock implements ClockInterface
 {
-    private static int $referenceTime = 0;
+    private readonly int $referenceTime;
 
     public function __construct()
     {
-        self::init();
+        $this->referenceTime = self::calculateReferenceTime(
+            microtime(true),
+            hrtime(true)
+        );
     }
 
     public static function create(): self
@@ -28,19 +31,7 @@ final class SystemClock implements ClockInterface
     #[\Override]
     public function now(): int
     {
-        return self::$referenceTime + hrtime(true);
-    }
-
-    private static function init(): void
-    {
-        if (self::$referenceTime > 0) {
-            return;
-        }
-
-        self::$referenceTime = self::calculateReferenceTime(
-            microtime(true),
-            hrtime(true)
-        );
+        return $this->referenceTime + hrtime(true);
     }
 
     /**


### PR DESCRIPTION
In the library code base `SystemClock` is used as a singleton (via `Clock::getDefault()`). So this change will not actually impact much.

Practically it simplifies `SystemClock` by removing its internal static state, which I consider to be a code smell.

- We maintain internal monotonicity by computing the reference time at construction
- The library maintains monotonicity by only using the singleton instance

We lose monotonicity between different instances, I do not think this is a bad thing, it could actually be a good thing.
For long running PHP processes (for example ReactPHP or other scenarios where a single process handles many requests) we could choose to instantiate a system clock for each request. Having a single reference time at process start means we can drift away from real time because we're not getting resynced with NTP.

FYI: While the code was edited by opencode, this description is handwritten.



